### PR TITLE
Added Travis CI build status badge. [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # C++ Client Libraries for Google Cloud
 
+[![Travis CI status][travis-shield]][travis-link]
+
+[travis-shield]: https://travis-ci.org/GoogleCloudPlatform/google-cloud-cpp.svg
+[travis-link]: https://travis-ci.org/GoogleCloudPlatform/google-cloud-cpp/builds
+
 This repo contains experimental client libraries for:
 
 * [Cloud Bigtable](bigtable/)


### PR DESCRIPTION
Now that we have a successful build, we can display our status in the `README.md` at the top of the repo.