### PR TITLE
Add basic Travis CI config for build & test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+dist: trusty
+sudo: required
+lang: cpp
+
+compiler:
+  - clang
+  - gcc
+
+install:
+  - sudo apt-get install -y cmake3
+  - cmake --version
+  - git submodule init
+  - git submodule update --init --recursive
+
+script:
+  - mkdir build && cd build && cmake ..
+  - make all
+  - make test


### PR DESCRIPTION
Fixes issue #1.

Note that I've already enabled Travis CI to run iff there is a `.travis.yml` config, so in theory, it should run on this PR as well (let's see).