### PR TITLE
Point Travis badge to results from master branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Travis CI status][travis-shield]][travis-link]
 [![Codecov Coverage status][codecov-shield]][codecov-link]
 
-[travis-shield]: https://travis-ci.org/GoogleCloudPlatform/google-cloud-cpp.svg
+[travis-shield]: https://travis-ci.org/GoogleCloudPlatform/google-cloud-cpp.svg?branch=master
 [travis-link]: https://travis-ci.org/GoogleCloudPlatform/google-cloud-cpp/builds
 [codecov-shield]: https://codecov.io/gh/GoogleCloudPlatform/google-cloud-cpp/branch/master/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/GoogleCloudPlatform/google-cloud-cpp


### PR DESCRIPTION
We can safely [skip ci] in this commit, so we do.  If we are going to have folks working on branches in the repository, we should expect (and tolerate) breakage on those branches.  Only `master` is important in this case.
