### PR TITLE
Rename bigtable::ClientInterface to bigtable::DataClient.

### DIFF
--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -119,6 +119,7 @@ target_link_libraries(bigtable_client
 
 add_library(bigtable_client_testing
     client/testing/chrono_literals.h
+    client/testing/mock_data_client.h
     client/testing/table_test_fixture.h
     client/testing/table_test_fixture.cc)
 target_link_libraries(bigtable_client_testing

--- a/bigtable/client/data.cc
+++ b/bigtable/client/data.cc
@@ -22,7 +22,7 @@ namespace btproto = ::google::bigtable::v2;
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-class Client : public ClientInterface {
+class Client : public DataClient {
  public:
   Client(std::string project, std::string instance, ClientOptions options)
       : project_(std::move(project)),
@@ -54,7 +54,7 @@ std::string const& Client::ProjectId() const { return project_; }
 
 std::string const& Client::InstanceId() const { return instance_; }
 
-std::shared_ptr<ClientInterface> CreateDefaultClient(
+std::shared_ptr<DataClient> CreateDefaultClient(
     std::string project_id, std::string instance_id,
     bigtable::ClientOptions options) {
   return std::make_shared<Client>(std::move(project_id), std::move(instance_id),

--- a/bigtable/client/data.h
+++ b/bigtable/client/data.h
@@ -28,9 +28,9 @@
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-class ClientInterface {
+class DataClient {
  public:
-  virtual ~ClientInterface() = default;
+  virtual ~DataClient() = default;
 
   virtual std::string const& ProjectId() const = 0;
   virtual std::string const& InstanceId() const = 0;
@@ -40,16 +40,16 @@ class ClientInterface {
 };
 
 /// Create the default implementation of ClientInterface.
-std::shared_ptr<ClientInterface> CreateDefaultClient(std::string project_id,
-                                                     std::string instance_id,
-                                                     ClientOptions options);
+std::shared_ptr<DataClient> CreateDefaultClient(std::string project_id,
+                                                std::string instance_id,
+                                                ClientOptions options);
 
-inline std::string InstanceName(std::shared_ptr<ClientInterface> client) {
+inline std::string InstanceName(std::shared_ptr<DataClient> client) {
   return absl::StrCat("projects/", client->ProjectId(), "/instances/",
                       client->InstanceId());
 }
 
-inline std::string TableName(std::shared_ptr<ClientInterface> client,
+inline std::string TableName(std::shared_ptr<DataClient> client,
                              absl::string_view table_id) {
   return absl::StrCat(InstanceName(std::move(client)), "/tables/", table_id);
 }
@@ -64,7 +64,7 @@ class Table {
    * @param table_id the table id within the instance defined by client.  The
    *     full table name is `client->instance_name() + '/tables/' + table_id`.
    */
-  Table(std::shared_ptr<ClientInterface> client, absl::string_view table_id)
+  Table(std::shared_ptr<DataClient> client, absl::string_view table_id)
       : client_(std::move(client)),
         table_name_(TableName(client_, table_id)),
         rpc_retry_policy_(bigtable::DefaultRPCRetryPolicy()),
@@ -96,7 +96,7 @@ class Table {
    */
   template <typename RPCRetryPolicy, typename RPCBackoffPolicy,
             typename IdempotentMutationPolicy>
-  Table(std::shared_ptr<ClientInterface> client, absl::string_view table_id,
+  Table(std::shared_ptr<DataClient> client, absl::string_view table_id,
         RPCRetryPolicy retry_policy, RPCBackoffPolicy backoff_policy,
         IdempotentMutationPolicy idempotent_mutation_policy)
       : client_(std::move(client)),
@@ -133,7 +133,7 @@ class Table {
   void BulkApply(BulkMutation&& mut);
 
  private:
-  std::shared_ptr<ClientInterface> client_;
+  std::shared_ptr<DataClient> client_;
   std::string table_name_;
   std::unique_ptr<RPCRetryPolicy> rpc_retry_policy_;
   std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy_;

--- a/bigtable/client/testing/mock_data_client.h
+++ b/bigtable/client/testing/mock_data_client.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_CLIENT_H_
-#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_CLIENT_H_
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_DATA_CLIENT_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_DATA_CLIENT_H_
 
 #include "bigtable/client/data.h"
 
@@ -24,7 +24,7 @@
 namespace bigtable {
 namespace testing {
 
-class MockClient : public bigtable::ClientInterface {
+class MockDataClient : public bigtable::DataClient {
  public:
   MOCK_CONST_METHOD0(ProjectId, std::string const&());
   MOCK_CONST_METHOD0(InstanceId, std::string const&());
@@ -34,4 +34,4 @@ class MockClient : public bigtable::ClientInterface {
 }  // namespace testing
 }  // namespace bigtable
 
-#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_CLIENT_H_
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_DATA_CLIENT_H_

--- a/bigtable/client/testing/table_test_fixture.h
+++ b/bigtable/client/testing/table_test_fixture.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_TABLE_TEST_FIXTURE_H_
 
 #include "bigtable/client/data.h"
-#include "bigtable/client/testing/mock_client.h"
+#include "bigtable/client/testing/mock_data_client.h"
 
 namespace bigtable {
 namespace testing {
@@ -28,8 +28,8 @@ class TableTestFixture : public ::testing::Test {
 
   void SetUp() override;
 
-  std::shared_ptr<MockClient> SetupMockClient() {
-    auto client = std::make_shared<MockClient>();
+  std::shared_ptr<MockDataClient> SetupMockClient() {
+    auto client = std::make_shared<MockDataClient>();
     EXPECT_CALL(*client, ProjectId())
         .WillRepeatedly(::testing::ReturnRef(project_id_));
     EXPECT_CALL(*client, InstanceId())
@@ -54,7 +54,7 @@ class TableTestFixture : public ::testing::Test {
   std::string instance_id_ = kInstanceId;
   std::shared_ptr<::google::bigtable::v2::MockBigtableStub> bigtable_stub_ =
       std::make_shared<::google::bigtable::v2::MockBigtableStub>();
-  std::shared_ptr<MockClient> client_ = SetupMockClient();
+  std::shared_ptr<MockDataClient> client_ = SetupMockClient();
   bigtable::Table table_ = bigtable::Table(client_, kTableId);
 };
 


### PR DESCRIPTION
This is part of the fixes for #101.  It makes the name more
consistent with bigtable::AdminClient.  #101 is being fixed
is a series of small-ish PRs, please read the issue for
more context.
