### PR TITLE
Use the latest Travis CI image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-dist: trusty
+group: travis_latest
 sudo: required
 language: cpp
 


### PR DESCRIPTION
The format `dist: trusty` is deprecated, and the new hotness is either
`group: travis_lts` or `group: travis_latest`. This change chooses the latter to
live on the bleeding edge; we run our tests in containers anyway.

More details and background in these blog posts:

* https://blog.travis-ci.com/2017-12-01-new-update-schedule-for-linux-build-images
* https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch