### PR TITLE
Generate doxygen docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ build-output/
 # Ignore IDEA / IntelliJ files
 .idea/
 cmake-build-*/
+
+# The Doxygen-generated documentation goes here:
+bigtable/doc/html/
+doc/html/

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
   include:
     - os: linux
       compiler: gcc
-      env: DISTRO=ubuntu DISTRO_VERSION=17.04 CHECK_STYLE=yes
+      env: DISTRO=ubuntu DISTRO_VERSION=17.04 CHECK_STYLE=yes GENERATE_DOCS=yes
     - os: linux
       compiler: clang
       env: DISTRO=ubuntu DISTRO_VERSION=16.04 ADDRESS_SANITIZER=yes
@@ -53,6 +53,7 @@ install:
 
 after_success:
   - ci/upload-codecov.sh
+  - ci/upload-docs.sh
 
 notifications:
   email: false

--- a/bigtable/client/data.cc
+++ b/bigtable/client/data.cc
@@ -44,9 +44,9 @@ void Table::Apply(SingleRowMutation&& mut) {
 
   btproto::MutateRowResponse response;
   while (true) {
-    // TODO(coryan) - the RPCRetryPolicy should configure the context.
-    // TODO(coryan) - consider renaming the policy to RPCControlPolicy.
     grpc::ClientContext client_context;
+    retry_policy->setup(client_context);
+    backoff_policy->setup(client_context);
     grpc::Status status =
         client_->Stub().MutateRow(&client_context, request, &response);
     if (status.ok()) {

--- a/bigtable/client/data.h
+++ b/bigtable/client/data.h
@@ -130,8 +130,6 @@ class Table {
    *
    * @param mut the mutation, notice that this function takes
    * ownership (and then discards) the data in the mutation.
-   * @param pol the retry policy, the application can control how many
-   * times the request is retried using this class.
    *
    * @throws std::exception based on how the retry policy handles
    * error conditions.

--- a/bigtable/doc/Doxyfile
+++ b/bigtable/doc/Doxyfile
@@ -1,0 +1,358 @@
+# Doxyfile 1.8.13
+
+#---------------------------------------------------------------------------
+# Project related configuration options
+#---------------------------------------------------------------------------
+DOXYFILE_ENCODING      = UTF-8
+PROJECT_NAME           = "Google Cloud Bigtable C++ Client"
+PROJECT_NUMBER         = 0.0.1
+PROJECT_BRIEF          = "A C++ Client Library for Google Cloud Bigtable"
+PROJECT_LOGO           =
+OUTPUT_DIRECTORY       = doc
+CREATE_SUBDIRS         = NO
+ALLOW_UNICODE_NAMES    = NO
+OUTPUT_LANGUAGE        = English
+BRIEF_MEMBER_DESC      = YES
+REPEAT_BRIEF           = YES
+ABBREVIATE_BRIEF       = "The $name class" \
+                         "The $name widget" \
+                         "The $name file" \
+                         is \
+                         provides \
+                         specifies \
+                         contains \
+                         represents \
+                         a \
+                         an \
+                         the
+ALWAYS_DETAILED_SEC    = NO
+INLINE_INHERITED_MEMB  = YES
+FULL_PATH_NAMES        = YES
+STRIP_FROM_PATH        =
+STRIP_FROM_INC_PATH    =
+SHORT_NAMES            = NO
+JAVADOC_AUTOBRIEF      = NO
+QT_AUTOBRIEF           = NO
+MULTILINE_CPP_IS_BRIEF = NO
+INHERIT_DOCS           = YES
+SEPARATE_MEMBER_PAGES  = NO
+TAB_SIZE               = 4
+ALIASES                =
+TCL_SUBST              =
+OPTIMIZE_OUTPUT_FOR_C  = NO
+OPTIMIZE_OUTPUT_JAVA   = NO
+OPTIMIZE_FOR_FORTRAN   = NO
+OPTIMIZE_OUTPUT_VHDL   = NO
+EXTENSION_MAPPING      =
+MARKDOWN_SUPPORT       = YES
+TOC_INCLUDE_HEADINGS   = 0
+AUTOLINK_SUPPORT       = YES
+BUILTIN_STL_SUPPORT    = YES
+CPP_CLI_SUPPORT        = NO
+SIP_SUPPORT            = NO
+IDL_PROPERTY_SUPPORT   = NO
+DISTRIBUTE_GROUP_DOC   = NO
+GROUP_NESTED_COMPOUNDS = NO
+SUBGROUPING            = YES
+INLINE_GROUPED_CLASSES = NO
+INLINE_SIMPLE_STRUCTS  = NO
+TYPEDEF_HIDES_STRUCT   = NO
+LOOKUP_CACHE_SIZE      = 0
+
+#---------------------------------------------------------------------------
+# Build related configuration options
+#---------------------------------------------------------------------------
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = NO
+EXTRACT_PACKAGE        = NO
+EXTRACT_STATIC         = YES
+EXTRACT_LOCAL_CLASSES  = YES
+EXTRACT_LOCAL_METHODS  = NO
+EXTRACT_ANON_NSPACES   = NO
+HIDE_UNDOC_MEMBERS     = NO
+HIDE_UNDOC_CLASSES     = NO
+HIDE_FRIEND_COMPOUNDS  = NO
+HIDE_IN_BODY_DOCS      = NO
+INTERNAL_DOCS          = NO
+CASE_SENSE_NAMES       = YES
+HIDE_SCOPE_NAMES       = NO
+HIDE_COMPOUND_REFERENCE= NO
+SHOW_INCLUDE_FILES     = YES
+SHOW_GROUPED_MEMB_INC  = NO
+FORCE_LOCAL_INCLUDES   = NO
+INLINE_INFO            = YES
+SORT_MEMBER_DOCS       = YES
+SORT_BRIEF_DOCS        = NO
+SORT_MEMBERS_CTORS_1ST = YES
+SORT_GROUP_NAMES       = NO
+SORT_BY_SCOPE_NAME     = NO
+STRICT_PROTO_MATCHING  = NO
+GENERATE_TODOLIST      = NO
+GENERATE_TESTLIST      = NO
+GENERATE_BUGLIST       = NO
+GENERATE_DEPRECATEDLIST= YES
+ENABLED_SECTIONS       =
+MAX_INITIALIZER_LINES  = 30
+SHOW_USED_FILES        = YES
+SHOW_FILES             = YES
+SHOW_NAMESPACES        = YES
+FILE_VERSION_FILTER    =
+LAYOUT_FILE            =
+CITE_BIB_FILES         =
+
+#---------------------------------------------------------------------------
+# Configuration options related to warning and progress messages
+#---------------------------------------------------------------------------
+QUIET                  = YES
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_DOC_ERROR      = YES
+WARN_NO_PARAMDOC       = NO
+WARN_AS_ERROR          = YES
+WARN_FORMAT            = "$file:$line: $text"
+WARN_LOGFILE           =
+
+#---------------------------------------------------------------------------
+# Configuration options related to the input files
+#---------------------------------------------------------------------------
+
+INPUT                  = README.md doc client
+INPUT_ENCODING         = UTF-8
+FILE_PATTERNS          = *.h *.cc *.md *.proto
+RECURSIVE              = YES
+EXCLUDE                = third_party
+EXCLUDE_SYMLINKS       = YES
+EXCLUDE_PATTERNS       =
+EXCLUDE_SYMBOLS        =
+EXAMPLE_PATH           =
+EXAMPLE_PATTERNS       = *
+EXAMPLE_RECURSIVE      = YES
+IMAGE_PATH             =
+INPUT_FILTER           =
+FILTER_PATTERNS        =
+FILTER_SOURCE_FILES    = NO
+FILTER_SOURCE_PATTERNS =
+USE_MDFILE_AS_MAINPAGE = README.md
+
+#---------------------------------------------------------------------------
+# Configuration options related to source browsing
+#---------------------------------------------------------------------------
+SOURCE_BROWSER         = NO
+INLINE_SOURCES         = NO
+STRIP_CODE_COMMENTS    = YES
+REFERENCED_BY_RELATION = NO
+REFERENCES_RELATION    = NO
+REFERENCES_LINK_SOURCE = YES
+SOURCE_TOOLTIPS        = YES
+USE_HTAGS              = NO
+VERBATIM_HEADERS       = YES
+CLANG_ASSISTED_PARSING = YES
+CLANG_OPTIONS          = -std=c++11 -I.. \
+    -I../third_party/googletest/googletest/include \
+    -I../third_party/googletest/googlemock/include
+
+#---------------------------------------------------------------------------
+# Configuration options related to the alphabetical class index
+#---------------------------------------------------------------------------
+ALPHABETICAL_INDEX     = YES
+COLS_IN_ALPHA_INDEX    = 5
+IGNORE_PREFIX          =
+
+#---------------------------------------------------------------------------
+# Configuration options related to the HTML output
+#---------------------------------------------------------------------------
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+HTML_FILE_EXTENSION    = .html
+HTML_HEADER            =
+HTML_FOOTER            =
+HTML_STYLESHEET        =
+HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_FILES       =
+HTML_COLORSTYLE_HUE    = 220
+HTML_COLORSTYLE_SAT    = 100
+HTML_COLORSTYLE_GAMMA  = 80
+HTML_TIMESTAMP         = YES
+HTML_DYNAMIC_SECTIONS  = NO
+HTML_INDEX_NUM_ENTRIES = 100
+GENERATE_DOCSET        = NO
+DOCSET_FEEDNAME        = "Doxygen generated docs"
+DOCSET_BUNDLE_ID       = org.doxygen.Project
+DOCSET_PUBLISHER_ID    = org.doxygen.Publisher
+DOCSET_PUBLISHER_NAME  = Publisher
+GENERATE_HTMLHELP      = NO
+CHM_FILE               =
+HHC_LOCATION           =
+GENERATE_CHI           = NO
+CHM_INDEX_ENCODING     =
+BINARY_TOC             = NO
+TOC_EXPAND             = NO
+GENERATE_QHP           = NO
+QCH_FILE               =
+QHP_NAMESPACE          = org.doxygen.Project
+QHP_VIRTUAL_FOLDER     = doc
+QHP_CUST_FILTER_NAME   =
+QHP_CUST_FILTER_ATTRS  =
+QHP_SECT_FILTER_ATTRS  =
+QHG_LOCATION           =
+GENERATE_ECLIPSEHELP   = NO
+ECLIPSE_DOC_ID         = org.doxygen.Project
+DISABLE_INDEX          = NO
+GENERATE_TREEVIEW      = NO
+ENUM_VALUES_PER_LINE   = 4
+TREEVIEW_WIDTH         = 250
+EXT_LINKS_IN_WINDOW    = NO
+FORMULA_FONTSIZE       = 10
+FORMULA_TRANSPARENT    = YES
+USE_MATHJAX            = NO
+MATHJAX_FORMAT         = HTML-CSS
+MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+MATHJAX_EXTENSIONS     =
+MATHJAX_CODEFILE       =
+SEARCHENGINE           = YES
+SERVER_BASED_SEARCH    = NO
+EXTERNAL_SEARCH        = NO
+SEARCHENGINE_URL       =
+SEARCHDATA_FILE        = searchdata.xml
+EXTERNAL_SEARCH_ID     =
+EXTRA_SEARCH_MAPPINGS  =
+
+#---------------------------------------------------------------------------
+# Configuration options related to the LaTeX output
+#---------------------------------------------------------------------------
+GENERATE_LATEX         = NO
+LATEX_OUTPUT           = latex
+LATEX_CMD_NAME         = latex
+MAKEINDEX_CMD_NAME     = makeindex
+COMPACT_LATEX          = NO
+PAPER_TYPE             = letter
+EXTRA_PACKAGES         =
+LATEX_HEADER           =
+LATEX_FOOTER           =
+LATEX_EXTRA_STYLESHEET =
+LATEX_EXTRA_FILES      =
+PDF_HYPERLINKS         = YES
+USE_PDFLATEX           = YES
+LATEX_BATCHMODE        = NO
+LATEX_HIDE_INDICES     = NO
+LATEX_SOURCE_CODE      = NO
+LATEX_BIB_STYLE        = plain
+LATEX_TIMESTAMP        = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the RTF output
+#---------------------------------------------------------------------------
+GENERATE_RTF           = NO
+RTF_OUTPUT             = rtf
+COMPACT_RTF            = NO
+RTF_HYPERLINKS         = NO
+RTF_STYLESHEET_FILE    =
+RTF_EXTENSIONS_FILE    =
+RTF_SOURCE_CODE        = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the man page output
+#---------------------------------------------------------------------------
+GENERATE_MAN           = NO
+MAN_OUTPUT             = man
+MAN_EXTENSION          = .3
+MAN_SUBDIR             =
+MAN_LINKS              = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the XML output
+#---------------------------------------------------------------------------
+
+# TODO(#18) - this could be the input into gulp (the doc system used by other Google Cloud clients).
+GENERATE_XML           = NO
+XML_OUTPUT             = xml
+XML_PROGRAMLISTING     = YES
+
+#---------------------------------------------------------------------------
+# Configuration options related to the DOCBOOK output
+#---------------------------------------------------------------------------
+
+GENERATE_DOCBOOK       = NO
+DOCBOOK_OUTPUT         = docbook
+DOCBOOK_PROGRAMLISTING = NO
+
+#---------------------------------------------------------------------------
+# Configuration options for the AutoGen Definitions output
+#---------------------------------------------------------------------------
+
+GENERATE_AUTOGEN_DEF   = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the Perl module output
+#---------------------------------------------------------------------------
+
+GENERATE_PERLMOD       = NO
+PERLMOD_LATEX          = NO
+PERLMOD_PRETTY         = YES
+PERLMOD_MAKEVAR_PREFIX =
+
+#---------------------------------------------------------------------------
+# Configuration options related to the preprocessor
+#---------------------------------------------------------------------------
+
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+EXPAND_ONLY_PREDEF     = YES
+SEARCH_INCLUDES        = YES
+INCLUDE_PATH           =
+INCLUDE_FILE_PATTERNS  =
+PREDEFINED             = BIGTABLE_CLIENT_NS=v0
+EXPAND_AS_DEFINED      =
+SKIP_FUNCTION_MACROS   = YES
+
+#---------------------------------------------------------------------------
+# Configuration options related to external references
+#---------------------------------------------------------------------------
+
+TAGFILES               =
+GENERATE_TAGFILE       =
+ALLEXTERNALS           = NO
+EXTERNAL_GROUPS        = YES
+EXTERNAL_PAGES         = YES
+PERL_PATH              = /usr/bin/perl
+
+#---------------------------------------------------------------------------
+# Configuration options related to the dot tool
+#---------------------------------------------------------------------------
+
+CLASS_DIAGRAMS         = YES
+MSCGEN_PATH            =
+DIA_PATH               =
+HIDE_UNDOC_RELATIONS   = YES
+HAVE_DOT               = YES
+DOT_NUM_THREADS        = 0
+DOT_FONTNAME           = Helvetica
+DOT_FONTSIZE           = 10
+DOT_FONTPATH           =
+CLASS_GRAPH            = YES
+COLLABORATION_GRAPH    = YES
+GROUP_GRAPHS           = YES
+UML_LOOK               = NO
+UML_LIMIT_NUM_FIELDS   = 10
+TEMPLATE_RELATIONS     = NO
+INCLUDE_GRAPH          = YES
+INCLUDED_BY_GRAPH      = YES
+CALL_GRAPH             = NO
+CALLER_GRAPH           = NO
+GRAPHICAL_HIERARCHY    = NO
+DIRECTORY_GRAPH        = NO
+DOT_IMAGE_FORMAT       = png
+INTERACTIVE_SVG        = NO
+DOT_PATH               =
+DOTFILE_DIRS           =
+MSCFILE_DIRS           =
+DIAFILE_DIRS           =
+PLANTUML_JAR_PATH      =
+PLANTUML_CFG_FILE      =
+PLANTUML_INCLUDE_PATH  =
+DOT_GRAPH_MAX_NODES    = 50
+MAX_DOT_GRAPH_DEPTH    = 0
+DOT_TRANSPARENT        = YES
+DOT_MULTI_TARGETS      = NO
+GENERATE_LEGEND        = YES
+DOT_CLEANUP            = YES

--- a/bigtable/doc/Doxyfile
+++ b/bigtable/doc/Doxyfile
@@ -1,5 +1,8 @@
 # Doxyfile 1.8.13
 
+# Please do not cut&paste this file when adding subdirectories in
+# google-cloud-cpp.  Look at #71 in github.com for alternatives.
+
 #---------------------------------------------------------------------------
 # Project related configuration options
 #---------------------------------------------------------------------------

--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -24,10 +24,12 @@ RUN dnf install -y \
     clang \
     cmake \
     curl \
+    dia \
     doxygen \
     gcc-c++ \
     git \
     golang \
+    graphviz \
     lcov \
     libtool \
     make \
@@ -44,6 +46,7 @@ ARG CXX=g++
 ARG CC=gcc
 ARG BUILD_TYPE=Debug
 ARG CHECK_STYLE=""
+ARG GENERATE_DOCS=""
 ARG SANITIZE_ADDRESS=""
 ARG SANITIZE_LEAKS=""
 ARG SANITIZE_MEMORY=""

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -20,10 +20,13 @@ RUN apt-get update
 RUN apt-get install -y \
   build-essential \
   curl \
+  dia \
+  doxygen \
   git \
   gcc \
   g++ \
   golang \
+  graphviz \
   clang \
   cmake \
   make \
@@ -49,6 +52,7 @@ ARG CXX=g++
 ARG CC=gcc
 ARG BUILD_TYPE=Debug
 ARG CHECK_STYLE=""
+ARG GENERATE_DOCS=""
 ARG SANITIZE_ADDRESS=""
 ARG SANITIZE_LEAKS=""
 ARG SANITIZE_MEMORY=""

--- a/ci/build-docker.sh
+++ b/ci/build-docker.sh
@@ -35,8 +35,20 @@ make -j ${NCPU} test || ( cat Testing/Temporary/LastTest.log; exit 1 )
 
 # Some of the sanitizers only emit errors and do not change the error code
 # of the tests, find any such errors and report them as a build failure.
-if [ grep -e '\.cc:[0-9][0-9]*' Testing/Temporary/LastTest.log ]; then
+echo
+echo "Searching for sanitizer errors in the test log:"
+echo
+if grep -e '/var/tmp/build/gccpp/.*\.cc:[0-9][0-9]*' \
+       Testing/Temporary/LastTest.log; then
   echo
   echo "Sanitizer errors found in the test logs."
   exit 1
+else
+  echo "no sanitizer errors found."
+fi
+
+# if document generation is enabled, run it now.
+if [ "${GENERATE_DOCS}" = "yes" ]; then
+  cd ../bigtable
+  doxygen doc/Doxyfile
 fi

--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -31,6 +31,7 @@ sudo docker build -t "${IMAGE}:tip" \
      --build-arg NCPU="${NCPU:-2}" \
      --build-arg BUILD_TYPE="${BUILD_TYPE:-Release}" \
      --build-arg CHECK_STYLE="${CHECK_STYLE:-}" \
+     --build-arg GENERATE_DOCS="${GENERATE_DOCS:-}" \
      --build-arg SANITIZE_ADDRESS="${SANITIZE_ADDRESS:-}" \
      --build-arg SANITIZE_LEAKS="${SANITIZE_LEAKS:-}" \
      --build-arg SANITIZE_MEMORY="${SANITIZE_MEMORY:-}" \

--- a/ci/upload-docs.sh
+++ b/ci/upload-docs.sh
@@ -17,18 +17,18 @@
 set -eu
 
 if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
-    echo "Skipping code generation as it is disabled for pull requests."
-    exit 0
+  echo "Skipping document generation as it is disabled for pull requests."
+  exit 0
 fi
 
 if [ "${GENERATE_DOCS:-}" != "yes" ]; then
-    echo "Skipping document generation as it is disabled for this build."
-    exit 0
+  echo "Skipping document generation as it is disabled for this build."
+  exit 0
 fi
 
 if [ "${TRAVIS_BRANCH:-}" != "master" ]; then
-    echo "Skipping document generation as it is disabled for non-master directories."
-    exit 0
+  echo "Skipping document generation as it is disabled for non-master branches."
+  exit 0
 fi
 
 # The usual way to host documentation in ${GIT_NAME}.github.io/${PROJECT_NAME}
@@ -44,7 +44,7 @@ git clone -b gh-pages "${REPO_URL}" doc/html
 # files in a second.
 (cd doc/html && git rm -qfr . || exit 0)
 
-# Copy the build results out of the docker image:
+# Copy the build results out of the Docker image.
 readonly IMAGE="cached-${DISTRO}-${DISTRO_VERSION}"
 sudo docker run --volume "$PWD/doc:/d" --rm -it "${IMAGE}:tip" cp -r /var/tmp/build/gccpp/bigtable/doc/html /d
 
@@ -55,7 +55,7 @@ git add --all .
 git commit -q -m"Automatically generated documentation" || exit 0
 
 if [ -z "${GH_TOKEN:-}" ]; then
-    echo "Skipping documentation upload as GH_TOKEN is not configured."
-    exit 0
+  echo "Skipping documentation upload as GH_TOKEN is not configured."
+  exit 0
 fi
 git push https://${GH_TOKEN}@${REPO_REF} gh-pages

--- a/ci/upload-docs.sh
+++ b/ci/upload-docs.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+    echo "Skipping code generation as it is disabled for pull requests."
+    exit 0
+fi
+
+if [ "${GENERATE_DOCS:-}" != "yes" ]; then
+    echo "Skipping document generation as it is disabled for this build."
+    exit 0
+fi
+
+# TODO(coryan) - change the branch name to "master" before sending the PR.
+if [ "${TRAVIS_BRANCH:-}" != "issue-18-generate-doxygen-docs" ]; then
+    echo "Skipping document generation as it is disabled for non-master directories."
+    exit 0
+fi
+
+# The usual way to host documentation in ${GIT_NAME}.github.io/${PROJECT_NAME}
+# is to create a branch (gh-pages) and post the documentation in that branch.
+# We first do some general git configuration:
+
+# Clone the gh-pages branch into the doc/html subdirectory.
+REPO_URL=$(git config remote.origin.url)
+REPO_REF=${REPO_URL/https:\/\/}
+git clone -b gh-pages "${REPO_URL}" doc/html
+
+# Remove any previous content of the branch.  We will recover any unmodified
+# files in a second.
+(cd doc/html && git rm -qfr . || exit 0)
+
+# Copy the build results out of the docker image:
+readonly IMAGE="cached-${DISTRO}-${DISTRO_VERSION}"
+sudo docker run --volume "$PWD/doc:/d" --rm -it "${IMAGE}:tip" cp -r /var/tmp/build/gccpp/bigtable/doc/html /d
+
+cd doc/html
+git config user.name "Travis Build Robot"
+git config user.email "nobody@users.noreply.github.com"
+git add --all .
+git commit -q -m"Automatically generated documentation" || exit 0
+
+if [ -z "${GH_TOKEN:-}" ]; then
+    echo "Skipping documentation upload as GH_TOKEN is not configured."
+    exit 0
+fi
+git push https://${GH_TOKEN}@${REPO_REF} gh-pages

--- a/ci/upload-docs.sh
+++ b/ci/upload-docs.sh
@@ -41,7 +41,7 @@ git clone -b gh-pages "${REPO_URL}" doc/html
 
 # Remove any previous content of the branch.  We will recover any unmodified
 # files in a second.
-(cd doc/html && git rm -qfr . || exit 0)
+(cd doc/html && git rm -qfr --ignore-unmatch .)
 
 # Copy the build results out of the Docker image.
 readonly IMAGE="cached-${DISTRO}-${DISTRO_VERSION}"
@@ -51,7 +51,13 @@ cd doc/html
 git config user.name "Travis Build Robot"
 git config user.email "nobody@users.noreply.github.com"
 git add --all .
-git commit -q -m"Automatically generated documentation" || exit 0
+
+if git diff --exit-code; then
+  echo "Skipping documentation upload as there are no differences to upload."
+  exit 0
+fi
+
+git commit -q -m"Automatically generated documentation"
 
 if [ "${REPO_URL:0:8}" != "https://" ]; then
   echo "Repository is not in https:// format, attempting push to ${REPO_URL}"

--- a/ci/upload-docs.sh
+++ b/ci/upload-docs.sh
@@ -36,8 +36,7 @@ fi
 # We first do some general git configuration:
 
 # Clone the gh-pages branch into the doc/html subdirectory.
-REPO_URL=$(git config remote.origin.url)
-REPO_REF=${REPO_URL/https:\/\/}
+readonly REPO_URL=$(git config remote.origin.url)
 git clone -b gh-pages "${REPO_URL}" doc/html
 
 # Remove any previous content of the branch.  We will recover any unmodified
@@ -54,8 +53,16 @@ git config user.email "nobody@users.noreply.github.com"
 git add --all .
 git commit -q -m"Automatically generated documentation" || exit 0
 
+if [ "${REPO_URL:0:8}" != "https://" ]; then
+  echo "Repository is not in https:// format, attempting push to ${REPO_URL}"
+  git push
+  exit 0
+fi
+
 if [ -z "${GH_TOKEN:-}" ]; then
   echo "Skipping documentation upload as GH_TOKEN is not configured."
   exit 0
 fi
+
+readonly REPO_REF=${REPO_URL/https:\/\/}
 git push https://${GH_TOKEN}@${REPO_REF} gh-pages

--- a/ci/upload-docs.sh
+++ b/ci/upload-docs.sh
@@ -26,8 +26,7 @@ if [ "${GENERATE_DOCS:-}" != "yes" ]; then
     exit 0
 fi
 
-# TODO(coryan) - change the branch name to "master" before sending the PR.
-if [ "${TRAVIS_BRANCH:-}" != "issue-18-generate-doxygen-docs" ]; then
+if [ "${TRAVIS_BRANCH:-}" != "master" ]; then
     echo "Skipping document generation as it is disabled for non-master directories."
     exit 0
 fi


### PR DESCRIPTION
This is part of the fixes for #18.  It is incomplete because it does not generate the documentation in the format used by other google-cloud-* repositories.  We will need to convert the doxygen output into the format we use in those other repositories.

The upload to github.io is only enabled if GH_TOKEN is set, we should consult with the owners of GoogleCloudPlatform.github.io before posting the docs there.

I think this partial implementation is still useful because (a) it will detect documentation errors, and (b) it will post to my fork, where at least we can see it it looks right.
