### PR TITLE
Fix formatting script and use it on missed files.

### DIFF
--- a/bigtable/admin/column_family.h
+++ b/bigtable/admin/column_family.h
@@ -63,7 +63,8 @@ class GcRule {
    *     expressed as a `std::ratio<>`), for our purposes it is simply a formal
    *     parameter.
    *
-   * @see [std::chrono::duration<>](http://en.cppreference.com/w/cpp/chrono/duration)
+   * @see
+   * [std::chrono::duration<>](http://en.cppreference.com/w/cpp/chrono/duration)
    *     for more details.
    */
   template <typename Rep, typename Period>

--- a/bigtable/client/client_options.h
+++ b/bigtable/client/client_options.h
@@ -155,7 +155,8 @@ class ClientOptions {
   /**
    * Set LB policy name.
    *
-   * Please see the docs for grpc::ChannelArguments::SetLoadBalancingPolicyName()
+   * Please see the docs for
+   * grpc::ChannelArguments::SetLoadBalancingPolicyName()
    * on https://grpc.io/grpc/cpp/classgrpc_1_1_channel_arguments.html
    * for more details.
    *

--- a/bigtable/client/data.h
+++ b/bigtable/client/data.h
@@ -46,8 +46,8 @@ class Client : public ClientInterface {
       : project_(project),
         instance_(instance),
         credentials_(options.credentials()),
-        channel_(
-            grpc::CreateChannel(options.data_endpoint(), options.credentials())),
+        channel_(grpc::CreateChannel(options.data_endpoint(),
+                                     options.credentials())),
         bt_stub_(google::bigtable::v2::Bigtable::NewStub(channel_)) {}
 
   Client(const std::string& project, const std::string& instance)

--- a/bigtable/client/filters.h
+++ b/bigtable/client/filters.h
@@ -153,7 +153,8 @@ class Filter {
    *     parameter.
    * @tparam Period2 similar formal parameter for the type of @p end.
    *
-   * @see [std::chrono::duration<>](http://en.cppreference.com/w/cpp/chrono/duration)
+   * @see
+   * [std::chrono::duration<>](http://en.cppreference.com/w/cpp/chrono/duration)
    *     for more details.
    */
   template <typename Rep1, typename Period1, typename Rep2, typename Period2>
@@ -469,7 +470,8 @@ class Filter {
    *
    * This filter executes each stream in parallel and then merges the results by
    * interleaving the output from each stream.  The
-   * [proto file](https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto)
+   * [proto
+   * file](https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto)
    * has a nice illustration in the documentation of
    * `google.bigtable.v2.RowFilter.Interleave`.
    *
@@ -502,7 +504,8 @@ class Filter {
    * Return a filter that outputs all cells ignoring intermediate filters.
    *
    * Please read the documentation in the
-   * [proto file](https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto)
+   * [proto
+   * file](https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto)
    * for a detailed description.  In short, this is an advanced filter to
    * facilitate debugging.  You can explore the intermediate results of a
    * complex filter expression by injecting a filter of this type.

--- a/bigtable/client/mutations.h
+++ b/bigtable/client/mutations.h
@@ -202,8 +202,7 @@ class PermanentMutationFailure : public std::runtime_error {
                            std::vector<FailedMutation>&& failures)
       : std::runtime_error(msg), failures_(std::move(failures)) {}
 
-  PermanentMutationFailure(char const* msg,
-                           grpc::Status status,
+  PermanentMutationFailure(char const* msg, grpc::Status status,
                            std::vector<FailedMutation>&& failures)
       : std::runtime_error(msg),
         failures_(std::move(failures)),

--- a/bigtable/client/testing/chrono_literals.h
+++ b/bigtable/client/testing/chrono_literals.h
@@ -20,27 +20,27 @@
 // TODO(#109) - these are generally useful, consider submitting to abseil.io
 namespace bigtable {
 namespace chrono_literals {
-constexpr std::chrono::hours operator "" _h(unsigned long long h) {
+constexpr std::chrono::hours operator"" _h(unsigned long long h) {
   return std::chrono::hours(h);
 }
 
-constexpr std::chrono::minutes operator "" _min(unsigned long long m) {
+constexpr std::chrono::minutes operator"" _min(unsigned long long m) {
   return std::chrono::minutes(m);
 }
 
-constexpr std::chrono::seconds operator "" _s(unsigned long long s) {
+constexpr std::chrono::seconds operator"" _s(unsigned long long s) {
   return std::chrono::seconds(s);
 }
 
-constexpr std::chrono::milliseconds operator "" _ms(unsigned long long ms) {
+constexpr std::chrono::milliseconds operator"" _ms(unsigned long long ms) {
   return std::chrono::milliseconds(ms);
 }
 
-constexpr std::chrono::microseconds operator "" _us(unsigned long long us) {
+constexpr std::chrono::microseconds operator"" _us(unsigned long long us) {
   return std::chrono::microseconds(us);
 }
 
-constexpr std::chrono::nanoseconds operator "" _ns(unsigned long long ns) {
+constexpr std::chrono::nanoseconds operator"" _ns(unsigned long long ns) {
   return std::chrono::nanoseconds(ns);
 }
 

--- a/bigtable/client/testing/table_test_fixture.h
+++ b/bigtable/client/testing/table_test_fixture.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_TABLE_TEST_FIXTURE_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_TABLE_TEST_FIXTURE_H_
 
-#include "bigtable/client/testing/mock_client.h"
 #include "bigtable/client/data.h"
+#include "bigtable/client/testing/mock_client.h"
 
 namespace bigtable {
 namespace testing {

--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -22,8 +22,10 @@ if [ "${CHECK_STYLE}" != "yes" ]; then
 fi
 
 # This script assumes it is running the top-level google-cloud-cpp directory.
-find . \( -path ./.git -prune -o -path ./third_party -prune \) \
-     -o -name '*.h' -o -name '*.cc' -print0 \
+find . \( -path ./.git -prune -o -path ./third_party -prune \
+          -o -path './cmake-build-*' -o -path ./build-output -prune \
+          -o -name '*.pb.h' -prune -o -name '*.pb.cc' -prune \) \
+     -o \( -name '*.cc' -o -name '*.h' \) -print0 \
      | xargs -0 clang-format -i
 
 # Report any differences created by running clang-format.


### PR DESCRIPTION
The formatting script was missing the header files, fixed the
script and use clang-format on the missed files.

Also, avoid reformatting files in the typical build directories, and avoid reformatting generated protobuf files, we do not care to reformat them, and we do care about recompiling them unnecessarily.
