### PR TITLE
Update third_party/grpc to a recent commit in master.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,6 +8,7 @@
 	path = third_party/grpc
 	url = https://github.com/grpc/grpc.git
 	branch = master
+	ignore = dirty
 [submodule "third_party/abseil"]
 	path = third_party/abseil
 	url = https://github.com/abseil/abseil-cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,8 +7,7 @@
 [submodule "third_party/grpc"]
 	path = third_party/grpc
 	url = https://github.com/grpc/grpc.git
-	branch = v1.6.x
-	ignore = dirty
+	branch = master
 [submodule "third_party/abseil"]
 	path = third_party/abseil
 	url = https://github.com/abseil/abseil-cpp.git


### PR DESCRIPTION
We need a newer version of grpc to compile with clang-3.9, which is sort of a dependency to build with clang-tidy and scan-build.  "Sort of" because it is much easier to do this than the alternatives.

Also because "Live at Head" is a thing apparently.
