### PR TITLE
Introduce policy to decide if mutations are idempotent.

### DIFF
--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -126,6 +126,8 @@ add_library(bigtable_data_api
         client/client_options.cc
         client/data.h
         client/data.cc
+        client/idempotent_mutation_policy.h
+        client/idempotent_mutation_policy.cc
         client/mutations.h
         client/mutations.cc
         client/rpc_backoff_policy.h
@@ -140,6 +142,7 @@ target_link_libraries(bigtable_data_api googleapis ${GRPCPP_LIBRARIES}
 set(all_unit_tests
         client/client_options_test.cc
         client/force_sanitizer_failures_test.cc
+        client/idempotent_mutation_policy_test.cc
         client/mutations_test.cc
         client/table_apply_test.cc
         client/rpc_backoff_policy_test.cc

--- a/bigtable/client/data.cc
+++ b/bigtable/client/data.cc
@@ -32,30 +32,43 @@ std::unique_ptr<Table> Client::Open(const std::string& table_id) {
 }
 
 void Table::Apply(SingleRowMutation&& mut) {
-  // This is the RPC Retry Policy in effect for the complete operation ...
-  auto retry_policy = rpc_retry_policy_->clone();
+  // Copy the policies in effect for the operation.
+  auto rpc_policy = rpc_retry_policy_->clone();
   auto backoff_policy = rpc_backoff_policy_->clone();
+  auto idempotent_policy = idempotent_mutation_policy_->clone();
 
-  // ... build the RPC request, try to minimize copying ...
+  // Build the RPC request, try to minimize copying.
   btproto::MutateRowRequest request;
   request.set_table_name(table_name_);
   request.set_row_key(std::move(mut.row_key_));
   request.mutable_mutations()->Swap(&mut.ops_);
+  bool is_idempotent =
+      std::all_of(request.mutations().begin(), request.mutations().end(),
+                  [&idempotent_policy](btproto::Mutation const& m) {
+                    return idempotent_policy->is_idempotent(m);
+                  });
 
   btproto::MutateRowResponse response;
   while (true) {
     grpc::ClientContext client_context;
-    retry_policy->setup(client_context);
+    rpc_policy->setup(client_context);
     backoff_policy->setup(client_context);
     grpc::Status status =
         client_->Stub().MutateRow(&client_context, request, &response);
     if (status.ok()) {
       return;
     }
-    // ... it is up to the policy to terminate this loop, it could run
-    // forever, but that would be a bad policy (pun intended) ...
-    if (not retry_policy->on_failure(status)) {
-      throw std::runtime_error("retry policy exhausted or permanent error");
+    // It is up to the policy to terminate this loop, it could run
+    // forever, but that would be a bad policy (pun intended).
+    if (not rpc_policy->on_failure(status) or not is_idempotent) {
+      std::vector<FailedMutation> failures;
+      google::rpc::Status rpc_status;
+      rpc_status.set_code(status.error_code());
+      rpc_status.set_message(status.error_message());
+      failures.emplace_back(SingleRowMutation(std::move(request)), rpc_status,
+                            0);
+      throw PermanentMutationFailures(
+          "retry policy exhausted or permanent error", std::move(failures));
     }
     auto delay = backoff_policy->on_completion(status);
     std::this_thread::sleep_for(delay);

--- a/bigtable/client/data.cc
+++ b/bigtable/client/data.cc
@@ -42,7 +42,7 @@ void Table::Apply(SingleRowMutation&& mut) {
   request.set_table_name(table_name_);
   request.set_row_key(std::move(mut.row_key_));
   request.mutable_mutations()->Swap(&mut.ops_);
-  bool is_idempotent =
+  bool const is_idempotent =
       std::all_of(request.mutations().begin(), request.mutations().end(),
                   [&idempotent_policy](btproto::Mutation const& m) {
                     return idempotent_policy->is_idempotent(m);
@@ -67,7 +67,7 @@ void Table::Apply(SingleRowMutation&& mut) {
       rpc_status.set_message(status.error_message());
       failures.emplace_back(SingleRowMutation(std::move(request)), rpc_status,
                             0);
-      throw PermanentMutationFailures(
+      throw PermanentMutationFailure(
           "retry policy exhausted or permanent error", std::move(failures));
     }
     auto delay = backoff_policy->on_completion(status);

--- a/bigtable/client/data.h
+++ b/bigtable/client/data.h
@@ -16,6 +16,7 @@
 #define BIGTABLE_CLIENT_DATA_H_
 
 #include <bigtable/client/client_options.h>
+#include <bigtable/client/idempotent_mutation_policy.h>
 #include <bigtable/client/mutations.h>
 #include <bigtable/client/rpc_backoff_policy.h>
 #include <bigtable/client/rpc_retry_policy.h>
@@ -112,16 +113,21 @@ class Table {
       : client_(client),
         table_name_(table_name),
         rpc_retry_policy_(bigtable::DefaultRPCRetryPolicy()),
-        rpc_backoff_policy_(bigtable::DefaultRPCBackoffPolicy()) {}
+        rpc_backoff_policy_(bigtable::DefaultRPCBackoffPolicy()),
+        idempotent_mutation_policy_(
+            bigtable::DefaultIdempotentMutationPolicy()) {}
 
   /// Constructor with explicit policies
-  template <typename RPCRetryPolicy, typename RPCBackoffPolicy>
+  template <typename RPCRetryPolicy, typename RPCBackoffPolicy,
+            typename IdempotentMutationPolicy>
   Table(const ClientInterface* client, const std::string& table_name,
-        RPCRetryPolicy retry_policy, RPCBackoffPolicy backoff_policy)
+        RPCRetryPolicy retry_policy, RPCBackoffPolicy backoff_policy,
+        IdempotentMutationPolicy idempotent_mutation_policy)
       : client_(client),
         table_name_(table_name),
         rpc_retry_policy_(retry_policy.clone()),
-        rpc_backoff_policy_(backoff_policy.clone()) {}
+        rpc_backoff_policy_(backoff_policy.clone()),
+        idempotent_mutation_policy_(idempotent_mutation_policy.clone()) {}
 
   const std::string& table_name() const { return table_name_; }
 
@@ -143,6 +149,7 @@ class Table {
   std::string table_name_;
   std::unique_ptr<RPCRetryPolicy> rpc_retry_policy_;
   std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy_;
+  std::unique_ptr<IdempotentMutationPolicy> idempotent_mutation_policy_;
 };
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/bigtable/client/idempotent_mutation_policy.cc
+++ b/bigtable/client/idempotent_mutation_policy.cc
@@ -17,14 +17,18 @@
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 std::unique_ptr<IdempotentMutationPolicy> DefaultIdempotentMutationPolicy() {
-  return std::unique_ptr<IdempotentMutationPolicy>(new SafeIdempotentMutationPolicy);
+  return std::unique_ptr<IdempotentMutationPolicy>(
+      new SafeIdempotentMutationPolicy);
 }
 
-std::unique_ptr<IdempotentMutationPolicy> SafeIdempotentMutationPolicy::clone() const {
-  return std::unique_ptr<IdempotentMutationPolicy>(new SafeIdempotentMutationPolicy(*this));
+std::unique_ptr<IdempotentMutationPolicy> SafeIdempotentMutationPolicy::clone()
+    const {
+  return std::unique_ptr<IdempotentMutationPolicy>(
+      new SafeIdempotentMutationPolicy(*this));
 }
 
-bool SafeIdempotentMutationPolicy::is_idempotent(const google::bigtable::v2::Mutation &m) {
+bool SafeIdempotentMutationPolicy::is_idempotent(
+    google::bigtable::v2::Mutation const& m) {
   if (not m.has_set_cell()) {
     return true;
   }

--- a/bigtable/client/idempotent_mutation_policy.cc
+++ b/bigtable/client/idempotent_mutation_policy.cc
@@ -34,5 +34,16 @@ bool SafeIdempotentMutationPolicy::is_idempotent(
   }
   return m.set_cell().timestamp_micros() != ServerSetTimestamp();
 }
+
+std::unique_ptr<IdempotentMutationPolicy> AlwaysRetryMutationPolicy::clone()
+    const {
+  return std::unique_ptr<IdempotentMutationPolicy>(
+      new AlwaysRetryMutationPolicy(*this));
+}
+
+bool AlwaysRetryMutationPolicy::is_idempotent(
+    google::bigtable::v2::Mutation const& m) {
+  return true;
+}
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/bigtable/client/idempotent_mutation_policy.cc
+++ b/bigtable/client/idempotent_mutation_policy.cc
@@ -1,0 +1,34 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/client/idempotent_mutation_policy.h"
+
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+std::unique_ptr<IdempotentMutationPolicy> DefaultIdempotentMutationPolicy() {
+  return std::unique_ptr<IdempotentMutationPolicy>(new SafeIdempotentMutationPolicy);
+}
+
+std::unique_ptr<IdempotentMutationPolicy> SafeIdempotentMutationPolicy::clone() const {
+  return std::unique_ptr<IdempotentMutationPolicy>(new SafeIdempotentMutationPolicy(*this));
+}
+
+bool SafeIdempotentMutationPolicy::is_idempotent(const google::bigtable::v2::Mutation &m) {
+  if (not m.has_set_cell()) {
+    return true;
+  }
+  return m.set_cell().timestamp_micros() != ServerSetTimestamp();
+}
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable

--- a/bigtable/client/idempotent_mutation_policy.h
+++ b/bigtable/client/idempotent_mutation_policy.h
@@ -54,6 +54,15 @@ class SafeIdempotentMutationPolicy : public IdempotentMutationPolicy {
   std::unique_ptr<IdempotentMutationPolicy> clone() const override;
   bool is_idempotent(google::bigtable::v2::Mutation const&) override;
 };
+
+/// Implements a policy that retries all mutations.
+class AlwaysRetryMutationPolicy : public IdempotentMutationPolicy {
+ public:
+  AlwaysRetryMutationPolicy() {}
+
+  std::unique_ptr<IdempotentMutationPolicy> clone() const override;
+  bool is_idempotent(google::bigtable::v2::Mutation const&) override;
+};
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
 

--- a/bigtable/client/idempotent_mutation_policy.h
+++ b/bigtable/client/idempotent_mutation_policy.h
@@ -55,7 +55,16 @@ class SafeIdempotentMutationPolicy : public IdempotentMutationPolicy {
   bool is_idempotent(google::bigtable::v2::Mutation const&) override;
 };
 
-/// Implements a policy that retries all mutations.
+/**
+ * Implements a policy that retries all mutations.
+ *
+ * Notice that this will may result in non-idempotent mutations being resent
+ * to the server.  Re-trying a SetCell() mutation where the server selects the
+ * timestamp can result in multiple copies of the data stored with different
+ * timestamps.  Only use this policy if your application is prepared to handle
+ * such problems, for example, by only querying the last value and setting
+ * garbage collection policies to delete the old values.
+ */
 class AlwaysRetryMutationPolicy : public IdempotentMutationPolicy {
  public:
   AlwaysRetryMutationPolicy() {}

--- a/bigtable/client/idempotent_mutation_policy.h
+++ b/bigtable/client/idempotent_mutation_policy.h
@@ -37,11 +37,15 @@ class IdempotentMutationPolicy {
   virtual bool is_idempotent(google::bigtable::v2::Mutation const&) = 0;
 };
 
-/// Return an instance of the default MutationRetryPolicy.
+/// Return an instance of the default IdempotentMutationPolicy.
 std::unique_ptr<IdempotentMutationPolicy> DefaultIdempotentMutationPolicy();
 
 /**
- * Implements a safe policy to determine if a mutation is idempotent.
+ * Implements a policy that only accepts truly idempotent mutations.
+ *
+ * This policy accepts only truly idempotent mutations, that is, it rejects
+ * mutations where the server sets the timestamp.  Some applications may find
+ * this too restrictive and can set their own policies if they wish.
  */
 class SafeIdempotentMutationPolicy : public IdempotentMutationPolicy {
  public:

--- a/bigtable/client/idempotent_mutation_policy.h
+++ b/bigtable/client/idempotent_mutation_policy.h
@@ -23,7 +23,8 @@
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
- * Defines the interface to control which mutations are idempotent and therefore can be re-tried.
+ * Defines the interface to control which mutations are idempotent and therefore
+ * can be re-tried.
  */
 class IdempotentMutationPolicy {
  public:
@@ -33,7 +34,7 @@ class IdempotentMutationPolicy {
   virtual std::unique_ptr<IdempotentMutationPolicy> clone() const = 0;
 
   /// Return true if the mutation is idempotent.
-  virtual bool is_idempotent(const google::bigtable::v2::Mutation &) = 0;
+  virtual bool is_idempotent(google::bigtable::v2::Mutation const&) = 0;
 };
 
 /// Return an instance of the default MutationRetryPolicy.
@@ -47,7 +48,7 @@ class SafeIdempotentMutationPolicy : public IdempotentMutationPolicy {
   SafeIdempotentMutationPolicy() {}
 
   std::unique_ptr<IdempotentMutationPolicy> clone() const override;
-  bool is_idempotent(const google::bigtable::v2::Mutation &) override;
+  bool is_idempotent(google::bigtable::v2::Mutation const&) override;
 };
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/bigtable/client/idempotent_mutation_policy.h
+++ b/bigtable/client/idempotent_mutation_policy.h
@@ -1,0 +1,55 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BIGTABLE_CLIENT_IDEMPOTENT_MUTATION_POLICY_H_
+#define BIGTABLE_CLIENT_IDEMPOTENT_MUTATION_POLICY_H_
+
+#include <bigtable/client/version.h>
+
+#include <memory>
+#include "bigtable/client/mutations.h"
+
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+/**
+ * Defines the interface to control which mutations are idempotent and therefore can be re-tried.
+ */
+class IdempotentMutationPolicy {
+ public:
+  virtual ~IdempotentMutationPolicy() = default;
+
+  /// Return a copy of the policy.
+  virtual std::unique_ptr<IdempotentMutationPolicy> clone() const = 0;
+
+  /// Return true if the mutation is idempotent.
+  virtual bool is_idempotent(const google::bigtable::v2::Mutation &) = 0;
+};
+
+/// Return an instance of the default MutationRetryPolicy.
+std::unique_ptr<IdempotentMutationPolicy> DefaultIdempotentMutationPolicy();
+
+/**
+ * Implements a safe policy to determine if a mutation is idempotent.
+ */
+class SafeIdempotentMutationPolicy : public IdempotentMutationPolicy {
+ public:
+  SafeIdempotentMutationPolicy() {}
+
+  std::unique_ptr<IdempotentMutationPolicy> clone() const override;
+  bool is_idempotent(const google::bigtable::v2::Mutation &) override;
+};
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+
+#endif  // BIGTABLE_CLIENT_IDEMPOTENT_MUTATION_POLICY_H_

--- a/bigtable/client/idempotent_mutation_policy_test.cc
+++ b/bigtable/client/idempotent_mutation_policy_test.cc
@@ -19,11 +19,13 @@
 /// @test Verify that the default policy works as expected.
 TEST(IdempotemntMutationPolicyTest, Simple) {
   auto policy = bigtable::DefaultIdempotentMutationPolicy();
-  EXPECT_TRUE(policy->is_idempotent(bigtable::DeleteFromColumn("fam", "col", 0, 10).op));
+  EXPECT_TRUE(policy->is_idempotent(
+      bigtable::DeleteFromColumn("fam", "col", 0, 10).op));
   EXPECT_TRUE(policy->is_idempotent(bigtable::DeleteFromFamily("fam").op));
 
-  EXPECT_TRUE(policy->is_idempotent(bigtable::SetCell("fam", "col", 0, "v1").op));
+  EXPECT_TRUE(
+      policy->is_idempotent(bigtable::SetCell("fam", "col", 0, "v1").op));
   EXPECT_FALSE(policy->is_idempotent(bigtable::SetCell("fam", "c2", "v2").op));
-  EXPECT_FALSE(policy->is_idempotent(bigtable::SetCell("f", "c", bigtable::ServerSetTimestamp(), "v").op));
+  EXPECT_FALSE(policy->is_idempotent(
+      bigtable::SetCell("f", "c", bigtable::ServerSetTimestamp(), "v").op));
 }
-

--- a/bigtable/client/idempotent_mutation_policy_test.cc
+++ b/bigtable/client/idempotent_mutation_policy_test.cc
@@ -1,0 +1,29 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/client/idempotent_mutation_policy.h"
+
+#include <gmock/gmock.h>
+
+/// @test Verify that the default policy works as expected.
+TEST(IdempotemntMutationPolicyTest, Simple) {
+  auto policy = bigtable::DefaultIdempotentMutationPolicy();
+  EXPECT_TRUE(policy->is_idempotent(bigtable::DeleteFromColumn("fam", "col", 0, 10).op));
+  EXPECT_TRUE(policy->is_idempotent(bigtable::DeleteFromFamily("fam").op));
+
+  EXPECT_TRUE(policy->is_idempotent(bigtable::SetCell("fam", "col", 0, "v1").op));
+  EXPECT_FALSE(policy->is_idempotent(bigtable::SetCell("fam", "c2", "v2").op));
+  EXPECT_FALSE(policy->is_idempotent(bigtable::SetCell("f", "c", bigtable::ServerSetTimestamp(), "v").op));
+}
+

--- a/bigtable/client/mutations.h
+++ b/bigtable/client/mutations.h
@@ -46,7 +46,12 @@ Mutation SetCell(std::string family, std::string column, std::int64_t timestamp,
  */
 Mutation SetCell(std::string family, std::string column, std::string value);
 
-/// A magic value where the server sets the timestamp.
+/**
+ * A magic value where the server sets the timestamp.
+ *
+ * Notice that using this value in a SetCell() mutation makes it non-idempotent,
+ * and by default the client will not retry such mutations.
+ */
 constexpr std::int64_t ServerSetTimestamp() { return -1; }
 
 //@{

--- a/bigtable/client/mutations.h
+++ b/bigtable/client/mutations.h
@@ -184,9 +184,9 @@ class FailedMutation {
 /**
  * Report unrecoverable errors in a partially completed mutation.
  */
-class PermanentMutationFailures : public std::runtime_error {
+class PermanentMutationFailure : public std::runtime_error {
  public:
-  PermanentMutationFailures(char const* msg,
+  PermanentMutationFailure(char const* msg,
                             std::vector<FailedMutation>&& failures)
       : std::runtime_error(msg),
         failures_(std::move(failures)) {}

--- a/bigtable/client/mutations.h
+++ b/bigtable/client/mutations.h
@@ -39,6 +39,12 @@ struct Mutation {
 Mutation SetCell(std::string family, std::string column, std::int64_t timestamp,
                  std::string value);
 
+/// Create a mutation to set a cell value where the server sets the time.
+Mutation SetCell(std::string family, std::string column, std::string value);
+
+/// A magic value where the server sets the timestamp.
+constexpr std::int64_t ServerSetTimestamp() { return -1; }
+
 //@{
 /**
  * @name Create mutations to delete a range of cells from a column.
@@ -99,9 +105,15 @@ class SingleRowMutation {
   }
 
   /// Create a row mutation from gRPC proto
-  SingleRowMutation(::google::bigtable::v2::MutateRowsRequest::Entry&& entry)
+  explicit SingleRowMutation(::google::bigtable::v2::MutateRowsRequest::Entry &&entry)
       : row_key_(std::move(*entry.mutable_row_key())), ops_() {
     ops_.Swap(entry.mutable_mutations());
+  }
+
+  /// Create a row mutation from gRPC proto
+  explicit SingleRowMutation(::google::bigtable::v2::MutateRowRequest &&request)
+      : row_key_(std::move(*request.mutable_row_key())), ops_() {
+    ops_.Swap(request.mutable_mutations());
   }
 
   // Add a mutation at the end.
@@ -131,6 +143,61 @@ class SingleRowMutation {
   google::protobuf::RepeatedPtrField<google::bigtable::v2::Mutation> ops_;
 };
 
+/**
+ * A SingleRowMutation that failed.
+ *
+ * A multi-row mutation returns the list of operations that failed,
+ * this class encapsulates both the failure and the original
+ * mutation.  The application can then choose to resend the mutation,
+ * or log it, or save it for processing via some other means.
+ */
+class FailedMutation {
+ public:
+  FailedMutation(SingleRowMutation mut, google::rpc::Status status)
+      : FailedMutation(std::move(mut), std::move(status), -1) {}
+  FailedMutation(SingleRowMutation mut, google::rpc::Status status, int index)
+      : mutation_(std::move(mut)),
+        status_(to_grpc_status(status)),
+        original_index_(index) {}
+
+  FailedMutation(FailedMutation &&) = default;
+  FailedMutation &operator=(FailedMutation &&) = default;
+
+  //@{
+  /// @name accessors
+  SingleRowMutation const &mutation() const { return mutation_; }
+  grpc::Status const &status() const { return status_; }
+  int original_index() const { return original_index_; }
+  //@}
+
+  friend class MultipleRowMutations;
+
+ private:
+  static grpc::Status to_grpc_status(google::rpc::Status const &status);
+
+ private:
+  SingleRowMutation mutation_;
+  grpc::Status status_;
+  int original_index_;
+};
+
+/**
+ * Report unrecoverable errors in a partially completed mutation.
+ */
+class PermanentMutationFailures : public std::runtime_error {
+ public:
+  PermanentMutationFailures(char const* msg,
+                            std::vector<FailedMutation>&& failures)
+      : std::runtime_error(msg),
+        failures_(std::move(failures)) {}
+
+  std::vector<FailedMutation> const& failures() const {
+    return failures_;
+  }
+
+ private:
+  std::vector<FailedMutation> failures_;
+};
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
 

--- a/bigtable/client/mutations_test.cc
+++ b/bigtable/client/mutations_test.cc
@@ -31,7 +31,8 @@ TEST(MutationsTest, SetCell) {
   EXPECT_EQ("fam", server_set.op.set_cell().family_name());
   EXPECT_EQ("col", server_set.op.set_cell().column_qualifier());
   EXPECT_EQ("v", server_set.op.set_cell().value());
-  EXPECT_EQ(bigtable::ServerSetTimestamp(), server_set.op.set_cell().timestamp_micros());
+  EXPECT_EQ(bigtable::ServerSetTimestamp(),
+            server_set.op.set_cell().timestamp_micros());
 
   std::string fam("fam2"), col("col2");
   // ... we want to make sure the strings are efficiently moved.  The

--- a/bigtable/client/mutations_test.cc
+++ b/bigtable/client/mutations_test.cc
@@ -26,6 +26,13 @@ TEST(MutationsTest, SetCell) {
   EXPECT_EQ(1234, actual.op.set_cell().timestamp_micros());
   EXPECT_EQ("value", actual.op.set_cell().value());
 
+  auto server_set = bigtable::SetCell("fam", "col", "v");
+  ASSERT_TRUE(server_set.op.has_set_cell());
+  EXPECT_EQ("fam", server_set.op.set_cell().family_name());
+  EXPECT_EQ("col", server_set.op.set_cell().column_qualifier());
+  EXPECT_EQ("v", server_set.op.set_cell().value());
+  EXPECT_EQ(bigtable::ServerSetTimestamp(), server_set.op.set_cell().timestamp_micros());
+
   std::string fam("fam2"), col("col2");
   // ... we want to make sure the strings are efficiently moved.  The
   // C++ library often implements the "small string optimization",

--- a/bigtable/client/table_apply_test.cc
+++ b/bigtable/client/table_apply_test.cc
@@ -111,10 +111,12 @@ TEST(TableApplyTest, RetryIdempotent) {
   try {
     table.Apply(bigtable::SingleRowMutation(
         "not-idempotent", {bigtable::SetCell("fam", "col", "val")}));
-  } catch (bigtable::PermanentMutationFailures const& ex) {
-    ASSERT_EQ(ex.failures().size(), 1UL);
-    EXPECT_EQ(ex.failures()[0].original_index(), 0);
+  } catch (bigtable::PermanentMutationFailure const& ex) {
+    ASSERT_EQ(1UL, ex.failures().size());
+    EXPECT_EQ(0, ex.failures()[0].original_index());
+  } catch (std::exception const& ex) {
+    FAIL() << "unexpected std::exception raised: " << ex.what();
   } catch (...) {
-    ADD_FAILURE();
+    FAIL() << "unexpected exception of unknown type raised";
   }
 }

--- a/bigtable/client/table_apply_test.cc
+++ b/bigtable/client/table_apply_test.cc
@@ -98,8 +98,8 @@ TEST(TableApplyTest, RetryIdempotent) {
   MockClient client;
   using namespace ::testing;
   EXPECT_CALL(client, Stub())
-      .WillRepeatedly(Invoke(
-          [&client]() -> google::bigtable::v2::Bigtable::StubInterface & {
+      .WillRepeatedly(
+          Invoke([&client]() -> google::bigtable::v2::Bigtable::StubInterface& {
             return *client.mock_stub;
           }));
   EXPECT_CALL(*client.mock_stub, MutateRow(_, _, _))
@@ -111,7 +111,7 @@ TEST(TableApplyTest, RetryIdempotent) {
   try {
     table.Apply(bigtable::SingleRowMutation(
         "not-idempotent", {bigtable::SetCell("fam", "col", "val")}));
-  } catch (bigtable::PermanentMutationFailures const &ex) {
+  } catch (bigtable::PermanentMutationFailures const& ex) {
     ASSERT_EQ(ex.failures().size(), 1UL);
     EXPECT_EQ(ex.failures()[0].original_index(), 0);
   } catch (...) {


### PR DESCRIPTION
Mutations that are not idempotent are not retried, regardless of whether we have time to do so.

This fixes #13.
