### PR TITLE
Fix flaky test for bigtable::LimitedTimeRetryPolicy.

### DIFF
--- a/bigtable/client/rpc_retry_policy_test.cc
+++ b/bigtable/client/rpc_retry_policy_test.cc
@@ -50,15 +50,17 @@ void CheckLimitedTime(bigtable::RPCRetryPolicy& tested) {
   //   - We do not care about the results from 40ms to 60ms.
   // I know 10ms feels like a long time, but it is not on a loaded VM running
   // the tests inside some container.
-  auto must_be_true_before = start + kLimitedTimeTestPeriod - kLimitedTimeTolerance;
-  auto must_be_false_after = start + kLimitedTimeTestPeriod + kLimitedTimeTolerance;
+  auto must_be_true_before =
+      start + kLimitedTimeTestPeriod - kLimitedTimeTolerance;
+  auto must_be_false_after =
+      start + kLimitedTimeTestPeriod + kLimitedTimeTolerance;
   for (int i = 0; i != 100; ++i) {
     auto actual = tested.on_failure(
         grpc::Status(grpc::StatusCode::UNAVAILABLE, "please try again"));
     auto now = std::chrono::system_clock::now();
     if (now < must_be_true_before) {
       EXPECT_TRUE(actual);
-    } if (must_be_false_after < now) {
+    } else if (must_be_false_after < now) {
       EXPECT_FALSE(actual);
     }
     std::this_thread::sleep_for(1_ms);

--- a/bigtable/client/rpc_retry_policy_test.cc
+++ b/bigtable/client/rpc_retry_policy_test.cc
@@ -30,22 +30,36 @@ grpc::Status CreatePermanentError() {
   return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "failed");
 }
 
+using namespace bigtable::chrono_literals;
+auto const kLimitedTimeTestPeriod = 50_ms;
+auto const kLimitedTimeTolerance = 10_ms;
+
 /**
  * @test Verify that a retry policy configured to run for 50ms works correctly.
  *
  * This eliminates some amount of code duplication in the following tests.
  */
 void CheckLimitedTime(bigtable::RPCRetryPolicy& tested) {
-  using namespace bigtable::chrono_literals;
   auto start = std::chrono::system_clock::now();
+  // This is one of those tests that can get annoyingly flaky, it is based on
+  // time.  Basically we want to know that the policy will accept failures
+  // until around its prescribed deadline (50ms in this test).  Instead of
+  // measuring for *exactly* 50ms, we pass the test if:
+  //   - All calls to on_failure() in the first 50ms - 10ms pass.
+  //   - Calls to on_failure() after 50ms + 10ms are rejected.
+  //   - We do not care about the results from 40ms to 60ms.
+  // I know 10ms feels like a long time, but it is not on a loaded VM running
+  // the tests inside some container.
+  auto must_be_true_before = start + kLimitedTimeTestPeriod - kLimitedTimeTolerance;
+  auto must_be_false_after = start + kLimitedTimeTestPeriod + kLimitedTimeTolerance;
   for (int i = 0; i != 100; ++i) {
     auto actual = tested.on_failure(
         grpc::Status(grpc::StatusCode::UNAVAILABLE, "please try again"));
-    if (std::chrono::system_clock::now() < start + 50_ms) {
+    auto now = std::chrono::system_clock::now();
+    if (now < must_be_true_before) {
       EXPECT_TRUE(actual);
-    } else {
+    } if (must_be_false_after < now) {
       EXPECT_FALSE(actual);
-      break;
     }
     std::this_thread::sleep_for(1_ms);
   }

--- a/bigtable/client/rpc_retry_policy_test.cc
+++ b/bigtable/client/rpc_retry_policy_test.cc
@@ -72,14 +72,14 @@ void CheckLimitedTime(bigtable::RPCRetryPolicy& tested) {
 /// @test A simple test for the LimitedTimeRetryPolicy.
 TEST(LimitedTimeRetryPolicy, Simple) {
   using namespace bigtable::chrono_literals;
-  bigtable::LimitedTimeRetryPolicy tested(50_ms);
+  bigtable::LimitedTimeRetryPolicy tested(kLimitedTimeTestPeriod);
   CheckLimitedTime(tested);
 }
 
 /// @test Test cloning for LimitedTimeRetryPolicy.
 TEST(LimitedTimeRetryPolicy, Clone) {
   using namespace bigtable::chrono_literals;
-  bigtable::LimitedTimeRetryPolicy original(50_ms);
+  bigtable::LimitedTimeRetryPolicy original(kLimitedTimeTestPeriod);
   auto tested = original.clone();
   CheckLimitedTime(*tested);
 }


### PR DESCRIPTION
Timing tests are awful, but necessary for timed things.  I think this makes the test useful, but less flaky (hopefully not flaky at all).
