### PR TITLE
Use default move assignment and move constructor.

### DIFF
--- a/bigtable/client/filters.h
+++ b/bigtable/client/filters.h
@@ -49,16 +49,8 @@ inline namespace BIGTABLE_CLIENT_NS {
  */
 class Filter {
  public:
-  // TODO() - replace with `= default` if protobuf gets move constructors.
-  Filter(Filter&& rhs) noexcept : Filter() { filter_.Swap(&rhs.filter_); }
-
-  // TODO() - replace with `= default` if protobuf gets move constructors.
-  Filter& operator=(Filter&& rhs) noexcept {
-    Filter tmp(std::move(rhs));
-    tmp.filter_.Swap(&filter_);
-    return *this;
-  }
-
+  Filter(Filter&& rhs) noexcept = default;
+  Filter& operator=(Filter&& rhs) noexcept = default;
   Filter(Filter const& rhs) = default;
   Filter& operator=(Filter const& rhs) = default;
 


### PR DESCRIPTION
With the new grpc introduced in #86 we got protobuf 3.4.x which
also has move constructor and assignment for generated protos.
That means we can use the default move constructor in the Filter
class.