### PR TITLE
Refactor code for simple RPCs

### DIFF
--- a/bigtable/admin/table_admin.cc
+++ b/bigtable/admin/table_admin.cc
@@ -33,8 +33,8 @@ inline namespace BIGTABLE_CLIENT_NS {
   request.set_table_id(std::move(table_id));
 
   auto error_message = absl::StrCat("CreateTable(", request.table_id(), ")");
-  return CallWithRetry(&btproto::BigtableTableAdmin::StubInterface::CreateTable,
-                       request, std::move(error_message));
+  return CallWithRetry(&StubType::CreateTable, request,
+                       std::move(error_message));
 }
 
 std::vector<::google::bigtable::admin::v2::Table> TableAdmin::ListTables(

--- a/bigtable/admin/table_admin.cc
+++ b/bigtable/admin/table_admin.cc
@@ -15,7 +15,6 @@
 #include "bigtable/admin/table_admin.h"
 
 #include <sstream>
-#include <thread>
 
 #include <absl/strings/str_cat.h>
 
@@ -33,9 +32,9 @@ inline namespace BIGTABLE_CLIENT_NS {
   request.set_parent(instance_name());
   request.set_table_id(std::move(table_id));
 
-  return call_with_retry(
-      &btproto::BigtableTableAdmin::StubInterface::CreateTable, request,
-      absl::StrCat("CreateTable(", request.table_id(), ")"));
+  auto error_message = absl::StrCat("CreateTable(", request.table_id(), ")");
+  return CallWithRetry(&btproto::BigtableTableAdmin::StubInterface::CreateTable,
+                       request, std::move(error_message));
 }
 
 std::vector<::google::bigtable::admin::v2::Table> TableAdmin::ListTables(
@@ -86,9 +85,8 @@ std::vector<::google::bigtable::admin::v2::Table> TableAdmin::ListTables(
   request.set_name(absl::StrCat(instance_name(), "/tables/", table_id));
   request.set_view(view);
 
-  return call_with_retry(&btproto::BigtableTableAdmin::StubInterface::GetTable,
-                         request,
-                         absl::StrCat("GetTable(", request.name(), ")"));
+  auto error_message = absl::StrCat("GetTable(", request.name(), ")");
+  return CallWithRetry(&StubType::GetTable, request, std::move(error_message));
 }
 
 std::string TableAdmin::CreateInstanceName() const {

--- a/bigtable/admin/table_admin.cc
+++ b/bigtable/admin/table_admin.cc
@@ -24,10 +24,6 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 ::google::bigtable::admin::v2::Table TableAdmin::CreateTable(
     std::string table_id, TableConfig config) {
-  // Copy the policies in effect for the operation.
-  auto rpc_policy = rpc_retry_policy_->clone();
-  auto backoff_policy = rpc_backoff_policy_->clone();
-
   auto request = config.as_proto_move();
   request.set_parent(instance_name());
   request.set_table_id(std::move(table_id));

--- a/bigtable/admin/table_admin.h
+++ b/bigtable/admin/table_admin.h
@@ -142,7 +142,7 @@ class TableAdmin {
    * signature.  The class derives from std::false_type, so
    * CheckSignature<T>::value is `false`.
    *
-   * @tparam T the type to check against the
+   * @tparam T the type to check against the expected signature.
    */
   template <typename T>
   struct CheckSignature : std::false_type {
@@ -181,7 +181,7 @@ class TableAdmin {
    * policies determine that this is an error.
    *
    * We use std::enable_if<> to stop signature errors at compile-time.  The
-   * CheckSignature meta function returns false if given a type that is not
+   * `CheckSignature` meta function returns `false` if given a type that is not
    * a pointer to member with the right signature, that disables this function
    * altogether, and the developer gets a nice-ish error message.
    *

--- a/bigtable/admin/table_admin.h
+++ b/bigtable/admin/table_admin.h
@@ -150,7 +150,6 @@ class TableAdmin {
     using ResponseType = int;
   };
 
-  /// Discover if a pointer to member function has the expected signature.
   /**
    * Determine if a type is a pointer to member function with the correct
    * signature for CallWithRetry()
@@ -167,8 +166,8 @@ class TableAdmin {
   struct CheckSignature<grpc::Status (StubType::*)(grpc::ClientContext*,
                                                    Request const&, Response*)>
       : public std::true_type {
-    using ResponseType = Response;
     using RequestType = Request;
+    using ResponseType = Response;
     using MemberFunctionType = grpc::Status (StubType::*)(grpc::ClientContext*,
                                                           Request const&,
                                                           Response*);

--- a/bigtable/admin/table_admin.h
+++ b/bigtable/admin/table_admin.h
@@ -130,41 +130,90 @@ class TableAdmin {
  private:
   std::string CreateInstanceName() const;
 
-  /// Discover if a pointer to member function has the expected signature.
+  /// A shortcut for the grpc stub this class wraps.
+  using StubType =
+      ::google::bigtable::admin::v2::BigtableTableAdmin::StubInterface;
+
+  /**
+   * Determine if @p T is a pointer to member function with the expected
+   * signature for CallWithRetry().
+   *
+   * This is the generic case, where the type does not match the expected
+   * signature.  The class derives from std::false_type, so
+   * CheckSignature<T>::value is `false`.
+   *
+   * @tparam T the type to check against the
+   */
   template <typename T>
-  struct check_signature : std::false_type {
-    using response_type = int;
+  struct CheckSignature : std::false_type {
+    /// Must define ResponseType because it is used in std::enable_if<>.
+    using ResponseType = int;
   };
 
   /// Discover if a pointer to member function has the expected signature.
-  template <typename Class, typename Request, typename Response>
-  struct check_signature<
-      grpc::Status (Class::*)(grpc::ClientContext*,Request const&,Response*)>
+  /**
+   * Determine if a type is a pointer to member function with the correct
+   * signature for CallWithRetry()
+   *
+   * This is the case where the type actually matches the expected signature.
+   * This class derives from std::true_type, so CheckSignature<T>::value is
+   * `true` in this case.  The class also extracts the request and response
+   * types used in the implementation of CallWithRetry().
+   *
+   * @tparam Request the RPC request type.
+   * @tparam Response the RPC response type.
+   */
+  template <typename Request, typename Response>
+  struct CheckSignature<grpc::Status (StubType::*)(grpc::ClientContext*,
+                                                   Request const&, Response*)>
       : public std::true_type {
-    using response_type = Response;
-    using request_type = Request;
-    using member_function_type = grpc::Status (Class::*)(grpc::ClientContext *, Request const &, Response *);
+    using ResponseType = Response;
+    using RequestType = Request;
+    using MemberFunctionType = grpc::Status (StubType::*)(grpc::ClientContext*,
+                                                          Request const&,
+                                                          Response*);
   };
 
-  /// Call a simple unary RPC with retries.
+  /**
+   * Call a simple unary RPC with retries.
+   *
+   * Given a pointer to member function in the grpc StubInterface class this
+   * generic function calls it with retries until success or until the RPC
+   * policies determine that this is an error.
+   *
+   * We use std::enable_if<> to stop signature errors at compile-time.  The
+   * CheckSignature meta function returns false if given a type that is not
+   * a pointer to member with the right signature, that disables this function
+   * altogether, and the developer gets a nice-ish error message.
+   *
+   * @tparam MemberFunction the signature of the member function.
+   * @param function the pointer to the member function to call.
+   * @param request an initialized request parameter for the RPC.
+   * @return the return parameter from the RPC.
+   * @throw std::exception with a description of the RPC error.
+   */
   template <typename MemberFunction>
+  // Disable the function if the provided member function does not match the
+  // expected signature.  Compilers also emit nice error messages in this case.
   typename std::enable_if<
-      check_signature<MemberFunction>::value,
-      typename check_signature<MemberFunction>::response_type>::type
-  call_with_retry(MemberFunction function,
-                  typename check_signature<MemberFunction>::request_type const& request,
-                  absl::string_view error_message) {
+      CheckSignature<MemberFunction>::value,
+      typename CheckSignature<MemberFunction>::ResponseType>::type
+  CallWithRetry(
+      MemberFunction function,
+      typename CheckSignature<MemberFunction>::RequestType const& request,
+      absl::string_view error_message) {
     // Copy the policies in effect for the operation.
     auto rpc_policy = rpc_retry_policy_->clone();
     auto backoff_policy = rpc_backoff_policy_->clone();
 
-    typename check_signature<MemberFunction>::response_type response;
+    typename CheckSignature<MemberFunction>::ResponseType response;
     while (true) {
       grpc::ClientContext client_context;
       rpc_policy->setup(client_context);
       backoff_policy->setup(client_context);
-      grpc::Status status =
-          (client_->table_admin().*function)(&client_context, request, &response);
+      // Call the pointer to member function.
+      grpc::Status status = (client_->table_admin().*function)(
+          &client_context, request, &response);
       client_->on_completion(status);
       if (status.ok()) {
         break;

--- a/bigtable/admin/table_admin_test.cc
+++ b/bigtable/admin/table_admin_test.cc
@@ -89,7 +89,7 @@ auto create_list_tables_lambda = [](std::string expected_token,
  * Helper class to create the expectations for a simple RPC call.
  *
  * Given the type of the request and responses, this struct provides a function
- * to create an mock implementation with the right signature and checks.
+ * to create a mock implementation with the right signature and checks.
  *
  * @tparam RequestType the protobuf type for the request.
  * @tparam ResponseType the protobuf type for the response.

--- a/bigtable/admin/table_admin_test.cc
+++ b/bigtable/admin/table_admin_test.cc
@@ -64,26 +64,63 @@ class TableAdminTest : public ::testing::Test {
 auto create_list_tables_lambda = [](std::string expected_token,
                                     std::string returned_token,
                                     std::vector<std::string> table_names) {
-  return [expected_token, returned_token, table_names](
-      grpc::ClientContext* ctx, btproto::ListTablesRequest const& request,
-      btproto::ListTablesResponse* response) {
-    auto const instance_name =
-        absl::StrCat("projects/", kProjectId, "/instances/", kInstanceId);
-    EXPECT_EQ(instance_name, request.parent());
-    EXPECT_EQ(btproto::Table::FULL, request.view());
-    EXPECT_EQ(expected_token, request.page_token());
+  return
+      [expected_token, returned_token, table_names](
+          grpc::ClientContext* ctx, btproto::ListTablesRequest const& request,
+          btproto::ListTablesResponse* response) {
+        auto const instance_name =
+            absl::StrCat("projects/", kProjectId, "/instances/", kInstanceId);
+        EXPECT_EQ(instance_name, request.parent());
+        EXPECT_EQ(btproto::Table::FULL, request.view());
+        EXPECT_EQ(expected_token, request.page_token());
 
-    EXPECT_NE(nullptr, response);
-    for (auto const& table_name : table_names) {
-      auto& table = *response->add_tables();
-      table.set_name(instance_name + "/tables/" + table_name);
-      table.set_granularity(btproto::Table::MILLIS);
-    }
-    // Return the right token.
-    response->set_next_page_token(returned_token);
-    return grpc::Status::OK;
-  };
+        EXPECT_NE(nullptr, response);
+        for (auto const& table_name : table_names) {
+          auto& table = *response->add_tables();
+          table.set_name(instance_name + "/tables/" + table_name);
+          table.set_granularity(btproto::Table::MILLIS);
+        }
+        // Return the right token.
+        response->set_next_page_token(returned_token);
+        return grpc::Status::OK;
+      };
 };
+
+/**
+ * Helper class to create the expectations for a simple RPC call.
+ *
+ * Given the type of the request and responses, this struct provides a function
+ * to create an mock implementation with the right signature and checks.
+ *
+ * @tparam RequestType the protobuf type for the request.
+ * @tparam ResponseType the protobuf type for the response.
+ */
+template <typename RequestType, typename ResponseType>
+struct MockRpcFactory {
+  using SignatureType = grpc::Status(grpc::ClientContext* ctx,
+                                     RequestType const& request,
+                                     ResponseType* response);
+
+  /// Refactor the boilerplate common to most tests.
+  static std::function<SignatureType> Create(std::string expected_request) {
+    return std::function<SignatureType>(
+        [expected_request](grpc::ClientContext* ctx, RequestType const& request,
+                           ResponseType* response) {
+          RequestType expected;
+          // Cannot use ASSERT_TRUE() here, it has an embedded "return;"
+          EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
+              expected_request, &expected));
+          std::string delta;
+          google::protobuf::util::MessageDifferencer differencer;
+          differencer.ReportDifferencesToString(&delta);
+          EXPECT_TRUE(differencer.Compare(expected, request)) << delta;
+
+          EXPECT_NE(nullptr, response);
+          return grpc::Status::OK;
+        });
+  }
+};
+
 }  // anonymous namespace
 
 /// @test Verify basic functionality in the `bigtable::TableAdmin` class.
@@ -154,11 +191,11 @@ TEST_F(TableAdminTest, ListTablesUnrecoverableFailures) {
   using namespace ::testing;
 
   bigtable::TableAdmin tested(client_, "the-instance");
-  auto mock_unrecoverable_failure = [](
-      grpc::ClientContext* ctx, btproto::ListTablesRequest const& request,
-      btproto::ListTablesResponse* response) {
-    return grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh");
-  };
+  auto mock_unrecoverable_failure =
+      [](grpc::ClientContext* ctx, btproto::ListTablesRequest const& request,
+         btproto::ListTablesResponse* response) {
+        return grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh");
+      };
   EXPECT_CALL(*table_admin_stub_, ListTables(_, _, _))
       .WillOnce(Invoke(mock_unrecoverable_failure));
   // We expect the TableAdmin to make a call to let the client know the request
@@ -221,92 +258,21 @@ initial_splits { key: 'a' }
 initial_splits { key: 'c' }
 initial_splits { key: 'p' }
 )""";
-  btproto::CreateTableRequest expected;
-  ASSERT_TRUE(
-      google::protobuf::TextFormat::ParseFromString(expected_text, &expected));
-  auto mock_create_table = [expected](
-      grpc::ClientContext* ctx, btproto::CreateTableRequest const& request,
-      btproto::Table* response) {
-    EXPECT_EQ("projects/the-project/instances/the-instance", request.parent());
-    std::string delta;
-    google::protobuf::util::MessageDifferencer differencer;
-    differencer.ReportDifferencesToString(&delta);
-    EXPECT_TRUE(differencer.Compare(expected, request)) << delta;
-
-    EXPECT_NE(nullptr, response);
-    response->set_name(request.parent() + "/tables/" + request.table_id());
-    return grpc::Status::OK;
-  };
+  auto mock_create_table =
+      MockRpcFactory<btproto::CreateTableRequest, btproto::Table>::Create(
+          expected_text);
   EXPECT_CALL(*table_admin_stub_, CreateTable(_, _, _))
-      .WillOnce(Invoke(mock_create_table));
-  EXPECT_CALL(*client_, on_completion(_)).Times(1);
-
-  // After all the setup, make the actual call we want to test.
-  using GC = bigtable::GcRule;
-  bigtable::TableConfig config(
-      {{"f1", GC::MaxNumVersions(1)}, {"f2", GC::MaxAge(1_s)}},
-      {"a", "c", "p"});
-  auto actual = tested.CreateTable("new-table", std::move(config));
-  EXPECT_EQ("projects/the-project/instances/the-instance/tables/new-table",
-            actual.name());
-}
-
-/**
- * @test Verify that `bigtable::TableAdmin::CreateTable` works with recoverable
- * failures.
- */
-TEST_F(TableAdminTest, CreateTableRecoverableFailure) {
-  using namespace ::testing;
-  using namespace bigtable::chrono_literals;
-
-  bigtable::TableAdmin tested(client_, "the-instance");
-
-  std::string expected_text = R"""(
-parent: 'projects/the-project/instances/the-instance'
-table_id: 'other-table'
-table {
-  column_families {
-    key: 'fam'
-    value { gc_rule { union {
-      rules { max_num_versions: 3 }
-      rules { max_age { seconds: 86400 }}
-    }}}
-  }
-  granularity: MILLIS
-}
-)""";
-  btproto::CreateTableRequest expected;
-  ASSERT_TRUE(
-      google::protobuf::TextFormat::ParseFromString(expected_text, &expected));
-  auto mock_create_table = [expected](
-      grpc::ClientContext* ctx, btproto::CreateTableRequest const& request,
-      btproto::Table* response) {
-    auto const instance_name =
-        absl::StrCat("projects/", kProjectId, "/instances/", kInstanceId);
-    EXPECT_EQ(instance_name, request.parent());
-    std::string delta;
-    google::protobuf::util::MessageDifferencer differencer;
-    differencer.ReportDifferencesToString(&delta);
-    EXPECT_TRUE(differencer.Compare(expected, request)) << delta;
-
-    EXPECT_NE(nullptr, response);
-    response->set_name(request.parent() + "/tables/" + request.table_id());
-    return grpc::Status::OK;
-  };
-  EXPECT_CALL(*table_admin_stub_, CreateTable(_, _, _))
-      .WillOnce(Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "")))
+      .WillOnce(
+          Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")))
       .WillOnce(Invoke(mock_create_table));
   EXPECT_CALL(*client_, on_completion(_)).Times(2);
 
   // After all the setup, make the actual call we want to test.
   using GC = bigtable::GcRule;
   bigtable::TableConfig config(
-      {{"fam", GC::Union(GC::MaxNumVersions(3), GC::MaxAge(24_h))}}, {});
-  config.set_timestamp_granularity(bigtable::TableConfig::MILLIS);
-
-  auto actual = tested.CreateTable("other-table", config);
-  EXPECT_EQ("projects/the-project/instances/the-instance/tables/other-table",
-            actual.name());
+      {{"f1", GC::MaxNumVersions(1)}, {"f2", GC::MaxAge(1_s)}},
+      {"a", "c", "p"});
+  EXPECT_NO_THROW(tested.CreateTable("new-table", std::move(config)));
 }
 
 /**
@@ -317,13 +283,9 @@ TEST_F(TableAdminTest, CreateTableUnrecoverableFailure) {
   using namespace ::testing;
 
   bigtable::TableAdmin tested(client_, "the-instance");
-  auto mock_unrecoverable_failure = [](
-      grpc::ClientContext* ctx, btproto::CreateTableRequest const& request,
-      btproto::Table* response) {
-    return grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh");
-  };
   EXPECT_CALL(*table_admin_stub_, CreateTable(_, _, _))
-      .WillOnce(Invoke(mock_unrecoverable_failure));
+      .WillOnce(
+          Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
   // We expect the TableAdmin to make a call to let the client know the request
   // failed.
   EXPECT_CALL(*client_, on_completion(_)).Times(1);
@@ -344,13 +306,9 @@ TEST_F(TableAdminTest, CreateTableTooManyFailures) {
   bigtable::TableAdmin tested(
       client_, "the-instance", bigtable::LimitedErrorCountRetryPolicy(3),
       bigtable::ExponentialBackoffPolicy(10_ms, 10_min));
-  auto mock_recoverable_failure = [](grpc::ClientContext* ctx,
-                                     btproto::CreateTableRequest const& request,
-                                     btproto::Table* response) {
-    return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
-  };
   EXPECT_CALL(*table_admin_stub_, CreateTable(_, _, _))
-      .WillRepeatedly(Invoke(mock_recoverable_failure));
+      .WillRepeatedly(
+          Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
   // We expect the TableAdmin to make a call to let the client know the request
   // failed. Notice that it is prepared to tolerate 3 failures, so it is the
   // fourth failure that actually raises an error.
@@ -362,7 +320,7 @@ TEST_F(TableAdminTest, CreateTableTooManyFailures) {
 }
 
 /// @test Verify that `bigtable::TableAdmin::GetTable` works in the easy case.
-TEST_F(TableAdminTest, GetTable) {
+TEST_F(TableAdminTest, GetTableSimple) {
   using namespace ::testing;
   using namespace bigtable::chrono_literals;
 
@@ -371,68 +329,16 @@ TEST_F(TableAdminTest, GetTable) {
 name: 'projects/the-project/instances/the-instance/tables/the-table'
 view: SCHEMA_VIEW
 )""";
-  btproto::GetTableRequest expected;
-  ASSERT_TRUE(
-      google::protobuf::TextFormat::ParseFromString(expected_text, &expected));
-  auto mock_create_table = [expected](grpc::ClientContext* ctx,
-                                      btproto::GetTableRequest const& request,
-                                      btproto::Table* response) {
-    std::string delta;
-    google::protobuf::util::MessageDifferencer differencer;
-    differencer.ReportDifferencesToString(&delta);
-    EXPECT_TRUE(differencer.Compare(expected, request)) << delta;
-
-    EXPECT_NE(nullptr, response);
-    response->set_name(request.name());
-    return grpc::Status::OK;
-  };
-  EXPECT_CALL(*table_admin_stub_, GetTable(_, _, _))
-      .WillOnce(Invoke(mock_create_table));
-  EXPECT_CALL(*client_, on_completion(_)).Times(1);
-
-  // After all the setup, make the actual call we want to test.
-  auto actual = tested.GetTable("the-table");
-  EXPECT_EQ("projects/the-project/instances/the-instance/tables/the-table",
-            actual.name());
-}
-
-/**
- * @test Verify that `bigtable::TableAdmin::GetTable` works with recoverable
- * failures.
- */
-TEST_F(TableAdminTest, GetTableRecoverableFailure) {
-  using namespace ::testing;
-  using namespace bigtable::chrono_literals;
-
-  bigtable::TableAdmin tested(client_, "the-instance");
-  std::string expected_text = R"""(
-name: 'projects/the-project/instances/the-instance/tables/the-table'
-view: SCHEMA_VIEW
-)""";
-  btproto::GetTableRequest expected;
-  ASSERT_TRUE(
-      google::protobuf::TextFormat::ParseFromString(expected_text, &expected));
-  auto mock_create_table = [expected](grpc::ClientContext* ctx,
-                                      btproto::GetTableRequest const& request,
-                                      btproto::Table* response) {
-    std::string delta;
-    google::protobuf::util::MessageDifferencer differencer;
-    differencer.ReportDifferencesToString(&delta);
-    EXPECT_TRUE(differencer.Compare(expected, request)) << delta;
-
-    EXPECT_NE(nullptr, response);
-    response->set_name(request.name());
-    return grpc::Status::OK;
-  };
+  auto mock = MockRpcFactory<btproto::GetTableRequest, btproto::Table>::Create(
+      expected_text);
   EXPECT_CALL(*table_admin_stub_, GetTable(_, _, _))
       .WillOnce(
           Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")))
-      .WillOnce(Invoke(mock_create_table));
+      .WillOnce(Invoke(mock));
   EXPECT_CALL(*client_, on_completion(_)).Times(2);
 
   // After all the setup, make the actual call we want to test.
-  auto actual = tested.GetTable("the-table");
-  EXPECT_EQ(tested.instance_name() + "/tables/the-table", actual.name());
+  EXPECT_NO_THROW(tested.GetTable("the-table"));
 }
 
 /**
@@ -444,13 +350,8 @@ TEST_F(TableAdminTest, GetTableUnrecoverableFailures) {
   using namespace bigtable::chrono_literals;
 
   bigtable::TableAdmin tested(client_, "the-instance");
-  auto mock_unrecoverable_failure = [](grpc::ClientContext* ctx,
-                                       btproto::GetTableRequest const& request,
-                                       btproto::Table* response) {
-    return grpc::Status(grpc::StatusCode::NOT_FOUND, "uh oh");
-  };
   EXPECT_CALL(*table_admin_stub_, GetTable(_, _, _))
-      .WillOnce(Invoke(mock_unrecoverable_failure));
+      .WillOnce(Return(grpc::Status(grpc::StatusCode::NOT_FOUND, "uh oh")));
   EXPECT_CALL(*client_, on_completion(_)).Times(1);
 
   // After all the setup, make the actual call we want to test.
@@ -468,13 +369,9 @@ TEST_F(TableAdminTest, GetTableTooManyFailures) {
   bigtable::TableAdmin tested(
       client_, "the-instance", bigtable::LimitedErrorCountRetryPolicy(3),
       bigtable::ExponentialBackoffPolicy(10_ms, 10_min));
-  auto mock_recoverable_failure = [](grpc::ClientContext* ctx,
-                                     btproto::GetTableRequest const& request,
-                                     btproto::Table* response) {
-    return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
-  };
   EXPECT_CALL(*table_admin_stub_, GetTable(_, _, _))
-      .WillRepeatedly(Invoke(mock_recoverable_failure));
+      .WillRepeatedly(
+          Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
   // We expect the TableAdmin to make a call to let the client know the request
   // failed. Notice that it is prepared to tolerate 3 failures, so it is the
   // fourth failure that actually raises an error.


### PR DESCRIPTION
This is part of the fixes for #79 .  It refactors the code used in GetTable() and CreateTable().  The next PR will use this code to implement the rest of the admin APIs.  The code is a template, with lots of explanations for future developers (including future me!).
