### PR TITLE
Ensure all TODO entries point to a bug.

### DIFF
--- a/bigtable/admin/admin_client_test.cc
+++ b/bigtable/admin/admin_client_test.cc
@@ -17,9 +17,7 @@
 #include <gmock/gmock.h>
 
 TEST(AdminClientTest, Simple) {
-  // TODO() - this is not much of a test because the behavior is not observable.
-  // We should change the AdminClient to have a dependency injection point to
-  // at least verify it is doing something.
+  // TODO(#107) - make the class behavior observable for testing purposes.
   auto admin_client =
       bigtable::CreateAdminClient("test-project", bigtable::ClientOptions());
   EXPECT_TRUE(admin_client);

--- a/bigtable/client/chrono_literals.h
+++ b/bigtable/client/chrono_literals.h
@@ -17,7 +17,7 @@
 
 #include <chrono>
 
-// TODO(coryan) - these are generally useful, consider submitting to abseil.io
+// TODO(#109) - these are generally useful, consider submitting to abseil.io
 namespace bigtable {
 namespace chrono_literals {
 constexpr std::chrono::hours operator "" _h(unsigned long long h) {

--- a/bigtable/client/detail/conjunction.h
+++ b/bigtable/client/detail/conjunction.h
@@ -22,7 +22,7 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace detail {
 
-// TODO() - use std::conjunction on C++17 environments?
+// TODO(#108) - use std::conjunction<> if available.
 /// A metafunction to fold && across a list of types, empty list case.
 template <typename...>
 struct conjunction : std::true_type {};


### PR DESCRIPTION
In some cases simply fix the issue, it was easier than creating
the bug.  This fixes #41.