### PR TITLE
Add a comment to explain how PrintTo() is used [skip ci]

### DIFF
--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -200,6 +200,10 @@ bool operator<(Cell const& lhs, Cell const& rhs) {
   return CellCompare(lhs, rhs) < 0;
 }
 
+/**
+ * This function is not used in this file, but it is used by GoogleTest; without
+ * it, failing tests will output binary blobs instead of human-readable text.
+ */
 void PrintTo(bigtable::Cell const& cell, std::ostream* os) {
   *os << "  row_key=" << cell.row_key() << ", family=" << cell.family_name()
       << ", column=" << cell.column_qualifier()


### PR DESCRIPTION
Although this function is not used in this file directly, it's not dead code:
it's indirectly used by GoogleTest to make human-readable output, so it should
not be removed.

Context:
https://github.com/GoogleCloudPlatform/google-cloud-cpp/pull/150#discussion_r160048494