### PR TITLE
Break client table cycle

### DIFF
--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -113,15 +113,16 @@ add_library(bigtable_client
     client/rpc_retry_policy.h
     client/rpc_retry_policy.cc
     client/version.h)
-target_link_libraries(bigtable_client bigtable_protos ${GRPCPP_LIBRARIES}
-  ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+target_link_libraries(bigtable_client
+    bigtable_protos absl::strings
+    ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 
 add_library(bigtable_client_testing
     client/testing/chrono_literals.h
     client/testing/table_test_fixture.h
     client/testing/table_test_fixture.cc)
 target_link_libraries(bigtable_client_testing
-    bigtable_protos gmock
+    bigtable_client bigtable_protos absl::strings gmock
     ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 
 # the admin library
@@ -179,8 +180,9 @@ foreach (fname ${bigtable_client_unit_tests})
     add_executable(${target} ${fname})
     get_target_property(tname ${target} NAME)
     target_link_libraries(${target}
-        bigtable_client_testing bigtable_client bigtable_protos gmock
-        ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+        bigtable_client_testing bigtable_client bigtable_protos
+        gmock absl::strings ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES}
+        ${PROTOBUF_LIBRARIES})
     add_test(NAME ${tname} COMMAND ${target})
     get_target_property(sources ${target} SOURCES)
     add_dependencies(tests-local ${target})
@@ -199,7 +201,7 @@ foreach (fname ${bigtable_admin_unit_tests})
     get_target_property(tname ${target} NAME)
     target_link_libraries(${target}
         bigtable_client_testing bigtable_admin_client bigtable_client
-        bigtable_protos gmock
+        bigtable_protos gmock absl::strings
         ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
     add_test(NAME ${tname} COMMAND ${target})
     get_target_property(sources ${target} SOURCES)
@@ -212,7 +214,7 @@ add_executable(bigtable_client_all_tests
     ${bigtable_client_unit_tests} ${bigtable_admin_unit_tests})
 target_link_libraries(bigtable_client_all_tests
     bigtable_client_testing bigtable_admin_client bigtable_client
-    bigtable_protos gmock
+    bigtable_protos gmock absl::strings
     ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 add_dependencies(tests-local bigtable_client_all_tests)
 
@@ -236,6 +238,6 @@ endif (FORCE_STATIC_ANALYZER_ERRORS)
 # Cloud Bigtable emulator.
 add_executable(integration_test tests/integration_test.cc)
 target_link_libraries(integration_test
-    bigtable_admin_client bigtable_client bigtable_protos
+    bigtable_admin_client bigtable_client bigtable_protos absl::strings
     ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 add_dependencies(tests-local integration_test)

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -171,6 +171,7 @@ set(bigtable_client_unit_tests
     client/mutations_test.cc
     client/table_apply_test.cc
     client/table_bulk_apply_test.cc
+    client/table_test.cc
     client/row_test.cc
     client/rpc_backoff_policy_test.cc
     client/rpc_retry_policy_test.cc)

--- a/bigtable/client/data.cc
+++ b/bigtable/client/data.cc
@@ -39,7 +39,7 @@ class Client : public ClientInterface {
   std::string const& ProjectId() const override;
   std::string const& InstanceId() const override;
 
-  google::bigtable::v2::Bigtable::StubInterface& Stub() const {
+  google::bigtable::v2::Bigtable::StubInterface& Stub() const override {
     return *bt_stub_;
   }
 

--- a/bigtable/client/data.cc
+++ b/bigtable/client/data.cc
@@ -24,17 +24,16 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 class Client : public ClientInterface {
  public:
-  Client(const std::string& project, const std::string& instance,
-         const ClientOptions& options)
-      : project_(project),
-        instance_(instance),
+  Client(std::string project, std::string instance, ClientOptions options)
+      : project_(std::move(project)),
+        instance_(std::move(instance)),
         credentials_(options.credentials()),
         channel_(grpc::CreateChannel(options.data_endpoint(),
                                      options.credentials())),
         bt_stub_(google::bigtable::v2::Bigtable::NewStub(channel_)) {}
 
-  Client(const std::string& project, const std::string& instance)
-      : Client(project, instance, ClientOptions()) {}
+  Client(std::string project, std::string instance)
+      : Client(std::move(project), std::move(instance), ClientOptions()) {}
 
   std::string const& ProjectId() const override;
   std::string const& InstanceId() const override;
@@ -57,9 +56,9 @@ std::string const& Client::InstanceId() const { return instance_; }
 
 std::shared_ptr<ClientInterface> CreateDefaultClient(
     std::string project_id, std::string instance_id,
-    bigtable::ClientOptions client_options) {
+    bigtable::ClientOptions options) {
   return std::make_shared<Client>(std::move(project_id), std::move(instance_id),
-                                  std::move(client_options));
+                                  std::move(options));
 }
 
 void Table::Apply(SingleRowMutation&& mut) {

--- a/bigtable/client/data.h
+++ b/bigtable/client/data.h
@@ -45,7 +45,7 @@ std::shared_ptr<ClientInterface> CreateDefaultClient(std::string project_id,
                                                      ClientOptions options);
 
 inline std::string CreateInstanceName(std::shared_ptr<ClientInterface> client) {
-  return absl::StrCat("projects", client->ProjectId(), "/instances/",
+  return absl::StrCat("projects/", client->ProjectId(), "/instances/",
                       client->InstanceId());
 }
 

--- a/bigtable/client/data.h
+++ b/bigtable/client/data.h
@@ -44,14 +44,14 @@ std::shared_ptr<ClientInterface> CreateDefaultClient(std::string project_id,
                                                      std::string instance_id,
                                                      ClientOptions options);
 
-inline std::string CreateInstanceName(std::shared_ptr<ClientInterface> client) {
+inline std::string InstanceName(std::shared_ptr<ClientInterface> client) {
   return absl::StrCat("projects/", client->ProjectId(), "/instances/",
                       client->InstanceId());
 }
 
-inline std::string CreateTableName(std::shared_ptr<ClientInterface> client,
-                                   absl::string_view table_id) {
-  return absl::StrCat(CreateInstanceName(std::move(client)), "/tables/", table_id);
+inline std::string TableName(std::shared_ptr<ClientInterface> client,
+                             absl::string_view table_id) {
+  return absl::StrCat(InstanceName(std::move(client)), "/tables/", table_id);
 }
 
 class Table {
@@ -66,7 +66,7 @@ class Table {
    */
   Table(std::shared_ptr<ClientInterface> client, absl::string_view table_id)
       : client_(std::move(client)),
-        table_name_(CreateTableName(client_, table_id)),
+        table_name_(TableName(client_, table_id)),
         rpc_retry_policy_(bigtable::DefaultRPCRetryPolicy()),
         rpc_backoff_policy_(bigtable::DefaultRPCBackoffPolicy()),
         idempotent_mutation_policy_(
@@ -100,7 +100,7 @@ class Table {
         RPCRetryPolicy retry_policy, RPCBackoffPolicy backoff_policy,
         IdempotentMutationPolicy idempotent_mutation_policy)
       : client_(std::move(client)),
-        table_name_(CreateTableName(client_, table_id)),
+        table_name_(TableName(client_, table_id)),
         rpc_retry_policy_(retry_policy.clone()),
         rpc_backoff_policy_(backoff_policy.clone()),
         idempotent_mutation_policy_(idempotent_mutation_policy.clone()) {}

--- a/bigtable/client/table_bulk_apply_test.cc
+++ b/bigtable/client/table_bulk_apply_test.cc
@@ -219,7 +219,7 @@ TEST_F(TableBulkApplyTest, TooManyFailures) {
   // without having to depend on timers expiring.  In this case tolerate only
   // 3 failures.
   bt::Table custom_table(
-      client_.get(), "foo_table",
+      client_, "foo_table",
       // Configure the Table to stop at 3 failures.
       bt::LimitedErrorCountRetryPolicy(2),
       // Use much shorter backoff than the default to test faster.

--- a/bigtable/client/table_test.cc
+++ b/bigtable/client/table_test.cc
@@ -31,12 +31,12 @@ TEST_F(TableTest, ClientInstanceId) {
   EXPECT_EQ(kInstanceId, client_->InstanceId());
 }
 
-TEST_F(TableTest, CreateInstanceName) {
-  EXPECT_EQ(kInstanceName, bigtable::CreateInstanceName(client_));
+TEST_F(TableTest, StandaloneInstanceName) {
+  EXPECT_EQ(kInstanceName, bigtable::InstanceName(client_));
 }
 
-TEST_F(TableTest, CreateTableName) {
-  EXPECT_EQ(kTableName, bigtable::CreateTableName(client_, kTableId));
+TEST_F(TableTest, StandaloneTableName) {
+  EXPECT_EQ(kTableName, bigtable::TableName(client_, kTableId));
 }
 
 TEST_F(TableTest, TableName) {
@@ -48,7 +48,7 @@ TEST_F(TableTest, TableName) {
 TEST_F(TableTest, TableConstructor) {
   std::string const kOtherTableId = "my-table";
   std::string const kOtherTableName =
-      bigtable::CreateTableName(client_, kOtherTableId);
+      bigtable::TableName(client_, kOtherTableId);
   bigtable::Table table(client_, kOtherTableId);
   EXPECT_EQ(kOtherTableName, table.table_name());
 }

--- a/bigtable/client/table_test.cc
+++ b/bigtable/client/table_test.cc
@@ -1,0 +1,54 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/client/data.h"
+
+#include <absl/memory/memory.h>
+
+#include "bigtable/client/testing/table_test_fixture.h"
+
+/// Define types and functions used in the tests.
+namespace {
+class TableTest : public bigtable::testing::TableTestFixture {};
+}  // anonymous namespace
+
+TEST_F(TableTest, ClientProjectId) {
+  EXPECT_EQ(kProjectId, client_->ProjectId());
+}
+
+TEST_F(TableTest, ClientInstanceId) {
+  EXPECT_EQ(kInstanceId, client_->InstanceId());
+}
+
+TEST_F(TableTest, CreateInstanceName) {
+  EXPECT_EQ(kInstanceName, bigtable::CreateInstanceName(client_));
+}
+
+TEST_F(TableTest, CreateTableName) {
+  EXPECT_EQ(kTableName, bigtable::CreateTableName(client_, kTableId));
+}
+
+TEST_F(TableTest, TableName) {
+  // clang-format: you are drunk, placing this short function in a single line
+  // is not nice.
+  EXPECT_EQ(kTableName, table_.table_name());
+}
+
+TEST_F(TableTest, TableConstructor) {
+  std::string const kOtherTableId = "my-table";
+  std::string const kOtherTableName =
+      bigtable::CreateTableName(client_, kOtherTableId);
+  bigtable::Table table(client_, kOtherTableId);
+  EXPECT_EQ(kOtherTableName, table.table_name());
+}

--- a/bigtable/client/testing/mock_client.h
+++ b/bigtable/client/testing/mock_client.h
@@ -26,8 +26,8 @@ namespace testing {
 
 class MockClient : public bigtable::ClientInterface {
  public:
-  MOCK_METHOD1(Open,
-               std::unique_ptr<bigtable::Table>(std::string const& table_id));
+  MOCK_CONST_METHOD0(ProjectId, std::string const&());
+  MOCK_CONST_METHOD0(InstanceId, std::string const&());
   MOCK_CONST_METHOD0(Stub, google::bigtable::v2::Bigtable::StubInterface&());
 };
 

--- a/bigtable/client/testing/table_test_fixture.cc
+++ b/bigtable/client/testing/table_test_fixture.cc
@@ -17,10 +17,7 @@
 namespace bigtable {
 namespace testing {
 
-void TableTestFixture::SetUp() {
-  EXPECT_CALL(*client_, Stub())
-      .WillRepeatedly(::testing::ReturnRef(*bigtable_stub_));
-}
+void TableTestFixture::SetUp() {}
 
 }  // namespace testing
 }  // namespace bigtable

--- a/bigtable/client/testing/table_test_fixture.h
+++ b/bigtable/client/testing/table_test_fixture.h
@@ -39,12 +39,22 @@ class TableTestFixture : public ::testing::Test {
     return client;
   }
 
-  std::string project_id_ = "the-project";
-  std::string instance_id_ = "the-instance";
+  std::string const kProjectId = "foo-project";
+  std::string const kInstanceId = "bar-instance";
+  std::string const kTableId = "baz-table";
+
+  // This is hardcoded and not computed because we want to test the compuation.
+  std::string const kInstanceName =
+      "projects/foo-project/instances/bar-instance";
+  std::string const kTableName =
+          "projects/foo-project/instances/bar-instance/tables/baz-table";
+
+  std::string project_id_ = kProjectId;
+  std::string instance_id_ = kInstanceId;
   std::shared_ptr<::google::bigtable::v2::MockBigtableStub> bigtable_stub_ =
       std::make_shared<::google::bigtable::v2::MockBigtableStub>();
   std::shared_ptr<MockClient> client_ = SetupMockClient();
-  bigtable::Table table_ = bigtable::Table(client_, "foo-table");
+  bigtable::Table table_ = bigtable::Table(client_, kTableId);
 };
 
 }  // namespace testing

--- a/bigtable/client/testing/table_test_fixture.h
+++ b/bigtable/client/testing/table_test_fixture.h
@@ -43,11 +43,12 @@ class TableTestFixture : public ::testing::Test {
   std::string const kInstanceId = "bar-instance";
   std::string const kTableId = "baz-table";
 
-  // This is hardcoded and not computed because we want to test the compuation.
+  // These are hardcoded, and not computed, because we want to test the
+  // computation.
   std::string const kInstanceName =
       "projects/foo-project/instances/bar-instance";
   std::string const kTableName =
-          "projects/foo-project/instances/bar-instance/tables/baz-table";
+      "projects/foo-project/instances/bar-instance/tables/baz-table";
 
   std::string project_id_ = kProjectId;
   std::string instance_id_ = kInstanceId;

--- a/bigtable/client/testing/table_test_fixture.h
+++ b/bigtable/client/testing/table_test_fixture.h
@@ -24,12 +24,27 @@ namespace testing {
 /// Common fixture for the bigtable::Table tests.
 class TableTestFixture : public ::testing::Test {
  protected:
+  TableTestFixture() {}
+
   void SetUp() override;
 
-  std::shared_ptr<MockClient> client_ = std::make_shared<MockClient>();
+  std::shared_ptr<MockClient> SetupMockClient() {
+    auto client = std::make_shared<MockClient>();
+    EXPECT_CALL(*client, ProjectId())
+        .WillRepeatedly(::testing::ReturnRef(project_id_));
+    EXPECT_CALL(*client, InstanceId())
+        .WillRepeatedly(::testing::ReturnRef(instance_id_));
+    EXPECT_CALL(*client, Stub())
+        .WillRepeatedly(::testing::ReturnRef(*bigtable_stub_));
+    return client;
+  }
+
+  std::string project_id_ = "the-project";
+  std::string instance_id_ = "the-instance";
   std::shared_ptr<::google::bigtable::v2::MockBigtableStub> bigtable_stub_ =
       std::make_shared<::google::bigtable::v2::MockBigtableStub>();
-  bigtable::Table table_ = bigtable::Table(client_.get(), "foo-table");
+  std::shared_ptr<MockClient> client_ = SetupMockClient();
+  bigtable::Table table_ = bigtable::Table(client_, "foo-table");
 };
 
 }  // namespace testing

--- a/bigtable/tests/integration_test.cc
+++ b/bigtable/tests/integration_test.cc
@@ -54,20 +54,21 @@ int main(int argc, char* argv[]) try {
   }
   std::cout << table_name << " found via ListTables()\n";
 
-  bigtable::Client client(project_id, instance_id);
-  std::unique_ptr<bigtable::Table> table = client.Open(table_name);
+  auto client = bigtable::CreateDefaultClient(project_id, instance_id,
+                                              bigtable::ClientOptions());
+  bigtable::Table table(client, table_name);
 
   // TODO(#29) we should read these rows back when we have a read path
   auto mutation = bigtable::SingleRowMutation("row-key-0");
   mutation.emplace_back(bigtable::SetCell(family, "col0", 0, "value-0-0"));
   mutation.emplace_back(bigtable::SetCell(family, "col1", 0, "value-0-1"));
-  table->Apply(std::move(mutation));
+  table.Apply(std::move(mutation));
   std::cout << "row-key-0 mutated successfully" << std::endl;
 
   mutation = bigtable::SingleRowMutation("row-key-1");
   mutation.emplace_back(bigtable::SetCell(family, "col0", 0, "value-1-0"));
   mutation.emplace_back(bigtable::SetCell(family, "col1", 0, "value-1-1"));
-  table->Apply(std::move(mutation));
+  table.Apply(std::move(mutation));
   std::cout << "row-key-1 mutated successfully" << std::endl;
 
   bigtable::BulkMutation bulk{
@@ -78,7 +79,7 @@ int main(int argc, char* argv[]) try {
                                   {bigtable::SetCell(family, "c0", 0, "v2"),
                                    bigtable::SetCell(family, "c1", 0, "v3")}),
   };
-  table->BulkApply(std::move(bulk));
+  table.BulkApply(std::move(bulk));
   std::cout << "bulk mutation successful" << std::endl;
 
   return 0;


### PR DESCRIPTION
This is part of the fixes for #101.  Please read the issue for a
full description of where these changes are headed, in this PR
we "simply" break a dependency cycle between two classes.