### PR TITLE
Fix document upload after #138.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ cmake-build-*/
 # The Doxygen-generated documentation goes here:
 bigtable/doc/html/
 doc/html/
+gh-pages/

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,6 @@ cmake-build-*/
 # The Doxygen-generated documentation goes here:
 bigtable/doc/html/
 doc/html/
-gh-pages/
+
+# This is a staging directory used to upload the documents to gihub.io
+github-io-staging/

--- a/ci/upload-docs.sh
+++ b/ci/upload-docs.sh
@@ -37,22 +37,21 @@ fi
 
 # Clone the gh-pages branch into the doc/html subdirectory.
 readonly REPO_URL=$(git config remote.origin.url)
-git clone -b gh-pages "${REPO_URL}" doc/html
+git clone -b gh-pages "${REPO_URL}" gh-pages
 
 # Remove any previous content of the branch.  We will recover any unmodified
 # files in a second.
-(cd doc/html && git rm -qfr --ignore-unmatch .)
+(cd gh-pages && git rm -qfr --ignore-unmatch .)
 
-# Copy the build results out of the Docker image.
-readonly IMAGE="cached-${DISTRO}-${DISTRO_VERSION}"
-sudo docker run --volume "$PWD/doc:/d" --rm -it "${IMAGE}:tip" cp -r /var/tmp/build/gccpp/bigtable/doc/html /d
+# Copy the build results into the gh-pages clone.
+cp -r bigtable/doc/html/. gh-pages
 
-cd doc/html
+cd gh-pages
 git config user.name "Travis Build Robot"
 git config user.email "nobody@users.noreply.github.com"
 git add --all .
 
-if git diff --exit-code; then
+if git diff --quiet HEAD; then
   echo "Skipping documentation upload as there are no differences to upload."
   exit 0
 fi

--- a/ci/upload-docs.sh
+++ b/ci/upload-docs.sh
@@ -35,18 +35,18 @@ fi
 # is to create a branch (gh-pages) and post the documentation in that branch.
 # We first do some general git configuration:
 
-# Clone the gh-pages branch into the doc/html subdirectory.
+# Clone the gh-pages branch into a staging directory.
 readonly REPO_URL=$(git config remote.origin.url)
-git clone -b gh-pages "${REPO_URL}" gh-pages
+git clone -b gh-pages "${REPO_URL}" github-io-staging
 
 # Remove any previous content of the branch.  We will recover any unmodified
 # files in a second.
-(cd gh-pages && git rm -qfr --ignore-unmatch .)
+(cd github-io-staging && git rm -qfr --ignore-unmatch .)
 
 # Copy the build results into the gh-pages clone.
-cp -r bigtable/doc/html/. gh-pages
+cp -r bigtable/doc/html/. github-io-staging
 
-cd gh-pages
+cd github-io-staging
 git config user.name "Travis Build Robot"
 git config user.email "nobody@users.noreply.github.com"
 git add --all .


### PR DESCRIPTION
The documents are generated inside a docker image, in a previous
change (#138), the path for the generated docs was changed. This
script should have been changed at the same time.

While testing I found out that there was another tiny problem, the
documents were never uploaded because the change detection was
broken.  Fix that too <blush>.