### PR TITLE
Cleanup and update READMEs. [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,30 @@
-# C++ Client Libraries for Google Cloud
+# Google Cloud Platform C++ Client Libraries
 
 [![Travis CI status][travis-shield]][travis-link]
 
 [travis-shield]: https://travis-ci.org/GoogleCloudPlatform/google-cloud-cpp.svg
 [travis-link]: https://travis-ci.org/GoogleCloudPlatform/google-cloud-cpp/builds
 
-This repo contains experimental client libraries for:
+This repo contains experimental client libraries for the following APIs:
 
-* [Cloud Bigtable](bigtable/)
+* [Google Cloud Bigtable](bigtable/)
 
 The libraries in this code base likely do not (yet) cover all the available
-calls.  See the [`googleapis` repo](https://github.com/googleapis/googleapis)
+APIs. See the [`googleapis` repo](https://github.com/googleapis/googleapis)
 for the full list of APIs callable using gRPC.
+
+To build the available libraries and run the tests, run the following commands
+after cloning this repo:
+
+```sh
+git submodule init
+git submodule update --init --recursive
+mkdir build
+cd build
+cmake ..
+make all
+make test
+```
 
 ## Contributing changes
 

--- a/bigtable/README.md
+++ b/bigtable/README.md
@@ -1,13 +1,4 @@
-To build and run with the latest protobuf and grpc, follow the steps below.
+# Google Cloud Bigtable
 
-1.  **Compile and Test:**
-    ```sh
-    cd google-cloud-cpp/
-    git submodule init
-    git submodule update --init --recursive
-    mkdir build
-    cd build
-    cmake ..
-    make all
-    make test
-    ```
+This directory contains the implementation of the Google Cloud Bigtable C++
+client. This is a work-in-progress and is not yet suitable for production use.


### PR DESCRIPTION
* Move build steps to top-level README as it's not Bigtable-specific
* Fix title and library to include "Google"
* Minor wording cleanups/updates