### PR TITLE
Implement integration tests for bigtable::Filter::* functions.

### DIFF
--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -252,11 +252,19 @@ target_link_libraries(data_integration_test
     ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 add_dependencies(tests-local data_integration_test)
 
+# An integration test for bigtable::TableAdmin.
 add_executable(admin_integration_test tests/admin_integration_test.cc)
 target_link_libraries(admin_integration_test
     bigtable_admin_client bigtable_client bigtable_protos absl::strings
     ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 add_dependencies(tests-local admin_integration_test)
+
+# An integration test for bigtable::Filter.
+add_executable(filters_integration_test tests/filters_integration_test.cc)
+target_link_libraries(filters_integration_test
+bigtable_admin_client bigtable_client bigtable_protos
+${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+add_dependencies(tests-local filters_integration_test)
 
 # Define the install target
 get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -262,8 +262,8 @@ add_dependencies(tests-local admin_integration_test)
 # An integration test for bigtable::Filter.
 add_executable(filters_integration_test tests/filters_integration_test.cc)
 target_link_libraries(filters_integration_test
-bigtable_admin_client bigtable_client bigtable_protos
-${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+    gmock bigtable_admin_client bigtable_client bigtable_protos
+    ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 add_dependencies(tests-local filters_integration_test)
 
 # Define the install target

--- a/bigtable/client/filters.h
+++ b/bigtable/client/filters.h
@@ -72,7 +72,8 @@ class Filter {
    * Return a filter that accepts only the last @p n values of each column.
    *
    * The server rejects filters where @p n <= 0, any ReadRows() request
-   * containing such a filter fails with grpc::StatusCode::INVALID_ARGUMENT.
+   * containing such a filter fails with `grpc::StatusCode::INVALID_ARGUMENT`.
+   * This function does not perform any local validation of @p n.
    */
   static Filter Latest(std::int32_t n) {
     Filter result;
@@ -210,7 +211,8 @@ class Filter {
    * - Within a column, the cells appear in descending order by timestamp.
    *
    * The server rejects filters where @p n <= 0, any ReadRows() request
-   * containing such a filter fails with grpc::StatusCode::INVALID_ARGUMENT.
+   * containing such a filter fails with `grpc::StatusCode::INVALID_ARGUMENT`.
+   * This function does not perform any local validation of @p n.
    */
   static Filter CellsRowLimit(std::int32_t n) {
     Filter tmp;
@@ -233,7 +235,8 @@ class Filter {
    * - Within a column, the cells appear in descending order by timestamp.
    *
    * The server rejects filters where @p n <= 0, any ReadRows() request
-   * containing such a filter fails with grpc::StatusCode::INVALID_ARGUMENT.
+   * containing such a filter fails with `grpc::StatusCode::INVALID_ARGUMENT`.
+   * This function does not perform any local validation of @p n.
    */
   static Filter CellsRowOffset(std::int32_t n) {
     Filter tmp;
@@ -244,10 +247,13 @@ class Filter {
   /**
    * Return a filter that samples rows with a given probability.
    *
-   * TODO(#84) - decide what happens if the probability is out of range.
+   * The server rejects filters where @p probability is outside the range
+   * (0.0, 1.0).  Any ReadRows() request containing such a filter fails with
+   * `grpc::StatusCode::INVALID_ARGUMENT`. This function does not perform any
+   * local validation of @p probability.
    *
    * @param probability the probability that any row will be selected.  It
-   *     must be in the range [0.0, 1.0].
+   *     must be in the range (0.0, 1.0).
    */
   static Filter RowSample(double probability) {
     Filter tmp;

--- a/bigtable/client/filters.h
+++ b/bigtable/client/filters.h
@@ -209,7 +209,8 @@ class Filter {
    *   column names are sorted lexicographically.
    * - Within a column, the cells appear in descending order by timestamp.
    *
-   * TODO(#84) - document what is the effect of n <= 0
+   * The server rejects filters where @p n <= 0, any ReadRows() request
+   * containing such a filter fails with grpc::StatusCode::INVALID_ARGUMENT.
    */
   static Filter CellsRowLimit(std::int32_t n) {
     Filter tmp;
@@ -231,7 +232,8 @@ class Filter {
    *   column names are sorted lexicographically.
    * - Within a column, the cells appear in descending order by timestamp.
    *
-   * TODO(#84) - document what is the effect of n <= 0
+   * The server rejects filters where @p n <= 0, any ReadRows() request
+   * containing such a filter fails with grpc::StatusCode::INVALID_ARGUMENT.
    */
   static Filter CellsRowOffset(std::int32_t n) {
     Filter tmp;

--- a/bigtable/client/filters.h
+++ b/bigtable/client/filters.h
@@ -71,7 +71,8 @@ class Filter {
   /**
    * Return a filter that accepts only the last @p n values of each column.
    *
-   * TODO(#84) - document what is the effect of n <= 0
+   * The server rejects filters where @p n <= 0, any ReadRows() request
+   * containing such a filter fails with grpc::StatusCode::INVALID_ARGUMENT.
    */
   static Filter Latest(std::int32_t n) {
     Filter result;

--- a/bigtable/client/filters_test.cc
+++ b/bigtable/client/filters_test.cc
@@ -37,6 +37,11 @@ TEST(FiltersTest, Latest) {
   EXPECT_EQ(3, proto.cells_per_column_limit_filter());
 }
 
+TEST(FiltersTest, FamilyRegex) {
+  auto proto = bigtable::Filter::FamilyRegex("fam[123]").as_proto();
+  EXPECT_EQ("fam[123]", proto.family_name_regex_filter());
+}
+
 TEST(FiltersTest, ColumnRegex) {
   auto proto = bigtable::Filter::ColumnRegex("col[A-E]").as_proto();
   EXPECT_EQ("col[A-E]", proto.column_qualifier_regex_filter());
@@ -51,11 +56,6 @@ TEST(FiltersTest, ColumnRange) {
   EXPECT_EQ(btproto::ColumnRange::kEndQualifierOpen,
             proto.column_range_filter().end_qualifier_case());
   EXPECT_EQ("colF", proto.column_range_filter().end_qualifier_open());
-}
-
-TEST(FiltersTest, FamilyRegex) {
-  auto proto = bigtable::Filter::FamilyRegex("fam[123]").as_proto();
-  EXPECT_EQ("fam[123]", proto.family_name_regex_filter());
 }
 
 TEST(FiltersTest, TimestampRangeMicros) {

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -35,26 +35,23 @@ void ReportException();
 //
 void CheckPassAll(bigtable::DataClient& client, bigtable::Table& table,
                   std::string const& row_key);
-void CheckBlockAll(bigtable::ClientInterface& client, bigtable::Table& table,
+void CheckBlockAll(bigtable::DataClient& client, bigtable::Table& table,
                    std::string const& row_key);
-void CheckLatest(bigtable::ClientInterface& client, bigtable::Table& table,
+void CheckLatest(bigtable::DataClient& client, bigtable::Table& table,
                  std::string const& row_key);
-void CheckFamilyRegex(bigtable::ClientInterface& client, bigtable::Table& table,
+void CheckFamilyRegex(bigtable::DataClient& client, bigtable::Table& table,
                       std::string const& row_key);
-void CheckColumnRegex(bigtable::ClientInterface& client, bigtable::Table& table,
+void CheckColumnRegex(bigtable::DataClient& client, bigtable::Table& table,
                       std::string const& row_key);
-void CheckColumnRange(bigtable::ClientInterface& client, bigtable::Table& table,
+void CheckColumnRange(bigtable::DataClient& client, bigtable::Table& table,
                       std::string const& row_key);
-void CheckTimestampRange(bigtable::ClientInterface& client,
-                         bigtable::Table& table, std::string const& row_key);
-void CheckCellsRowLimit(bigtable::ClientInterface& client,
-                        bigtable::Table& table,
+void CheckTimestampRange(bigtable::DataClient& client, bigtable::Table& table,
+                         std::string const& row_key);
+void CheckCellsRowLimit(bigtable::DataClient& client, bigtable::Table& table,
                         std::string const& row_key_prefix);
-void CheckCellsRowOffset(bigtable::ClientInterface& client,
-                         bigtable::Table& table,
+void CheckCellsRowOffset(bigtable::DataClient& client, bigtable::Table& table,
                          std::string const& row_key_prefix);
-void CheckCellsRowSample(bigtable::ClientInterface& client,
-                         bigtable::Table& table,
+void CheckCellsRowSample(bigtable::DataClient& client, bigtable::Table& table,
                          std::string const& row_key_prefix);
 }  // anonymous namespace
 
@@ -231,7 +228,7 @@ std::vector<bigtable::Cell> ReadRow(bigtable::DataClient& client,
 }
 
 // TODO(#32) remove this when Table::ReadRow() is a thing.
-std::vector<bigtable::Cell> ReadRows(bigtable::ClientInterface& client,
+std::vector<bigtable::Cell> ReadRows(bigtable::DataClient& client,
                                      bigtable::Table& table, std::string start,
                                      std::string end, bigtable::Filter filter) {
   btproto::ReadRowsRequest request;
@@ -339,7 +336,7 @@ void CheckPassAll(bigtable::DataClient& client, bigtable::Table& table,
   std::cout << __func__ << " was successful" << std::endl;
 }
 
-void CheckBlockAll(bigtable::ClientInterface& client, bigtable::Table& table,
+void CheckBlockAll(bigtable::DataClient& client, bigtable::Table& table,
                    std::string const& row_key) {
   std::vector<bigtable::Cell> created{
       {row_key, "fam0", "c", 0, "v-c-0-0", {}},
@@ -358,7 +355,7 @@ void CheckBlockAll(bigtable::ClientInterface& client, bigtable::Table& table,
   std::cout << __func__ << " was successful" << std::endl;
 }
 
-void CheckLatest(bigtable::ClientInterface& client, bigtable::Table& table,
+void CheckLatest(bigtable::DataClient& client, bigtable::Table& table,
                  std::string const& row_key) {
   std::vector<bigtable::Cell> created{
       {row_key, "fam0", "c", 0, "v-c-0-0", {}},
@@ -383,7 +380,7 @@ void CheckLatest(bigtable::ClientInterface& client, bigtable::Table& table,
   std::cout << __func__ << " was successful" << std::endl;
 }
 
-void CheckFamilyRegex(bigtable::ClientInterface& client, bigtable::Table& table,
+void CheckFamilyRegex(bigtable::DataClient& client, bigtable::Table& table,
                       std::string const& row_key) {
   std::vector<bigtable::Cell> created{
       {row_key, "fam0", "c2", 0, "bar", {}},
@@ -407,7 +404,7 @@ void CheckFamilyRegex(bigtable::ClientInterface& client, bigtable::Table& table,
   std::cout << __func__ << " was successful" << std::endl;
 }
 
-void CheckColumnRegex(bigtable::ClientInterface& client, bigtable::Table& table,
+void CheckColumnRegex(bigtable::DataClient& client, bigtable::Table& table,
                       std::string const& row_key) {
   std::vector<bigtable::Cell> created{
       {row_key, "fam0", "abc", 0, "bar", {}},
@@ -431,7 +428,7 @@ void CheckColumnRegex(bigtable::ClientInterface& client, bigtable::Table& table,
   std::cout << __func__ << " was successful" << std::endl;
 }
 
-void CheckColumnRange(bigtable::ClientInterface& client, bigtable::Table& table,
+void CheckColumnRange(bigtable::DataClient& client, bigtable::Table& table,
                       std::string const& row_key) {
   std::vector<bigtable::Cell> created{
       {row_key, "fam0", "a00", 0, "bar", {}},
@@ -454,8 +451,8 @@ void CheckColumnRange(bigtable::ClientInterface& client, bigtable::Table& table,
   std::cout << __func__ << " was successful" << std::endl;
 }
 
-void CheckTimestampRange(bigtable::ClientInterface& client,
-                         bigtable::Table& table, std::string const& row_key) {
+void CheckTimestampRange(bigtable::DataClient& client, bigtable::Table& table,
+                         std::string const& row_key) {
   std::vector<bigtable::Cell> created{
       {row_key, "fam0", "c0", 1000, "v1000", {}},
       {row_key, "fam1", "c1", 2000, "v2000", {}},
@@ -535,8 +532,8 @@ void CheckEqualRowKeyCount(absl::string_view where,
  *   | "{prefix}/complex"      | fam1   | col9   | cell @ 3000, 6000 |
  *
  */
-void CreateComplexRows(bigtable::ClientInterface& client,
-                       bigtable::Table& table, std::string const& prefix) {
+void CreateComplexRows(bigtable::DataClient& client, bigtable::Table& table,
+                       std::string const& prefix) {
   namespace bt = bigtable;
   bt::BulkMutation mutation;
   // Prepare a set of rows, with different numbers of cells, columns, and
@@ -574,8 +571,7 @@ void CreateComplexRows(bigtable::ClientInterface& client,
   table.BulkApply(std::move(mutation));
 }
 
-void CheckCellsRowLimit(bigtable::ClientInterface& client,
-                        bigtable::Table& table,
+void CheckCellsRowLimit(bigtable::DataClient& client, bigtable::Table& table,
                         std::string const& row_key_prefix) {
   CreateComplexRows(client, table, row_key_prefix);
 
@@ -600,8 +596,7 @@ void CheckCellsRowLimit(bigtable::ClientInterface& client,
   std::cout << __func__ << " was successful" << std::endl;
 }
 
-void CheckCellsRowOffset(bigtable::ClientInterface& client,
-                         bigtable::Table& table,
+void CheckCellsRowOffset(bigtable::DataClient& client, bigtable::Table& table,
                          std::string const& row_key_prefix) {
   CreateComplexRows(client, table, row_key_prefix);
 
@@ -624,7 +619,7 @@ void CheckCellsRowOffset(bigtable::ClientInterface& client,
   std::cout << __func__ << " was successful" << std::endl;
 }
 
-void CreateManyRows(bigtable::ClientInterface& client, bigtable::Table& table,
+void CreateManyRows(bigtable::DataClient& client, bigtable::Table& table,
                     std::string const& prefix, int count) {
   namespace bt = bigtable;
   bt::BulkMutation bulk;
@@ -636,8 +631,7 @@ void CreateManyRows(bigtable::ClientInterface& client, bigtable::Table& table,
   table.BulkApply(std::move(bulk));
 }
 
-void CheckCellsRowSample(bigtable::ClientInterface& client,
-                         bigtable::Table& table,
+void CheckCellsRowSample(bigtable::DataClient& client, bigtable::Table& table,
                          std::string const& row_key_prefix) {
   constexpr int row_count = 20000;
   CreateManyRows(client, table, row_key_prefix, row_count);

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -460,7 +460,7 @@ void CheckCellsRowLimit(bigtable::ClientInterface& client,
 
   std::map<std::string, int> actual;
   for (auto const& c : result) {
-    auto ins = actual.emplace(c.row_key(), 0);
+    auto ins = actual.emplace(static_cast<std::string>(c.row_key()), 0);
     ins.first->second++;
   }
   std::map<std::string, int> expected{{row_key_prefix + "/one-cell", 1},
@@ -486,7 +486,7 @@ void CheckCellsRowOffset(bigtable::ClientInterface& client,
 
   std::map<std::string, int> actual;
   for (auto const& c : result) {
-    auto ins = actual.emplace(c.row_key(), 0);
+    auto ins = actual.emplace(static_cast<std::string>(c.row_key()), 0);
     ins.first->second++;
   }
   std::map<std::string, int> expected{{row_key_prefix + "/many", 2},

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -43,9 +43,6 @@ class FilterTestEnvironment : public ::testing::Environment {
     instance_id_ = std::move(instance);
   }
 
-  void SetUp() override {}
-  void TearDown() override {}
-
   static std::string const& project_id() { return project_id_; }
   static std::string const& instance_id() { return instance_id_; }
 
@@ -57,14 +54,13 @@ class FilterTestEnvironment : public ::testing::Environment {
 class FilterIntegrationTest : public ::testing::Test {
  protected:
   void SetUp() override;
-  void TearDown() override {}
 
   std::unique_ptr<bigtable::Table> CreateTable(std::string const& table_id);
 
   /**
    * Return all the cells included in @p request.
    *
-   * // TODO(#32) remove this when Table::ReadRows() is a thing.
+   * TODO(#32) remove this when Table::ReadRows() is a thing.
    */
   std::vector<bigtable::Cell> ReadRows(bigtable::Table& table,
                                        btproto::ReadRowsRequest request);
@@ -93,25 +89,24 @@ class FilterIntegrationTest : public ::testing::Test {
    * Create the following rows in @p table, the magic values for the column
    * families are defined above.
    *
-   *   | Row Key                 | Family | Column | Contents      |
-   *   | :---------------------- | :----- | :----- | :------------ |
-   *   | "{prefix}/one-cell"     | fam0   | c      | cell @ 3000 |
-   *   | "{prefix}/two-cells"    | fam0   | c      | cell @ 3000 |
-   *   | "{prefix}/two-cells"    | fam0   | c2     | cell @ 3000 |
-   *   | "{prefix}/many"         | fam0   | c      | cells @ 0, 1000, 200, 3000
-   * |
-   *   | "{prefix}/many-columns" | fam0   | c0     | cell @ 3000 |
-   *   | "{prefix}/many-columns" | fam0   | c1     | cell @ 3000 |
-   *   | "{prefix}/many-columns" | fam0   | c2     | cell @ 3000 |
-   *   | "{prefix}/many-columns" | fam0   | c3     | cell @ 3000 |
-   *   | "{prefix}/complex"      | fam0   | col0   | cell @ 3000, 6000 |
-   *   | "{prefix}/complex"      | fam0   | col1   | cell @ 3000, 6000 |
-   *   | "{prefix}/complex"      | fam0   | ...    | cell @ 3000, 6000 |
-   *   | "{prefix}/complex"      | fam0   | col9   | cell @ 3000, 6000 |
-   *   | "{prefix}/complex"      | fam1   | col0   | cell @ 3000, 6000 |
-   *   | "{prefix}/complex"      | fam1   | col1   | cell @ 3000, 6000 |
-   *   | "{prefix}/complex"      | fam1   | ...    | cell @ 3000, 6000 |
-   *   | "{prefix}/complex"      | fam1   | col9   | cell @ 3000, 6000 |
+   * | Row Key                 | Family | Column | Contents      |
+   * | :---------------------- | :----- | :----- | :------------ |
+   * | "{prefix}/one-cell"     | fam0   | c      | cell @ 3000 |
+   * | "{prefix}/two-cells"    | fam0   | c      | cell @ 3000 |
+   * | "{prefix}/two-cells"    | fam0   | c2     | cell @ 3000 |
+   * | "{prefix}/many"         | fam0   | c      | cells @ 0, 1000, 2000, 3000 |
+   * | "{prefix}/many-columns" | fam0   | c0     | cell @ 3000 |
+   * | "{prefix}/many-columns" | fam0   | c1     | cell @ 3000 |
+   * | "{prefix}/many-columns" | fam0   | c2     | cell @ 3000 |
+   * | "{prefix}/many-columns" | fam0   | c3     | cell @ 3000 |
+   * | "{prefix}/complex"      | fam0   | col0   | cell @ 3000, 6000 |
+   * | "{prefix}/complex"      | fam0   | col1   | cell @ 3000, 6000 |
+   * | "{prefix}/complex"      | fam0   | ...    | cell @ 3000, 6000 |
+   * | "{prefix}/complex"      | fam0   | col9   | cell @ 3000, 6000 |
+   * | "{prefix}/complex"      | fam1   | col0   | cell @ 3000, 6000 |
+   * | "{prefix}/complex"      | fam1   | col1   | cell @ 3000, 6000 |
+   * | "{prefix}/complex"      | fam1   | ...    | cell @ 3000, 6000 |
+   * | "{prefix}/complex"      | fam1   | col9   | cell @ 3000, 6000 |
    *
    */
   void CreateComplexRows(bigtable::Table& table, std::string const& prefix);
@@ -200,9 +195,11 @@ namespace bigtable {
 bool operator==(Cell const& lhs, Cell const& rhs) {
   return CellCompare(lhs, rhs) == 0;
 }
+
 bool operator<(Cell const& lhs, Cell const& rhs) {
   return CellCompare(lhs, rhs) < 0;
 }
+
 void PrintTo(bigtable::Cell const& cell, std::ostream* os) {
   *os << "  row_key=" << cell.row_key() << ", family=" << cell.family_name()
       << ", column=" << cell.column_qualifier()
@@ -633,8 +630,8 @@ void FilterIntegrationTest::CreateComplexRows(bigtable::Table& table,
                              bt::SetCell("fam0", "c1", 3000, "foo"),
                              bt::SetCell("fam0", "c2", 3000, "foo"),
                              bt::SetCell("fam0", "c3", 3000, "foo")}));
-  // This one is complicated, create a mutation with several families and
-  // columns
+  // This one is complicated: create a mutation with several families and
+  // columns.
   bt::SingleRowMutation complex(prefix + "/complex");
   for (int i = 0; i != 4; ++i) {
     for (int j = 0; j != 10; ++j) {

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -39,6 +39,8 @@ void CheckBlockAll(bigtable::ClientInterface& client, bigtable::Table& table,
                    std::string const& row_key);
 void CheckLatest(bigtable::ClientInterface& client, bigtable::Table& table,
                  std::string const& row_key);
+void CheckFamilyRegex(bigtable::ClientInterface& client, bigtable::Table& table,
+                      std::string const& row_key);
 void CheckCellsRowLimit(bigtable::ClientInterface& client,
                         bigtable::Table& table,
                         std::string const& row_key_prefix);
@@ -103,6 +105,7 @@ int main(int argc, char* argv[]) try {
   } catch(...) {}
 
   CheckLatest(*client, table, "aaa003-latest");
+  CheckFamilyRegex(*client, table, "aaa004-family-regex");
   CheckCellsRowLimit(*client, table, "aaa004-cells-row-limit");
   CheckCellsRowOffset(*client, table, "aaa005-cells-row-offset");
 
@@ -350,6 +353,37 @@ void CheckLatest(bigtable::ClientInterface& client, bigtable::Table& table,
   auto actual = ReadRow(client, table, row_key, bigtable::Filter::Latest(2));
   CheckEqual("CheckLatest()", expected, actual);
   std::cout << "CheckLatest() is successful" << std::endl;
+}
+
+void CheckFamilyRegex(bigtable::ClientInterface& client, bigtable::Table& table,
+                      std::string const& row_key) {
+  std::vector<bigtable::Cell> created{
+      {row_key, "fam", "c2", 0, "bar", {}},
+      {row_key, "fam0", "c", 0, "bar", {}},
+      {row_key, "fam1", "c", 0, "bar", {}},
+      {row_key, "fam2", "c", 0, "bar", {}},
+      {row_key, "fam2", "c2", 0, "bar", {}},
+      {row_key, "fam3", "c2", 0, "bar", {}},
+  };
+
+  auto mutation = bigtable::SingleRowMutation(row_key);
+  for (auto const& cell : created) {
+    mutation.emplace_back(bigtable::SetCell(
+        static_cast<std::string>(cell.family_name()),
+        static_cast<std::string>(cell.column_qualifier()), cell.timestamp(),
+        static_cast<std::string>(cell.value())));
+  }
+  table.Apply(std::move(mutation));
+
+  std::vector<bigtable::Cell> expected{
+      {row_key, "fam0", "c", 0, "bar", {}},
+      {row_key, "fam2", "c", 0, "bar", {}},
+      {row_key, "fam2", "c2", 0, "bar", {}},
+  };
+  auto actual =
+      ReadRow(client, table, row_key, bigtable::Filter::FamilyRegex("fam[02]"));
+  CheckEqual("CheckFamilyRegex()", expected, actual);
+  std::cout << "CheckFamilyRegex() is successful" << std::endl;
 }
 
 void CheckEqualRowKeyCount(absl::string_view where,

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -19,8 +19,8 @@
 #include "bigtable/admin/table_admin.h"
 #include "bigtable/client/cell.h"
 #include "bigtable/client/data_client.h"
-#include "bigtable/client/table.h"
 #include "bigtable/client/filters.h"
+#include "bigtable/client/table.h"
 
 namespace btproto = ::google::bigtable::v2;
 

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -520,7 +520,7 @@ std::vector<bigtable::Cell> FilterIntegrationTest::ReadRows(
     bigtable::Table& table, btproto::ReadRowsRequest request) {
   std::vector<bigtable::Cell> result;
   grpc::ClientContext client_context;
-  auto stream = data_client_->Stub().ReadRows(&client_context, request);
+  auto stream = data_client_->Stub()->ReadRows(&client_context, request);
   btproto::ReadRowsResponse response;
 
   std::string current_row_key;

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -58,6 +58,7 @@ void CheckCellsRowSample(bigtable::ClientInterface& client,
                          std::string const& row_key_prefix);
 }  // anonymous namespace
 
+// TODO(#153) - consider implementing integration tests with googletest.
 int main(int argc, char* argv[]) try {
   namespace admin_proto = ::google::bigtable::admin::v2;
 
@@ -103,7 +104,7 @@ int main(int argc, char* argv[]) try {
 
   CheckPassAll(*client, table, "aaa0001-pass-all");
 
-  // TODO(google-cloud-go#839) - remove workarounds for emulator bug(s).
+  // TODO(#151) - remove workarounds for emulator bug(s).
   try {
     CheckBlockAll(*client, table, "aaa0002-block-all");
   } catch (...) {
@@ -115,19 +116,21 @@ int main(int argc, char* argv[]) try {
   CheckColumnRegex(*client, table, "aaa005-column-regex");
   CheckColumnRange(*client, table, "aaa006-column-range");
   CheckTimestampRange(*client, table, "aaa007-timestamp-range");
+  // TODO(#152) - implement the following integration tests.
   // CheckRowKeysRegex(*client, table, "aaa008-row-key-regex");
   // CheckValueRegex(*client, table, "aaa009-value-regex");
   // CheckValueRange(*client, table, "aaa010-value-range");
   CheckCellsRowLimit(*client, table, "aaa011-cells-row-limit");
   CheckCellsRowOffset(*client, table, "aaa012-cells-row-offset");
 
-  // TODO(google-cloud-go#840) - remove workarounds for emulator bug(s).
+  // TODO(#151) - remove workarounds for emulator bug(s).
   try {
     CheckCellsRowSample(*client, table, "aaa013-cells-row-sample");
   } catch (...) {
     ReportException();
   }
 
+  // TODO(#152) - implement the following integration tests.
   // CheckStripValueTransformer(client, *table, "aaa014-strip-value");
   // CheckCondition(client, *table, "aaa015-condition");
   // CheckChain(client, *table, "aaa016-chain");
@@ -150,8 +153,9 @@ void ReportException() {
               << "], details=" << ex.status().error_details() << std::endl;
     int count = 0;
     for (auto const& failure : ex.failures()) {
-      std::cerr << "failure[" << count++ << "] {key="
-                << failure.mutation().row_key() << "}" << std::endl;
+      std::cerr << "failure[" << count++
+                << "] {key=" << failure.mutation().row_key() << "}"
+                << std::endl;
     }
   } catch (std::exception const& ex) {
     std::cerr << "Standard exception raised: " << ex.what() << std::endl;
@@ -487,7 +491,7 @@ void CheckEqualRowKeyCount(absl::string_view where,
   }
 
   std::ostringstream os;
-  // In C++14 we could use
+  // In C++14 we could use a single lambda with auto parameters, sigh? meh?
   auto stream_map = [&os](std::pair<std::string const, int> const& x) {
     os << "{" << x.first << "," << x.second << "}, ";
   };
@@ -640,9 +644,9 @@ void CheckCellsRowSample(bigtable::ClientInterface& client,
 
   // We want to check that the sampling rate was "more or less" the prescribed
   // value.  We use 5% as the allowed error, this is arbitrary.  If we wanted to
-  // get serious about testing the sampling rate we would do some statistics.
+  // get serious about testing the sampling rate, we would do some statistics.
   // We do not really need to, because we are testing the library, not the
-  // server. But for what is worth, the outline would be:
+  // server. But for what it's worth, the outline would be:
   //
   //   - Model sampling as a binomial process.
   //   - Perform power analysis to decide the size of the sample.

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -1,0 +1,239 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <google/protobuf/text_format.h>
+#include <sstream>
+#include "bigtable/admin/admin_client.h"
+#include "bigtable/admin/table_admin.h"
+#include "bigtable/client/cell.h"
+#include "bigtable/client/data_client.h"
+#include "bigtable/client/table.h"
+#include "bigtable/client/filters.h"
+
+namespace btproto = ::google::bigtable::v2;
+
+namespace {
+// TODO(#32) - change the function signature when Table::ReadRows() is a thing.
+// All these functions would become:
+//     `Function(bigtable::Table& table, std::string const& row_key)`
+//     `Function(bigtable::Table& table, std::string const& begin,
+//               std::string const& end)`
+//
+void CheckPassAll(bigtable::DataClient& client, bigtable::Table& table,
+                  std::string const& row_key);
+}  // anonymous namespace
+
+int main(int argc, char* argv[]) try {
+  namespace admin_proto = ::google::bigtable::admin::v2;
+
+  // Make sure the arguments are valid.
+  if (argc != 4) {
+    std::string const cmd = argv[0];
+    auto last_slash = std::string(argv[0]).find_last_of("/");
+    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
+              << " <project> <instance> <table>" << std::endl;
+    return 1;
+  }
+  std::string const project_id = argv[1];
+  std::string const instance_id = argv[2];
+  std::string const table_name = argv[3];
+  std::string const family = "fam";
+  std::string const fam0 = "fam0";
+  std::string const fam1 = "fam1";
+  std::string const fam2 = "fam2";
+  std::string const fam3 = "fam3";
+
+  auto admin_client =
+      bigtable::CreateAdminClient(project_id, bigtable::ClientOptions());
+  bigtable::TableAdmin admin(admin_client, instance_id);
+
+  auto table_list = admin.ListTables(admin_proto::Table::NAME_ONLY);
+  if (not table_list.empty()) {
+    std::ostringstream os;
+    os << "Expected empty instance at the beginning of integration test";
+    throw std::runtime_error(os.str());
+  }
+
+  auto created_table = admin.CreateTable(
+      table_name,
+      bigtable::TableConfig({{family, bigtable::GcRule::MaxNumVersions(10)},
+                             {fam0, bigtable::GcRule::MaxNumVersions(10)},
+                             {fam1, bigtable::GcRule::MaxNumVersions(10)},
+                             {fam2, bigtable::GcRule::MaxNumVersions(10)},
+                             {fam3, bigtable::GcRule::MaxNumVersions(10)}},
+                            {}));
+  std::cout << table_name << " created successfully" << std::endl;
+
+  auto client = bigtable::CreateDefaultClient(project_id, instance_id,
+                                              bigtable::ClientOptions());
+  bigtable::Table table(client, table_name);
+
+  CheckPassAll(*client, table, "aaa0001-pass-all");
+
+  return 0;
+} catch (bigtable::PermanentMutationFailure const& ex) {
+  std::cerr << "bigtable::PermanentMutationFailure raised: " << ex.what()
+            << " - " << ex.status().error_message() << " ["
+            << ex.status().error_code()
+            << "], details=" << ex.status().error_details() << std::endl;
+  return 1;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard exception raised: " << ex.what() << std::endl;
+  return 1;
+}
+
+namespace {
+// TODO(#32) remove this when Table::ReadRows() is a thing.
+std::vector<bigtable::Cell> ReadRows(bigtable::DataClient& client,
+                                     bigtable::Table& table,
+                                     btproto::ReadRowsRequest request) {
+  std::vector<bigtable::Cell> result;
+  grpc::ClientContext client_context;
+  auto stream = client.Stub().ReadRows(&client_context, request);
+  btproto::ReadRowsResponse response;
+
+  std::string current_row_key;
+  std::string current_family;
+  std::string current_column;
+  std::string current_value;
+  std::vector<std::string> current_labels;
+  while (stream->Read(&response)) {
+    for (btproto::ReadRowsResponse::CellChunk const& chunk :
+         response.chunks()) {
+      if (not chunk.row_key().empty()) {
+        current_row_key = chunk.row_key();
+      }
+      if (chunk.has_family_name()) {
+        current_family = chunk.family_name().value();
+      }
+      if (chunk.has_qualifier()) {
+        current_column = chunk.qualifier().value();
+      }
+      // Most of the time `chunk.labels()` is empty, but the following copy is
+      // fast in that case.
+      std::copy(chunk.labels().begin(), chunk.labels().end(),
+                std::back_inserter(current_labels));
+      if (chunk.value_size() > 0) {
+        current_value.reserve(chunk.value_size());
+      }
+      current_value.append(chunk.value());
+      if (chunk.value_size() == 0 or chunk.commit_row()) {
+        // This was the last chunk.
+        result.emplace_back(current_row_key, current_family, current_column,
+                            chunk.timestamp_micros(), std::move(current_value),
+                            std::move(current_labels));
+      }
+    }
+  }
+  auto status = stream->Finish();
+  if (not status.ok()) {
+    std::ostringstream os;
+    os << "gRPC error in ReadRow() - " << status.error_message() << " ["
+       << status.error_code() << "] details=" << status.error_details();
+    throw std::runtime_error(os.str());
+  }
+  return result;
+}
+
+// TODO(#29) remove this when Table::ReadRow() is a thing.
+std::vector<bigtable::Cell> ReadRow(bigtable::DataClient& client,
+                                    bigtable::Table& table, std::string key,
+                                    bigtable::Filter filter) {
+  btproto::ReadRowsRequest request;
+  request.set_table_name(table.table_name());
+  request.set_rows_limit(1);
+  auto& row = *request.mutable_rows();
+  *row.add_row_keys() = std::move(key);
+  *request.mutable_filter() = filter.as_proto_move();
+
+  return ReadRows(client, table, std::move(request));
+}
+
+int CellCompare(bigtable::Cell const& lhs, bigtable::Cell const& rhs) {
+  auto compare_row_key = lhs.row_key().compare(lhs.row_key());
+  if (compare_row_key != 0) {
+    return compare_row_key;
+  }
+  auto compare_family_name = lhs.family_name().compare(rhs.family_name());
+  if (compare_family_name != 0) {
+    return compare_family_name;
+  }
+  auto compare_column_qualifier =
+      lhs.column_qualifier().compare(rhs.column_qualifier());
+  if (compare_column_qualifier != 0) {
+    return compare_column_qualifier;
+  }
+  return rhs.timestamp() - lhs.timestamp();
+}
+
+bool CellLess(bigtable::Cell const& lhs, bigtable::Cell const& rhs) {
+  return CellCompare(lhs, rhs) < 0;
+}
+
+void PrintCells(std::ostream& os, std::vector<bigtable::Cell> const& cells) {
+  for (auto const& cell : cells) {
+    os << "  row_key=" << cell.row_key() << "\n  family=" << cell.family_name()
+       << "\n  column=" << cell.column_qualifier()
+       << "\n  timestamp=" << cell.timestamp() << "\n  value=" << cell.value();
+  }
+}
+
+void CheckEqual(absl::string_view where, std::vector<bigtable::Cell> expected,
+                std::vector<bigtable::Cell> actual) {
+  std::sort(expected.begin(), expected.end(), CellLess);
+  std::sort(actual.begin(), actual.end(), CellLess);
+  std::vector<bigtable::Cell> differences;
+  std::set_symmetric_difference(expected.begin(), expected.end(),
+                                actual.begin(), actual.end(),
+                                std::back_inserter(differences), CellLess);
+  if (differences.empty()) {
+    return;
+  }
+  std::ostringstream os;
+  os << "Mismatched cells in " << where << " differences=<\n";
+  PrintCells(os, differences);
+  os << ">\nexpected=<";
+  PrintCells(os, expected);
+  os << ">\nactual=<";
+  PrintCells(os, actual);
+  os << ">";
+  throw std::runtime_error(os.str());
+}
+
+void CheckPassAll(bigtable::DataClient& client, bigtable::Table& table,
+                  std::string const& row_key) {
+  std::vector<bigtable::Cell> expected{
+      {row_key, "fam", "c", 0, "v-c-0-0", {}},
+      {row_key, "fam", "c", 1000, "v-c-0-1", {}},
+      {row_key, "fam", "c", 2000, "v-c-0-2", {}},
+      {row_key, "fam0", "c0", 0, "v-c0-0-0", {}},
+      {row_key, "fam0", "c1", 1000, "v-c1-0-1", {}},
+      {row_key, "fam0", "c1", 2000, "v-c1-0-2", {}},
+  };
+
+  auto mutation = bigtable::SingleRowMutation(row_key);
+  for (auto const& cell : expected) {
+    mutation.emplace_back(bigtable::SetCell(
+        static_cast<std::string>(cell.family_name()),
+        static_cast<std::string>(cell.column_qualifier()), cell.timestamp(),
+        static_cast<std::string>(cell.value())));
+  }
+  table.Apply(std::move(mutation));
+
+  auto actual =
+      ReadRow(client, table, row_key, bigtable::Filter::PassAllFilter());
+  CheckEqual("CheckPassAll()", expected, actual);
+  std::cout << "CheckPassAll() is sucessful" << std::endl;
+}
+}  // anonymous namespace

--- a/bigtable/tests/run_integration_tests.sh
+++ b/bigtable/tests/run_integration_tests.sh
@@ -62,12 +62,12 @@ fi
 echo
 echo "Running Table::Apply() integration test."
 # The project and instance do not matter for the Cloud Bigtable emulator.
-./data_integration_test emulated emulated test-table
+./data_integration_test emulated data-test test-table
 
 echo
 echo "Running TableAdmin integration test."
-./admin_integration_test emulated admin-tests
+./admin_integration_test emulated admin-test
 
 echo
 echo "Running bigtable::Filters integration tests."
-./filters_integration_test emulated filters filters-table
+./filters_integration_test emulated filters-test

--- a/bigtable/tests/run_integration_tests.sh
+++ b/bigtable/tests/run_integration_tests.sh
@@ -67,3 +67,7 @@ echo "Running Table::Apply() integration test."
 echo
 echo "Running TableAdmin integration test."
 ./admin_integration_test emulated admin-tests
+
+echo
+echo "Running bigtable::Filters integration tests."
+./filters_integration_test emulated filters filters-table


### PR DESCRIPTION
This PR introduces an integration test for `bigtable::Filter`, and it has some of the fixes for #84.

The PR does not have all the integration tests, but it was getting too large, in fact, it might be too large already.
