### PR TITLE
Enable Clang static analyzer build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
       env: DISTRO=ubuntu DISTRO_VERSION=17.04 CHECK_STYLE=yes GENERATE_DOCS=yes
     - os: linux
       compiler: clang
-      env: DISTRO=ubuntu DISTRO_VERSION=17.04 SCAN_BUILD=yes
+      env: DISTRO=ubuntu DISTRO_VERSION=17.04 BUILD_TYPE=Debug SCAN_BUILD=yes
     - os: linux
       compiler: clang
       env: DISTRO=ubuntu DISTRO_VERSION=16.04 BUILD_TYPE=Debug \

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ matrix:
       env: DISTRO=ubuntu DISTRO_VERSION=17.04 CHECK_STYLE=yes GENERATE_DOCS=yes
     - os: linux
       compiler: clang
+      env: DISTRO=ubuntu DISTRO_VERSION=17.04 SCAN_BUILD=yes
+    - os: linux
+      compiler: clang
       env: DISTRO=ubuntu DISTRO_VERSION=16.04 BUILD_TYPE=Debug \
            CMAKE_FLAGS=-DSANITIZE_ADDRESS=yes
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
     - os: linux
       compiler: clang
       env: DISTRO=ubuntu DISTRO_VERSION=17.04 BUILD_TYPE=Debug SCAN_BUILD=yes
+      if: type != pull_request
     - os: linux
       compiler: clang
       env: DISTRO=ubuntu DISTRO_VERSION=16.04 BUILD_TYPE=Debug \

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -185,6 +185,13 @@ if (CLANG_TIDY_EXE AND BIGTABLE_CLIENT_CLANG_TIDY)
     )
 endif ()
 
+# Define custom targets to simplify the scan-build scripts.
+add_custom_target(depends-local)
+add_dependencies(depends-local absl::strings gmock bigtable_protos)
+
+# All tests get added to this target below.
+add_custom_target(tests-local)
+
 # List the unit tests, then setup the targets and dependencies.
 set(bigtable_client_unit_tests
     client/cell_test.cc
@@ -208,6 +215,7 @@ foreach (fname ${bigtable_client_unit_tests})
         ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
     add_test(NAME ${tname} COMMAND ${target})
     get_target_property(sources ${target} SOURCES)
+    add_dependencies(tests-local ${target})
 endforeach ()
 
 # List the unit tests, then setup the targets and dependencies.
@@ -227,6 +235,7 @@ foreach (fname ${bigtable_admin_unit_tests})
         ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
     add_test(NAME ${tname} COMMAND ${target})
     get_target_property(sources ${target} SOURCES)
+    add_dependencies(tests-local ${target})
 endforeach ()
 
 # Create a single executable that rolls up all the tests, this is convenient
@@ -237,6 +246,7 @@ target_link_libraries(bigtable_client_all_tests
     bigtable_client_testing bigtable_admin_client bigtable_client
     bigtable_protos gmock
     ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+add_dependencies(tests-local bigtable_client_all_tests)
 
 option(FORCE_SANITIZER_ERRORS
     "If set, enable tests that force errors detected by the sanitizers."
@@ -260,3 +270,4 @@ add_executable(integration_test tests/integration_test.cc)
 target_link_libraries(integration_test
     bigtable_admin_client bigtable_client bigtable_protos
     ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+add_dependencies(tests-local apply_test)

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -270,4 +270,4 @@ add_executable(integration_test tests/integration_test.cc)
 target_link_libraries(integration_test
     bigtable_admin_client bigtable_client bigtable_protos
     ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
-add_dependencies(tests-local apply_test)
+add_dependencies(tests-local integration_test)

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -246,6 +246,14 @@ if (FORCE_SANITIZER_ERRORS)
             PRIVATE -DBIGTABLE_CLIENT_FORCE_SANITIZER_ERRORS)
 endif (FORCE_SANITIZER_ERRORS)
 
+option(FORCE_STATIC_ANALYZER_ERRORS
+    "If set enable tests that force errors detected by the static analyzer."
+    "")
+if (FORCE_STATIC_ANALYZER_ERRORS)
+    target_compile_definitions(client_force_sanitizer_failures_test
+        PRIVATE -DBIGTABLE_CLIENT_FORCE_STATIC_ANALYZER_ERRORS)
+endif (FORCE_STATIC_ANALYZER_ERRORS)
+
 # The integration tests, these are simply programs that connect to the
 # Cloud Bigtable emulator.
 add_executable(integration_test tests/integration_test.cc)

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -239,7 +239,7 @@ target_link_libraries(bigtable_client_all_tests
     ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 
 option(FORCE_SANITIZER_ERRORS
-    "If set enable tests that force errors detected by the sanitizers."
+    "If set, enable tests that force errors detected by the sanitizers."
     "")
 if (FORCE_SANITIZER_ERRORS)
     target_compile_definitions(client_force_sanitizer_failures_test
@@ -247,7 +247,7 @@ if (FORCE_SANITIZER_ERRORS)
 endif (FORCE_SANITIZER_ERRORS)
 
 option(FORCE_STATIC_ANALYZER_ERRORS
-    "If set enable tests that force errors detected by the static analyzer."
+    "If set, enable tests that force errors detected by the static analyzer."
     "")
 if (FORCE_STATIC_ANALYZER_ERRORS)
     target_compile_definitions(client_force_sanitizer_failures_test

--- a/bigtable/client/force_sanitizer_failures_test.cc
+++ b/bigtable/client/force_sanitizer_failures_test.cc
@@ -17,6 +17,19 @@
 /// @test a trivial test to keep the compiler happy when all tests are disabled.
 TEST(ForceSanitizerFailuresTest, Trivial) {}
 
+#ifdef BIGTABLE_CLIENT_FORCE_STATIC_ANALYZER_ERRORS
+TEST(ForceScanBuildDiagnostic, Test) {
+  int r = std::rand();
+  if (r != 0) {
+    int x = std::numeric_limits<int>::max() / r;
+    EXPECT_LE(0, x);
+  } else {
+    int x = std::numeric_limits<int>::min() / r;
+    EXPECT_GE(0, x);
+  }
+}
+#endif  // BIGTABLE_CLIENT_FORCE_STATIC_ANALYZER_ERRORS
+
 // These tests are only used when testing the CI scripts, we want to keep them
 // as documentation and a quick way to exercise the tests.  It might be
 // interesting to figure out a way to always enable these tests.

--- a/ci/Dockerfile.centos
+++ b/ci/Dockerfile.centos
@@ -61,6 +61,7 @@ ARG CC=gcc
 ARG BUILD_TYPE=Debug
 ARG CHECK_STYLE=""
 ARG GENERATE_DOCS=""
+ARG SCAN_BUILD=""
 ARG CMAKE_FLAGS=""
 
 # We assume that this is running on a (clean-ish) checkout of

--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -54,6 +54,7 @@ ARG CC=gcc
 ARG BUILD_TYPE=Debug
 ARG CHECK_STYLE=""
 ARG GENERATE_DOCS=""
+ARG SCAN_BUILD=""
 ARG CMAKE_FLAGS=""
 
 # We assume that this is running on a (clean-ish) checkout of

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -66,6 +66,7 @@ ARG CC=gcc
 ARG BUILD_TYPE=Debug
 ARG CHECK_STYLE=""
 ARG GENERATE_DOCS=""
+ARG SCAN_BUILD=""
 ARG CMAKE_FLAGS=""
 
 # We assume that this is running on a (clean-ish) checkout of

--- a/ci/build-docker.sh
+++ b/ci/build-docker.sh
@@ -24,7 +24,7 @@ cd gccpp/build-output
 
 CMAKE_COMMAND="cmake"
 if [ "${SCAN_BUILD}" = "yes" ]; then
-    CMAKE_COMMAND="scan-build cmake"
+  CMAKE_COMMAND="scan-build cmake"
 fi
 ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" ${CMAKE_FLAGS:-} ..
 
@@ -32,10 +32,10 @@ ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" ${CMAKE_FLAGS:-} ..
 # otherwise the static analyzer finds issues in them, and there is no way to
 # ignore them.
 if [ "${SCAN_BUILD}" = "yes" ]; then
-    make -j ${NCPU} -C bigtable googleapis
-    scan-build make -j ${NCPU} -C bigtable all
+  make -j ${NCPU} -C bigtable googleapis
+  scan-build make -j ${NCPU} -C bigtable all
 else
-    make -j ${NCPU} all
+  make -j ${NCPU} all
 fi
 
 CTEST_OUTPUT_ON_FAILURE=1 make -j ${NCPU} test

--- a/ci/build-docker.sh
+++ b/ci/build-docker.sh
@@ -32,8 +32,8 @@ ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" ${CMAKE_FLAGS:-} ..
 # otherwise the static analyzer finds issues in them, and there is no way to
 # ignore them.
 if [ "${SCAN_BUILD}" = "yes" ]; then
-  make -j ${NCPU} -C bigtable bigtable_protos
-  scan-build make -j ${NCPU} -C bigtable all
+  make -j ${NCPU} -C bigtable depends-local
+  scan-build make -j ${NCPU} -C bigtable tests-local
 else
   make -j ${NCPU} all
 fi

--- a/ci/build-docker.sh
+++ b/ci/build-docker.sh
@@ -32,7 +32,7 @@ ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" ${CMAKE_FLAGS:-} ..
 # otherwise the static analyzer finds issues in them, and there is no way to
 # ignore them.
 if [ "${SCAN_BUILD}" = "yes" ]; then
-  make -j ${NCPU} -C bigtable googleapis
+  make -j ${NCPU} -C bigtable bigtable_protos
   scan-build make -j ${NCPU} -C bigtable all
 else
   make -j ${NCPU} all

--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright 2017 Google Inc.
 #
@@ -22,8 +22,6 @@ if [ "${TRAVIS_OS_NAME}" != "linux" ]; then
 fi
 
 readonly IMAGE="cached-${DISTRO}-${DISTRO_VERSION}"
-echo "IMAGE = ${IMAGE}"
-
 sudo docker build -t "${IMAGE}:tip" \
      --build-arg DISTRO_VERSION="${DISTRO_VERSION}" \
      --build-arg CXX="${CXX}" \
@@ -31,6 +29,28 @@ sudo docker build -t "${IMAGE}:tip" \
      --build-arg NCPU="${NCPU:-2}" \
      --build-arg BUILD_TYPE="${BUILD_TYPE:-Release}" \
      --build-arg CHECK_STYLE="${CHECK_STYLE:-}" \
+     --build-arg SCAN_BUILD="${SCAN_BUILD:-}" \
      --build-arg GENERATE_DOCS="${GENERATE_DOCS:-}" \
      --build-arg CMAKE_FLAGS="${CMAKE_FLAGS:-}" \
      -f "ci/Dockerfile.${DISTRO}" .
+
+if [ "${SCAN_BUILD:-}" = "yes" ]; then
+    sudo docker run --rm -it --volume $PWD:/d ${IMAGE}:tip \
+	 bash -c 'if [ ! -z "$(ls -1d /tmp/scan-build-* 2>/dev/null)" ]; then cp -r /tmp/scan-build-* /d/scan-build-output; fi'
+    if [ -r scan-build-output/index.html ]; then
+        echo -n $(tput setaf 1)
+	echo "scan-build detected errors.  Please read the log for details."
+	echo "To run scan-build locally, and examine the html output please"
+	echo "install and configure Docker, then run:"
+        echo
+        echo "DISTRO=ubuntu DISTRO_VERSION=17.04 SCAN_BUILD=yes NCPU=8 TRAVIS_OS_NAME=linux CXX=clang++ CC=clang ./ci/build-linux.sh"
+        echo
+        echo "the html output will be copied into the scan-build-output"
+	echo "subdirectory."
+        exit 1
+    else
+        echo -n $(tput setaf 2)
+        echo "scan-build completed without errors."
+        echo -n $(tput sgr0)
+    fi
+fi


### PR DESCRIPTION
The changes are pretty simple, except for the tweaks to speed up
the build.  This is a fix for #10.