### PR TITLE
Start work on a minimal admin client.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,3 +12,6 @@
 [submodule "third_party/abseil"]
 	path = third_party/abseil
 	url = https://github.com/abseil/abseil-cpp.git
+[submodule "third_party/cctz"]
+	path = third_party/cctz
+	url = https://github.com/google/cctz.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,5 +104,8 @@ elseif ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "package")
     add_subdirectory(googletest EXCLUDE_FROM_ALL)
 endif ()
 
+# We need to enable testing in this directory so we can do a top-level `make test`.
+enable_testing()
+
 # Add subprojects here.
 add_subdirectory(bigtable)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,8 +104,5 @@ elseif ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "package")
     add_subdirectory(googletest EXCLUDE_FROM_ALL)
 endif ()
 
-# Enable unit tests.
-enable_testing()
-
 # Add subprojects here.
 add_subdirectory(bigtable)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ elseif ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "package")
     add_subdirectory(googletest EXCLUDE_FROM_ALL)
 endif ()
 
-# We need to enable testing in this directory so we can do a top-level `make test`.
+# Enable testing in this directory so we can do a top-level `make test`.
 enable_testing()
 
 # Add subprojects here.

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -84,7 +84,9 @@ include(${PROJECT_SOURCE_DIR}/cmake/EnableClangTidy.cmake)
 # We use abseil.io .
 set(BUILD_TESTING OFF)
 include(${PROJECT_SOURCE_DIR}/cmake/IncludeAbseil.cmake)
-include_directories(${ABSEIL_INCLUDE_DIRS})
+if (ABSEIL_ROOT_DIR)
+    include_directories(${ABSEIL_INCLUDE_DIRS})
+endif (ABSEIL_ROOT_DIR)
 
 # Configure the location of proto files, particulary the googleapis protos.
 include_directories(${GRPCPP_INCLUDE_DIRS} ${GRPC_INCLUDE_DIRS} ${PROTOBUF_INCLUDE_DIRS})

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -150,8 +150,8 @@ target_link_libraries(bigtable_client bigtable_protos ${GRPCPP_LIBRARIES}
 add_library(bigtable_admin_client
     admin/admin_client.h
     admin/admin_client.cc
-    admin/table_admin.cc
-    admin/table_admin.h)
+    admin/table_admin.h
+    admin/table_admin.cc)
 target_link_libraries(bigtable_admin_client bigtable_client bigtable_protos
     ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -116,35 +116,42 @@ GRPC_GENERATE_CPP_MOCKS(GRPCPP_SOURCES GRPCPP_HDRS GRPC_MOCK_HDRS
 include_directories("${PROJECT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
 
 # Create a library with the generated files from the relevant protos.
-add_library(googleapis ${PROTO_SOURCES} ${PROTO_HDRS} ${GRPCPP_SOURCES} ${GRPCPP_HDRS})
-target_link_libraries(googleapis ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+add_library(bigtable_protos ${PROTO_SOURCES} ${PROTO_HDRS} ${GRPCPP_SOURCES} ${GRPCPP_HDRS})
+target_link_libraries(bigtable_protos ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 
 # Enable unit tests
 enable_testing()
 
 # the client library
-add_library(bigtable_data_api
-        client/cell.h
-        client/chrono_literals.h
-        client/client_options.h
-        client/client_options.cc
-        client/data.h
-        client/data.cc
-        client/filters.h
-        client/filters.cc
-        client/idempotent_mutation_policy.h
-        client/idempotent_mutation_policy.cc
-        client/detail/bulk_mutator.h
-        client/detail/bulk_mutator.cc
-        client/mutations.h
-        client/mutations.cc
-        client/rpc_backoff_policy.h
-        client/rpc_backoff_policy.cc
-        client/rpc_retry_policy.h
-        client/rpc_retry_policy.cc
-        client/version.h)
-target_link_libraries(bigtable_data_api googleapis ${GRPCPP_LIBRARIES}
+add_library(bigtable_client
+    client/cell.h
+    client/chrono_literals.h
+    client/client_options.h
+    client/client_options.cc
+    client/data.h
+    client/data.cc
+    client/detail/bulk_mutator.h
+    client/detail/bulk_mutator.cc
+    client/filters.h
+    client/filters.cc
+    client/idempotent_mutation_policy.h
+    client/idempotent_mutation_policy.cc
+    client/mutations.h
+    client/mutations.cc
+    client/rpc_backoff_policy.h
+    client/rpc_backoff_policy.cc
+    client/rpc_retry_policy.h
+    client/rpc_retry_policy.cc
+    client/version.h)
+target_link_libraries(bigtable_client bigtable_protos ${GRPCPP_LIBRARIES}
   ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+
+# the admin library
+add_library(bigtable_admin_client
+    admin/admin_client.h
+    admin/admin_client.cc)
+target_link_libraries(bigtable_admin_client bigtable_protos ${GRPCPP_LIBRARIES}
+    ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 
 option(BIGTABLE_CLIENT_CLANG_TIDY
     "If set compiles the Cloud Bigtable client with clang-tidy."
@@ -157,8 +164,21 @@ if (CLANG_TIDY_EXE AND BIGTABLE_CLIENT_CLANG_TIDY)
     )
 endif ()
 
+# Compile the googlemock library.  This library is rarely installed or
+# pre-compiled because it should be configured with the same flags as the
+# application.
+add_library(gmock
+    ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest/src/gtest_main.cc
+    ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest/src/gtest-all.cc
+    ${PROJECT_THIRD_PARTY_DIR}/googletest/googlemock/src/gmock-all.cc)
+target_include_directories(gmock
+    PUBLIC ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest/include
+    PUBLIC ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest
+    PUBLIC ${PROJECT_THIRD_PARTY_DIR}/googletest/googlemock/include
+    PUBLIC ${PROJECT_THIRD_PARTY_DIR}/googletest/googlemock)
+
 # List the unit tests, then setup the targets and dependencies.
-set(all_unit_tests
+set(bigtable_client_unit_tests
         client/cell_test.cc
         client/client_options_test.cc
         client/filters_test.cc
@@ -170,38 +190,38 @@ set(all_unit_tests
         client/table_bulk_apply_test.cc
         client/rpc_backoff_policy_test.cc
         client/rpc_retry_policy_test.cc)
-foreach (fname ${all_unit_tests})
+foreach (fname ${bigtable_client_unit_tests})
     string(REPLACE "/" "_" target ${fname})
     string(REPLACE ".cc" "" target ${target})
-    add_executable(${target} ${fname}
-            ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest/src/gtest_main.cc
-            ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest/src/gtest-all.cc
-            ${PROJECT_THIRD_PARTY_DIR}/googletest/googlemock/src/gmock-all.cc)
+    add_executable(${target} ${fname})
     get_target_property(tname ${target} NAME)
-    target_include_directories(${target}
-            PRIVATE ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest/include
-            PRIVATE ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest
-            PRIVATE ${PROJECT_THIRD_PARTY_DIR}/googletest/googlemock/include
-            PRIVATE ${PROJECT_THIRD_PARTY_DIR}/googletest/googlemock)
-    target_link_libraries(${target} bigtable_data_api googleapis
-            ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+    target_link_libraries(${target} bigtable_client bigtable_protos
+        gmock ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+    add_test(NAME ${tname} COMMAND ${target})
+    get_target_property(sources ${target} SOURCES)
+endforeach()
+
+# List the unit tests, then setup the targets and dependencies.
+set(bigtable_admin_unit_tests
+    admin/admin_client_test.cc)
+foreach (fname ${bigtable_admin_unit_tests})
+    string(REPLACE "/" "_" target ${fname})
+    string(REPLACE ".cc" "" target ${target})
+    add_executable(${target} ${fname})
+    get_target_property(tname ${target} NAME)
+    target_link_libraries(${target} bigtable_admin_client bigtable_protos
+        gmock ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
     add_test(NAME ${tname} COMMAND ${target})
     get_target_property(sources ${target} SOURCES)
 endforeach()
 
 # Create a single executable that rolls up all the tests, this is convenient
 # for CLion and other IDEs.
-add_executable(bigtable_client_all_tests ${all_unit_tests}
-        ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest/src/gtest_main.cc
-        ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest/src/gtest-all.cc
-        ${PROJECT_THIRD_PARTY_DIR}/googletest/googlemock/src/gmock-all.cc)
-target_include_directories(bigtable_client_all_tests
-        PRIVATE ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest/include
-        PRIVATE ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest
-        PRIVATE ${PROJECT_THIRD_PARTY_DIR}/googletest/googlemock/include
-        PRIVATE ${PROJECT_THIRD_PARTY_DIR}/googletest/googlemock)
-target_link_libraries(bigtable_client_all_tests bigtable_data_api googleapis
-        ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+add_executable(bigtable_client_all_tests
+    ${bigtable_client_unit_tests} ${bigtable_admin_unit_tests})
+target_link_libraries(bigtable_client_all_tests
+    bigtable_client bigtable_admin_client bigtable_protos
+    gmock ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 
 option(FORCE_SANITIZER_ERRORS
         "If set enable tests that force errors detected by the sanitizers."
@@ -214,5 +234,5 @@ endif (FORCE_SANITIZER_ERRORS)
 # The integration tests, these are simply programs that connect to the
 # Cloud Bigtable emulator.
 add_executable(apply_test tests/apply_test.cc)
-target_link_libraries(apply_test bigtable_data_api googleapis
+target_link_libraries(apply_test bigtable_client bigtable_protos
         ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -82,7 +82,9 @@ include(${PROJECT_SOURCE_DIR}/cmake/EnableSanitizers.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/EnableClangTidy.cmake)
 
 # We use abseil.io .
-include_directories(${PROJECT_THIRD_PARTY_DIR}/abseil)
+set(BUILD_TESTING OFF)
+include(${PROJECT_SOURCE_DIR}/cmake/IncludeAbseil.cmake)
+include_directories(${ABSEIL_INCLUDE_DIRS})
 
 # Configure the location of proto files, particulary the googleapis protos.
 include_directories(${GRPCPP_INCLUDE_DIRS} ${GRPC_INCLUDE_DIRS} ${PROTOBUF_INCLUDE_DIRS})
@@ -153,7 +155,7 @@ add_library(bigtable_admin_client
     admin/table_admin.h
     admin/table_admin.cc)
 target_link_libraries(bigtable_admin_client bigtable_client bigtable_protos
-    ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+    absl::strings ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 
 option(BIGTABLE_CLIENT_CLANG_TIDY
     "If set compiles the Cloud Bigtable client with clang-tidy."
@@ -169,19 +171,6 @@ if (CLANG_TIDY_EXE AND BIGTABLE_CLIENT_CLANG_TIDY)
         CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
     )
 endif ()
-
-# Compile the googlemock library.  This library is rarely installed or
-# pre-compiled because it should be configured with the same flags as the
-# application.
-add_library(gmock
-    ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest/src/gtest_main.cc
-    ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest/src/gtest-all.cc
-    ${PROJECT_THIRD_PARTY_DIR}/googletest/googlemock/src/gmock-all.cc)
-target_include_directories(gmock
-    PUBLIC ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest/include
-    PUBLIC ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest
-    PUBLIC ${PROJECT_THIRD_PARTY_DIR}/googletest/googlemock/include
-    PUBLIC ${PROJECT_THIRD_PARTY_DIR}/googletest/googlemock)
 
 # List the unit tests, then setup the targets and dependencies.
 set(bigtable_client_unit_tests

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -159,7 +159,11 @@ option(BIGTABLE_CLIENT_CLANG_TIDY
 if (CLANG_TIDY_EXE AND BIGTABLE_CLIENT_CLANG_TIDY)
     message(STATUS "clang-tidy build enabled.")
     set_target_properties(
-        bigtable_data_api PROPERTIES
+        bigtable_client PROPERTIES
+        CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
+    )
+    set_target_properties(
+        bigtable_admin_client PROPERTIES
         CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
     )
 endif ()

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -149,7 +149,9 @@ target_link_libraries(bigtable_client bigtable_protos ${GRPCPP_LIBRARIES}
 # the admin library
 add_library(bigtable_admin_client
     admin/admin_client.h
-    admin/admin_client.cc)
+    admin/admin_client.cc
+    admin/table_admin.cc
+    admin/table_admin.h)
 target_link_libraries(bigtable_admin_client bigtable_client bigtable_protos
     ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 
@@ -207,7 +209,8 @@ endforeach ()
 
 # List the unit tests, then setup the targets and dependencies.
 set(bigtable_admin_unit_tests
-    admin/admin_client_test.cc)
+    admin/admin_client_test.cc
+    admin/table_admin_test.cc)
 foreach (fname ${bigtable_admin_unit_tests})
     string(REPLACE "/" "_" target ${fname})
     string(REPLACE ".cc" "" target ${target})

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -150,8 +150,8 @@ target_link_libraries(bigtable_client bigtable_protos ${GRPCPP_LIBRARIES}
 add_library(bigtable_admin_client
     admin/admin_client.h
     admin/admin_client.cc)
-target_link_libraries(bigtable_admin_client bigtable_protos ${GRPCPP_LIBRARIES}
-    ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+target_link_libraries(bigtable_admin_client bigtable_client bigtable_protos
+    ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 
 option(BIGTABLE_CLIENT_CLANG_TIDY
     "If set compiles the Cloud Bigtable client with clang-tidy."
@@ -203,7 +203,7 @@ foreach (fname ${bigtable_client_unit_tests})
         gmock ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
     add_test(NAME ${tname} COMMAND ${target})
     get_target_property(sources ${target} SOURCES)
-endforeach()
+endforeach ()
 
 # List the unit tests, then setup the targets and dependencies.
 set(bigtable_admin_unit_tests
@@ -213,11 +213,12 @@ foreach (fname ${bigtable_admin_unit_tests})
     string(REPLACE ".cc" "" target ${target})
     add_executable(${target} ${fname})
     get_target_property(tname ${target} NAME)
-    target_link_libraries(${target} bigtable_admin_client bigtable_protos
-        gmock ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+    target_link_libraries(${target} bigtable_admin_client
+        bigtable_client bigtable_protos gmock
+        ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
     add_test(NAME ${tname} COMMAND ${target})
     get_target_property(sources ${target} SOURCES)
-endforeach()
+endforeach ()
 
 # Create a single executable that rolls up all the tests, this is convenient
 # for CLion and other IDEs.

--- a/bigtable/admin/admin_client.cc
+++ b/bigtable/admin/admin_client.cc
@@ -1,0 +1,96 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/admin/admin_client.h"
+
+#include <absl/memory/memory.h>
+
+namespace {
+class SimpleAdminClient : public bigtable::AdminClient {
+ public:
+  SimpleAdminClient(std::string project, bigtable::ClientOptions options)
+      : project_(std::move(project)),
+        options_(std::move(options)),
+        channel_(),
+        table_admin_stub_() {}
+
+  std::unique_ptr<bigtable::Instance> Open(std::string instance_name) override;
+  void OnFailure(grpc::Status const& status) override;
+  ::google::bigtable::admin::v2::BigtableTableAdmin::StubInterface& table_admin() override;
+
+ private:
+  void Refresh();
+
+ private:
+  std::string project_;
+  bigtable::ClientOptions options_;
+  mutable std::mutex mu_;
+  std::shared_ptr<grpc::Channel> channel_;
+  std::unique_ptr<
+      google::bigtable::admin::v2::BigtableTableAdmin::StubInterface>
+      table_admin_stub_;
+};
+}  // anonymous namespace
+
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+std::unique_ptr<AdminClient> CreateAdminClient(
+    std::string project, bigtable::ClientOptions options) {
+  return absl::make_unique<AdminClient>(std::move(project), std::move(options));
+}
+
+struct Instance {
+  AdminClient& client;
+  std::string instance_name;
+};
+
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+
+namespace {
+std::unique_ptr<bigtable::Instance> SimpleAdminClient::Open(
+    std::string instance_id) {
+  return new bigtable::Instance{
+      *this, std::string("project/") + project_ + "/instances/" + instance_id};
+}
+
+void SimpleAdminClient::OnFailure(grpc::Status const& status) {
+  std::unique_lock<std::mutex> lk(mu_);
+  channel_.reset();
+  table_admin_stub_.reset();
+}
+
+::google::bigtable::admin::v2::BigtableTableAdmin::StubInterface&
+SimpleAdminClient::table_admin() {
+  Refresh();
+  return *table_admin_stub_;
+}
+
+void SimpleAdminClient::Refresh() {
+  std::unique_lock<std::mutex> lk(mu_);
+  if (table_admin_stub_) {
+    return;
+  }
+  lk.unlock();
+  auto channel = grpc::CreateCustomChannel(options_.admin_endpoint(),
+                                           options_.credentials(),
+                                           options_.channel_arguments());
+  auto stub =
+      ::google::bigtable::admin::v2::BigtableTableAdmin::NewStub(channel);
+  lk.lock();
+  table_admin_stub_ = std::move(stub);
+  channel_ = std::move(channel);
+}
+
+}  // anonymous namespace

--- a/bigtable/admin/admin_client.cc
+++ b/bigtable/admin/admin_client.cc
@@ -91,6 +91,7 @@ void SimpleAdminClient::Refresh() {
   if (table_admin_stub_) {
     return;
   }
+  // Release the lock before executing potentially slow operations.
   lk.unlock();
   auto channel = grpc::CreateCustomChannel(options_.admin_endpoint(),
                                            options_.credentials(),

--- a/bigtable/admin/admin_client.cc
+++ b/bigtable/admin/admin_client.cc
@@ -23,7 +23,7 @@ namespace {
  *
  * This class should not be used by multiple threads, it makes no attempt to
  * protect its critical sections.  While it is rare that the admin interface
- * will be used by multiple threads we should use the same approach here and in
+ * will be used by multiple threads, we should use the same approach here and in
  * the regular client to support multi-threaded programs.
  *
  * The class also aggressively reconnects on any gRPC errors. A future version
@@ -41,7 +41,7 @@ class SimpleAdminClient : public bigtable::AdminClient {
   table_admin() override;
 
  private:
-  void refresh_credentials_and_channel();
+  void RefreshCredentialsAndChannel();
 
  private:
   std::string project_;
@@ -75,7 +75,7 @@ void SimpleAdminClient::on_completion(grpc::Status const& status) {
 
 ::google::bigtable::admin::v2::BigtableTableAdmin::StubInterface&
 SimpleAdminClient::table_admin() {
-  refresh_credentials_and_channel();
+  RefreshCredentialsAndChannel();
   // TODO(#101) - this is inherently unsafe if we plan to support multiple
   // threads, returning an object that is supposed to be locked.  May need to
   // rethink the interface completely, or declare the class to be not
@@ -83,7 +83,7 @@ SimpleAdminClient::table_admin() {
   return *table_admin_stub_;
 }
 
-void SimpleAdminClient::refresh_credentials_and_channel() {
+void SimpleAdminClient::RefreshCredentialsAndChannel() {
   if (table_admin_stub_) {
     return;
   }

--- a/bigtable/admin/admin_client.cc
+++ b/bigtable/admin/admin_client.cc
@@ -21,8 +21,7 @@ namespace {
 class SimpleAdminClient : public bigtable::AdminClient {
  public:
   SimpleAdminClient(std::string project, bigtable::ClientOptions options)
-      : project_(std::move(project)),
-        options_(std::move(options)) {}
+      : project_(std::move(project)), options_(std::move(options)) {}
 
   std::string const& project() const override { return project_; }
   void on_completion(grpc::Status const& status) override;

--- a/bigtable/admin/admin_client.cc
+++ b/bigtable/admin/admin_client.cc
@@ -26,9 +26,7 @@ class SimpleAdminClient : public bigtable::AdminClient {
         channel_(),
         table_admin_stub_() {}
 
-  absl::string_view project() const override { return project_; }
-  std::unique_ptr<bigtable::TableAdmin> CreateTableAdmin(
-      std::string instance_id) override;
+  std::string const& project() const override { return project_; }
   void OnFailure(grpc::Status const& status) override;
   ::google::bigtable::admin::v2::BigtableTableAdmin::StubInterface&
   table_admin() override;
@@ -49,10 +47,10 @@ class SimpleAdminClient : public bigtable::AdminClient {
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-std::unique_ptr<AdminClient> CreateAdminClient(
+std::shared_ptr<AdminClient> CreateAdminClient(
     std::string project, bigtable::ClientOptions options) {
-  return absl::make_unique<SimpleAdminClient>(std::move(project),
-                                              std::move(options));
+  return std::make_shared<SimpleAdminClient>(std::move(project),
+                                             std::move(options));
 }
 
 class TableAdmin {
@@ -68,12 +66,6 @@ class TableAdmin {
 }  // namespace bigtable
 
 namespace {
-std::unique_ptr<bigtable::TableAdmin> SimpleAdminClient::CreateTableAdmin(
-    std::string instance_id) {
-  return absl::make_unique<bigtable::TableAdmin>(
-      *this, std::string("project/") + project_ + "/instances/" + instance_id);
-}
-
 void SimpleAdminClient::OnFailure(grpc::Status const& status) {
   std::unique_lock<std::mutex> lk(mu_);
   channel_.reset();

--- a/bigtable/admin/admin_client.cc
+++ b/bigtable/admin/admin_client.cc
@@ -51,7 +51,8 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 std::unique_ptr<AdminClient> CreateAdminClient(
     std::string project, bigtable::ClientOptions options) {
-  return absl::make_unique<SimpleAdminClient>(std::move(project), std::move(options));
+  return absl::make_unique<SimpleAdminClient>(std::move(project),
+                                              std::move(options));
 }
 
 class TableAdmin {

--- a/bigtable/admin/admin_client.cc
+++ b/bigtable/admin/admin_client.cc
@@ -37,7 +37,7 @@ class SimpleAdminClient : public bigtable::AdminClient {
   std::shared_ptr<grpc::Channel> channel_;
   std::unique_ptr<
       ::google::bigtable::admin::v2::BigtableTableAdmin::StubInterface>
-      table_admin_stub_ ;
+      table_admin_stub_;
 };
 }  // anonymous namespace
 

--- a/bigtable/admin/admin_client.cc
+++ b/bigtable/admin/admin_client.cc
@@ -27,7 +27,7 @@ class SimpleAdminClient : public bigtable::AdminClient {
         table_admin_stub_() {}
 
   std::string const& project() const override { return project_; }
-  void OnFailure(grpc::Status const& status) override;
+  void on_completion(grpc::Status const& status) override;
   ::google::bigtable::admin::v2::BigtableTableAdmin::StubInterface&
   table_admin() override;
 
@@ -66,7 +66,10 @@ class TableAdmin {
 }  // namespace bigtable
 
 namespace {
-void SimpleAdminClient::OnFailure(grpc::Status const& status) {
+void SimpleAdminClient::on_completion(grpc::Status const& status) {
+  if (status.ok()) {
+    return;
+  }
   std::unique_lock<std::mutex> lk(mu_);
   channel_.reset();
   table_admin_stub_.reset();

--- a/bigtable/admin/admin_client.cc
+++ b/bigtable/admin/admin_client.cc
@@ -17,7 +17,19 @@
 #include <absl/memory/memory.h>
 
 namespace {
-/// An implementation of the bigtable::AdminClient interface.
+/**
+ * An AdminClient for single-threaded programs that refreshes credentials on all
+ * gRPC errors.
+ *
+ * This class should not be used by multiple threads, it makes no attempt to
+ * protect its critical sections.  While it is rare that the admin interface
+ * will be used by multiple threads we should use the same approach here and in
+ * the regular client to support multi-threaded programs.
+ *
+ * The class also aggressively reconnects on any gRPC errors. A future version
+ * should only reconnect on those errors that indicate the credentials or
+ * connections need refreshing.
+ */
 class SimpleAdminClient : public bigtable::AdminClient {
  public:
   SimpleAdminClient(std::string project, bigtable::ClientOptions options)

--- a/bigtable/admin/admin_client.h
+++ b/bigtable/admin/admin_client.h
@@ -31,7 +31,7 @@ class AdminClient {
   virtual ~AdminClient() = default;
 
   /// The project that this AdminClient works on.
-  virtual const std::string & project() const = 0;
+  virtual const std::string& project() const = 0;
 
   /**
    * A callback to handle failures in the client.

--- a/bigtable/admin/admin_client.h
+++ b/bigtable/admin/admin_client.h
@@ -17,23 +17,26 @@
 
 #include "bigtable/client/client_options.h"
 
-#include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
 #include <memory>
 #include <string>
 
+#include <absl/strings/string_view.h>
+
+#include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
+
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-class Instance;
+class TableAdmin;
 
 class AdminClient {
  public:
   virtual ~AdminClient() = default;
 
   /// The project that this AdminClient works on.
-  std::string const& project() const;
+  virtual absl::string_view project() const = 0;
 
   /// Create a new object to manage an specific instance.
-  virtual std::unique_ptr<Instance> Open(std::string instance_name) = 0;
+  virtual std::unique_ptr<TableAdmin> CreateTableAdmin(std::string instance_id) = 0;
 
   /**
    * A callback to handle failures in the client.

--- a/bigtable/admin/admin_client.h
+++ b/bigtable/admin/admin_client.h
@@ -34,14 +34,15 @@ class AdminClient {
   virtual const std::string& project() const = 0;
 
   /**
-   * A callback to handle failures in the client.
+   * A callback to report completed RPCs to the client.
    *
-   * The client may need to update its data structures (e.g. any grpc channels),
-   * or refresh the credentials used to contact the server.
+   * On failures, he client may need to update its internal data structures,
+   * such as which channels are working, maybe reauthenticate with the server,
+   * or simply count the number of failed operations for monitoring purposes.
    *
    * @param status the grpc error.
    */
-  virtual void OnFailure(grpc::Status const& status) = 0;
+  virtual void on_completion(grpc::Status const& status) = 0;
 
   /// Return a new stub to handle admin operations.
   virtual ::google::bigtable::admin::v2::BigtableTableAdmin::StubInterface&

--- a/bigtable/admin/admin_client.h
+++ b/bigtable/admin/admin_client.h
@@ -1,0 +1,60 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_ADMIN_ADMIN_CLIENT_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_ADMIN_ADMIN_CLIENT_H_
+
+#include "bigtable/client/client_options.h"
+
+#include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
+#include <memory>
+#include <string>
+
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+class Instance;
+
+class AdminClient {
+ public:
+  virtual ~AdminClient() = default;
+
+  /// The project that this AdminClient works on.
+  std::string const& project() const;
+
+  /// Create a new object to manage an specific instance.
+  virtual std::unique_ptr<Instance> Open(std::string instance_name) = 0;
+
+  /**
+   * A callback to handle failures in the client.
+   *
+   * The client may need to update its data structures (e.g. any grpc channels),
+   * or refresh the credentials used to contact the server.
+   *
+   * @param status the grpc error.
+   */
+  virtual void OnFailure(grpc::Status const& status) = 0;
+
+  /// Return a new stub to handle admin operations.
+  virtual ::google::bigtable::admin::v2::BigtableTableAdmin::StubInterface&
+  table_admin() = 0;
+};
+
+/// Create a new admin client configured via @p options.
+std::unique_ptr<AdminClient> CreateAdminClient(std::string project,
+                                               bigtable::ClientOptions options);
+
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_ADMIN_ADMIN_CLIENT_H_

--- a/bigtable/admin/admin_client.h
+++ b/bigtable/admin/admin_client.h
@@ -36,7 +36,8 @@ class AdminClient {
   virtual absl::string_view project() const = 0;
 
   /// Create a new object to manage an specific instance.
-  virtual std::unique_ptr<TableAdmin> CreateTableAdmin(std::string instance_id) = 0;
+  virtual std::unique_ptr<TableAdmin> CreateTableAdmin(
+      std::string instance_id) = 0;
 
   /**
    * A callback to handle failures in the client.

--- a/bigtable/admin/admin_client.h
+++ b/bigtable/admin/admin_client.h
@@ -26,18 +26,12 @@
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-class TableAdmin;
-
 class AdminClient {
  public:
   virtual ~AdminClient() = default;
 
   /// The project that this AdminClient works on.
-  virtual absl::string_view project() const = 0;
-
-  /// Create a new object to manage an specific instance.
-  virtual std::unique_ptr<TableAdmin> CreateTableAdmin(
-      std::string instance_id) = 0;
+  virtual const std::string & project() const = 0;
 
   /**
    * A callback to handle failures in the client.
@@ -55,7 +49,7 @@ class AdminClient {
 };
 
 /// Create a new admin client configured via @p options.
-std::unique_ptr<AdminClient> CreateAdminClient(std::string project,
+std::shared_ptr<AdminClient> CreateAdminClient(std::string project,
                                                bigtable::ClientOptions options);
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/bigtable/admin/admin_client.h
+++ b/bigtable/admin/admin_client.h
@@ -20,8 +20,6 @@
 #include <memory>
 #include <string>
 
-#include <absl/strings/string_view.h>
-
 #include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
 
 namespace bigtable {
@@ -31,7 +29,7 @@ class AdminClient {
   virtual ~AdminClient() = default;
 
   /// The project that this AdminClient works on.
-  virtual const std::string& project() const = 0;
+  virtual std::string const& project() const = 0;
 
   /**
    * A callback to report completed RPCs to the client.

--- a/bigtable/admin/admin_client_test.cc
+++ b/bigtable/admin/admin_client_test.cc
@@ -20,4 +20,5 @@ TEST(AdminClientTest, Simple) {
   auto admin_client =
       bigtable::CreateAdminClient("test-project", bigtable::ClientOptions());
   EXPECT_TRUE(admin_client);
+  EXPECT_EQ("test-project", admin_client->project());
 }

--- a/bigtable/admin/admin_client_test.cc
+++ b/bigtable/admin/admin_client_test.cc
@@ -25,5 +25,4 @@ TEST(AdminClientTest, Simple) {
   EXPECT_TRUE(admin_client);
   EXPECT_EQ("test-project", admin_client->project());
   EXPECT_NO_THROW(admin_client->OnFailure(grpc::Status::CANCELLED));
-  EXPECT_NO_THROW(admin_client->CreateTableAdmin("the-instance"));
 }

--- a/bigtable/admin/admin_client_test.cc
+++ b/bigtable/admin/admin_client_test.cc
@@ -17,8 +17,13 @@
 #include <gmock/gmock.h>
 
 TEST(AdminClientTest, Simple) {
+  // TODO() - this is not much of a test because the behavior is not observable.
+  // We should change the AdminClient to have a dependency injection point to
+  // at least verify it is doing something.
   auto admin_client =
       bigtable::CreateAdminClient("test-project", bigtable::ClientOptions());
   EXPECT_TRUE(admin_client);
   EXPECT_EQ("test-project", admin_client->project());
+  EXPECT_NO_THROW(admin_client->OnFailure(grpc::Status::CANCELLED));
+  EXPECT_NO_THROW(admin_client->CreateTableAdmin("the-instance"));
 }

--- a/bigtable/admin/admin_client_test.cc
+++ b/bigtable/admin/admin_client_test.cc
@@ -1,0 +1,23 @@
+//   Copyright 2017 Google Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+#include "bigtable/admin/admin_client.h"
+
+#include <gmock/gmock.h>
+
+TEST(AdminClientTest, Simple) {
+  auto admin_client =
+      bigtable::CreateAdminClient("test-project", bigtable::ClientOptions());
+  EXPECT_TRUE(admin_client);
+}

--- a/bigtable/admin/admin_client_test.cc
+++ b/bigtable/admin/admin_client_test.cc
@@ -24,5 +24,5 @@ TEST(AdminClientTest, Simple) {
       bigtable::CreateAdminClient("test-project", bigtable::ClientOptions());
   EXPECT_TRUE(admin_client);
   EXPECT_EQ("test-project", admin_client->project());
-  EXPECT_NO_THROW(admin_client->OnFailure(grpc::Status::CANCELLED));
+  EXPECT_NO_THROW(admin_client->on_completion(grpc::Status::CANCELLED));
 }

--- a/bigtable/admin/admin_client_test.cc
+++ b/bigtable/admin/admin_client_test.cc
@@ -24,5 +24,7 @@ TEST(AdminClientTest, Simple) {
       bigtable::CreateAdminClient("test-project", bigtable::ClientOptions());
   EXPECT_TRUE(admin_client);
   EXPECT_EQ("test-project", admin_client->project());
+  EXPECT_NO_THROW(admin_client->table_admin());
   EXPECT_NO_THROW(admin_client->on_completion(grpc::Status::CANCELLED));
+  EXPECT_NO_THROW(admin_client->table_admin());
 }

--- a/bigtable/admin/admin_client_test.cc
+++ b/bigtable/admin/admin_client_test.cc
@@ -1,16 +1,16 @@
-//   Copyright 2017 Google Inc.
+// Copyright 2017 Google Inc.
 //
-//   Licensed under the Apache License, Version 2.0 (the "License");
-//   you may not use this file except in compliance with the License.
-//   You may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, software
-//   distributed under the License is distributed on an "AS IS" BASIS,
-//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//   See the License for the specific language governing permissions and
-//   limitations under the License.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "bigtable/admin/admin_client.h"
 

--- a/bigtable/admin/table_admin.cc
+++ b/bigtable/admin/table_admin.cc
@@ -61,6 +61,7 @@ std::vector<::google::bigtable::admin::v2::Table> TableAdmin::ListTables(
     }
     page_token = std::move(*request.mutable_page_token());
     if (not rpc_policy->on_failure(status)) {
+      // TODO(#35) - implement non-throwing version of this class.
       throw std::runtime_error("could not fetch all tables");
     }
     auto delay = backoff_policy->on_completion(status);

--- a/bigtable/admin/table_admin.cc
+++ b/bigtable/admin/table_admin.cc
@@ -16,16 +16,14 @@
 
 #include <thread>
 
+#include <absl/strings/str_cat.h>
+
 namespace btproto = ::google::bigtable::admin::v2;
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 std::string TableAdmin::CreateInstanceName() const {
-  std::string result("projects/");
-  result += client_->project();
-  result += "/instances/";
-  result += instance_id_;
-  return result;
+  return absl::StrCat("projects/", client_->project(), "/instances/", instance_id_);
 }
 
 std::vector<::google::bigtable::admin::v2::Table> TableAdmin::ListTables(

--- a/bigtable/admin/table_admin.cc
+++ b/bigtable/admin/table_admin.cc
@@ -23,7 +23,8 @@ namespace btproto = ::google::bigtable::admin::v2;
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 std::string TableAdmin::CreateInstanceName() const {
-  return absl::StrCat("projects/", client_->project(), "/instances/", instance_id_);
+  return absl::StrCat("projects/", client_->project(), "/instances/",
+                      instance_id_);
 }
 
 std::vector<::google::bigtable::admin::v2::Table> TableAdmin::ListTables(

--- a/bigtable/admin/table_admin.cc
+++ b/bigtable/admin/table_admin.cc
@@ -20,7 +20,6 @@ namespace btproto = ::google::bigtable::admin::v2;
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-
 std::string TableAdmin::CreateInstanceName() const {
   std::string result("projects/");
   result += client_->project();

--- a/bigtable/admin/table_admin.cc
+++ b/bigtable/admin/table_admin.cc
@@ -29,7 +29,7 @@ std::string TableAdmin::CreateInstanceName() const {
 }
 
 std::vector<::google::bigtable::admin::v2::Table> TableAdmin::ListTables(
-    google::bigtable::admin::v2::Table::View view) {
+    ::google::bigtable::admin::v2::Table::View view) {
   // Copy the policies in effect for the operation.
   auto rpc_policy = rpc_retry_policy_->clone();
   auto backoff_policy = rpc_backoff_policy_->clone();

--- a/bigtable/admin/table_admin.cc
+++ b/bigtable/admin/table_admin.cc
@@ -1,0 +1,29 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/admin/table_admin.h"
+
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+
+std::string TableAdmin::CreateInstanceName() const {
+  std::string result("/projects/");
+  result += client_->project();
+  result += "/instances/";
+  result += instance_id_;
+  return result;
+}
+
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable

--- a/bigtable/admin/table_admin.cc
+++ b/bigtable/admin/table_admin.cc
@@ -49,7 +49,7 @@ std::vector<::google::bigtable::admin::v2::Table> TableAdmin::ListTables(
     backoff_policy->setup(client_context);
     grpc::Status status =
         client_->table_admin().ListTables(&client_context, request, &response);
-    client_->OnFailure(status);
+    client_->on_completion(status);
     if (status.ok()) {
       for (auto& table : response.tables()) {
         result.emplace_back(std::move(table));
@@ -60,6 +60,7 @@ std::vector<::google::bigtable::admin::v2::Table> TableAdmin::ListTables(
       page_token = std::move(*response.mutable_next_page_token());
       continue;
     }
+    page_token = std::move(*request.mutable_page_token());
     if (not rpc_policy->on_failure(status)) {
       throw std::runtime_error("could not fetch all tables");
     }

--- a/bigtable/admin/table_admin.cc
+++ b/bigtable/admin/table_admin.cc
@@ -14,14 +14,59 @@
 
 #include "bigtable/admin/table_admin.h"
 
+#include <thread>
+
+namespace btproto = ::google::bigtable::admin::v2;
+
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 
 std::string TableAdmin::CreateInstanceName() const {
-  std::string result("/projects/");
+  std::string result("projects/");
   result += client_->project();
   result += "/instances/";
   result += instance_id_;
+  return result;
+}
+
+std::vector<::google::bigtable::admin::v2::Table> TableAdmin::ListTables(
+    google::bigtable::admin::v2::Table::View view) {
+  // Copy the policies in effect for the operation.
+  auto rpc_policy = rpc_retry_policy_->clone();
+  auto backoff_policy = rpc_backoff_policy_->clone();
+
+  // Build the RPC request, try to minimize copying.
+  std::vector<btproto::Table> result;
+  std::string page_token;
+  while (true) {
+    btproto::ListTablesRequest request;
+    request.set_page_token(std::move(page_token));
+    request.set_parent(instance_name());
+    request.set_view(view);
+
+    btproto::ListTablesResponse response;
+    grpc::ClientContext client_context;
+    rpc_policy->setup(client_context);
+    backoff_policy->setup(client_context);
+    grpc::Status status =
+        client_->table_admin().ListTables(&client_context, request, &response);
+    client_->OnFailure(status);
+    if (status.ok()) {
+      for (auto& table : response.tables()) {
+        result.emplace_back(std::move(table));
+      }
+      if (response.next_page_token().empty()) {
+        break;
+      }
+      page_token = std::move(*response.mutable_next_page_token());
+      continue;
+    }
+    if (not rpc_policy->on_failure(status)) {
+      throw std::runtime_error("could not fetch all tables");
+    }
+    auto delay = backoff_policy->on_completion(status);
+    std::this_thread::sleep_for(delay);
+  }
   return result;
 }
 

--- a/bigtable/admin/table_admin.h
+++ b/bigtable/admin/table_admin.h
@@ -1,0 +1,88 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_ADMIN_TABLE_ADMIN_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_ADMIN_TABLE_ADMIN_H_
+
+#include "bigtable/admin/admin_client.h"
+
+#include <memory>
+
+#include "bigtable/client/rpc_backoff_policy.h"
+#include "bigtable/client/rpc_retry_policy.h"
+
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+/**
+ * Implements the API to administer tables instance a Cloud Bigtable instance.
+ */
+class TableAdmin {
+ public:
+  /**
+   * @param client the interface to create grpc stubs, report errors, etc.
+   * @param instance_id the id of the instance, e.g., "my-instance", the full
+   *   name (e.g. '/projects/my-project/instances/my-instance') is built using
+   *   the project id in the @p client parameter.
+   */
+  TableAdmin(std::shared_ptr<AdminClient> client, std::string instance_id)
+      : client_(client),
+        instance_id_(std::move(instance_id)),
+        instance_name_(CreateInstanceName()),
+        rpc_retry_policy_(DefaultRPCRetryPolicy()),
+        rpc_backoff_policy_(DefaultRPCBackoffPolicy()) {}
+
+  /**
+   * Create a new TableAdmin using explicit policies to handle RPC errors.
+   *
+   * @tparam RPCRetryPolicy control which operations to retry and for how long.
+   * @tparam RPCBackoffPolicy control how does the client backs off after an RPC
+   *     error.
+   * @param
+   */
+  template <typename RPCRetryPolicy, typename RPCBackoffPolicy>
+  TableAdmin(std::shared_ptr<AdminClient> client, std::string instance_id,
+             RPCRetryPolicy retry_policy, RPCBackoffPolicy backoff_policy)
+      : client_(client),
+        instance_id_(std::move(instance_id)),
+        instance_name_(CreateInstanceName()),
+        rpc_retry_policy_(retry_policy.clone()),
+        rpc_backoff_policy_(backoff_policy.clone()) {}
+
+  absl::string_view instance_id() const { return instance_id_; }
+  absl::string_view instance_name() const { return instance_name_; }
+
+  /**
+   * Return all the tables in the instance.
+   *
+   * @param view define what
+   * @return
+   */
+  std::vector<google::bigtable::admin::v2::Table> ListTables(
+      google::bigtable::admin::v2::Table::View view);
+
+ private:
+  std::string CreateInstanceName() const;
+
+ private:
+  std::shared_ptr<AdminClient> client_;
+  std::string instance_id_;
+  std::string instance_name_;
+  std::unique_ptr<RPCRetryPolicy> rpc_retry_policy_;
+  std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy_;
+};
+
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_ADMIN_TABLE_ADMIN_H_

--- a/bigtable/admin/table_admin.h
+++ b/bigtable/admin/table_admin.h
@@ -70,8 +70,11 @@ class TableAdmin {
   /**
    * Return all the tables in the instance.
    *
-   * @param view define what
-   * @return
+   * @param view define what information about the tables is retrieved.
+   *   - VIEW_UNSPECIFIED: equivalent to VIEW_SCHEMA.
+   *   - NAME: return only the name of the table.
+   *   - VIEW_SCHEMA: return the name and the schema.
+   *   - FULL: return all the information about the table.
    */
   std::vector<::google::bigtable::admin::v2::Table> ListTables(
       ::google::bigtable::admin::v2::Table::View view);

--- a/bigtable/admin/table_admin.h
+++ b/bigtable/admin/table_admin.h
@@ -48,7 +48,12 @@ class TableAdmin {
    * @tparam RPCRetryPolicy control which operations to retry and for how long.
    * @tparam RPCBackoffPolicy control how does the client backs off after an RPC
    *     error.
-   * @param
+   * @param client the interface to create grpc stubs, report errors, etc.
+   * @param instance_id the id of the instance, e.g., "my-instance", the full
+   *   name (e.g. '/projects/my-project/instances/my-instance') is built using
+   *   the project id in the @p client parameter.
+   * @param retry_policy the policy to handle RPC errors.
+   * @param backoff_policy the policy to control backoff after an error.
    */
   template <typename RPCRetryPolicy, typename RPCBackoffPolicy>
   TableAdmin(std::shared_ptr<AdminClient> client, std::string instance_id,

--- a/bigtable/admin/table_admin.h
+++ b/bigtable/admin/table_admin.h
@@ -59,8 +59,8 @@ class TableAdmin {
         rpc_retry_policy_(retry_policy.clone()),
         rpc_backoff_policy_(backoff_policy.clone()) {}
 
-  absl::string_view instance_id() const { return instance_id_; }
-  absl::string_view instance_name() const { return instance_name_; }
+  std::string const& instance_id() const { return instance_id_; }
+  std::string const& instance_name() const { return instance_name_; }
 
   /**
    * Return all the tables in the instance.

--- a/bigtable/admin/table_admin.h
+++ b/bigtable/admin/table_admin.h
@@ -73,8 +73,8 @@ class TableAdmin {
    * @param view define what
    * @return
    */
-  std::vector<google::bigtable::admin::v2::Table> ListTables(
-      google::bigtable::admin::v2::Table::View view);
+  std::vector<::google::bigtable::admin::v2::Table> ListTables(
+      ::google::bigtable::admin::v2::Table::View view);
 
  private:
   std::string CreateInstanceName() const;

--- a/bigtable/admin/table_admin_test.cc
+++ b/bigtable/admin/table_admin_test.cc
@@ -154,8 +154,8 @@ TEST_F(TableAdminTest, ListTablesUnrecoverableFailures) {
   };
   EXPECT_CALL(*table_admin_stub_, ListTables(_, _, _))
       .WillOnce(Invoke(mock_unrecoverable_failure));
-  // We expect the TableAdmin to make 5 calls and to let the client know about
-  // them.
+  // We expect the TableAdmin to make a call to let the client know the request
+  // failed.
   EXPECT_CALL(*client_, on_completion(_)).Times(1);
 
   // After all the setup, make the actual call we want to test.

--- a/bigtable/admin/table_admin_test.cc
+++ b/bigtable/admin/table_admin_test.cc
@@ -78,12 +78,10 @@ TEST_F(TableAdminTest, ListTables) {
     EXPECT_NE(nullptr, response);
 
     auto& t0 = *response->add_tables();
-    t0.set_name(
-        "projects/the-project/instances/the-instance/tables/t0");
+    t0.set_name("projects/the-project/instances/the-instance/tables/t0");
     t0.set_granularity(btproto::Table::MILLIS);
     auto& t1 = *response->add_tables();
-    t1.set_name(
-        "projects/the-project/instances/the-instance/tables/t1");
+    t1.set_name("projects/the-project/instances/the-instance/tables/t1");
     t1.set_granularity(btproto::Table::MILLIS);
     response->set_next_page_token("");
     return grpc::Status::OK;

--- a/bigtable/admin/table_admin_test.cc
+++ b/bigtable/admin/table_admin_test.cc
@@ -56,9 +56,8 @@ class TableAdminTest : public ::testing::Test {
 auto create_list_tables_lambda = [](std::string expected_token,
                                     std::string returned_token) {
   return [expected_token, returned_token](
-             grpc::ClientContext* ctx,
-             btproto::ListTablesRequest const& request,
-             btproto::ListTablesResponse* response) {
+      grpc::ClientContext* ctx, btproto::ListTablesRequest const& request,
+      btproto::ListTablesResponse* response) {
     EXPECT_EQ("projects/the-project/instances/the-instance", request.parent());
     EXPECT_EQ(btproto::Table::FULL, request.view());
     EXPECT_EQ(expected_token, request.page_token());

--- a/bigtable/admin/table_admin_test.cc
+++ b/bigtable/admin/table_admin_test.cc
@@ -1,16 +1,16 @@
-//   Copyright 2017 Google Inc.
+// Copyright 2017 Google Inc.
 //
-//   Licensed under the Apache License, Version 2.0 (the "License");
-//   you may not use this file except in compliance with the License.
-//   You may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, software
-//   distributed under the License is distributed on an "AS IS" BASIS,
-//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//   See the License for the specific language governing permissions and
-//   limitations under the License.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "bigtable/admin/table_admin.h"
 

--- a/bigtable/admin/table_admin_test.cc
+++ b/bigtable/admin/table_admin_test.cc
@@ -1,0 +1,42 @@
+//   Copyright 2017 Google Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+#include "bigtable/admin/table_admin.h"
+
+#include <gmock/gmock.h>
+
+namespace {
+class MockAdminClient : public bigtable::AdminClient {
+ public:
+  MOCK_CONST_METHOD0(project, std::string const&());
+  MOCK_METHOD1(OnFailure, void(grpc::Status const& status));
+  MOCK_METHOD0(
+      table_admin,
+      ::google::bigtable::admin::v2::BigtableTableAdmin::StubInterface&());
+};
+}  // namespace
+
+/// @test Verify basic functionality in the bigtable::TableAdmin class.
+TEST(TableAdmin, Simple) {
+  using namespace ::testing;
+  std::string const project_id = "the-project";
+
+  auto client = std::make_shared<MockAdminClient>();
+  EXPECT_CALL(*client, project())
+      .WillRepeatedly(ReturnRef(project_id));
+  bigtable::TableAdmin tested(client, "the-instance");
+  EXPECT_EQ("the-instance", tested.instance_id());
+  EXPECT_EQ("/projects/the-project/instances/the-instance",
+            tested.instance_name());
+}

--- a/bigtable/admin/table_admin_test.cc
+++ b/bigtable/admin/table_admin_test.cc
@@ -16,27 +16,84 @@
 
 #include <gmock/gmock.h>
 
+#include <google/bigtable/admin/v2/bigtable_table_admin_mock.grpc.pb.h>
+
+#include <absl/memory/memory.h>
+
 namespace {
+namespace btproto = ::google::bigtable::admin::v2;
+
 class MockAdminClient : public bigtable::AdminClient {
  public:
   MOCK_CONST_METHOD0(project, std::string const&());
   MOCK_METHOD1(OnFailure, void(grpc::Status const& status));
-  MOCK_METHOD0(
-      table_admin,
-      ::google::bigtable::admin::v2::BigtableTableAdmin::StubInterface&());
+  MOCK_METHOD0(table_admin, btproto::BigtableTableAdmin::StubInterface&());
 };
+
+/// A fixture for the bigtable::TableAdmin tests.
+class TableAdminTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    using namespace ::testing;
+
+    EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(project_id_));
+    EXPECT_CALL(*client_, table_admin())
+        .WillRepeatedly(
+            Invoke([this]() -> btproto::BigtableTableAdmin::StubInterface& {
+              return *table_admin_stub_;
+            }));
+  }
+
+  std::string const project_id_ = "the-project";
+  std::shared_ptr<MockAdminClient> client_ =
+      std::make_shared<MockAdminClient>();
+  std::unique_ptr<btproto::MockBigtableTableAdminStub> table_admin_stub_ =
+      absl::make_unique<btproto::MockBigtableTableAdminStub>();
+};
+
 }  // namespace
 
 /// @test Verify basic functionality in the bigtable::TableAdmin class.
-TEST(TableAdmin, Simple) {
+TEST_F(TableAdminTest, Simple) {
   using namespace ::testing;
-  std::string const project_id = "the-project";
 
-  auto client = std::make_shared<MockAdminClient>();
-  EXPECT_CALL(*client, project())
-      .WillRepeatedly(ReturnRef(project_id));
-  bigtable::TableAdmin tested(client, "the-instance");
+  bigtable::TableAdmin tested(client_, "the-instance");
   EXPECT_EQ("the-instance", tested.instance_id());
-  EXPECT_EQ("/projects/the-project/instances/the-instance",
+  EXPECT_EQ("projects/the-project/instances/the-instance",
             tested.instance_name());
+}
+
+/// @test Verify that bigtable::TableAdmin::ListTables works in the easy case.
+TEST_F(TableAdminTest, ListTables) {
+  using namespace ::testing;
+
+  bigtable::TableAdmin tested(client_, "the-instance");
+  auto mock_list_tables = [](grpc::ClientContext* ctx,
+                             btproto::ListTablesRequest const& request,
+                             btproto::ListTablesResponse* response) {
+
+    EXPECT_EQ("projects/the-project/instances/the-instance", request.parent());
+    EXPECT_EQ(btproto::Table::FULL, request.view());
+    EXPECT_TRUE(request.page_token().empty());
+    EXPECT_NE(nullptr, response);
+
+    auto& t0 = *response->add_tables();
+    t0.set_name(
+        "projects/the-project/instances/the-instance/tables/t0");
+    t0.set_granularity(btproto::Table::MILLIS);
+    auto& t1 = *response->add_tables();
+    t1.set_name(
+        "projects/the-project/instances/the-instance/tables/t1");
+    t1.set_granularity(btproto::Table::MILLIS);
+    response->set_next_page_token("");
+    return grpc::Status::OK;
+  };
+  EXPECT_CALL(*table_admin_stub_, ListTables(_, _, _))
+      .WillOnce(Invoke(mock_list_tables));
+  auto actual = tested.ListTables(btproto::Table::FULL);
+
+  std::string instance_name = static_cast<std::string>(tested.instance_name());
+  ASSERT_EQ(2UL, actual.size());
+  EXPECT_EQ(instance_name + "/tables/t0", actual[0].name());
+  EXPECT_EQ(instance_name + "/tables/t1", actual[1].name());
 }

--- a/bigtable/client/client_options.cc
+++ b/bigtable/client/client_options.cc
@@ -15,14 +15,15 @@
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-// TODO() resolve issue #52
 ClientOptions::ClientOptions() {
   char const* emulator = std::getenv("BIGTABLE_EMULATOR_HOST");
   if (emulator != nullptr) {
-    endpoint_ = emulator;
+    data_endpoint_ = emulator;
+    admin_endpoint_ = emulator;
     credentials_ = grpc::InsecureChannelCredentials();
   } else {
-    endpoint_ = "bigtable.googleapis.com";
+    data_endpoint_ = "bigtable.googleapis.com";
+    admin_endpoint_ = "bigtableadmin.googleapis.com";
     credentials_ = grpc::GoogleDefaultCredentials();
   }
   channel_arguments_ = grpc::ChannelArguments();

--- a/bigtable/client/client_options.h
+++ b/bigtable/client/client_options.h
@@ -15,6 +15,8 @@
 #ifndef BIGTABLE_CLIENT_CLIENTOPTIONS_H_
 #define BIGTABLE_CLIENT_CLIENTOPTIONS_H_
 
+#include "bigtable/client/version.h"
+
 #include <grpc++/grpc++.h>
 
 namespace bigtable {

--- a/bigtable/client/client_options.h
+++ b/bigtable/client/client_options.h
@@ -31,11 +31,22 @@ inline namespace BIGTABLE_CLIENT_NS {
 class ClientOptions {
  public:
   ClientOptions();
-  const std::string& endpoint() const { return endpoint_; }
-  ClientOptions& SetEndpoint(const std::string& endpoint) {
-    endpoint_ = endpoint;
+
+  /// Return the current endpoint for data RPCs.
+  const std::string& data_endpoint() const { return data_endpoint_; }
+  ClientOptions& SetDataEndpoint(std::string endpoint) {
+    data_endpoint_ = std::move(endpoint);
     return *this;
   }
+
+  /// Return the current endpoint for admin RPCs.
+  const std::string& admin_endpoint() const { return admin_endpoint_; }
+  ClientOptions& SetAdminEndpoint(std::string endpoint) {
+    admin_endpoint_ = std::move(endpoint);
+    return *this;
+  }
+
+  /// Return the current credentials.
   std::shared_ptr<grpc::ChannelCredentials> credentials() const {
     return credentials_;
   }
@@ -44,7 +55,8 @@ class ClientOptions {
     credentials_ = credentials;
     return *this;
   }
-  // TODO() create setter/getter for each channel argument. Issue #53
+
+  // TODO(#53) create setter/getter for each channel argument.
   const grpc::ChannelArguments channel_arguments() const {
     return channel_arguments_;
   }
@@ -54,8 +66,8 @@ class ClientOptions {
   }
 
  private:
-  // Endpoint here stands for data endpoint for fetching data.
-  std::string endpoint_;
+  std::string data_endpoint_;
+  std::string admin_endpoint_;
   std::shared_ptr<grpc::ChannelCredentials> credentials_;
   grpc::ChannelArguments channel_arguments_;
 };

--- a/bigtable/client/client_options.h
+++ b/bigtable/client/client_options.h
@@ -36,14 +36,14 @@ class ClientOptions {
 
   /// Return the current endpoint for data RPCs.
   const std::string& data_endpoint() const { return data_endpoint_; }
-  ClientOptions& SetDataEndpoint(std::string endpoint) {
+  ClientOptions& set_data_endpoint(std::string endpoint) {
     data_endpoint_ = std::move(endpoint);
     return *this;
   }
 
   /// Return the current endpoint for admin RPCs.
   const std::string& admin_endpoint() const { return admin_endpoint_; }
-  ClientOptions& SetAdminEndpoint(std::string endpoint) {
+  ClientOptions& set_admin_endpoint(std::string endpoint) {
     admin_endpoint_ = std::move(endpoint);
     return *this;
   }
@@ -62,7 +62,8 @@ class ClientOptions {
   const grpc::ChannelArguments channel_arguments() const {
     return channel_arguments_;
   }
-  ClientOptions& SetChannelArguments(grpc::ChannelArguments channel_arguments) {
+  ClientOptions& set_channel_arguments(
+      grpc::ChannelArguments channel_arguments) {
     channel_arguments_ = channel_arguments;
     return *this;
   }

--- a/bigtable/client/client_options_test.cc
+++ b/bigtable/client/client_options_test.cc
@@ -34,6 +34,7 @@ class ClientOptionsEmulatorTest : public ::testing::Test {
     setenv("BIGTABLE_EMULATOR_HOST", "testendpoint.googleapis.com", 1);
   }
   void TearDown() override {
+    // TODO(#100) - setenv()/unsetenv() are a Unix specific calls.
     if (previous_) {
       setenv("BIGTABLE_EMULATOR_HOST", previous_, 1);
     } else {
@@ -46,7 +47,7 @@ class ClientOptionsEmulatorTest : public ::testing::Test {
 };
 }  // anonymous namespace
 
-TEST_F(ClientOptionsEmulatorTest, Simple) {
+TEST_F(ClientOptionsEmulatorTest, Default) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   EXPECT_EQ("testendpoint.googleapis.com",
             client_options_object.data_endpoint());
@@ -56,7 +57,7 @@ TEST_F(ClientOptionsEmulatorTest, Simple) {
             typeid(client_options_object.credentials()));
 }
 
-TEST(ClientOptionsTest, EditEndpoint) {
+TEST(ClientOptionsTest, EditDataEndpoint) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   client_options_object =
       client_options_object.set_data_endpoint("customendpoint.com");

--- a/bigtable/client/client_options_test.cc
+++ b/bigtable/client/client_options_test.cc
@@ -29,7 +29,7 @@ namespace {
 class ClientOptionsEmulatorTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    // TODO(#23) - setenv() is a Unix specific call ...
+    // TODO(#100) - setenv() is a Unix specific call ...
     setenv("BIGTABLE_EMULATOR_HOST", "testendpoint.googleapis.com", 1);
     previous_ = std::getenv("BIGTABLE_EMULATOR_HOST");
   }

--- a/bigtable/client/client_options_test.cc
+++ b/bigtable/client/client_options_test.cc
@@ -33,9 +33,7 @@ class ClientOptionsEmulatorTest : public ::testing::Test {
     setenv("BIGTABLE_EMULATOR_HOST", "testendpoint.googleapis.com", 1);
     previous_ = std::getenv("BIGTABLE_EMULATOR_HOST");
   }
-  void TearDown() override {
-    unsetenv("BIGTABLE_EMULATOR_HOST");
-  }
+  void TearDown() override { unsetenv("BIGTABLE_EMULATOR_HOST"); }
 
  protected:
   char const *previous_ = nullptr;

--- a/bigtable/client/client_options_test.cc
+++ b/bigtable/client/client_options_test.cc
@@ -25,9 +25,24 @@ TEST(ClientOptionsTest, ClientOptionsDefaultSettings) {
             typeid(client_options_object.credentials()));
 }
 
-TEST(ClientOptionsTest, ClientOptionsCustomEndpoint) {
-  // TODO(#23) - setenv() is a Unix specific call ...
-  setenv("BIGTABLE_EMULATOR_HOST", "testendpoint.googleapis.com", 1);
+namespace {
+class ClientOptionsEmulatorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // TODO(#23) - setenv() is a Unix specific call ...
+    setenv("BIGTABLE_EMULATOR_HOST", "testendpoint.googleapis.com", 1);
+    previous_ = std::getenv("BIGTABLE_EMULATOR_HOST");
+  }
+  void TearDown() override {
+    unsetenv("BIGTABLE_EMULATOR_HOST");
+  }
+
+ protected:
+  char const *previous_ = nullptr;
+};
+}  // anonymous namespace
+
+TEST_F(ClientOptionsEmulatorTest, Simple) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   EXPECT_EQ("testendpoint.googleapis.com",
             client_options_object.data_endpoint());
@@ -35,7 +50,6 @@ TEST(ClientOptionsTest, ClientOptionsCustomEndpoint) {
             client_options_object.admin_endpoint());
   EXPECT_EQ(typeid(grpc::InsecureChannelCredentials()),
             typeid(client_options_object.credentials()));
-  unsetenv("BIGTABLE_EMULATOR_HOST");
 }
 
 TEST(ClientOptionsTest, EditEndpoint) {

--- a/bigtable/client/client_options_test.cc
+++ b/bigtable/client/client_options_test.cc
@@ -29,11 +29,17 @@ namespace {
 class ClientOptionsEmulatorTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    // TODO(#100) - setenv() is a Unix specific call ...
-    setenv("BIGTABLE_EMULATOR_HOST", "testendpoint.googleapis.com", 1);
+    // TODO(#100) - setenv() is a Unix specific call.
     previous_ = std::getenv("BIGTABLE_EMULATOR_HOST");
+    setenv("BIGTABLE_EMULATOR_HOST", "testendpoint.googleapis.com", 1);
   }
-  void TearDown() override { unsetenv("BIGTABLE_EMULATOR_HOST"); }
+  void TearDown() override {
+    if (previous_) {
+      setenv("BIGTABLE_EMULATOR_HOST", previous_, 1);
+    } else {
+      unsetenv("BIGTABLE_EMULATOR_HOST");
+    }
+  }
 
  protected:
   char const *previous_ = nullptr;
@@ -53,14 +59,14 @@ TEST_F(ClientOptionsEmulatorTest, Simple) {
 TEST(ClientOptionsTest, EditEndpoint) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   client_options_object =
-      client_options_object.SetDataEndpoint("customendpoint.com");
+      client_options_object.set_data_endpoint("customendpoint.com");
   EXPECT_EQ("customendpoint.com", client_options_object.data_endpoint());
 }
 
 TEST(ClientOptionsTest, EditAdminEndpoint) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   client_options_object =
-      client_options_object.SetAdminEndpoint("customendpoint.com");
+      client_options_object.set_admin_endpoint("customendpoint.com");
   EXPECT_EQ("customendpoint.com", client_options_object.admin_endpoint());
 }
 

--- a/bigtable/client/client_options_test.cc
+++ b/bigtable/client/client_options_test.cc
@@ -18,15 +18,21 @@
 
 TEST(ClientOptionsTest, ClientOptionsDefaultSettings) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
-  EXPECT_EQ("bigtable.googleapis.com", client_options_object.endpoint());
+  EXPECT_EQ("bigtable.googleapis.com", client_options_object.data_endpoint());
+  EXPECT_EQ("bigtableadmin.googleapis.com",
+            client_options_object.admin_endpoint());
   EXPECT_EQ(typeid(grpc::GoogleDefaultCredentials()),
             typeid(client_options_object.credentials()));
 }
 
 TEST(ClientOptionsTest, ClientOptionsCustomEndpoint) {
+  // TODO(#23) - setenv() is a Unix specific call ...
   setenv("BIGTABLE_EMULATOR_HOST", "testendpoint.googleapis.com", 1);
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
-  EXPECT_EQ("testendpoint.googleapis.com", client_options_object.endpoint());
+  EXPECT_EQ("testendpoint.googleapis.com",
+            client_options_object.data_endpoint());
+  EXPECT_EQ("testendpoint.googleapis.com",
+            client_options_object.admin_endpoint());
   EXPECT_EQ(typeid(grpc::InsecureChannelCredentials()),
             typeid(client_options_object.credentials()));
   unsetenv("BIGTABLE_EMULATOR_HOST");
@@ -35,8 +41,15 @@ TEST(ClientOptionsTest, ClientOptionsCustomEndpoint) {
 TEST(ClientOptionsTest, EditEndpoint) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   client_options_object =
-      client_options_object.SetEndpoint("customendpoint.com");
-  EXPECT_EQ("customendpoint.com", client_options_object.endpoint());
+      client_options_object.SetDataEndpoint("customendpoint.com");
+  EXPECT_EQ("customendpoint.com", client_options_object.data_endpoint());
+}
+
+TEST(ClientOptionsTest, EditAdminEndpoint) {
+  bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
+  client_options_object =
+      client_options_object.SetAdminEndpoint("customendpoint.com");
+  EXPECT_EQ("customendpoint.com", client_options_object.admin_endpoint());
 }
 
 TEST(ClientOptionsTest, EditCredentials) {

--- a/bigtable/client/data.h
+++ b/bigtable/client/data.h
@@ -47,7 +47,7 @@ class Client : public ClientInterface {
         instance_(instance),
         credentials_(options.credentials()),
         channel_(
-            grpc::CreateChannel(options.endpoint(), options.credentials())),
+            grpc::CreateChannel(options.data_endpoint(), options.credentials())),
         bt_stub_(google::bigtable::v2::Bigtable::NewStub(channel_)) {}
 
   Client(const std::string& project, const std::string& instance)

--- a/bigtable/doc/Doxyfile
+++ b/bigtable/doc/Doxyfile
@@ -119,7 +119,7 @@ WARN_LOGFILE           =
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
 
-INPUT                  = README.md doc client
+INPUT                  = README.md doc client admin
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.h *.cc *.md *.proto
 RECURSIVE              = YES

--- a/cmake/IncludeAbseil.cmake
+++ b/cmake/IncludeAbseil.cmake
@@ -1,0 +1,41 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(${PROJECT_SOURCE_DIR}/cmake/IncludeCctz.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/IncludeGMock.cmake)
+
+set(GOOGLE_CLOUD_CPP_ABSEIL_PROVIDER "module" CACHE STRING "How to find the abseil libraries")
+set_property(CACHE GOOGLE_CLOUD_CPP_ABSEIL_PROVIDER PROPERTY STRINGS "module" "package")
+
+if ("${GOOGLE_CLOUD_CPP_ABSEIL_PROVIDER}" STREQUAL "module")
+    if (NOT ABSEIL_ROOT_DIR)
+        set(ABSEIL_ROOT_DIR ${PROJECT_SOURCE_DIR}/third_party/abseil)
+    endif ()
+    if (NOT EXISTS "${ABSEIL_ROOT_DIR}/CMakeLists.txt")
+        message(ERROR "GOOGLE_CLOUD_CPP_ABSEIL_PROVIDER is \"module\" but ABSEIL_ROOT_DIR is wrong")
+    endif ()
+    add_subdirectory(${ABSEIL_ROOT_DIR} third_party/abseil)
+    set(ABSEIL_LIBRARIES abseil)
+    set(ABSEIL_INCLUDE_DIRS ${ABSEIL_ROOT_DIR}/absl)
+elseif ("${GOOGLE_CLOUD_CPP_ABSEIL_PROVIDER}" STREQUAL "package")
+    if (WIN32)
+        # On Windows we will probably use the vcpkg port (github.com/Microsoft/vcpkg).
+        message(ERROR "TODO() - configure abseil under Windows")
+    else ()
+        # Use pkg-config on Unix and macOS.
+        include(FindPkgConfig)
+        pkg_check_modules(ABSEIL REQUIRED abseil)
+        link_directories(${ABSEIL_LIBRARY_DIRS})
+    endif ()
+endif ()

--- a/cmake/IncludeAbseil.cmake
+++ b/cmake/IncludeAbseil.cmake
@@ -27,7 +27,7 @@ if ("${GOOGLE_CLOUD_CPP_ABSEIL_PROVIDER}" STREQUAL "module")
     endif ()
     add_subdirectory(${ABSEIL_ROOT_DIR} third_party/abseil)
     set(ABSEIL_LIBRARIES abseil)
-    set(ABSEIL_INCLUDE_DIRS ${ABSEIL_ROOT_DIR}/absl)
+    set(ABSEIL_INCLUDE_DIRS ${ABSEIL_ROOT_DIR})
 elseif ("${GOOGLE_CLOUD_CPP_ABSEIL_PROVIDER}" STREQUAL "package")
     if (WIN32)
         # On Windows we will probably use the vcpkg port (github.com/Microsoft/vcpkg).

--- a/cmake/IncludeCctz.cmake
+++ b/cmake/IncludeCctz.cmake
@@ -22,6 +22,10 @@ if ("${GOOGLE_CLOUD_CPP_CCTZ_PROVIDER}" STREQUAL "module")
     if (NOT EXISTS "${CCTZ_ROOT_DIR}/CMakeLists.txt")
         message(ERROR "GOOGLE_CLOUD_CPP_CCTZ_PROVIDER is \"module\" but CCTZ_ROOT_DIR is wrong")
     endif ()
+    # cctz will include the `CTest` module and always compile the cctz tests, we want to disable that.  The only way is
+    # to include the module first, disable the tests, and then include the cctz CMakeLists.txt files.
+    include(CTest)
+    set(BUILD_TESTING OFF)
     add_subdirectory(${CCTZ_ROOT_DIR} third_party/cctz)
     set(CCTZ_LIBRARIES cctz)
     set(CCTZ_INCLUDE_DIRS ${CCTZ_ROOT_DIR}/absl)

--- a/cmake/IncludeCctz.cmake
+++ b/cmake/IncludeCctz.cmake
@@ -1,0 +1,38 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(GOOGLE_CLOUD_CPP_CCTZ_PROVIDER "module" CACHE STRING "How to find the cctz libraries")
+set_property(CACHE GOOGLE_CLOUD_CPP_CCTZ_PROVIDER PROPERTY STRINGS "module" "package")
+
+if ("${GOOGLE_CLOUD_CPP_CCTZ_PROVIDER}" STREQUAL "module")
+    if (NOT CCTZ_ROOT_DIR)
+        set(CCTZ_ROOT_DIR ${PROJECT_SOURCE_DIR}/third_party/cctz)
+    endif ()
+    if (NOT EXISTS "${CCTZ_ROOT_DIR}/CMakeLists.txt")
+        message(ERROR "GOOGLE_CLOUD_CPP_CCTZ_PROVIDER is \"module\" but CCTZ_ROOT_DIR is wrong")
+    endif ()
+    add_subdirectory(${CCTZ_ROOT_DIR} third_party/cctz)
+    set(CCTZ_LIBRARIES cctz)
+    set(CCTZ_INCLUDE_DIRS ${CCTZ_ROOT_DIR}/absl)
+elseif ("${GOOGLE_CLOUD_CPP_CCTZ_PROVIDER}" STREQUAL "package")
+    if (WIN32)
+        # On Windows we will probably use the vcpkg port (github.com/Microsoft/vcpkg).
+        message(ERROR "TODO() - configure cctz under Windows")
+    else ()
+        # Use pkg-config on Unix and macOS.
+        include(FindPkgConfig)
+        pkg_check_modules(CCTZ REQUIRED cctz)
+        link_directories(${CCTZ_LIBRARY_DIRS})
+    endif ()
+endif ()

--- a/cmake/IncludeGMock.cmake
+++ b/cmake/IncludeGMock.cmake
@@ -24,4 +24,3 @@ target_include_directories(gmock
         PUBLIC ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest
         PUBLIC ${PROJECT_THIRD_PARTY_DIR}/googletest/googlemock/include
         PUBLIC ${PROJECT_THIRD_PARTY_DIR}/googletest/googlemock)
-

--- a/cmake/IncludeGMock.cmake
+++ b/cmake/IncludeGMock.cmake
@@ -1,0 +1,27 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Compile the googlemock library.  This library is rarely installed or
+# pre-compiled because it should be configured with the same flags as the
+# application.
+add_library(gmock
+        ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest/src/gtest_main.cc
+        ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest/src/gtest-all.cc
+        ${PROJECT_THIRD_PARTY_DIR}/googletest/googlemock/src/gmock-all.cc)
+target_include_directories(gmock
+        PUBLIC ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest/include
+        PUBLIC ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest
+        PUBLIC ${PROJECT_THIRD_PARTY_DIR}/googletest/googlemock/include
+        PUBLIC ${PROJECT_THIRD_PARTY_DIR}/googletest/googlemock)
+


### PR DESCRIPTION
This is part of the fixes for #79.  While this is not needed for the MVP milestone it might help us with some of our integration tests.  In this PR we just introduce the `AdminClient` and `TableAdmin` classes, and `TableAdmin` has a single `ListTables` member function.

Future PRs will introduce additional member functions to implement the full API for `TableAdmin`.
