### PR TITLE
Enable a CentOS:7 build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,9 @@ matrix:
       compiler: clang
       env: DISTRO=fedora DISTRO_VERSION=27 BUILD_TYPE=Debug \
             CMAKE_FLAGS=-DBIGTABLE_CLIENT_CLANG_TIDY=yes
+    - os: linux
+      compiler: gcc
+      env: DISTRO=centos DISTRO_VERSION=7 BUILD_TYPE=Release
 
 script:
   - ci/build-linux.sh

--- a/ci/Dockerfile.centos
+++ b/ci/Dockerfile.centos
@@ -48,8 +48,8 @@ RUN yum makecache && yum install -y \
 # Install cmake3 as cmake.
 RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake
 
-# Install the Cloud Bigtable emulator and the bigtable command-line client.
-# They are used in the integration tests.
+# Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
+# client.  They are used in the integration tests.
 ARG GOPATH=/var/tmp/build/cbt
 WORKDIR ${GOPATH}
 RUN go get cloud.google.com/go/bigtable/cmd/cbt \

--- a/ci/Dockerfile.centos
+++ b/ci/Dockerfile.centos
@@ -12,17 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=27
-FROM fedora:${DISTRO_VERSION}
+ARG DISTRO_VERSION=7
+FROM centos:${DISTRO_VERSION}
 MAINTAINER "Carlos O'Ryan <coryan@google.com>"
 
-RUN dnf makecache && dnf install -y \
+# We meed the "Extra Packages for Enterprise Linux" for cmake3
+RUN rpm -Uvh \
+    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+
+RUN yum makecache && yum install -y \
     autoconf \
     automake \
     c-ares-devel \
     clang \
     clang-tools-extra \
-    cmake \
+    cmake3 \
     curl \
     dia \
     doxygen \
@@ -40,6 +44,9 @@ RUN dnf makecache && dnf install -y \
     unzip \
     wget \
     zlib-devel
+
+# Install cmake3 as cmake.
+RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake
 
 # Install the Cloud Bigtable emulator and the bigtable command-line client.
 # They are used in the integration tests.

--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -41,8 +41,8 @@ RUN dnf makecache && dnf install -y \
     wget \
     zlib-devel
 
-# Install the Cloud Bigtable emulator and the bigtable command-line client.
-# They are used in the integration tests.
+# Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
+# client.  They are used in the integration tests.
 ARG GOPATH=/var/tmp/build/cbt
 WORKDIR ${GOPATH}
 RUN go get cloud.google.com/go/bigtable/cmd/cbt \

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -16,8 +16,7 @@ ARG DISTRO_VERSION=17.04
 FROM ubuntu:${DISTRO_VERSION}
 MAINTAINER "Carlos O'Ryan <coryan@google.com>"
 
-RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
   build-essential \
   clang \
   cmake \

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -49,8 +49,8 @@ RUN apt-get install -y \
     g++-4.8 \
   || /bin/true
 
-# Install the Cloud Bigtable emulator and the bigtable command-line client.
-# They are used in the integration tests.
+# Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
+# client.  They are used in the integration tests.
 ARG GOPATH=/var/tmp/build/cbt
 WORKDIR ${GOPATH}
 RUN if grep -q 14.04 /etc/lsb-release; then \


### PR DESCRIPTION
This fixes #42, CentOS 7 support turns out to be not that hard, so
there is every reason to make it one of our target platforms.