### PR TITLE
Refactor bigtable::AdminClient and bigtable::DataClient.

### DIFF
--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -98,6 +98,7 @@ add_library(bigtable_client
     client/data_client.cc
     client/internal/bulk_mutator.h
     client/internal/bulk_mutator.cc
+    client/internal/common_client.h
     client/internal/conjunction.h
     client/internal/prefix_range_end.h
     client/internal/prefix_range_end.cc
@@ -177,6 +178,7 @@ add_custom_target(tests-local)
 set(bigtable_client_unit_tests
     client/cell_test.cc
     client/client_options_test.cc
+    client/data_client_test.cc
     client/filters_test.cc
     client/force_sanitizer_failures_test.cc
     client/idempotent_mutation_policy_test.cc

--- a/bigtable/admin/admin_client.cc
+++ b/bigtable/admin/admin_client.cc
@@ -29,7 +29,7 @@ namespace {
  * should only reconnect on those errors that indicate the credentials or
  * connections need refreshing.
  */
-class SimpleAdminClient : public bigtable::AdminClient {
+class DefaultAdminClient : public bigtable::AdminClient {
  private:
   // Introduce an early `private:` section because this type is used to define
   // the public interface, it should not be part of the public interface.
@@ -45,7 +45,7 @@ class SimpleAdminClient : public bigtable::AdminClient {
  public:
   using AdminStubPtr = Impl::StubPtr;
 
-  SimpleAdminClient(std::string project, bigtable::ClientOptions options)
+  DefaultAdminClient(std::string project, bigtable::ClientOptions options)
       : project_(std::move(project)), impl_(std::move(options)) {}
 
   std::string const& project() const override { return project_; }
@@ -61,10 +61,10 @@ class SimpleAdminClient : public bigtable::AdminClient {
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-std::shared_ptr<AdminClient> CreateAdminClient(
+std::shared_ptr<AdminClient> CreateDefaultAdminClient(
     std::string project, bigtable::ClientOptions options) {
-  return std::make_shared<SimpleAdminClient>(std::move(project),
-                                             std::move(options));
+  return std::make_shared<DefaultAdminClient>(std::move(project),
+                                              std::move(options));
 }
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/bigtable/admin/admin_client.cc
+++ b/bigtable/admin/admin_client.cc
@@ -34,7 +34,7 @@ class SimpleAdminClient : public bigtable::AdminClient {
   // Introduce an early `private:` section because this type is used to define
   // the public interface, it should not be part of the public interface.
   struct AdminTraits {
-    static std::string const& endpoint(bigtable::ClientOptions& options) {
+    static std::string const& Endpoint(bigtable::ClientOptions& options) {
       return options.admin_endpoint();
     }
   };
@@ -51,7 +51,7 @@ class SimpleAdminClient : public bigtable::AdminClient {
   std::string const& project() const override { return project_; }
   AdminStubPtr Stub() override { return impl_.Stub(); }
   void reset() override { return impl_.reset(); }
-  void on_completion(grpc::Status const&) override {}
+  void on_completion(grpc::Status const& status) override {}
 
  private:
   std::string project_;

--- a/bigtable/admin/admin_client.cc
+++ b/bigtable/admin/admin_client.cc
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 #include "bigtable/admin/admin_client.h"
-
-#include <absl/memory/memory.h>
+#include "bigtable/client/internal/common_client.h"
 
 namespace {
 /**
@@ -31,44 +30,32 @@ namespace {
  * connections need refreshing.
  */
 class SimpleAdminClient : public bigtable::AdminClient {
+ private:
+  // Introduce an early `private:` section because this type is used to define
+  // the public interface, it should not be part of the public interface.
+  struct AdminTraits {
+    static std::string const& endpoint(bigtable::ClientOptions& options) {
+      return options.admin_endpoint();
+    }
+  };
+
+  using Impl = bigtable::internal::CommonClient<
+      AdminTraits, ::google::bigtable::admin::v2::BigtableTableAdmin>;
+
  public:
+  using AdminStubPtr = Impl::StubPtr;
+
   SimpleAdminClient(std::string project, bigtable::ClientOptions options)
-      : project_(std::move(project)), options_(std::move(options)) {}
+      : project_(std::move(project)), impl_(std::move(options)) {}
 
   std::string const& project() const override { return project_; }
-  void on_completion(grpc::Status const& status) override {
-    if (not status.ok()) {
-      channel_.reset();
-      table_admin_stub_.reset();
-    }
-  }
-
-  using AdminStubPtr = std::shared_ptr<
-      ::google::bigtable::admin::v2::BigtableTableAdmin::StubInterface>;
-
-  AdminStubPtr Stub() override {
-    RefreshCredentialsAndChannel();
-    return table_admin_stub_;
-  }
-
- private:
-  void RefreshCredentialsAndChannel() {
-    if (table_admin_stub_) {
-      return;
-    }
-    auto channel = grpc::CreateCustomChannel(options_.admin_endpoint(),
-                                             options_.credentials(),
-                                             options_.channel_arguments());
-    table_admin_stub_ =
-        ::google::bigtable::admin::v2::BigtableTableAdmin::NewStub(channel);
-    channel_ = std::move(channel);
-  }
+  AdminStubPtr Stub() override { return impl_.Stub(); }
+  void reset() override { return impl_.reset(); }
+  void on_completion(grpc::Status const&) override {}
 
  private:
   std::string project_;
-  bigtable::ClientOptions options_;
-  std::shared_ptr<grpc::Channel> channel_;
-  AdminStubPtr table_admin_stub_;
+  Impl impl_;
 };
 }  // anonymous namespace
 

--- a/bigtable/admin/admin_client.h
+++ b/bigtable/admin/admin_client.h
@@ -31,21 +31,27 @@ class AdminClient {
   /// The project that this AdminClient works on.
   virtual std::string const& project() const = 0;
 
-  /**
-   * A callback to report completed RPCs to the client.
-   *
-   * On failures, he client may need to update its internal data structures,
-   * such as which channels are working, maybe reauthenticate with the server,
-   * or simply count the number of failed operations for monitoring purposes.
-   *
-   * @param status the grpc error.
-   */
-  virtual void on_completion(grpc::Status const& status) = 0;
-
   /// Return a new stub to handle admin operations.
   virtual std::shared_ptr<
       ::google::bigtable::admin::v2::BigtableTableAdmin::StubInterface>
   Stub() = 0;
+
+  /**
+   * Reset and create a new Stub().
+   *
+   * Currently this is only used in testing.  In the future, we expect this,
+   * or a similar member function, will be needed to handle errors that require
+   * a new connection, or an explicit refresh of the credentials.
+   */
+  virtual void reset() = 0;
+
+  /**
+   * A callback for completed RPCs.
+   *
+   * Currently this is only used in testing.  In the future, we expect that
+   * some errors may require the class to update its state.
+   */
+  virtual void on_completion(grpc::Status const&) = 0;
 };
 
 /// Create a new admin client configured via @p options.

--- a/bigtable/admin/admin_client.h
+++ b/bigtable/admin/admin_client.h
@@ -55,8 +55,8 @@ class AdminClient {
 };
 
 /// Create a new admin client configured via @p options.
-std::shared_ptr<AdminClient> CreateAdminClient(std::string project,
-                                               bigtable::ClientOptions options);
+std::shared_ptr<AdminClient> CreateDefaultAdminClient(
+    std::string project, bigtable::ClientOptions options);
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/bigtable/admin/admin_client_test.cc
+++ b/bigtable/admin/admin_client_test.cc
@@ -17,8 +17,8 @@
 #include <gmock/gmock.h>
 
 TEST(AdminClientTest, Default) {
-  auto admin_client =
-      bigtable::CreateAdminClient("test-project", bigtable::ClientOptions());
+  auto admin_client = bigtable::CreateDefaultAdminClient(
+      "test-project", bigtable::ClientOptions());
   ASSERT_TRUE(admin_client);
   EXPECT_EQ("test-project", admin_client->project());
 

--- a/bigtable/admin/table_admin_test.cc
+++ b/bigtable/admin/table_admin_test.cc
@@ -31,9 +31,10 @@ namespace btproto = ::google::bigtable::admin::v2;
 class MockAdminClient : public bigtable::AdminClient {
  public:
   MOCK_CONST_METHOD0(project, std::string const&());
-  MOCK_METHOD1(on_completion, void(grpc::Status const& status));
   MOCK_METHOD0(Stub,
                std::shared_ptr<btproto::BigtableTableAdmin::StubInterface>());
+  MOCK_METHOD1(on_completion, void(grpc::Status const& status));
+  MOCK_METHOD0(reset, void());
 };
 
 std::string const kProjectId = "the-project";

--- a/bigtable/client/data_client.cc
+++ b/bigtable/client/data_client.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "bigtable/client/data_client.h"
+#include "bigtable/client/internal/common_client.h"
 
 namespace btproto = ::google::bigtable::v2;
 
@@ -21,20 +22,29 @@ inline namespace BIGTABLE_CLIENT_NS {
 /**
  * Implement a simple DataClient.
  *
- * This implementation does not support multiple threads, handle GOAWAY
- * responses, nor does it refresh authorization tokens.  In other words, it is
- * extremely bare bones.
+ * This implementation does not support multiple threads, or refresh
+ * authorization tokens.  In other words, it is extremely bare bones.
  */
 class DefaultDataClient : public DataClient {
+ private:
+  // Introduce an early `private:` section because this type is used to define
+  // the public interface, it should not be part of the public interface.
+  struct DataTraits {
+    static std::string const& endpoint(bigtable::ClientOptions& options) {
+      return options.data_endpoint();
+    }
+  };
+
+  using Impl =
+      bigtable::internal::CommonClient<DataTraits,
+                                       ::google::bigtable::v2::Bigtable>;
+
  public:
   DefaultDataClient(std::string project, std::string instance,
                     ClientOptions options)
       : project_(std::move(project)),
         instance_(std::move(instance)),
-        credentials_(options.credentials()),
-        channel_(grpc::CreateChannel(options.data_endpoint(),
-                                     options.credentials())),
-        bt_stub_(google::bigtable::v2::Bigtable::NewStub(channel_)) {}
+        impl_(std::move(options)) {}
 
   DefaultDataClient(std::string project, std::string instance)
       : DefaultDataClient(std::move(project), std::move(instance),
@@ -46,14 +56,14 @@ class DefaultDataClient : public DataClient {
   using BigtableStubPtr =
       std::shared_ptr<google::bigtable::v2::Bigtable::StubInterface>;
 
-  BigtableStubPtr Stub() override { return bt_stub_; }
+  BigtableStubPtr Stub() override { return impl_.Stub(); }
+  void reset() override { impl_.reset(); }
+  void on_completion(grpc::Status const&) override {}
 
  private:
   std::string project_;
   std::string instance_;
-  std::shared_ptr<grpc::ChannelCredentials> credentials_;
-  std::shared_ptr<grpc::Channel> channel_;
-  BigtableStubPtr bt_stub_;
+  Impl impl_;
 };
 
 std::string const& DefaultDataClient::project_id() const { return project_; }

--- a/bigtable/client/data_client.cc
+++ b/bigtable/client/data_client.cc
@@ -70,7 +70,7 @@ std::string const& DefaultDataClient::project_id() const { return project_; }
 
 std::string const& DefaultDataClient::instance_id() const { return instance_; }
 
-std::shared_ptr<DataClient> CreateDefaultClient(
+std::shared_ptr<DataClient> CreateDefaultDataClient(
     std::string project_id, std::string instance_id,
     bigtable::ClientOptions options) {
   return std::make_shared<DefaultDataClient>(

--- a/bigtable/client/data_client.cc
+++ b/bigtable/client/data_client.cc
@@ -30,7 +30,7 @@ class DefaultDataClient : public DataClient {
   // Introduce an early `private:` section because this type is used to define
   // the public interface, it should not be part of the public interface.
   struct DataTraits {
-    static std::string const& endpoint(bigtable::ClientOptions& options) {
+    static std::string const& Endpoint(bigtable::ClientOptions& options) {
       return options.data_endpoint();
     }
   };
@@ -58,7 +58,7 @@ class DefaultDataClient : public DataClient {
 
   BigtableStubPtr Stub() override { return impl_.Stub(); }
   void reset() override { impl_.reset(); }
-  void on_completion(grpc::Status const&) override {}
+  void on_completion(grpc::Status const& status) override {}
 
  private:
   std::string project_;

--- a/bigtable/client/data_client.h
+++ b/bigtable/client/data_client.h
@@ -40,6 +40,23 @@ class DataClient {
 
   virtual std::shared_ptr<google::bigtable::v2::Bigtable::StubInterface>
   Stub() = 0;
+
+  /**
+   * Reset and create a new Stub().
+   *
+   * Currently this is only used in testing.  In the future, we expect this,
+   * or a similar member function, will be needed to handle errors that require
+   * a new connection, or an explicit refresh of the credentials.
+   */
+  virtual void reset() = 0;
+
+  /**
+   * A callback for completed RPCs.
+   *
+   * Currently this is only used in testing.  In the future, we expect that
+   * some errors may require the class to update its state.
+   */
+  virtual void on_completion(grpc::Status const&) = 0;
 };
 
 /// Create the default implementation of ClientInterface.

--- a/bigtable/client/data_client.h
+++ b/bigtable/client/data_client.h
@@ -60,9 +60,9 @@ class DataClient {
 };
 
 /// Create the default implementation of ClientInterface.
-std::shared_ptr<DataClient> CreateDefaultClient(std::string project_id,
-                                                std::string instance_id,
-                                                ClientOptions options);
+std::shared_ptr<DataClient> CreateDefaultDataClient(std::string project_id,
+                                                    std::string instance_id,
+                                                    ClientOptions options);
 
 /**
  * Return the fully qualified instance name for the @p client.

--- a/bigtable/client/data_client_test.cc
+++ b/bigtable/client/data_client_test.cc
@@ -17,7 +17,7 @@
 #include <gmock/gmock.h>
 
 TEST(DataClientTest, Default) {
-  auto data_client = bigtable::CreateDefaultClient(
+  auto data_client = bigtable::CreateDefaultDataClient(
       "test-project", "test-instance", bigtable::ClientOptions());
   ASSERT_TRUE(data_client);
   EXPECT_EQ("test-project", data_client->project_id());

--- a/bigtable/client/data_client_test.cc
+++ b/bigtable/client/data_client_test.cc
@@ -12,24 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "bigtable/admin/admin_client.h"
+#include "bigtable/client/data_client.h"
 
 #include <gmock/gmock.h>
 
-TEST(AdminClientTest, Default) {
-  auto admin_client =
-      bigtable::CreateAdminClient("test-project", bigtable::ClientOptions());
-  ASSERT_TRUE(admin_client);
-  EXPECT_EQ("test-project", admin_client->project());
+TEST(DataClientTest, Default) {
+  auto data_client = bigtable::CreateDefaultClient(
+      "test-project", "test-instance", bigtable::ClientOptions());
+  ASSERT_TRUE(data_client);
+  EXPECT_EQ("test-project", data_client->project_id());
+  EXPECT_EQ("test-instance", data_client->instance_id());
 
-  auto stub0 = admin_client->Stub();
+  auto stub0 = data_client->Stub();
   EXPECT_TRUE(stub0);
 
-  auto stub1 = admin_client->Stub();
+  auto stub1 = data_client->Stub();
   EXPECT_EQ(stub0.get(), stub1.get());
 
-  admin_client->reset();
-  stub1 = admin_client->Stub();
+  data_client->reset();
+  stub1 = data_client->Stub();
   EXPECT_TRUE(stub1);
   EXPECT_NE(stub0.get(), stub1.get());
 }

--- a/bigtable/client/internal/common_client.h
+++ b/bigtable/client/internal/common_client.h
@@ -50,7 +50,7 @@ class CommonClient {
 
   StubPtr Stub() {
     if (not stub_) {
-      auto channel = grpc::CreateCustomChannel(Traits::endpoint(options_),
+      auto channel = grpc::CreateCustomChannel(Traits::Endpoint(options_),
                                                options_.credentials(),
                                                options_.channel_arguments());
       stub_ = Interface::NewStub(channel);

--- a/bigtable/client/internal/common_client.h
+++ b/bigtable/client/internal/common_client.h
@@ -1,0 +1,72 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_COMMON_CLIENT_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_COMMON_CLIENT_H_
+
+#include <grpc++/grpc++.h>
+#include "bigtable/client/client_options.h"
+
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
+/**
+ * Refactor implementation of `bigtable::AdminClient` and `bigtable::DataClient`
+ *
+ * @tparam Traits encapsulates variations between the clients.  Currently, which
+ *   `*_endpoint()` member function is used.
+ * @tparam Interface the gRPC object returned by `Stub()`.
+ */
+template <typename Traits, typename Interface>
+class CommonClient {
+ public:
+  CommonClient(bigtable::ClientOptions options)
+      : options_(std::move(options)) {}
+
+  using StubPtr = std::shared_ptr<typename Interface::StubInterface>;
+
+  /**
+   * Reset the channel and stub.
+   *
+   * This is just used for testing at the moment.  In the future, we expect that
+   * the channel and stub will need to be reset under some error conditions
+   * and/or when the credentials require explicit refresh.
+   */
+  void reset() {
+    stub_.reset();
+    channel_.reset();
+  }
+
+  StubPtr Stub() {
+    if (not stub_) {
+      auto channel = grpc::CreateCustomChannel(Traits::endpoint(options_),
+                                               options_.credentials(),
+                                               options_.channel_arguments());
+      stub_ = Interface::NewStub(channel);
+      channel_ = channel;
+    }
+    return stub_;
+  }
+
+ private:
+  ClientOptions options_;
+  std::shared_ptr<grpc::Channel> channel_;
+  StubPtr stub_;
+};
+
+}  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_COMMON_CLIENT_H_

--- a/bigtable/client/testing/mock_data_client.h
+++ b/bigtable/client/testing/mock_data_client.h
@@ -30,6 +30,8 @@ class MockDataClient : public bigtable::DataClient {
   MOCK_CONST_METHOD0(instance_id, std::string const&());
   MOCK_METHOD0(
       Stub, std::shared_ptr<::google::bigtable::v2::Bigtable::StubInterface>());
+  MOCK_METHOD0(reset, void());
+  MOCK_METHOD1(on_completion, void(grpc::Status const&));
 };
 
 }  // namespace testing

--- a/bigtable/tests/admin_integration_test.cc
+++ b/bigtable/tests/admin_integration_test.cc
@@ -169,7 +169,7 @@ int main(int argc, char* argv[]) try {
   std::string const table2 = "table2";
 
   auto admin_client =
-      bigtable::CreateAdminClient(project_id, bigtable::ClientOptions());
+      bigtable::CreateDefaultAdminClient(project_id, bigtable::ClientOptions());
   bigtable::TableAdmin admin(admin_client, instance_id);
 
   auto instance_name = admin.instance_name();

--- a/bigtable/tests/data_integration_test.cc
+++ b/bigtable/tests/data_integration_test.cc
@@ -33,7 +33,7 @@ int main(int argc, char* argv[]) try {
   std::string const family = "fam";
 
   auto admin_client =
-      bigtable::CreateAdminClient(project_id, bigtable::ClientOptions());
+      bigtable::CreateDefaultAdminClient(project_id, bigtable::ClientOptions());
   bigtable::TableAdmin admin(admin_client, instance_id);
 
   auto created_table = admin.CreateTable(
@@ -54,8 +54,8 @@ int main(int argc, char* argv[]) try {
   }
   std::cout << table_name << " found via ListTables()" << std::endl;
 
-  auto client = bigtable::CreateDefaultClient(project_id, instance_id,
-                                              bigtable::ClientOptions());
+  auto client = bigtable::CreateDefaultDataClient(project_id, instance_id,
+                                                  bigtable::ClientOptions());
   bigtable::Table table(client, table_name);
 
   // TODO(#29) we should read these rows back when we have a read path

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -116,7 +116,7 @@ int main(int argc, char* argv[]) try {
   std::string const instance_id = argv[2];
 
   auto admin_client =
-      bigtable::CreateAdminClient(project_id, bigtable::ClientOptions());
+      bigtable::CreateDefaultAdminClient(project_id, bigtable::ClientOptions());
   bigtable::TableAdmin admin(admin_client, instance_id);
 
   auto table_list = admin.ListTables(admin_proto::Table::NAME_ONLY);
@@ -650,11 +650,11 @@ std::string FilterTestEnvironment::project_id_;
 std::string FilterTestEnvironment::instance_id_;
 
 void FilterIntegrationTest::SetUp() {
-  admin_client_ = bigtable::CreateAdminClient(
+  admin_client_ = bigtable::CreateDefaultAdminClient(
       FilterTestEnvironment::project_id(), bigtable::ClientOptions());
   table_admin_ = absl::make_unique<bigtable::TableAdmin>(
       admin_client_, FilterTestEnvironment::instance_id());
-  data_client_ = bigtable::CreateDefaultClient(
+  data_client_ = bigtable::CreateDefaultDataClient(
       FilterTestEnvironment::project_id(), FilterTestEnvironment::instance_id(),
       bigtable::ClientOptions());
 }


### PR DESCRIPTION
There was a certain amount of duplication in these classes. This
change fixes that.  As a side-effect, it fixes #107 too.

This change does not attempt to *use* both classes the same way,
though we should: I do not want to introduce more changes in a
PR that basically refactors things.
