### PR TITLE
Cleanups for CI shell scripts.

### DIFF
--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+#
 # Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,32 +14,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -eu
 
 if [ "${TRAVIS_OS_NAME}" != "linux" ]; then
-  echo "Not a Linux-based build, exit successfully."
+  echo "Not a Linux-based build, skipping Linux-specific build steps."
   exit 0
 fi
 
-readonly IMAGE="cached-${DISTRO?}-${DISTRO_VERSION?}"
-readonly LATEST_ID=$(sudo docker inspect -f '{{ .Id }}' ${IMAGE?}:latest 2>/dev/null || echo "")
+readonly IMAGE="cached-${DISTRO}-${DISTRO_VERSION}"
+readonly LATEST_ID="$(sudo docker inspect -f '{{ .Id }}' ${IMAGE}:latest 2>/dev/null || echo)"
 
-echo IMAGE = ${IMAGE}
-echo IMAGE LATEST ID = ${LATEST_ID}
+echo "IMAGE = ${IMAGE}"
+echo "IMAGE LATEST ID = ${LATEST_ID}"
 
 # TODO() - on cron buiids, we would want to disable the cache
 # altogether, to make sure we can still build against recent versions
-# of grpc, protobug, the compilers, etc.
+# of grpc, protobuf, the compilers, etc.
 cacheargs=""
 if [ -z "${LATEST_ID}" ]; then
-  cacheargs="--cache-from ${IMAGE?}:latest"
+  cacheargs="--cache-from ${IMAGE}:latest"
 fi
 
-echo cache args = ${cacheargs}
+echo "cache args = ${cacheargs}"
 
-sudo docker build -t ${IMAGE?}:tip ${cacheargs?} \
-     --build-arg DISTRO_VERSION=${DISTRO_VERSION?} \
-     --build-arg CXX=${CXX?} \
-     --build-arg CC=${CC?} \
-     --build-arg TRAVIS_JOB_NUMBER=${TRAVIS_JOB_NUMBER} \
-     -f ci/Dockerfile.${DISTRO?} .
+# Note: ${cacheargs} is explicitly not quoted since it may contain multiple
+# arguments, so we want it to be expanded as-is rather than a single arg with
+# spaces.
+sudo docker build -t "${IMAGE}:tip" ${cacheargs} \
+     --build-arg DISTRO_VERSION="${DISTRO_VERSION}" \
+     --build-arg CXX="${CXX}" \
+     --build-arg CC="${CC}" \
+     --build-arg TRAVIS_JOB_NUMBER="${TRAVIS_JOB_NUMBER}" \
+     -f "ci/Dockerfile.${DISTRO}" .

--- a/ci/build-macosx.sh
+++ b/ci/build-macosx.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+#
 # Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -eu
 
 if [ "${TRAVIS_OS_NAME}" != "osx" ]; then
   echo "Not a Mac OS X build, exit successfully"
@@ -27,5 +28,5 @@ test -d .build || mkdir .build
 
 cd .build
 cmake ..
-make -j ${NCPU:-2}
-make -j ${NCPU:-2} test || ( cat Testing/Temporary/LastTest.log; exit 1 )
+make -j "${NCPU:-2}" all
+make -j "${NCPU:-2}" test || ( cat Testing/Temporary/LastTest.log; exit 1 )

--- a/ci/cache-linux.sh
+++ b/ci/cache-linux.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+#
 # Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,18 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -eu
 
 if [ "${TRAVIS_OS_NAME}" != "linux" ]; then
-  echo "Not a Linux-based build, exit successfully."
+  echo "Not a Linux-based build; skipping Docker image caching."
   exit 0
 fi
 
-readonly IMAGE=cached-${DISTRO?}-${DISTRO_VERSION?}
-readonly TARBALL=docker-images/${DISTRO?}/${DISTRO_VERSION?}/saved.tar.gz
+readonly IMAGE="cached-${DISTRO}-${DISTRO_VERSION}"
+readonly TARBALL="docker-images/${DISTRO}/${DISTRO_VERSION}/saved.tar.gz"
 
 # The build creates a new "*:tip" image, we want to save it as
 # "*:latest" so it can be used as a cache source in the next build.
-sudo docker image tag ${IMAGE?}:tip ${IMAGE?}:latest
+sudo docker image tag "${IMAGE}:tip" "${IMAGE}:latest"
 
-sudo docker save ${IMAGE?}:latest | gzip - > ${TARBALL?}
+sudo docker save "${IMAGE}:latest" | gzip - > "${TARBALL}"

--- a/ci/install-linux.sh
+++ b/ci/install-linux.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+#
 # Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -eu
 
-if [ "x${TRAVIS_OS_NAME}" != "xlinux" ]; then
-  echo "Not a Linux-based build, exit successfully."
+if [ "${TRAVIS_OS_NAME}" != "linux" ]; then
+  echo "Not a Linux-based build; skipping Docker installation and restore from cache."
   exit 0
 fi
 
@@ -24,10 +25,10 @@ sudo apt-get update
 sudo apt-get install -y docker-ce
 sudo docker --version
 
-readonly TARBALL=docker-images/${DISTRO?}/${DISTRO_VERSION?}/saved.tar.gz
-if [ -f ${TARBALL?} ]; then
-  gunzip <${TARBALL?} | sudo docker load \
-    || echo "Could not load saved image, continuing without cache"
+readonly TARBALL="docker-images/${DISTRO}/${DISTRO_VERSION}/saved.tar.gz"
+if [ -f "${TARBALL}" ]; then
+  gunzip < "${TARBALL}" | sudo docker load \
+    || echo "Could not load saved image, continuing without cache."
 fi
 
 sudo docker image ls


### PR DESCRIPTION
* Use `set -eu` rather than just `set -e`; this allows dropping all the trailing
  `?` from env variable lookups with the same result (exit with error if unset),
  while being more readable, and it avoids user error from forgetting to add it
* Add double-quoting around variable names; recommended in
  https://google.github.io/styleguide/shell.xml#Quoting
* `echo ""` is equivalent to `echo` so that lets us simplify code;
  `diff <(echo) <(echo "")` returns empty and exits with status code 0
* Clarify messaging to users when we're exiting scripts with specific messages,
  rather than "exiting", since the build log on Travis will actually continue
  (we're just skipping a specific step that doesn't apply to that platform)
* Added blank lines between the `#!/bin/bash` line and the license for
  readability