### PR TITLE
Cleanup ... comments.

### DIFF
--- a/bigtable/client/mutations.h
+++ b/bigtable/client/mutations.h
@@ -23,6 +23,8 @@
 
 #include <type_traits>
 
+#include "bigtable/client/detail/conjunction.h"
+
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -272,10 +274,14 @@ class BulkMutation {
     emplace_back(std::move(m2));
   }
 
-  /// Create a muti-row mutation from a vargarg of SingleRowMutation
-  /// TODO(coryan) - use the standard tricks to improve error messages here ...
+  /// Create a muti-row mutation from a variadic list.
   template <typename... M>
   BulkMutation(M&&... m) : BulkMutation() {
+    static_assert(
+        detail::conjunction<
+            std::is_convertible<M, SingleRowMutation>...>::value,
+        "The arguments passed to BulkMutation(...) must be convertible"
+        " to SingleRowMutation");
     emplace_many(std::forward<M>(m)...);
   }
 

--- a/bigtable/client/table_bulk_apply_test.cc
+++ b/bigtable/client/table_bulk_apply_test.cc
@@ -102,7 +102,7 @@ TEST_F(TableBulkApplyTest, RetryPartialFailure) {
   auto r1 = absl::make_unique<MockReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse *r) {
-        // ... simulate a partial (recoverable) failure ...
+        // Simulate a partial (recoverable) failure.
         auto &e0 = *r->add_entries();
         e0.set_index(0);
         e0.mutable_status()->set_code(grpc::UNAVAILABLE);


### PR DESCRIPTION
This fixes #50.

In one case it was easier to implement what the TODO() said rather than create a bug and then implement the fix.
