### PR TITLE
Check coding style first if enabled.

### DIFF
--- a/ci/Dockerfile.centos
+++ b/ci/Dockerfile.centos
@@ -69,8 +69,8 @@ ARG CMAKE_FLAGS=""
 WORKDIR /var/tmp/build
 COPY . /var/tmp/build/gccpp
 
-RUN ./gccpp/ci/build-docker.sh
 RUN ./gccpp/ci/check-style.sh
+RUN ./gccpp/ci/build-docker.sh
 
 WORKDIR /var/tmp/build/gccpp/build-output/bigtable
 RUN ../../bigtable/tests/run_integration_tests.sh

--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -62,8 +62,8 @@ ARG CMAKE_FLAGS=""
 WORKDIR /var/tmp/build
 COPY . /var/tmp/build/gccpp
 
-RUN ./gccpp/ci/build-docker.sh
 RUN ./gccpp/ci/check-style.sh
+RUN ./gccpp/ci/build-docker.sh
 
 WORKDIR /var/tmp/build/gccpp/build-output/bigtable
 RUN ../../bigtable/tests/run_integration_tests.sh

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -74,8 +74,8 @@ ARG CMAKE_FLAGS=""
 WORKDIR /var/tmp/build
 COPY . /var/tmp/build/gccpp
 
-RUN ./gccpp/ci/build-docker.sh
 RUN ./gccpp/ci/check-style.sh
+RUN ./gccpp/ci/build-docker.sh
 
 WORKDIR /var/tmp/build/gccpp/build-output/bigtable
 RUN if grep -q 14.04 /etc/lsb-release; then \


### PR DESCRIPTION
No sense in waiting until the end of the build to report errors that could be reported earlier.