### PR TITLE
Complete integration tests for bigtable::Filter

### DIFF
--- a/bigtable/client/filters.h
+++ b/bigtable/client/filters.h
@@ -88,7 +88,7 @@ class Filter {
    *     [RE2](https://github.com/google/re2/wiki/Syntax) pattern.  For
    *     technical reasons, the regex must not contain the ':' character, even
    *     if it is not being used as a literal. The server rejects filters with
-   *     an invalid patterns, including patterns containing the ':' character.
+   *     invalid patterns, including patterns containing the ':' character.
    *     The server fails the ReadRows() request with a
    *     `grpc::StatusCode::INVALID_ARGUMENT` status code. This function makes
    *     no attempt to validate the pattern before sending it to the server.

--- a/bigtable/client/filters.h
+++ b/bigtable/client/filters.h
@@ -120,6 +120,10 @@ class Filter {
   /**
    * Return a filter that accepts cells with timestamps in the range
    * [@p start, @p end).
+   *
+   * The timestamp range must be non-empty, i.e. @p start must be strictly
+   * smaller than  @p end.  The server will reject empty ranges with a
+   * `grpc::StatusCode::INVALID_ARGUMENT` error.
    */
   static Filter TimestampRangeMicros(std::int64_t start, std::int64_t end) {
     Filter tmp;
@@ -141,6 +145,10 @@ class Filter {
    * auto r1 = bigtable::Filter::TimestampRange(10ms, 500ms);
    * auto r2 = bigtable::Filter::TimestampRange(10min, 10min + 2s);
    * @endcode
+   *
+   * The timestamp range must be non-empty, i.e. @p start must be strictly
+   * smaller than  @p end.  The server will reject empty ranges with a
+   * `grpc::StatusCode::INVALID_ARGUMENT` error.
    *
    * @tparam Rep1 a placeholder to match the Rep tparam for @p start type,
    *     the semantics of this template parameter are documented in

--- a/bigtable/client/filters.h
+++ b/bigtable/client/filters.h
@@ -461,9 +461,10 @@ class Filter {
    *     gets a different label.
    *
    * @param label the label applied to each cell.  The labels must be at most 15
-   *     characters long, and must match the `[a-z0-9\\-]` pattern.
-   *
-   * TODO(#84) - change this if we decide to validate inputs in the client side
+   *     characters long, and must match the `[a-z0-9\\-]+` pattern.  The server
+   *     validates the filter and will return a
+   *     `grpc::StatusCode::INVALID_ARGUMENT` if the label does not meet these
+   *     requirements.
    */
   static Filter ApplyLabelTransformer(std::string label) {
     Filter tmp;

--- a/bigtable/client/filters.h
+++ b/bigtable/client/filters.h
@@ -218,7 +218,11 @@ class Filter {
     return tmp;
   }
 
-  /// Return a filter matching values in the range [@p start, @p end).
+  /**
+   * Return filter matching values in the range [@p start, @p end).
+   *
+   * @see ValueRangeRightOpen() for more details.
+   */
   static Filter ValueRange(std::string start, std::string end) {
     return ValueRangeRightOpen(std::move(start), std::move(end));
   }
@@ -301,7 +305,9 @@ class Filter {
   /**
    * Return a filter that accepts values in the range [@p start, @p end).
    *
-   * TODO(#84) - document what happens if end < start
+   * The range must be non-empty. The server will reject empty ranges with a
+   * `grpc::StatusCode::INVALID_ARGUMENT` error. This function makes no
+   * attempt to validate the timestamp range before sending it to the server.
    */
   static Filter ValueRangeLeftOpen(std::string start, std::string end) {
     Filter tmp;
@@ -314,7 +320,9 @@ class Filter {
   /**
    * Return a filter that accepts values in the range [@p start, @p end].
    *
-   * TODO(#84) - document what happens if end < start
+   * The range must be non-empty. The server will reject empty ranges with a
+   * `grpc::StatusCode::INVALID_ARGUMENT` error. This function makes no
+   * attempt to validate the timestamp range before sending it to the server.
    */
   static Filter ValueRangeRightOpen(std::string start, std::string end) {
     Filter tmp;
@@ -327,7 +335,9 @@ class Filter {
   /**
    * Return a filter that accepts values in the range [@p start, @p end].
    *
-   * TODO(#84) - document what happens if end < start
+   * The range must be non-empty. The server will reject empty ranges with a
+   * `grpc::StatusCode::INVALID_ARGUMENT` error. This function makes no
+   * attempt to validate the timestamp range before sending it to the server.
    */
   static Filter ValueRangeClosed(std::string start, std::string end) {
     Filter tmp;
@@ -340,7 +350,9 @@ class Filter {
   /**
    * Return a filter that accepts values in the range (@p start, @p end).
    *
-   * TODO(#84) - document what happens if end < start
+   * The range must be non-empty. The server will reject empty ranges with a
+   * `grpc::StatusCode::INVALID_ARGUMENT` error. This function makes no
+   * attempt to validate the timestamp range before sending it to the server.
    */
   static Filter ValueRangeOpen(std::string start, std::string end) {
     Filter tmp;
@@ -354,7 +366,9 @@ class Filter {
    * Return a filter that accepts columns in the range [@p start, @p end)
    * within the @p column_family.
    *
-   * TODO(#84) - document what happens if end < start
+   * The range must be non-empty. The server will reject empty ranges with a
+   * `grpc::StatusCode::INVALID_ARGUMENT` error. This function makes no
+   * attempt to validate the timestamp range before sending it to the server.
    */
   static Filter ColumnRangeRightOpen(std::string column_family,
                                      std::string start, std::string end) {
@@ -370,7 +384,9 @@ class Filter {
    * Return a filter that accepts columns in the range (@p start, @p end]
    * within the @p column_family.
    *
-   * TODO(#84) - document what happens if end < start
+   * The range must be non-empty. The server will reject empty ranges with a
+   * `grpc::StatusCode::INVALID_ARGUMENT` error. This function makes no
+   * attempt to validate the timestamp range before sending it to the server.
    */
   static Filter ColumnRangeLeftOpen(std::string column_family,
                                     std::string start, std::string end) {
@@ -386,7 +402,9 @@ class Filter {
    * Return a filter that accepts columns in the range [@p start, @p end]
    * within the @p column_family.
    *
-   * TODO(#84) - document what happens if end < start
+   * The range must be non-empty. The server will reject empty ranges with a
+   * `grpc::StatusCode::INVALID_ARGUMENT` error. This function makes no
+   * attempt to validate the timestamp range before sending it to the server.
    */
   static Filter ColumnRangeClosed(std::string column_family, std::string start,
                                   std::string end) {
@@ -402,7 +420,9 @@ class Filter {
    * Return a filter that accepts columns in the range (@p start, @p end)
    * within the @p column_family.
    *
-   * TODO(#84) - document what happens if end < start
+   * The range must be non-empty. The server will reject empty ranges with a
+   * `grpc::StatusCode::INVALID_ARGUMENT` error. This function makes no
+   * attempt to validate the timestamp range before sending it to the server.
    */
   static Filter ColumnRangeOpen(std::string column_family, std::string start,
                                 std::string end) {

--- a/bigtable/client/filters.h
+++ b/bigtable/client/filters.h
@@ -513,9 +513,9 @@ class Filter {
    * @param stages the filter stages.  The filter must contain at least two
    *    stages. The server validates each stage, and will reject them as
    *    described in their corresponding function. The server may also impose
-   *    additional restrictions, for example, only one of the stages can be an
-   *    ApplyLabelTransformer().  This function makes no attempt at validating
-   *    the chain before sending it to the server.
+   *    additional restrictions on the composition of the Chain. This function
+   *    makes no attempt at validating the stages locally, the Chain filter is
+   *    sent as-is it to the server.
    */
   template <typename... FilterTypes>
   static Filter Chain(FilterTypes&&... stages) {
@@ -552,8 +552,13 @@ class Filter {
    * cell altogether.
    *
    * @tparam FilterTypes the type of the filter arguments.  They must all be
-   *     convertible for Filter.
-   * @param streams the filters to interleave.
+   *    convertible for Filter.
+   * @param streams the filters to interleave. The filter must contain at least
+   *    two streams. The server validates each stream, and will reject them as
+   *    described in their corresponding function. The server may also impose
+   *    additional restrictions on the overall composition of the Interleave
+   *    filter. This function makes no attempt at validating the streams
+   *    locally, the Interleave filter is sent as-is to the server.
    */
   template <typename... FilterTypes>
   static Filter Interleave(FilterTypes&&... streams) {

--- a/bigtable/client/filters.h
+++ b/bigtable/client/filters.h
@@ -85,9 +85,13 @@ class Filter {
    * Return a filter that matches column families matching the given regexp.
    *
    * @param pattern the regular expression.  It must be a valid
-   *     [RE2](https://github.com/google/re2/wiki/Syntax) pattern.
-   *     For technical reasons, the regex must not contain the ':' character,
-   *     even if it is not being used as a literal.
+   *     [RE2](https://github.com/google/re2/wiki/Syntax) pattern.  For
+   *     technical reasons, the regex must not contain the ':' character, even
+   *     if it is not being used as a literal. The server rejects filters with
+   *     an invalid patterns, including patterns containing the ':' character.
+   *     The server fails the ReadRows() request with a
+   *     `grpc::StatusCode::INVALID_ARGUMENT` status code. This function makes
+   *     no attempt to validate the pattern before sending it to the server.
    */
   static Filter FamilyRegex(std::string pattern) {
     Filter tmp;
@@ -99,7 +103,10 @@ class Filter {
    * Return a filter that accepts only columns matching the given regexp.
    *
    * @param pattern the regular expression.  It must be a valid
-   *     [RE2](https://github.com/google/re2/wiki/Syntax) pattern.
+   *     [RE2](https://github.com/google/re2/wiki/Syntax) pattern. The server
+   *     rejects filters with an invalid pattern with a
+   *     `grpc::StatusCode::INVALID_ARGUMENT` status code.  This function makes
+   *     no attempt to validate the pattern before sending it to the server.
    */
   static Filter ColumnRegex(std::string pattern) {
     Filter tmp;
@@ -110,6 +117,12 @@ class Filter {
   /**
    * Return a filter that accepts columns in the range [@p start, @p end)
    * within the @p family column family.
+   *
+   * The column range must be non-empty, i.e., @p start must be strictly
+   * smaller than  @p end.  The server will reject empty ranges with a
+   * `grpc::StatusCode::INVALID_ARGUMENT` status code. This function makes no
+   * attempt to validate the column family or column range before sending them
+   * to the server.
    */
   static Filter ColumnRange(std::string family, std::string start,
                             std::string end) {
@@ -123,7 +136,8 @@ class Filter {
    *
    * The timestamp range must be non-empty, i.e. @p start must be strictly
    * smaller than  @p end.  The server will reject empty ranges with a
-   * `grpc::StatusCode::INVALID_ARGUMENT` error.
+   * `grpc::StatusCode::INVALID_ARGUMENT` status code. This function makes no
+   * attempt to validate the timestamp range before sending it to the server.
    */
   static Filter TimestampRangeMicros(std::int64_t start, std::int64_t end) {
     Filter tmp;
@@ -148,7 +162,8 @@ class Filter {
    *
    * The timestamp range must be non-empty, i.e. @p start must be strictly
    * smaller than  @p end.  The server will reject empty ranges with a
-   * `grpc::StatusCode::INVALID_ARGUMENT` error.
+   * `grpc::StatusCode::INVALID_ARGUMENT` error. This function makes no
+   * attempt to validate the timestamp range before sending it to the server.
    *
    * @tparam Rep1 a placeholder to match the Rep tparam for @p start type,
    *     the semantics of this template parameter are documented in
@@ -188,10 +203,14 @@ class Filter {
   }
 
   /**
-   * Return a filter that matches values matching the given regexp.
+   * Return a filter that matches cells with values matching the given regexp.
    *
    * @param pattern the regular expression.  It must be a valid
-   *     [RE2](https://github.com/google/re2/wiki/Syntax) pattern.
+   *     [RE2](https://github.com/google/re2/wiki/Syntax) pattern. The server
+   *     rejects filters with an invalid pattern with a
+   *     `grpc::StatusCode::INVALID_ARGUMENT` status code. This function makes
+   *     no attempt to validate the timestamp range before sending it to
+   *     the server.
    */
   static Filter ValueRegex(std::string pattern) {
     Filter tmp;

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -618,8 +618,28 @@ TEST_F(FilterIntegrationTest, Condition) {
   CheckEqualUnordered(expected, actual);
 }
 
-// TODO(#152) - implement the following integration test.
-TEST_F(FilterIntegrationTest, Chain) {}
+TEST_F(FilterIntegrationTest, Chain) {
+  auto table = CreateTable("chain-filter-table");
+  std::string const prefix = "chain-prefix";
+  std::vector<bigtable::Cell> created{
+      {prefix + "/abc0", "fam0", "c0", 1000, "v1000", {}},
+      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000", {}},
+      {prefix + "/abc1", "fam2", "c2", 3000, "v3000", {}},
+      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000", {}},
+      {prefix + "/hij0", "fam1", "c4", 4000, "v5000", {}},
+      {prefix + "/hij1", "fam2", "c5", 6000, "v6000", {}},
+  };
+  CreateCells(*table, created);
+  std::vector<bigtable::Cell> expected{
+      {prefix + "/fgh0", "fam0", "c3", 4000, "", {}},
+  };
+  using F = bigtable::Filter;
+  auto actual =
+      ReadRows(*table, F::Chain(F::ValueRangeClosed("v2000", "v5000"),
+                                F::StripValueTransformer(),
+                                F::ColumnRangeClosed("fam0", "c2", "c3")));
+  CheckEqualUnordered(expected, actual);
+}
 
 // TODO(#152) - implement the following integration test.
 TEST_F(FilterIntegrationTest, Interleave) {

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -367,9 +367,8 @@ TEST_F(FilterIntegrationTest, TimestampRange) {
       {row_key, "fam1", "c4", 4000, "v5000", {}},
   };
   using std::chrono::milliseconds;
-  auto actual = ReadRow(
-      *table, row_key,
-      bigtable::Filter::TimestampRange(milliseconds(3), milliseconds(6)));
+  auto actual = ReadRow(*table, row_key, bigtable::Filter::TimestampRange(
+                                             milliseconds(3), milliseconds(6)));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -662,10 +661,9 @@ TEST_F(FilterIntegrationTest, Interleave) {
   };
   using F = bigtable::Filter;
   auto actual = ReadRows(
-      *table,
-      F::Interleave(F::Chain(F::ValueRangeClosed("v2000", "v5000"),
-                             F::StripValueTransformer()),
-                    F::Chain(F::ColumnRangeClosed("fam0", "c2", "c3"))));
+      *table, F::Interleave(F::Chain(F::ValueRangeClosed("v2000", "v5000"),
+                                     F::StripValueTransformer()),
+                            F::ColumnRangeClosed("fam0", "c2", "c3")));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -793,19 +791,22 @@ void FilterIntegrationTest::CreateComplexRows(bigtable::Table& table,
   // column families.
   mutation.emplace_back(bt::SingleRowMutation(
       prefix + "/one-cell", {bt::SetCell("fam0", "c", 3000, "foo")}));
-  mutation.emplace_back(bt::SingleRowMutation(
-      prefix + "/two-cells", {bt::SetCell("fam0", "c", 3000, "foo"),
-                              bt::SetCell("fam0", "c2", 3000, "foo")}));
-  mutation.emplace_back(bt::SingleRowMutation(
-      prefix + "/many", {bt::SetCell("fam0", "c", 0, "foo"),
-                         bt::SetCell("fam0", "c", 1000, "foo"),
-                         bt::SetCell("fam0", "c", 2000, "foo"),
-                         bt::SetCell("fam0", "c", 3000, "foo")}));
-  mutation.emplace_back(bt::SingleRowMutation(
-      prefix + "/many-columns", {bt::SetCell("fam0", "c0", 3000, "foo"),
-                                 bt::SetCell("fam0", "c1", 3000, "foo"),
-                                 bt::SetCell("fam0", "c2", 3000, "foo"),
-                                 bt::SetCell("fam0", "c3", 3000, "foo")}));
+  mutation.emplace_back(
+      bt::SingleRowMutation(prefix + "/two-cells",
+                            {bt::SetCell("fam0", "c", 3000, "foo"),
+                             bt::SetCell("fam0", "c2", 3000, "foo")}));
+  mutation.emplace_back(
+      bt::SingleRowMutation(prefix + "/many",
+                            {bt::SetCell("fam0", "c", 0, "foo"),
+                             bt::SetCell("fam0", "c", 1000, "foo"),
+                             bt::SetCell("fam0", "c", 2000, "foo"),
+                             bt::SetCell("fam0", "c", 3000, "foo")}));
+  mutation.emplace_back(
+      bt::SingleRowMutation(prefix + "/many-columns",
+                            {bt::SetCell("fam0", "c0", 3000, "foo"),
+                             bt::SetCell("fam0", "c1", 3000, "foo"),
+                             bt::SetCell("fam0", "c2", 3000, "foo"),
+                             bt::SetCell("fam0", "c3", 3000, "foo")}));
   // This one is complicated: create a mutation with several families and
   // columns.
   bt::SingleRowMutation complex(prefix + "/complex");

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -641,12 +641,32 @@ TEST_F(FilterIntegrationTest, Chain) {
   CheckEqualUnordered(expected, actual);
 }
 
-// TODO(#152) - implement the following integration test.
 TEST_F(FilterIntegrationTest, Interleave) {
-  // TODO(#151) - remove workarounds for emulator bug(s).
-  if (UsingCloudBigtableEmulator()) {
-    return;
-  }
+  auto table = CreateTable("interleave-filter-table");
+  std::string const prefix = "interleave-prefix";
+  std::vector<bigtable::Cell> created{
+      {prefix + "/abc0", "fam0", "c0", 1000, "v1000", {}},
+      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000", {}},
+      {prefix + "/abc1", "fam2", "c2", 3000, "v3000", {}},
+      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000", {}},
+      {prefix + "/hij0", "fam1", "c4", 4000, "v5000", {}},
+      {prefix + "/hij1", "fam2", "c5", 6000, "v6000", {}},
+  };
+  CreateCells(*table, created);
+  std::vector<bigtable::Cell> expected{
+      {prefix + "/bcd0", "fam1", "c1", 2000, "", {}},
+      {prefix + "/abc1", "fam2", "c2", 3000, "", {}},
+      {prefix + "/fgh0", "fam0", "c3", 4000, "", {}},
+      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000", {}},
+      {prefix + "/hij0", "fam1", "c4", 4000, "", {}},
+  };
+  using F = bigtable::Filter;
+  auto actual = ReadRows(
+      *table,
+      F::Interleave(F::Chain(F::ValueRangeClosed("v2000", "v5000"),
+                             F::StripValueTransformer()),
+                    F::Chain(F::ColumnRangeClosed("fam0", "c2", "c3"))));
+  CheckEqualUnordered(expected, actual);
 }
 
 namespace {

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -389,7 +389,6 @@ TEST_F(FilterIntegrationTest, RowKeysRegex) {
   std::vector<bigtable::Cell> expected{
       {row_key + "/bcd0", "fam1", "c1", 2000, "v2000", {}},
   };
-  using std::chrono::milliseconds;
   auto actual =
       ReadRows(*table, bigtable::Filter::RowKeysRegex(row_key + "/bc.*"));
   CheckEqualUnordered(expected, actual);
@@ -406,18 +405,37 @@ TEST_F(FilterIntegrationTest, ValueRegex) {
       {prefix + "/hij0", "fam1", "c4", 4000, "v5000", {}},
       {prefix + "/hij1", "fam2", "c5", 6000, "v6000", {}},
   };
-  CreateCells(table, created);
+  CreateCells(*table, created);
   std::vector<bigtable::Cell> expected{
       {prefix + "/abc1", "fam2", "c2", 3000, "v3000", {}},
       {prefix + "/fgh0", "fam0", "c3", 4000, "v4000", {}},
   };
-  using std::chrono::milliseconds;
   auto actual = ReadRows(*table, bigtable::Filter::ValueRegex("v[34][0-9].*"));
   CheckEqualUnordered(expected, actual);
 }
 
-// TODO(#152) - implement the following integration test.
-TEST_F(FilterIntegrationTest, ValueRange) {}
+TEST_F(FilterIntegrationTest, ValueRange) {
+  auto table = CreateTable("value-range-filter-table");
+  std::string const prefix = "value-range-prefix";
+  std::vector<bigtable::Cell> created{
+      {prefix + "/abc0", "fam0", "c0", 1000, "v1000", {}},
+      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000", {}},
+      {prefix + "/abc1", "fam2", "c2", 3000, "v3000", {}},
+      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000", {}},
+      {prefix + "/hij0", "fam1", "c4", 4000, "v5000", {}},
+      {prefix + "/hij1", "fam2", "c5", 6000, "v6000", {}},
+  };
+  CreateCells(*table, created);
+  std::vector<bigtable::Cell> expected{
+      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000", {}},
+      {prefix + "/abc1", "fam2", "c2", 3000, "v3000", {}},
+      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000", {}},
+      {prefix + "/hij0", "fam1", "c4", 4000, "v5000", {}},
+  };
+  auto actual =
+      ReadRows(*table, bigtable::Filter::ValueRange("v2000", "v6000"));
+  CheckEqualUnordered(expected, actual);
+}
 
 TEST_F(FilterIntegrationTest, CellsRowLimit) {
   auto table = CreateTable("cells-row-limit-filter-table");

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -395,8 +395,26 @@ TEST_F(FilterIntegrationTest, RowKeysRegex) {
   CheckEqualUnordered(expected, actual);
 }
 
-// TODO(#152) - implement the following integration test.
-TEST_F(FilterIntegrationTest, ValueRegex) {}
+TEST_F(FilterIntegrationTest, ValueRegex) {
+  auto table = CreateTable("value-regex-filter-table");
+  std::string const prefix = "value-regex-prefix";
+  std::vector<bigtable::Cell> created{
+      {prefix + "/abc0", "fam0", "c0", 1000, "v1000", {}},
+      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000", {}},
+      {prefix + "/abc1", "fam2", "c2", 3000, "v3000", {}},
+      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000", {}},
+      {prefix + "/hij0", "fam1", "c4", 4000, "v5000", {}},
+      {prefix + "/hij1", "fam2", "c5", 6000, "v6000", {}},
+  };
+  CreateCells(table, created);
+  std::vector<bigtable::Cell> expected{
+      {prefix + "/abc1", "fam2", "c2", 3000, "v3000", {}},
+      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000", {}},
+  };
+  using std::chrono::milliseconds;
+  auto actual = ReadRows(*table, bigtable::Filter::ValueRegex("v[34][0-9].*"));
+  CheckEqualUnordered(expected, actual);
+}
 
 // TODO(#152) - implement the following integration test.
 TEST_F(FilterIntegrationTest, ValueRange) {}

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -538,8 +538,29 @@ TEST_F(FilterIntegrationTest, RowSample) {
   EXPECT_GE(kMaxCount, result.size());
 }
 
-// TODO(#152) - implement the following integration test.
-TEST_F(FilterIntegrationTest, StripValueTransformer) {}
+TEST_F(FilterIntegrationTest, StripValueTransformer) {
+  auto table = CreateTable("strip-value-transformer-filter-table");
+  std::string const prefix = "strip-value-transformer-prefix";
+  std::vector<bigtable::Cell> created{
+      {prefix + "/abc0", "fam0", "c0", 1000, "v1000", {}},
+      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000", {}},
+      {prefix + "/abc1", "fam2", "c2", 3000, "v3000", {}},
+      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000", {}},
+      {prefix + "/hij0", "fam1", "c4", 4000, "v5000", {}},
+      {prefix + "/hij1", "fam2", "c5", 6000, "v6000", {}},
+  };
+  CreateCells(*table, created);
+  std::vector<bigtable::Cell> expected{
+      {prefix + "/abc0", "fam0", "c0", 1000, "", {}},
+      {prefix + "/bcd0", "fam1", "c1", 2000, "", {}},
+      {prefix + "/abc1", "fam2", "c2", 3000, "", {}},
+      {prefix + "/fgh0", "fam0", "c3", 4000, "", {}},
+      {prefix + "/hij0", "fam1", "c4", 4000, "", {}},
+      {prefix + "/hij1", "fam2", "c5", 6000, "", {}},
+  };
+  auto actual = ReadRows(*table, bigtable::Filter::StripValueTransformer());
+  CheckEqualUnordered(expected, actual);
+}
 
 // TODO(#152) - implement the following integration test.
 TEST_F(FilterIntegrationTest, Condition) {}


### PR DESCRIPTION
This fixes #150, it completes the implementation of the integration tests for `bigtable::Filter`.  Incidentally, it also fixes #84.  All the filters have documented behaviors on invalid inputs.
