### PR TITLE
Make the bigtable::ClientAdmin and bigtable::DataAdmin interfaces thread-safe

### DIFF
--- a/bigtable/admin/admin_client.cc
+++ b/bigtable/admin/admin_client.cc
@@ -60,7 +60,8 @@ class SimpleAdminClient : public bigtable::AdminClient {
     auto channel = grpc::CreateCustomChannel(options_.admin_endpoint(),
                                              options_.credentials(),
                                              options_.channel_arguments());
-    table_admin_stub_ = ::google::bigtable::admin::v2::BigtableTableAdmin::NewStub(channel);
+    table_admin_stub_ =
+        ::google::bigtable::admin::v2::BigtableTableAdmin::NewStub(channel);
     channel_ = std::move(channel);
   }
 

--- a/bigtable/admin/admin_client.cc
+++ b/bigtable/admin/admin_client.cc
@@ -37,11 +37,10 @@ class SimpleAdminClient : public bigtable::AdminClient {
 
   std::string const& project() const override { return project_; }
   void on_completion(grpc::Status const& status) override {
-    if (status.ok()) {
-      return;
+    if (not status.ok()) {
+      channel_.reset();
+      table_admin_stub_.reset();
     }
-    channel_.reset();
-    table_admin_stub_.reset();
   }
 
   using AdminStubPtr = std::shared_ptr<

--- a/bigtable/admin/admin_client.h
+++ b/bigtable/admin/admin_client.h
@@ -43,8 +43,9 @@ class AdminClient {
   virtual void on_completion(grpc::Status const& status) = 0;
 
   /// Return a new stub to handle admin operations.
-  virtual ::google::bigtable::admin::v2::BigtableTableAdmin::StubInterface&
-  table_admin() = 0;
+  virtual std::shared_ptr<
+      ::google::bigtable::admin::v2::BigtableTableAdmin::StubInterface>
+  Stub() = 0;
 };
 
 /// Create a new admin client configured via @p options.

--- a/bigtable/admin/admin_client_test.cc
+++ b/bigtable/admin/admin_client_test.cc
@@ -22,7 +22,7 @@ TEST(AdminClientTest, Simple) {
       bigtable::CreateAdminClient("test-project", bigtable::ClientOptions());
   EXPECT_TRUE(admin_client);
   EXPECT_EQ("test-project", admin_client->project());
-  EXPECT_NO_THROW(admin_client->table_admin());
+  EXPECT_NO_THROW(admin_client->Stub());
   EXPECT_NO_THROW(admin_client->on_completion(grpc::Status::CANCELLED));
-  EXPECT_NO_THROW(admin_client->table_admin());
+  EXPECT_NO_THROW(admin_client->Stub());
 }

--- a/bigtable/admin/table_admin.cc
+++ b/bigtable/admin/table_admin.cc
@@ -53,7 +53,7 @@ std::vector<::google::bigtable::admin::v2::Table> TableAdmin::ListTables(
     rpc_policy->setup(client_context);
     backoff_policy->setup(client_context);
     grpc::Status status =
-        client_->table_admin().ListTables(&client_context, request, &response);
+        client_->Stub()->ListTables(&client_context, request, &response);
     client_->on_completion(status);
     if (status.ok()) {
       for (auto& table : response.tables()) {

--- a/bigtable/admin/table_admin.h
+++ b/bigtable/admin/table_admin.h
@@ -266,8 +266,8 @@ class TableAdmin {
       rpc_policy->setup(client_context);
       backoff_policy->setup(client_context);
       // Call the pointer to member function.
-      grpc::Status status = ((*client_->Stub()).*function)(
-          &client_context, request, &response);
+      grpc::Status status =
+          ((*client_->Stub()).*function)(&client_context, request, &response);
       client_->on_completion(status);
       if (status.ok()) {
         break;

--- a/bigtable/admin/table_admin.h
+++ b/bigtable/admin/table_admin.h
@@ -266,7 +266,7 @@ class TableAdmin {
       rpc_policy->setup(client_context);
       backoff_policy->setup(client_context);
       // Call the pointer to member function.
-      grpc::Status status = (client_->table_admin().*function)(
+      grpc::Status status = ((*client_->Stub()).*function)(
           &client_context, request, &response);
       client_->on_completion(status);
       if (status.ok()) {

--- a/bigtable/client/data_client.cc
+++ b/bigtable/client/data_client.cc
@@ -43,16 +43,17 @@ class DefaultDataClient : public DataClient {
   std::string const& project_id() const override;
   std::string const& instance_id() const override;
 
-  google::bigtable::v2::Bigtable::StubInterface& Stub() const override {
-    return *bt_stub_;
-  }
+  using BigtableStubPtr =
+      std::shared_ptr<google::bigtable::v2::Bigtable::StubInterface>;
+
+  BigtableStubPtr Stub() override { return bt_stub_; }
 
  private:
   std::string project_;
   std::string instance_;
   std::shared_ptr<grpc::ChannelCredentials> credentials_;
   std::shared_ptr<grpc::Channel> channel_;
-  std::unique_ptr<google::bigtable::v2::Bigtable::StubInterface> bt_stub_;
+  BigtableStubPtr bt_stub_;
 };
 
 std::string const& DefaultDataClient::project_id() const { return project_; }

--- a/bigtable/client/data_client.h
+++ b/bigtable/client/data_client.h
@@ -38,8 +38,8 @@ class DataClient {
   virtual std::string const& project_id() const = 0;
   virtual std::string const& instance_id() const = 0;
 
-  // Access the stub to send RPC calls.
-  virtual google::bigtable::v2::Bigtable::StubInterface& Stub() const = 0;
+  virtual std::shared_ptr<google::bigtable::v2::Bigtable::StubInterface>
+  Stub() = 0;
 };
 
 /// Create the default implementation of ClientInterface.

--- a/bigtable/client/table.cc
+++ b/bigtable/client/table.cc
@@ -49,7 +49,7 @@ void Table::Apply(SingleRowMutation&& mut) {
     rpc_policy->setup(client_context);
     backoff_policy->setup(client_context);
     grpc::Status status =
-        client_->Stub().MutateRow(&client_context, request, &response);
+        client_->Stub()->MutateRow(&client_context, request, &response);
     if (status.ok()) {
       return;
     }
@@ -92,7 +92,7 @@ void Table::BulkApply(BulkMutation&& mut) {
     backoff_policy->setup(client_context);
     retry_policy->setup(client_context);
 
-    status = mutator.MakeOneRequest(client_->Stub(), client_context);
+    status = mutator.MakeOneRequest(*client_->Stub(), client_context);
     if (not status.ok() and not retry_policy->on_failure(status)) {
       break;
     }

--- a/bigtable/client/testing/mock_data_client.h
+++ b/bigtable/client/testing/mock_data_client.h
@@ -28,7 +28,8 @@ class MockDataClient : public bigtable::DataClient {
  public:
   MOCK_CONST_METHOD0(project_id, std::string const&());
   MOCK_CONST_METHOD0(instance_id, std::string const&());
-  MOCK_CONST_METHOD0(Stub, google::bigtable::v2::Bigtable::StubInterface&());
+  MOCK_METHOD0(
+      Stub, std::shared_ptr<::google::bigtable::v2::Bigtable::StubInterface>());
 };
 
 }  // namespace testing

--- a/bigtable/client/testing/table_test_fixture.cc
+++ b/bigtable/client/testing/table_test_fixture.cc
@@ -19,5 +19,16 @@ namespace testing {
 
 void TableTestFixture::SetUp() {}
 
+std::shared_ptr<MockDataClient> TableTestFixture::SetupMockClient() {
+  auto client = std::make_shared<MockDataClient>();
+  EXPECT_CALL(*client, project_id())
+      .WillRepeatedly(::testing::ReturnRef(project_id_));
+  EXPECT_CALL(*client, instance_id())
+      .WillRepeatedly(::testing::ReturnRef(instance_id_));
+  EXPECT_CALL(*client, Stub())
+      .WillRepeatedly(::testing::Return(bigtable_stub_));
+  return client;
+}
+
 }  // namespace testing
 }  // namespace bigtable

--- a/bigtable/client/testing/table_test_fixture.h
+++ b/bigtable/client/testing/table_test_fixture.h
@@ -28,16 +28,7 @@ class TableTestFixture : public ::testing::Test {
 
   void SetUp() override;
 
-  std::shared_ptr<MockDataClient> SetupMockClient() {
-    auto client = std::make_shared<MockDataClient>();
-    EXPECT_CALL(*client, project_id())
-        .WillRepeatedly(::testing::ReturnRef(project_id_));
-    EXPECT_CALL(*client, instance_id())
-        .WillRepeatedly(::testing::ReturnRef(instance_id_));
-    EXPECT_CALL(*client, Stub())
-        .WillRepeatedly(::testing::ReturnRef(*bigtable_stub_));
-    return client;
-  }
+  std::shared_ptr<MockDataClient> SetupMockClient();
 
   std::string const kProjectId = "foo-project";
   std::string const kInstanceId = "bar-instance";


### PR DESCRIPTION
This is part of the changes for #101.  Finally we change the interface to return a type that can be made thread safe.  All is left after this is a bit of refactoring and adding some mutexes.
