### PR TITLE
Create a build with clang-tidy enabled.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,4 +4,18 @@
 # Disabled:
 #  -google-readability-namespace-comments the BIGTABLE_CLIENT_NS is a macro, and
 #   clang-tidy fails to match it against the initial value.
-Checks: google-readability-*,modernize-*,-google-readability-namespace-comments
+Checks: google-readability-*,modernize-*,readability-*,-google-readability-namespace-comments
+
+# Enable most warnings as errors.
+WarningsAsErrors: *,-readability-identifier-naming
+
+CheckOptions:
+  - { key: readability-identifier-naming.NamespaceCase,         value: lower_case }
+  - { key: readability-identifier-naming.ClassCase,             value: CamelCase  }
+  - { key: readability-identifier-naming.StructCase,            value: CamelCase  }
+  - { key: readability-identifier-naming.FunctionCase,          value: CamelCase  }
+  - { key: readability-identifier-naming.VariableCase,          value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberSuffix,   value: _          }
+  - { key: readability-identifier-naming.ProtectedMemberSuffix, value: _          }
+  - { key: readability-identifier-naming.MacroDefinition,       value: UPPER_CASE }
+  - { key: readability-identifier-naming.TemplateParameter,     value: CamelCase  }

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,7 @@
+---
+# Configure clang-tidy for this project.
+
+# Disabled:
+#  -google-readability-namespace-comments the BIGTABLE_CLIENT_NS is a macro, and
+#   clang-tidy fails to match it against the initial value.
+Checks: google-readability-*,modernize-*,-google-readability-namespace-comments

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,7 +7,7 @@
 Checks: google-readability-*,modernize-*,readability-*,-google-readability-namespace-comments
 
 # Enable most warnings as errors.
-WarningsAsErrors: *,-readability-identifier-naming
+WarningsAsErrors: clang-*,google-*,modernize-*,readability-*,-readability-identifier-naming
 
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,         value: lower_case }

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ matrix:
            CMAKE_FLAGS=-DSANITIZE_ADDRESS=yes
     - os: linux
       compiler: clang
-      env: DISTRO=ubuntu DISTRO_VERSION=16.04 \
-           CMAKE_FLAGS=-DSANITIZE_UNDEFINED=yes BUILD_TYPE=Debug
+      env: DISTRO=ubuntu DISTRO_VERSION=16.04 BUILD_TYPE=Debug \
+           CMAKE_FLAGS=-DSANITIZE_UNDEFINED=yes
     - os: linux
       compiler: gcc
       env: DISTRO=ubuntu DISTRO_VERSION=14.04 BUILD_TYPE=Coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
       if: type != pull_request
     - os: linux
       compiler: clang
-      env: DISTRO=ubuntu DISTRO_VERSION=17.04 BUILD_TYPE=Debug \
+      env: DISTRO=fedora DISTRO_VERSION=27 BUILD_TYPE=Debug \
             CMAKE_FLAGS=-DBIGTABLE_CLIENT_CLANG_TIDY=yes
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,12 @@ matrix:
       env: DISTRO=ubuntu DISTRO_VERSION=17.04 CHECK_STYLE=yes GENERATE_DOCS=yes
     - os: linux
       compiler: clang
-      env: DISTRO=ubuntu DISTRO_VERSION=16.04 SANITIZE_ADDRESS=yes BUILD_TYPE=Debug
+      env: DISTRO=ubuntu DISTRO_VERSION=16.04 BUILD_TYPE=Debug \
+           CMAKE_FLAGS=-DSANITIZE_ADDRESS=yes
     - os: linux
       compiler: clang
-      env: DISTRO=ubuntu DISTRO_VERSION=16.04 SANITIZE_UNDEFINED=yes BUILD_TYPE=Debug
+      env: DISTRO=ubuntu DISTRO_VERSION=16.04 \
+           CMAKE_FLAGS=-DSANITIZE_UNDEFINED=yes BUILD_TYPE=Debug
     - os: linux
       compiler: gcc
       env: DISTRO=ubuntu DISTRO_VERSION=14.04 BUILD_TYPE=Coverage
@@ -38,6 +40,10 @@ matrix:
     - os: osx
       compiler: clang
       if: type != pull_request
+    - os: linux
+      compiler: clang
+      env: DISTRO=ubuntu DISTRO_VERSION=17.04 BUILD_TYPE=Debug \
+            CMAKE_FLAGS=-DBIGTABLE_CLIENT_CLANG_TIDY=yes
 
 script:
   - ci/build-linux.sh

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -78,6 +78,9 @@ endif()
 # Include the functions to enable Clang sanitizers.
 include(${PROJECT_SOURCE_DIR}/cmake/EnableSanitizers.cmake)
 
+# Include support for clang-tidy if available
+include(${PROJECT_SOURCE_DIR}/cmake/EnableClangTidy.cmake)
+
 # We use abseil.io .
 include_directories(${PROJECT_THIRD_PARTY_DIR}/abseil)
 
@@ -137,6 +140,17 @@ add_library(bigtable_data_api
         client/version.h)
 target_link_libraries(bigtable_data_api googleapis ${GRPCPP_LIBRARIES}
   ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+
+option(BIGTABLE_CLIENT_CLANG_TIDY
+    "If set compiles the Cloud Bigtable client with clang-tidy."
+    "")
+if (CLANG_TIDY_EXE AND BIGTABLE_CLIENT_CLANG_TIDY)
+    message(STATUS "clang-tidy build enabled.")
+    set_target_properties(
+        bigtable_data_api PROPERTIES
+        CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
+    )
+endif()
 
 # List the unit tests, then setup the targets and dependencies.
 set(all_unit_tests

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -150,7 +150,7 @@ if (CLANG_TIDY_EXE AND BIGTABLE_CLIENT_CLANG_TIDY)
         bigtable_data_api PROPERTIES
         CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
     )
-endif()
+endif ()
 
 # List the unit tests, then setup the targets and dependencies.
 set(all_unit_tests

--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -22,6 +22,7 @@ RUN dnf install -y \
     automake \
     c-ares-devel \
     clang \
+    clang-tools-extra \
     cmake \
     curl \
     dia \

--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -54,11 +54,7 @@ ARG CC=gcc
 ARG BUILD_TYPE=Debug
 ARG CHECK_STYLE=""
 ARG GENERATE_DOCS=""
-ARG SANITIZE_ADDRESS=""
-ARG SANITIZE_LEAKS=""
-ARG SANITIZE_MEMORY=""
-ARG SANITIZE_THREAD=""
-ARG SANITIZE_UNDEFINED=""
+ARG CMAKE_FLAGS=""
 
 # We assume that this is running on a (clean-ish) checkout of
 # google-cloud-cpp, including submodules, and copy the files to a

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -67,11 +67,7 @@ ARG CC=gcc
 ARG BUILD_TYPE=Debug
 ARG CHECK_STYLE=""
 ARG GENERATE_DOCS=""
-ARG SANITIZE_ADDRESS=""
-ARG SANITIZE_LEAKS=""
-ARG SANITIZE_MEMORY=""
-ARG SANITIZE_THREAD=""
-ARG SANITIZE_UNDEFINED=""
+ARG CMAKE_FLAGS=""
 
 # We assume that this is running on a (clean-ish) checkout of
 # google-cloud-cpp, including submodules, and copy the files to a

--- a/ci/build-docker.sh
+++ b/ci/build-docker.sh
@@ -22,13 +22,7 @@ set -eu
 mkdir -p gccpp/build-output
 cd gccpp/build-output
 
-cmake -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
-    -DSANITIZE_ADDRESS="${SANITIZE_ADDRESS}" \
-    -DSANITIZE_LEAKS="${SANITIZE_LEAKS}" \
-    -DSANITIZE_MEMORY="${SANITIZE_MEMORY}" \
-    -DSANITIZE_THREAD="${SANITIZE_THREAD}" \
-    -DSANITIZE_UNDEFINED="${SANITIZE_UNDEFINED}" \
-    ..
+cmake -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" ${CMAKE_FLAGS:-} ..
 
 make -j ${NCPU} all
 make -j ${NCPU} test || ( cat Testing/Temporary/LastTest.log; exit 1 )

--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -32,9 +32,5 @@ sudo docker build -t "${IMAGE}:tip" \
      --build-arg BUILD_TYPE="${BUILD_TYPE:-Release}" \
      --build-arg CHECK_STYLE="${CHECK_STYLE:-}" \
      --build-arg GENERATE_DOCS="${GENERATE_DOCS:-}" \
-     --build-arg SANITIZE_ADDRESS="${SANITIZE_ADDRESS:-}" \
-     --build-arg SANITIZE_LEAKS="${SANITIZE_LEAKS:-}" \
-     --build-arg SANITIZE_MEMORY="${SANITIZE_MEMORY:-}" \
-     --build-arg SANITIZE_THREAD="${SANITIZE_THREAD:-}" \
-     --build-arg SANITIZE_UNDEFINED="${SANITIZE_UNDEFINED:-}" \
+     --build-arg CMAKE_FLAGS="${CMAKE_FLAGS:-}" \
      -f "ci/Dockerfile.${DISTRO}" .

--- a/cmake/EnableClangTidy.cmake
+++ b/cmake/EnableClangTidy.cmake
@@ -15,6 +15,9 @@
 if (${CMAKE_VERSION} VERSION_LESS "3.6")
     message(STATUS "clang-tidy is not enabled because cmake version is too old")
 else ()
+    if (${CMAKE_VERSION} VERSION_LESS "3.8")
+        message(WARNING "clang-tidy exit code ignored in this version of cmake")
+    endif ()
     find_program(
             CLANG_TIDY_EXE
             NAMES "clang-tidy"

--- a/cmake/EnableClangTidy.cmake
+++ b/cmake/EnableClangTidy.cmake
@@ -1,0 +1,28 @@
+#   Copyright 2017 Google Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+if (${CMAKE_VERSION} VERSION_LESS "3.6")
+    message(STATUS "clang-tidy is not enabled because cmake version is too old")
+else ()
+    find_program(
+            CLANG_TIDY_EXE
+            NAMES "clang-tidy"
+            DOC "Path to clang-tidy executable"
+    )
+    if(NOT CLANG_TIDY_EXE)
+        message(STATUS "clang-tidy not found.")
+    else()
+        message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
+    endif()
+endif()

--- a/cmake/EnableClangTidy.cmake
+++ b/cmake/EnableClangTidy.cmake
@@ -23,9 +23,10 @@ else ()
             NAMES "clang-tidy"
             DOC "Path to clang-tidy executable"
     )
-    if(NOT CLANG_TIDY_EXE)
+
+    if (NOT CLANG_TIDY_EXE)
         message(STATUS "clang-tidy not found.")
-    else()
+    else ()
         message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
-    endif()
-endif()
+    endif ()
+endif ()


### PR DESCRIPTION
This fixes #22.  And should be submitted after #86.  It creates a new build that breaks when our code (and not grpc or its dependencies), fails to pass the clang-tidy checks.  A few checks are just warnings because (a) clang-tidy is giving us a false positive, or (b) the checks are not fully configured and could emit false positives.
