### PR TITLE
Fix the name of the robot account used to commit gh-pages.

### DIFF
--- a/ci/upload-docs.sh
+++ b/ci/upload-docs.sh
@@ -47,8 +47,8 @@ git clone -b gh-pages "${REPO_URL}" github-io-staging
 cp -r bigtable/doc/html/. github-io-staging
 
 cd github-io-staging
-git config user.name "Travis Build Robot"
-git config user.email "nobody@users.noreply.github.com"
+git config user.name "Google Cloud C++ Project Robot"
+git config user.email "google-cloud-cpp-bot@users.noreply.github.com"
 git add --all .
 
 if git diff --quiet HEAD; then


### PR DESCRIPTION
Does not matter much, but there is a 'nobody' user in github,
looks better to use the actual robot account we use for these
commits.