### PR TITLE
Separate bigtable::DataClient and bigtable::Table.

### DIFF
--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -197,7 +197,7 @@ set(bigtable_admin_unit_tests
     admin/admin_client_test.cc
     admin/column_family_test.cc
     admin/table_admin_test.cc
-    admin/table_config_test.cc client/data_client.cc client/data_client.h)
+    admin/table_config_test.cc)
 foreach (fname ${bigtable_admin_unit_tests})
     string(REPLACE "/" "_" target ${fname})
     string(REPLACE ".cc" "" target ${target})

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -94,8 +94,8 @@ add_library(bigtable_client
     client/cell.h
     client/client_options.h
     client/client_options.cc
-    client/data.h
-    client/data.cc
+    client/data_client.h
+    client/data_client.cc
     client/internal/bulk_mutator.h
     client/internal/bulk_mutator.cc
     client/internal/conjunction.h
@@ -112,6 +112,8 @@ add_library(bigtable_client
     client/rpc_backoff_policy.cc
     client/rpc_retry_policy.h
     client/rpc_retry_policy.cc
+    client/table.h
+    client/table.cc
     client/version.h)
 target_link_libraries(bigtable_client
     bigtable_protos absl::strings
@@ -195,7 +197,7 @@ set(bigtable_admin_unit_tests
     admin/admin_client_test.cc
     admin/column_family_test.cc
     admin/table_admin_test.cc
-    admin/table_config_test.cc)
+    admin/table_config_test.cc client/data_client.cc client/data_client.h)
 foreach (fname ${bigtable_admin_unit_tests})
     string(REPLACE "/" "_" target ${fname})
     string(REPLACE ".cc" "" target ${target})

--- a/bigtable/client/data_client.cc
+++ b/bigtable/client/data_client.cc
@@ -40,8 +40,8 @@ class DefaultDataClient : public DataClient {
       : DefaultDataClient(std::move(project), std::move(instance),
                           ClientOptions()) {}
 
-  std::string const& ProjectId() const override;
-  std::string const& InstanceId() const override;
+  std::string const& project_id() const override;
+  std::string const& instance_id() const override;
 
   google::bigtable::v2::Bigtable::StubInterface& Stub() const override {
     return *bt_stub_;
@@ -55,9 +55,9 @@ class DefaultDataClient : public DataClient {
   std::unique_ptr<google::bigtable::v2::Bigtable::StubInterface> bt_stub_;
 };
 
-std::string const& DefaultDataClient::ProjectId() const { return project_; }
+std::string const& DefaultDataClient::project_id() const { return project_; }
 
-std::string const& DefaultDataClient::InstanceId() const { return instance_; }
+std::string const& DefaultDataClient::instance_id() const { return instance_; }
 
 std::shared_ptr<DataClient> CreateDefaultClient(
     std::string project_id, std::string instance_id,

--- a/bigtable/client/data_client.cc
+++ b/bigtable/client/data_client.cc
@@ -1,0 +1,70 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/client/data_client.h"
+
+namespace btproto = ::google::bigtable::v2;
+
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+/**
+ * Implement a simple DataClient.
+ *
+ * This implementation does not support multiple threads, handle GOAWAY
+ * responses, nor does it refresh authorization tokens.  In other words, it is
+ * extremely bare bones.
+ */
+class DefaultDataClient : public DataClient {
+ public:
+  DefaultDataClient(std::string project, std::string instance,
+                    ClientOptions options)
+      : project_(std::move(project)),
+        instance_(std::move(instance)),
+        credentials_(options.credentials()),
+        channel_(grpc::CreateChannel(options.data_endpoint(),
+                                     options.credentials())),
+        bt_stub_(google::bigtable::v2::Bigtable::NewStub(channel_)) {}
+
+  DefaultDataClient(std::string project, std::string instance)
+      : DefaultDataClient(std::move(project), std::move(instance),
+                          ClientOptions()) {}
+
+  std::string const& ProjectId() const override;
+  std::string const& InstanceId() const override;
+
+  google::bigtable::v2::Bigtable::StubInterface& Stub() const override {
+    return *bt_stub_;
+  }
+
+ private:
+  std::string project_;
+  std::string instance_;
+  std::shared_ptr<grpc::ChannelCredentials> credentials_;
+  std::shared_ptr<grpc::Channel> channel_;
+  std::unique_ptr<google::bigtable::v2::Bigtable::StubInterface> bt_stub_;
+};
+
+std::string const& DefaultDataClient::ProjectId() const { return project_; }
+
+std::string const& DefaultDataClient::InstanceId() const { return instance_; }
+
+std::shared_ptr<DataClient> CreateDefaultClient(
+    std::string project_id, std::string instance_id,
+    bigtable::ClientOptions options) {
+  return std::make_shared<DefaultDataClient>(
+      std::move(project_id), std::move(instance_id), std::move(options));
+}
+
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable

--- a/bigtable/client/data_client.h
+++ b/bigtable/client/data_client.h
@@ -35,8 +35,8 @@ class DataClient {
  public:
   virtual ~DataClient() = default;
 
-  virtual std::string const& ProjectId() const = 0;
-  virtual std::string const& InstanceId() const = 0;
+  virtual std::string const& project_id() const = 0;
+  virtual std::string const& instance_id() const = 0;
 
   // Access the stub to send RPC calls.
   virtual google::bigtable::v2::Bigtable::StubInterface& Stub() const = 0;
@@ -51,11 +51,11 @@ std::shared_ptr<DataClient> CreateDefaultClient(std::string project_id,
  * Return the fully qualified instance name for the @p client.
  *
  * Compute the full path of the instance associated with the client, i.e.,
- * `projects/instances/<client->ProjectId()>/instances/<client->InstanceId()>`
+ * `projects/instances/<client->project_id()>/instances/<client->instance_id()>`
  */
 inline std::string InstanceName(std::shared_ptr<DataClient> client) {
-  return absl::StrCat("projects/", client->ProjectId(), "/instances/",
-                      client->InstanceId());
+  return absl::StrCat("projects/", client->project_id(), "/instances/",
+                      client->instance_id());
 }
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/bigtable/client/data_client.h
+++ b/bigtable/client/data_client.h
@@ -1,0 +1,64 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_DATA_CLIENT_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_DATA_CLIENT_H_
+
+#include "bigtable/client/client_options.h"
+
+#include <google/bigtable/v2/bigtable.grpc.pb.h>
+
+#include <absl/strings/str_cat.h>
+#include <absl/strings/string_view.h>
+
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+/**
+ * Define the interface to access Cloud Bigtable.
+ *
+ * This class is used by the Cloud Bigtable wrappers to access Cloud Bigtable.
+ * It provides a configuration point to control how we do load-balancing, how we
+ * handle reconnections, refresh authorization tokens, etc.
+ */
+class DataClient {
+ public:
+  virtual ~DataClient() = default;
+
+  virtual std::string const& ProjectId() const = 0;
+  virtual std::string const& InstanceId() const = 0;
+
+  // Access the stub to send RPC calls.
+  virtual google::bigtable::v2::Bigtable::StubInterface& Stub() const = 0;
+};
+
+/// Create the default implementation of ClientInterface.
+std::shared_ptr<DataClient> CreateDefaultClient(std::string project_id,
+                                                std::string instance_id,
+                                                ClientOptions options);
+
+/**
+ * Return the fully qualified instance name for the @p client.
+ *
+ * Compute the full path of the instance associated with the client, i.e.,
+ * `projects/instances/<client->ProjectId()>/instances/<client->InstanceId()>`
+ */
+inline std::string InstanceName(std::shared_ptr<DataClient> client) {
+  return absl::StrCat("projects/", client->ProjectId(), "/instances/",
+                      client->InstanceId());
+}
+
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_DATA_CLIENT_H_

--- a/bigtable/client/table.cc
+++ b/bigtable/client/table.cc
@@ -22,8 +22,13 @@ namespace btproto = ::google::bigtable::v2;
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+
+// Call the `google.bigtable.v2.Bigtable.MutateRow` RPC repeatedly until
+// successful, or until the policies in effect tell us to stop.
 void Table::Apply(SingleRowMutation&& mut) {
-  // Copy the policies in effect for the operation.
+  // Copy the policies in effect for this operation.  Many policy classes change
+  // their state as the operation makes progress (or fails to make progress), so
+  // we need fresh instances.
   auto rpc_policy = rpc_retry_policy_->clone();
   auto backoff_policy = rpc_backoff_policy_->clone();
   auto idempotent_policy = idempotent_mutation_policy_->clone();
@@ -67,7 +72,14 @@ void Table::Apply(SingleRowMutation&& mut) {
   }
 }
 
+// Call the `google.bigtable.v2.Bigtable.MutateRows` RPC repeatedly until
+// successful, or until the policies in effect tell us to stop.  When the RPC
+// is partially successful, this function retries only the mutations that did
+// not succeed.
 void Table::BulkApply(BulkMutation&& mut) {
+  // Copy the policies in effect for this operation.  Many policy classes change
+  // their state as the operation makes progress (or fails to make progress), so
+  // we need fresh instances.
   auto backoff_policy = rpc_backoff_policy_->clone();
   auto retry_policy = rpc_retry_policy_->clone();
   auto idemponent_policy = idempotent_mutation_policy_->clone();

--- a/bigtable/client/table.cc
+++ b/bigtable/client/table.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "bigtable/client/data.h"
+#include "bigtable/client/table.h"
 
 #include <thread>
 
@@ -22,45 +22,6 @@ namespace btproto = ::google::bigtable::v2;
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-class Client : public DataClient {
- public:
-  Client(std::string project, std::string instance, ClientOptions options)
-      : project_(std::move(project)),
-        instance_(std::move(instance)),
-        credentials_(options.credentials()),
-        channel_(grpc::CreateChannel(options.data_endpoint(),
-                                     options.credentials())),
-        bt_stub_(google::bigtable::v2::Bigtable::NewStub(channel_)) {}
-
-  Client(std::string project, std::string instance)
-      : Client(std::move(project), std::move(instance), ClientOptions()) {}
-
-  std::string const& ProjectId() const override;
-  std::string const& InstanceId() const override;
-
-  google::bigtable::v2::Bigtable::StubInterface& Stub() const override {
-    return *bt_stub_;
-  }
-
- private:
-  std::string project_;
-  std::string instance_;
-  std::shared_ptr<grpc::ChannelCredentials> credentials_;
-  std::shared_ptr<grpc::Channel> channel_;
-  std::unique_ptr<google::bigtable::v2::Bigtable::StubInterface> bt_stub_;
-};
-
-std::string const& Client::ProjectId() const { return project_; }
-
-std::string const& Client::InstanceId() const { return instance_; }
-
-std::shared_ptr<DataClient> CreateDefaultClient(
-    std::string project_id, std::string instance_id,
-    bigtable::ClientOptions options) {
-  return std::make_shared<Client>(std::move(project_id), std::move(instance_id),
-                                  std::move(options));
-}
-
 void Table::Apply(SingleRowMutation&& mut) {
   // Copy the policies in effect for the operation.
   auto rpc_policy = rpc_retry_policy_->clone();

--- a/bigtable/client/table.cc
+++ b/bigtable/client/table.cc
@@ -22,7 +22,6 @@ namespace btproto = ::google::bigtable::v2;
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-
 // Call the `google.bigtable.v2.Bigtable.MutateRow` RPC repeatedly until
 // successful, or until the policies in effect tell us to stop.
 void Table::Apply(SingleRowMutation&& mut) {

--- a/bigtable/client/table.h
+++ b/bigtable/client/table.h
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_DATA_H_
-#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_DATA_H_
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TABLE_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TABLE_H_
 
-#include "bigtable/client/client_options.h"
+#include "bigtable/client/data_client.h"
 #include "bigtable/client/idempotent_mutation_policy.h"
 #include "bigtable/client/mutations.h"
 #include "bigtable/client/rpc_backoff_policy.h"
@@ -28,27 +28,6 @@
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-class DataClient {
- public:
-  virtual ~DataClient() = default;
-
-  virtual std::string const& ProjectId() const = 0;
-  virtual std::string const& InstanceId() const = 0;
-
-  // Access the stub to send RPC calls.
-  virtual google::bigtable::v2::Bigtable::StubInterface& Stub() const = 0;
-};
-
-/// Create the default implementation of ClientInterface.
-std::shared_ptr<DataClient> CreateDefaultClient(std::string project_id,
-                                                std::string instance_id,
-                                                ClientOptions options);
-
-inline std::string InstanceName(std::shared_ptr<DataClient> client) {
-  return absl::StrCat("projects/", client->ProjectId(), "/instances/",
-                      client->InstanceId());
-}
-
 inline std::string TableName(std::shared_ptr<DataClient> client,
                              absl::string_view table_id) {
   return absl::StrCat(InstanceName(std::move(client)), "/tables/", table_id);
@@ -143,4 +122,4 @@ class Table {
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
 
-#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_DATA_H_
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TABLE_H_

--- a/bigtable/client/table.h
+++ b/bigtable/client/table.h
@@ -42,7 +42,6 @@ inline std::string TableName(std::shared_ptr<DataClient> client,
   return absl::StrCat(InstanceName(std::move(client)), "/tables/", table_id);
 }
 
-
 /**
  * The main interface to interact with data in a Cloud Bigtable table.
  *

--- a/bigtable/client/table_apply_test.cc
+++ b/bigtable/client/table_apply_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "bigtable/client/data.h"
+#include "bigtable/client/table.h"
 #include "bigtable/client/testing/table_test_fixture.h"
 
 /// Define helper types and functions for this test.

--- a/bigtable/client/table_bulk_apply_test.cc
+++ b/bigtable/client/table_bulk_apply_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "bigtable/client/data.h"
+#include "bigtable/client/table.h"
 
 #include <absl/memory/memory.h>
 

--- a/bigtable/client/table_test.cc
+++ b/bigtable/client/table_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "bigtable/client/data.h"
+#include "bigtable/client/table.h"
 
 #include <absl/memory/memory.h>
 

--- a/bigtable/client/table_test.cc
+++ b/bigtable/client/table_test.cc
@@ -24,11 +24,11 @@ class TableTest : public bigtable::testing::TableTestFixture {};
 }  // anonymous namespace
 
 TEST_F(TableTest, ClientProjectId) {
-  EXPECT_EQ(kProjectId, client_->ProjectId());
+  EXPECT_EQ(kProjectId, client_->project_id());
 }
 
 TEST_F(TableTest, ClientInstanceId) {
-  EXPECT_EQ(kInstanceId, client_->InstanceId());
+  EXPECT_EQ(kInstanceId, client_->instance_id());
 }
 
 TEST_F(TableTest, StandaloneInstanceName) {

--- a/bigtable/client/testing/mock_data_client.h
+++ b/bigtable/client/testing/mock_data_client.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_DATA_CLIENT_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_DATA_CLIENT_H_
 
-#include "bigtable/client/data.h"
+#include "bigtable/client/table.h"
 
 #include <google/bigtable/v2/bigtable_mock.grpc.pb.h>
 

--- a/bigtable/client/testing/mock_data_client.h
+++ b/bigtable/client/testing/mock_data_client.h
@@ -26,8 +26,8 @@ namespace testing {
 
 class MockDataClient : public bigtable::DataClient {
  public:
-  MOCK_CONST_METHOD0(ProjectId, std::string const&());
-  MOCK_CONST_METHOD0(InstanceId, std::string const&());
+  MOCK_CONST_METHOD0(project_id, std::string const&());
+  MOCK_CONST_METHOD0(instance_id, std::string const&());
   MOCK_CONST_METHOD0(Stub, google::bigtable::v2::Bigtable::StubInterface&());
 };
 

--- a/bigtable/client/testing/table_test_fixture.h
+++ b/bigtable/client/testing/table_test_fixture.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_TABLE_TEST_FIXTURE_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_TABLE_TEST_FIXTURE_H_
 
-#include "bigtable/client/data.h"
+#include "bigtable/client/table.h"
 #include "bigtable/client/testing/mock_data_client.h"
 
 namespace bigtable {

--- a/bigtable/client/testing/table_test_fixture.h
+++ b/bigtable/client/testing/table_test_fixture.h
@@ -30,9 +30,9 @@ class TableTestFixture : public ::testing::Test {
 
   std::shared_ptr<MockDataClient> SetupMockClient() {
     auto client = std::make_shared<MockDataClient>();
-    EXPECT_CALL(*client, ProjectId())
+    EXPECT_CALL(*client, project_id())
         .WillRepeatedly(::testing::ReturnRef(project_id_));
-    EXPECT_CALL(*client, InstanceId())
+    EXPECT_CALL(*client, instance_id())
         .WillRepeatedly(::testing::ReturnRef(instance_id_));
     EXPECT_CALL(*client, Stub())
         .WillRepeatedly(::testing::ReturnRef(*bigtable_stub_));

--- a/bigtable/tests/data_integration_test.cc
+++ b/bigtable/tests/data_integration_test.cc
@@ -14,7 +14,7 @@
 
 #include "bigtable/admin/admin_client.h"
 #include "bigtable/admin/table_admin.h"
-#include "bigtable/client/data.h"
+#include "bigtable/client/table.h"
 
 int main(int argc, char* argv[]) try {
   namespace admin_proto = ::google::bigtable::admin::v2;


### PR DESCRIPTION
This is part of the changes for #101.  It moves the classes to
their own files.  More changes are coming to cleanup the
code duplication and fix the thread safety issue.