### PR TITLE
Implement TableAdmin::GetTable() member function.

### DIFF
--- a/bigtable/admin/table_admin.cc
+++ b/bigtable/admin/table_admin.cc
@@ -102,7 +102,7 @@ std::vector<::google::bigtable::admin::v2::Table> TableAdmin::ListTables(
   auto backoff_policy = rpc_backoff_policy_->clone();
 
   btproto::GetTableRequest request;
-  request.set_name(instance_name() + "/tables/" + table_id);
+  request.set_name(absl::StrCat(instance_name(), "/tables/", table_id));
   request.set_view(view);
 
   btproto::Table response;

--- a/bigtable/admin/table_admin.cc
+++ b/bigtable/admin/table_admin.cc
@@ -95,6 +95,36 @@ std::vector<::google::bigtable::admin::v2::Table> TableAdmin::ListTables(
   return result;
 }
 
+::google::bigtable::admin::v2::Table TableAdmin::GetTable(
+    std::string table_id, ::google::bigtable::admin::v2::Table::View view) {
+  // Copy the policies in effect for the operation.
+  auto rpc_policy = rpc_retry_policy_->clone();
+  auto backoff_policy = rpc_backoff_policy_->clone();
+
+  btproto::GetTableRequest request;
+  request.set_name(instance_name() + "/tables/" + table_id);
+  request.set_view(view);
+
+  btproto::Table response;
+  while (true) {
+    grpc::ClientContext client_context;
+    rpc_policy->setup(client_context);
+    backoff_policy->setup(client_context);
+    grpc::Status status =
+        client_->table_admin().GetTable(&client_context, request, &response);
+    client_->on_completion(status);
+    if (status.ok()) {
+      break;
+    }
+    if (not rpc_policy->on_failure(status)) {
+      throw std::runtime_error("could not get table");
+    }
+    auto delay = backoff_policy->on_completion(status);
+    std::this_thread::sleep_for(delay);
+  }
+  return response;
+}
+
 std::string TableAdmin::CreateInstanceName() const {
   return absl::StrCat("projects/", client_->project(), "/instances/",
                       instance_id_);

--- a/bigtable/admin/table_admin.h
+++ b/bigtable/admin/table_admin.h
@@ -80,7 +80,8 @@ class TableAdmin {
    * @code
    * bigtable::TableAdmin admin = ...;
    * admin.CreateTable(
-   *     "my-table", {{"family", bigtable::GcRule::MaxNumVersions(1)}}, {});
+   *     "my-table", bigtable::TableConfig(
+   *         {{"family", bigtable::GcRule::MaxNumVersions(1)}}, {}));
    * @endcode
    *
    * @param table_id the name of the table relative to the instance managed by
@@ -93,8 +94,8 @@ class TableAdmin {
    *     only populates the table_name() field at this time.
    * @throws std::exception if the operation cannot be completed.
    */
-  ::google::bigtable::admin::v2::Table CreateTable(
-      std::string table_id, TableConfig config);
+  ::google::bigtable::admin::v2::Table CreateTable(std::string table_id,
+                                                   TableConfig config);
 
   /**
    * Return all the tables in the instance.
@@ -107,6 +108,23 @@ class TableAdmin {
    */
   std::vector<::google::bigtable::admin::v2::Table> ListTables(
       ::google::bigtable::admin::v2::Table::View view);
+
+  /**
+   *
+   * @param table_id the id of the table within the instance associated with
+   *     this object. The full name of the table is
+   *     `this->instance_name() + "/tables/" + table_id`
+   * @param view describes how much information to get about the name.
+   *   - VIEW_UNSPECIFIED: equivalent to VIEW_SCHEMA.
+   *   - NAME: return only the name of the table.
+   *   - VIEW_SCHEMA: return the name and the schema.
+   *   - FULL: return all the information about the table.
+   * @return
+   */
+  ::google::bigtable::admin::v2::Table GetTable(
+      std::string table_id,
+      ::google::bigtable::admin::v2::Table::View view =
+          ::google::bigtable::admin::v2::Table::SCHEMA_VIEW);
 
  private:
   std::string CreateInstanceName() const;


### PR DESCRIPTION
You will most certainly notice that there is some duplication of code here.  The next PR cleans that up.
If you want, I can include those changes in this PR, I just thought it would get too big in that case.

If you are curious, here are the main commits from that future PR:

https://github.com/coryan/google-cloud-cpp/commits/minimal-admin-client-p5

in particular:

https://github.com/coryan/google-cloud-cpp/commit/d36fbc4847a6df6314bd996bbc2980986fb28482
https://github.com/coryan/google-cloud-cpp/commit/d5655294444f50a4ff80ffc27c29e9f900f501b3

