### PR TITLE
Implement bigtable::RowSet::Intersect()

### DIFF
--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -113,6 +113,7 @@ add_library(bigtable_client
     client/row_range.h
     client/row_range.cc
     client/row_set.h
+    client/row_set.cc
     client/rpc_backoff_policy.h
     client/rpc_backoff_policy.cc
     client/rpc_retry_policy.h

--- a/bigtable/client/row_range.cc
+++ b/bigtable/client/row_range.cc
@@ -88,5 +88,144 @@ bool RowRange::AboveEnd(absl::string_view key) const {
   return false;
 }
 
+std::pair<bool, RowRange> RowRange::Intersect(RowRange const& range) const {
+  if (range.IsEmpty()) {
+    return std::make_pair(false, RowRange::Empty());
+  }
+  std::string empty;
+
+  // The algorithm is simple.  The two ranges have no intersection only if
+  // @p range is completely below this range or complete above this range.
+
+  // First check if the start of @p range is below *this.
+  std::string const* start = &empty;
+  bool start_closed = true;
+  switch (range.row_range_.start_key_case()) {
+    case btproto::RowRange::START_KEY_NOT_SET:
+      break;
+    case btproto::RowRange::kStartKeyClosed:
+      if (AboveEnd(range.row_range_.start_key_closed())) {
+        return std::make_pair(false, Empty());
+      }
+      start = &range.row_range_.start_key_closed();
+      break;
+    case btproto::RowRange::kStartKeyOpen:
+      if (AboveEnd(range.row_range_.start_key_open())) {
+        return std::make_pair(false, Empty());
+      }
+      start = &range.row_range_.start_key_open();
+      start_closed = false;
+      break;
+  }
+
+  // Then check if the end limit of @p range is below *this.
+  std::string const* end = &empty;
+  bool end_closed = true;
+  switch (range.row_range_.end_key_case()) {
+    case btproto::RowRange::END_KEY_NOT_SET:
+      break;
+    case btproto::RowRange::kEndKeyClosed:
+      if (BelowStart(range.row_range_.end_key_closed())) {
+        return std::make_pair(false, Empty());
+      }
+      end = &range.row_range_.end_key_closed();
+      break;
+    case btproto::RowRange::kEndKeyOpen:
+      if (BelowStart(range.row_range_.end_key_open())) {
+        return std::make_pair(false, Empty());
+      }
+      end = &range.row_range_.end_key_open();
+      end_closed = false;
+      break;
+  }
+
+  // If we hit this point there is some intersection.  Start with the current
+  // range and clip it as needed.
+  RowRange intersection(*this);
+  // If *start is inside, then the intersection must start at *start, and it is
+  // a closed interval on the left.  Note that otherwise the existing start is
+  // the right place for the intersection.
+  if (intersection.Contains(*start)) {
+    if (start_closed) {
+      intersection.row_range_.set_start_key_closed(*start);
+    } else {
+      intersection.row_range_.set_start_key_open(*start);
+    }
+  }
+  // Do the analogous thing for *end.
+  if (intersection.Contains(*end)) {
+    if (end_closed) {
+      intersection.row_range_.set_end_key_closed(*end);
+    } else {
+      intersection.row_range_.set_end_key_open(*end);
+    }
+  }
+
+  bool is_empty = intersection.IsEmpty();
+  return std::make_pair(not is_empty, std::move(intersection));
+}
+
+bool RowRange::operator==(RowRange const& rhs) const {
+  if (row_range_.start_key_case() != rhs.row_range_.start_key_case()) {
+    return false;
+  }
+  switch (row_range_.start_key_case()) {
+    case btproto::RowRange::START_KEY_NOT_SET:
+      break;
+    case btproto::RowRange::kStartKeyClosed:
+      if (row_range_.start_key_closed() != rhs.row_range_.start_key_closed()) {
+        return false;
+      }
+    case btproto::RowRange::kStartKeyOpen:
+      if (row_range_.start_key_open() != rhs.row_range_.start_key_open()) {
+        return false;
+      }
+  }
+
+  if (row_range_.end_key_case() != rhs.row_range_.end_key_case()) {
+    return false;
+  }
+  switch (row_range_.end_key_case()) {
+    case btproto::RowRange::END_KEY_NOT_SET:
+      break;
+    case btproto::RowRange::kEndKeyClosed:
+      if (row_range_.end_key_closed() != rhs.row_range_.end_key_closed()) {
+        return false;
+      }
+    case btproto::RowRange::kEndKeyOpen:
+      if (row_range_.end_key_open() != rhs.row_range_.end_key_open()) {
+        return false;
+      }
+  }
+
+  return true;
+}
+
+std::ostream& operator<<(std::ostream& os, RowRange const& x) {
+  switch (x.row_range_.start_key_case()) {
+    case btproto::RowRange::START_KEY_NOT_SET:
+      os << "['', ";
+      break;
+    case btproto::RowRange::kStartKeyClosed:
+      os << "['" << x.row_range_.start_key_closed() << "', ";
+      break;
+    case btproto::RowRange::kStartKeyOpen:
+      os << "('" << x.row_range_.start_key_open() << "', ";
+  }
+
+  switch (x.row_range_.end_key_case()) {
+    case btproto::RowRange::END_KEY_NOT_SET:
+      os << "'')";
+      break;
+    case btproto::RowRange::kEndKeyClosed:
+      os << "'" << x.row_range_.end_key_closed() << "']";
+      break;
+    case btproto::RowRange::kEndKeyOpen:
+      os << "'" << x.row_range_.end_key_open() << "')";
+      break;
+  }
+  return os;
+}
+
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/bigtable/client/row_range.h
+++ b/bigtable/client/row_range.h
@@ -38,6 +38,9 @@ inline namespace BIGTABLE_CLIENT_NS {
  */
 class RowRange {
  public:
+  explicit RowRange(::google::bigtable::v2::RowRange rhs)
+    : row_range_(std::move(rhs)) {}
+
   RowRange(RowRange&& rhs) noexcept = default;
   RowRange& operator=(RowRange&& rhs) noexcept = default;
   RowRange(RowRange const& rhs) = default;
@@ -141,6 +144,19 @@ class RowRange {
   /// Return true if @p key is in the range.
   bool Contains(absl::string_view key) const;
 
+  /**
+   * Compute the intersection against another RowRange.
+   *
+   * @return a 2-tuple, the first element is a boolean, with value `true` if
+   *     there is some intersection, the second element is the intersection.
+   *     If there is no intersection the first element is `false` and the second
+   *     element has a valid, but unspecified value.
+   */
+  std::pair<bool,RowRange> Intersect(RowRange const& range) const;
+
+  bool operator==(RowRange const& rhs) const;
+  bool operator!=(RowRange const& rhs) const { return !(*this == rhs); }
+
   /// Return the filter expression as a protobuf.
   ::google::bigtable::v2::RowRange as_proto() const { return row_range_; }
 
@@ -149,8 +165,11 @@ class RowRange {
     return std::move(row_range_);
   }
 
+  /// Streaming operator, mostly used for testing.
+  friend std::ostream& operator<<(std::ostream& os, RowRange const& x);
+
  private:
-  /// Private to avoid mistaken creation of unitialized ranges.
+  /// Private to avoid mistaken creation of uninitialized ranges.
   RowRange() {}
 
   /// Return true if @p key is below the start.

--- a/bigtable/client/row_range.h
+++ b/bigtable/client/row_range.h
@@ -39,7 +39,7 @@ inline namespace BIGTABLE_CLIENT_NS {
 class RowRange {
  public:
   explicit RowRange(::google::bigtable::v2::RowRange rhs)
-    : row_range_(std::move(rhs)) {}
+      : row_range_(std::move(rhs)) {}
 
   RowRange(RowRange&& rhs) noexcept = default;
   RowRange& operator=(RowRange&& rhs) noexcept = default;
@@ -152,7 +152,7 @@ class RowRange {
    *     If there is no intersection the first element is `false` and the second
    *     element has a valid, but unspecified value.
    */
-  std::pair<bool,RowRange> Intersect(RowRange const& range) const;
+  std::pair<bool, RowRange> Intersect(RowRange const& range) const;
 
   bool operator==(RowRange const& rhs) const;
   bool operator!=(RowRange const& rhs) const { return !(*this == rhs); }

--- a/bigtable/client/row_range_test.cc
+++ b/bigtable/client/row_range_test.cc
@@ -270,148 +270,148 @@ TEST(RowRangeTest, EqualsEndingAt) {
 // intersecting a RightOpen range against other ranges.
 using R = bigtable::RowRange;
 
-TEST(RowRangeTest, InterserctRightOpen_Empty) {
+TEST(RowRangeTest, IntersectRightOpen_Empty) {
   auto tuple = R::RightOpen("c", "m").Intersect(R::Empty());
   EXPECT_FALSE(std::get<0>(tuple));
 }
 
-TEST(RowRangeTest, InterserctRightOpen_CompletelyBelow) {
+TEST(RowRangeTest, IntersectRightOpen_CompletelyBelow) {
   auto tuple = R::RightOpen("c", "m").Intersect(R::RightOpen("a", "b"));
   EXPECT_FALSE(std::get<0>(tuple));
 }
 
-TEST(RowRangeTest, InterserctRightOpen_MatchingBoundariesBelow) {
+TEST(RowRangeTest, IntersectRightOpen_MatchingBoundariesBelow) {
   auto tuple = R::RightOpen("c", "m").Intersect(R::RightOpen("a", "c"));
   EXPECT_FALSE(std::get<0>(tuple));
 }
 
-TEST(RowRangeTest, InterserctRightOpen_CompletelyAbove) {
+TEST(RowRangeTest, IntersectRightOpen_CompletelyAbove) {
   auto tuple = R::RightOpen("c", "m").Intersect(R::RightOpen("n", "q"));
   EXPECT_FALSE(std::get<0>(tuple));
 }
 
-TEST(RowRangeTest, InterserctRightOpen_MatchingBoundariesAbove) {
+TEST(RowRangeTest, IntersectRightOpen_MatchingBoundariesAbove) {
   auto tuple = R::RightOpen("c", "m").Intersect(R::RightOpen("m", "q"));
   EXPECT_FALSE(std::get<0>(tuple));
 }
 
-TEST(RowRangeTest, InterserctRightOpen_StartBelowEndInside) {
+TEST(RowRangeTest, IntersectRightOpen_StartBelowEndInside) {
   auto tuple = R::RightOpen("c", "m").Intersect(R::RightOpen("a", "d"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::RightOpen("c", "d"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctRightOpen_StartBelowEndInsideClosed) {
+TEST(RowRangeTest, IntersectRightOpen_StartBelowEndInsideClosed) {
   auto tuple = R::RightOpen("c", "m").Intersect(R::LeftOpen("a", "d"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::Closed("c", "d"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctRightOpen_CompletelyInsideRightOpen) {
+TEST(RowRangeTest, IntersectRightOpen_CompletelyInsideRightOpen) {
   auto tuple = R::RightOpen("c", "m").Intersect(R::RightOpen("d", "k"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::RightOpen("d", "k"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctRightOpen_CompletelyInsideLeftOpen) {
+TEST(RowRangeTest, IntersectRightOpen_CompletelyInsideLeftOpen) {
   auto tuple = R::RightOpen("c", "m").Intersect(R::LeftOpen("d", "k"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::LeftOpen("d", "k"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctRightOpen_CompletelyInsideOpen) {
+TEST(RowRangeTest, IntersectRightOpen_CompletelyInsideOpen) {
   auto tuple = R::RightOpen("c", "m").Intersect(R::Open("d", "k"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::Open("d", "k"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctRightOpen_CompletelyInsideClosed) {
+TEST(RowRangeTest, IntersectRightOpen_CompletelyInsideClosed) {
   auto tuple = R::RightOpen("c", "m").Intersect(R::Closed("d", "k"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::Closed("d", "k"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctRightOpen_StartInsideEndAbove) {
+TEST(RowRangeTest, IntersectRightOpen_StartInsideEndAbove) {
   auto tuple = R::RightOpen("c", "m").Intersect(R::RightOpen("k", "z"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::RightOpen("k", "m"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctRightOpen_StartInsideEndAboveOpen) {
+TEST(RowRangeTest, IntersectRightOpen_StartInsideEndAboveOpen) {
   auto tuple = R::RightOpen("c", "m").Intersect(R::LeftOpen("k", "z"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::Open("k", "m"), std::get<1>(tuple));
 }
 
 // The cases for a LeftOpen interval.
-TEST(RowRangeTest, InterserctLeftOpen_Empty) {
+TEST(RowRangeTest, IntersectLeftOpen_Empty) {
   auto tuple = R::LeftOpen("c", "m").Intersect(R::Empty());
   EXPECT_FALSE(std::get<0>(tuple));
 }
 
-TEST(RowRangeTest, InterserctLeftOpen_CompletelyBelow) {
-  auto tuple = R::LeftOpen("c", "m").Intersect(R::RightOpen("a", "b"));
+TEST(RowRangeTest, IntersectLeftOpen_CompletelyBelow) {
+  auto tuple = R::LeftOpen("c", "m").Intersect(R::LeftOpen("a", "b"));
   EXPECT_FALSE(std::get<0>(tuple));
 }
 
-TEST(RowRangeTest, InterserctLeftOpen_MatchingBoundariesBelow) {
+TEST(RowRangeTest, IntersectLeftOpen_MatchingBoundariesBelow) {
   auto tuple = R::LeftOpen("c", "m").Intersect(R::RightOpen("a", "c"));
   EXPECT_FALSE(std::get<0>(tuple));
 }
 
-TEST(RowRangeTest, InterserctLeftOpen_CompletelyAbove) {
-  auto tuple = R::LeftOpen("c", "m").Intersect(R::RightOpen("n", "q"));
+TEST(RowRangeTest, IntersectLeftOpen_CompletelyAbove) {
+  auto tuple = R::LeftOpen("c", "m").Intersect(R::LeftOpen("n", "q"));
   EXPECT_FALSE(std::get<0>(tuple));
 }
 
-TEST(RowRangeTest, InterserctLeftOpen_MatchingBoundariesAbove) {
+TEST(RowRangeTest, IntersectLeftOpen_MatchingBoundariesAbove) {
   auto tuple = R::LeftOpen("c", "m").Intersect(R::LeftOpen("m", "q"));
   EXPECT_FALSE(std::get<0>(tuple));
 }
 
-TEST(RowRangeTest, InterserctLeftOpen_StartBelowEndInside) {
+TEST(RowRangeTest, IntersectLeftOpen_StartBelowEndInside) {
   auto tuple = R::LeftOpen("c", "m").Intersect(R::RightOpen("a", "d"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::Open("c", "d"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctLeftOpen_StartBelowEndInsideClosed) {
+TEST(RowRangeTest, IntersectLeftOpen_StartBelowEndInsideClosed) {
   auto tuple = R::LeftOpen("c", "m").Intersect(R::LeftOpen("a", "d"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::LeftOpen("c", "d"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctLeftOpen_CompletelyInsideRightOpen) {
+TEST(RowRangeTest, IntersectLeftOpen_CompletelyInsideRightOpen) {
   auto tuple = R::LeftOpen("c", "m").Intersect(R::RightOpen("d", "k"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::RightOpen("d", "k"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctLeftOpen_CompletelyInsideLeftOpen) {
+TEST(RowRangeTest, IntersectLeftOpen_CompletelyInsideLeftOpen) {
   auto tuple = R::LeftOpen("c", "m").Intersect(R::LeftOpen("d", "k"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::LeftOpen("d", "k"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctLeftOpen_CompletelyInsideOpen) {
+TEST(RowRangeTest, IntersectLeftOpen_CompletelyInsideOpen) {
   auto tuple = R::LeftOpen("c", "m").Intersect(R::Open("d", "k"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::Open("d", "k"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctLeftOpen_CompletelyInsideClosed) {
+TEST(RowRangeTest, IntersectLeftOpen_CompletelyInsideClosed) {
   auto tuple = R::LeftOpen("c", "m").Intersect(R::Closed("d", "k"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::Closed("d", "k"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctLeftOpen_StartInsideEndAbove) {
+TEST(RowRangeTest, IntersectLeftOpen_StartInsideEndAbove) {
   auto tuple = R::LeftOpen("c", "m").Intersect(R::RightOpen("k", "z"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::Closed("k", "m"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctLeftOpen_StartInsideEndAboveOpen) {
+TEST(RowRangeTest, IntersectLeftOpen_StartInsideEndAboveOpen) {
   auto tuple = R::LeftOpen("c", "m").Intersect(R::LeftOpen("k", "z"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::LeftOpen("k", "m"), std::get<1>(tuple));
@@ -566,64 +566,64 @@ TEST(RowRangeTest, IntersectClosed_StartInsideEndAboveOpen) {
 }
 
 // The cases for a StartingAt interval.
-TEST(RowRangeTest, InterserctStartingAt_Empty) {
+TEST(RowRangeTest, IntersectStartingAt_Empty) {
   auto tuple = R::StartingAt("c").Intersect(R::Empty());
   EXPECT_FALSE(std::get<0>(tuple));
 }
 
-TEST(RowRangeTest, InterserctStartingAt_CompletelyBelow) {
+TEST(RowRangeTest, IntersectStartingAt_CompletelyBelow) {
   auto tuple = R::StartingAt("c").Intersect(R::RightOpen("a", "b"));
   EXPECT_FALSE(std::get<0>(tuple));
 }
 
-TEST(RowRangeTest, InterserctStartingAt_MatchingBoundariesBelow) {
+TEST(RowRangeTest, IntersectStartingAt_MatchingBoundariesBelow) {
   auto tuple = R::StartingAt("c").Intersect(R::RightOpen("a", "c"));
   EXPECT_FALSE(std::get<0>(tuple));
 }
 
-TEST(RowRangeTest, InterserctStartingAt_StartBelowEndInside) {
+TEST(RowRangeTest, IntersectStartingAt_StartBelowEndInside) {
   auto tuple = R::StartingAt("c").Intersect(R::RightOpen("a", "d"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::RightOpen("c", "d"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctStartingAt_StartBelowEndInsideClosed) {
+TEST(RowRangeTest, IntersectStartingAt_StartBelowEndInsideClosed) {
   auto tuple = R::StartingAt("c").Intersect(R::LeftOpen("a", "d"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::Closed("c", "d"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctStartingAt_CompletelyInsideRightOpen) {
+TEST(RowRangeTest, IntersectStartingAt_CompletelyInsideRightOpen) {
   auto tuple = R::StartingAt("c").Intersect(R::RightOpen("d", "k"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::RightOpen("d", "k"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctStartingAt_CompletelyInsideLeftOpen) {
+TEST(RowRangeTest, IntersectStartingAt_CompletelyInsideLeftOpen) {
   auto tuple = R::StartingAt("c").Intersect(R::LeftOpen("d", "k"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::LeftOpen("d", "k"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctStartingAt_CompletelyInsideOpen) {
+TEST(RowRangeTest, IntersectStartingAt_CompletelyInsideOpen) {
   auto tuple = R::StartingAt("c").Intersect(R::Open("d", "k"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::Open("d", "k"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctStartingAt_CompletelyInsideClosed) {
+TEST(RowRangeTest, IntersectStartingAt_CompletelyInsideClosed) {
   auto tuple = R::StartingAt("c").Intersect(R::Closed("d", "k"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::Closed("d", "k"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctStartingAt_StartInsideEndAbove) {
+TEST(RowRangeTest, IntersectStartingAt_StartInsideEndAbove) {
   auto tuple = R::StartingAt("c").Intersect(R::StartingAt("k"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::StartingAt("k"), std::get<1>(tuple));
 }
 
-TEST(RowRangeTest, InterserctStartingAt_StartInsideEndAboveOpen) {
+TEST(RowRangeTest, IntersectStartingAt_StartInsideEndAboveOpen) {
   auto tuple = R::StartingAt("c").Intersect(R::LeftOpen("k", ""));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::Open("k", ""), std::get<1>(tuple));
@@ -679,4 +679,10 @@ TEST(RowRangeTest, IntersectEndingAt_StartInsideEndAboveOpen) {
   auto tuple = R::EndingAt("m").Intersect(R::LeftOpen("k", "z"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::LeftOpen("k", "m"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, IntersectEndingAt_EndingAt) {
+  auto tuple = R::EndingAt("m").Intersect(R::EndingAt("k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::EndingAt("k"), std::get<1>(tuple));
 }

--- a/bigtable/client/row_range_test.cc
+++ b/bigtable/client/row_range_test.cc
@@ -266,29 +266,417 @@ TEST(RowRangeTest, EqualsEndingAt) {
   EXPECT_NE(R::EndingAt("b"), R::Closed("a", "b"));
 }
 
-TEST(RowRangeTest, IntersectRightOpen) {
-  using R = bigtable::RowRange;
+// This is a fairly exhausting (and maybe exhaustive) set of cases for
+// intersecting a RightOpen range against other ranges.
+using R = bigtable::RowRange;
 
-  auto range = R::RightOpen("c", "m");
-  auto tuple = range.Intersect(R::Empty());
+TEST(RowRangeTest, InterserctRightOpen_Empty) {
+  auto tuple = R::RightOpen("c", "m").Intersect(R::Empty());
   EXPECT_FALSE(std::get<0>(tuple));
-  tuple = range.Intersect(R::RightOpen("a", "b"));
-  EXPECT_FALSE(std::get<0>(tuple));
-  tuple = range.Intersect(R::RightOpen("a", "c"));
-  EXPECT_FALSE(std::get<0>(tuple));
-  tuple = range.Intersect(R::RightOpen("n", "q"));
-  EXPECT_FALSE(std::get<0>(tuple));
-  tuple = range.Intersect(R::RightOpen("m", "q"));
-  EXPECT_FALSE(std::get<0>(tuple));
+}
 
-  tuple = range.Intersect(R::RightOpen("a", "d"));
+TEST(RowRangeTest, InterserctRightOpen_CompletelyBelow) {
+  auto tuple = R::RightOpen("c", "m").Intersect(R::RightOpen("a", "b"));
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, InterserctRightOpen_MatchingBoundariesBelow) {
+  auto tuple = R::RightOpen("c", "m").Intersect(R::RightOpen("a", "c"));
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, InterserctRightOpen_CompletelyAbove) {
+  auto tuple = R::RightOpen("c", "m").Intersect(R::RightOpen("n", "q"));
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, InterserctRightOpen_MatchingBoundariesAbove) {
+  auto tuple = R::RightOpen("c", "m").Intersect(R::RightOpen("m", "q"));
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, InterserctRightOpen_StartBelowEndInside) {
+  auto tuple = R::RightOpen("c", "m").Intersect(R::RightOpen("a", "d"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::RightOpen("c", "d"), std::get<1>(tuple));
-  tuple = range.Intersect(R::LeftOpen("a", "d"));
+}
+
+TEST(RowRangeTest, InterserctRightOpen_StartBelowEndInsideClosed) {
+  auto tuple = R::RightOpen("c", "m").Intersect(R::LeftOpen("a", "d"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::Closed("c", "d"), std::get<1>(tuple));
+}
 
-  tuple = range.Intersect(R::Open("d", "k"));
+TEST(RowRangeTest, InterserctRightOpen_CompletelyInsideRightOpen) {
+  auto tuple = R::RightOpen("c", "m").Intersect(R::RightOpen("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::RightOpen("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, InterserctRightOpen_CompletelyInsideLeftOpen) {
+  auto tuple = R::RightOpen("c", "m").Intersect(R::LeftOpen("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::LeftOpen("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, InterserctRightOpen_CompletelyInsideOpen) {
+  auto tuple = R::RightOpen("c", "m").Intersect(R::Open("d", "k"));
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::Open("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, InterserctRightOpen_CompletelyInsideClosed) {
+  auto tuple = R::RightOpen("c", "m").Intersect(R::Closed("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Closed("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, InterserctRightOpen_StartInsideEndAbove) {
+  auto tuple = R::RightOpen("c", "m").Intersect(R::RightOpen("k", "z"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::RightOpen("k", "m"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, InterserctRightOpen_StartInsideEndAboveOpen) {
+  auto tuple = R::RightOpen("c", "m").Intersect(R::LeftOpen("k", "z"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Open("k", "m"), std::get<1>(tuple));
+}
+
+// The cases for a LeftOpen interval.
+TEST(RowRangeTest, InterserctLeftOpen_Empty) {
+  auto tuple = R::LeftOpen("c", "m").Intersect(R::Empty());
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, InterserctLeftOpen_CompletelyBelow) {
+  auto tuple = R::LeftOpen("c", "m").Intersect(R::RightOpen("a", "b"));
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, InterserctLeftOpen_MatchingBoundariesBelow) {
+  auto tuple = R::LeftOpen("c", "m").Intersect(R::RightOpen("a", "c"));
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, InterserctLeftOpen_CompletelyAbove) {
+  auto tuple = R::LeftOpen("c", "m").Intersect(R::RightOpen("n", "q"));
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, InterserctLeftOpen_MatchingBoundariesAbove) {
+  auto tuple = R::LeftOpen("c", "m").Intersect(R::LeftOpen("m", "q"));
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, InterserctLeftOpen_StartBelowEndInside) {
+  auto tuple = R::LeftOpen("c", "m").Intersect(R::RightOpen("a", "d"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Open("c", "d"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, InterserctLeftOpen_StartBelowEndInsideClosed) {
+  auto tuple = R::LeftOpen("c", "m").Intersect(R::LeftOpen("a", "d"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::LeftOpen("c", "d"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, InterserctLeftOpen_CompletelyInsideRightOpen) {
+  auto tuple = R::LeftOpen("c", "m").Intersect(R::RightOpen("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::RightOpen("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, InterserctLeftOpen_CompletelyInsideLeftOpen) {
+  auto tuple = R::LeftOpen("c", "m").Intersect(R::LeftOpen("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::LeftOpen("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, InterserctLeftOpen_CompletelyInsideOpen) {
+  auto tuple = R::LeftOpen("c", "m").Intersect(R::Open("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Open("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, InterserctLeftOpen_CompletelyInsideClosed) {
+  auto tuple = R::LeftOpen("c", "m").Intersect(R::Closed("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Closed("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, InterserctLeftOpen_StartInsideEndAbove) {
+  auto tuple = R::LeftOpen("c", "m").Intersect(R::RightOpen("k", "z"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Closed("k", "m"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, InterserctLeftOpen_StartInsideEndAboveOpen) {
+  auto tuple = R::LeftOpen("c", "m").Intersect(R::LeftOpen("k", "z"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::LeftOpen("k", "m"), std::get<1>(tuple));
+}
+
+// The cases for a Open interval.
+TEST(RowRangeTest, IntersectOpen_Empty) {
+  auto tuple = R::Open("c", "m").Intersect(R::Empty());
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, IntersectOpen_CompletelyBelow) {
+  auto tuple = R::Open("c", "m").Intersect(R::RightOpen("a", "b"));
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, IntersectOpen_MatchingBoundariesBelow) {
+  auto tuple = R::Open("c", "m").Intersect(R::RightOpen("a", "c"));
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, IntersectOpen_CompletelyAbove) {
+  auto tuple = R::Open("c", "m").Intersect(R::RightOpen("n", "q"));
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, IntersectOpen_MatchingBoundariesAbove) {
+  auto tuple = R::Open("c", "m").Intersect(R::RightOpen("m", "q"));
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, IntersectOpen_StartBelowEndInside) {
+  auto tuple = R::Open("c", "m").Intersect(R::RightOpen("a", "d"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Open("c", "d"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, IntersectOpen_StartBelowEndInsideClosed) {
+  auto tuple = R::Open("c", "m").Intersect(R::LeftOpen("a", "d"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::LeftOpen("c", "d"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, IntersectOpen_CompletelyInsideRightOpen) {
+  auto tuple = R::Open("c", "m").Intersect(R::RightOpen("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::RightOpen("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, IntersectOpen_CompletelyInsideLeftOpen) {
+  auto tuple = R::Open("c", "m").Intersect(R::LeftOpen("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::LeftOpen("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, IntersectOpen_CompletelyInsideOpen) {
+  auto tuple = R::Open("c", "m").Intersect(R::Open("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Open("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, IntersectOpen_CompletelyInsideClosed) {
+  auto tuple = R::Open("c", "m").Intersect(R::Closed("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Closed("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, IntersectOpen_StartInsideEndAbove) {
+  auto tuple = R::Open("c", "m").Intersect(R::RightOpen("k", "z"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::RightOpen("k", "m"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, IntersectOpen_StartInsideEndAboveOpen) {
+  auto tuple = R::Open("c", "m").Intersect(R::LeftOpen("k", "z"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Open("k", "m"), std::get<1>(tuple));
+}
+
+// The cases for a Closed interval.
+TEST(RowRangeTest, IntersectClosed_Empty) {
+  auto tuple = R::Closed("c", "m").Intersect(R::Empty());
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, IntersectClosed_CompletelyBelow) {
+  auto tuple = R::Closed("c", "m").Intersect(R::RightOpen("a", "b"));
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, IntersectClosed_MatchingBoundariesBelow) {
+  auto tuple = R::Closed("c", "m").Intersect(R::RightOpen("a", "c"));
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, IntersectClosed_CompletelyAbove) {
+  auto tuple = R::Closed("c", "m").Intersect(R::RightOpen("n", "q"));
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, IntersectClosed_MatchingBoundariesAbove) {
+  auto tuple = R::Closed("c", "m").Intersect(R::LeftOpen("m", "q"));
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, IntersectClosed_StartBelowEndInside) {
+  auto tuple = R::Closed("c", "m").Intersect(R::RightOpen("a", "d"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::RightOpen("c", "d"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, IntersectClosed_StartBelowEndInsideClosed) {
+  auto tuple = R::Closed("c", "m").Intersect(R::LeftOpen("a", "d"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Closed("c", "d"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, IntersectClosed_CompletelyInsideRightOpen) {
+  auto tuple = R::Closed("c", "m").Intersect(R::RightOpen("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::RightOpen("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, IntersectClosed_CompletelyInsideLeftOpen) {
+  auto tuple = R::Closed("c", "m").Intersect(R::LeftOpen("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::LeftOpen("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, IntersectClosed_CompletelyInsideOpen) {
+  auto tuple = R::Closed("c", "m").Intersect(R::Open("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Open("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, IntersectClosed_CompletelyInsideClosed) {
+  auto tuple = R::Closed("c", "m").Intersect(R::Closed("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Closed("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, IntersectClosed_StartInsideEndAbove) {
+  auto tuple = R::Closed("c", "m").Intersect(R::RightOpen("k", "z"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Closed("k", "m"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, IntersectClosed_StartInsideEndAboveOpen) {
+  auto tuple = R::Closed("c", "m").Intersect(R::LeftOpen("k", "z"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::LeftOpen("k", "m"), std::get<1>(tuple));
+}
+
+// The cases for a StartingAt interval.
+TEST(RowRangeTest, InterserctStartingAt_Empty) {
+  auto tuple = R::StartingAt("c").Intersect(R::Empty());
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, InterserctStartingAt_CompletelyBelow) {
+  auto tuple = R::StartingAt("c").Intersect(R::RightOpen("a", "b"));
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, InterserctStartingAt_MatchingBoundariesBelow) {
+  auto tuple = R::StartingAt("c").Intersect(R::RightOpen("a", "c"));
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, InterserctStartingAt_StartBelowEndInside) {
+  auto tuple = R::StartingAt("c").Intersect(R::RightOpen("a", "d"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::RightOpen("c", "d"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, InterserctStartingAt_StartBelowEndInsideClosed) {
+  auto tuple = R::StartingAt("c").Intersect(R::LeftOpen("a", "d"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Closed("c", "d"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, InterserctStartingAt_CompletelyInsideRightOpen) {
+  auto tuple = R::StartingAt("c").Intersect(R::RightOpen("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::RightOpen("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, InterserctStartingAt_CompletelyInsideLeftOpen) {
+  auto tuple = R::StartingAt("c").Intersect(R::LeftOpen("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::LeftOpen("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, InterserctStartingAt_CompletelyInsideOpen) {
+  auto tuple = R::StartingAt("c").Intersect(R::Open("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Open("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, InterserctStartingAt_CompletelyInsideClosed) {
+  auto tuple = R::StartingAt("c").Intersect(R::Closed("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Closed("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, InterserctStartingAt_StartInsideEndAbove) {
+  auto tuple = R::StartingAt("c").Intersect(R::StartingAt("k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::StartingAt("k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, InterserctStartingAt_StartInsideEndAboveOpen) {
+  auto tuple = R::StartingAt("c").Intersect(R::LeftOpen("k", ""));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Open("k", ""), std::get<1>(tuple));
+}
+
+// The cases for a EndingAt interval.
+TEST(RowRangeTest, IntersectEndingAt_Empty) {
+  auto tuple = R::EndingAt("m").Intersect(R::Empty());
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, IntersectEndingAt_CompletelyAbove) {
+  auto tuple = R::EndingAt("m").Intersect(R::RightOpen("n", "q"));
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, IntersectEndingAt_MatchingBoundariesAbove) {
+  auto tuple = R::EndingAt("m").Intersect(R::LeftOpen("m", "q"));
+  EXPECT_FALSE(std::get<0>(tuple));
+}
+
+TEST(RowRangeTest, IntersectEndingAt_CompletelyInsideRightOpen) {
+  auto tuple = R::EndingAt("m").Intersect(R::RightOpen("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::RightOpen("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, IntersectEndingAt_CompletelyInsideLeftOpen) {
+  auto tuple = R::EndingAt("m").Intersect(R::LeftOpen("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::LeftOpen("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, IntersectEndingAt_CompletelyInsideOpen) {
+  auto tuple = R::EndingAt("m").Intersect(R::Open("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Open("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, IntersectEndingAt_CompletelyInsideClosed) {
+  auto tuple = R::EndingAt("m").Intersect(R::Closed("d", "k"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Closed("d", "k"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, IntersectEndingAt_StartInsideEndAbove) {
+  auto tuple = R::EndingAt("m").Intersect(R::RightOpen("k", "z"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::Closed("k", "m"), std::get<1>(tuple));
+}
+
+TEST(RowRangeTest, IntersectEndingAt_StartInsideEndAboveOpen) {
+  auto tuple = R::EndingAt("m").Intersect(R::LeftOpen("k", "z"));
+  EXPECT_TRUE(std::get<0>(tuple));
+  EXPECT_EQ(R::LeftOpen("k", "m"), std::get<1>(tuple));
 }

--- a/bigtable/client/row_set.cc
+++ b/bigtable/client/row_set.cc
@@ -1,0 +1,37 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/client/row_set.h"
+
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace btproto = ::google::bigtable::v2;
+
+void RowSet::Intersect(bigtable::RowRange const& range) {
+  btproto::RowSet result;
+  for (auto const& key : row_set_.row_keys()) {
+    if (range.Contains(key)) {
+      *result.add_row_keys() = key;
+    }
+  }
+  for (auto const& r : row_set_.row_ranges()) {
+    auto i = range.Intersect(RowRange(r));
+    if (std::get<0>(i)) {
+      *result.add_row_ranges() = std::get<1>(i).as_proto_move();
+    }
+  }
+  row_set_.Swap(&result);
+}
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable

--- a/bigtable/client/row_set.cc
+++ b/bigtable/client/row_set.cc
@@ -18,20 +18,20 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace btproto = ::google::bigtable::v2;
 
-void RowSet::Intersect(bigtable::RowRange const& range) {
-  btproto::RowSet result;
+RowSet RowSet::Intersect(bigtable::RowRange const& range) const {
+  RowSet result;
   for (auto const& key : row_set_.row_keys()) {
     if (range.Contains(key)) {
-      *result.add_row_keys() = key;
+      *result.row_set_.add_row_keys() = key;
     }
   }
   for (auto const& r : row_set_.row_ranges()) {
     auto i = range.Intersect(RowRange(r));
     if (std::get<0>(i)) {
-      *result.add_row_ranges() = std::get<1>(i).as_proto_move();
+      *result.row_set_.add_row_ranges() = std::get<1>(i).as_proto_move();
     }
   }
-  row_set_.Swap(&result);
+  return result;
 }
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/bigtable/client/row_set.h
+++ b/bigtable/client/row_set.h
@@ -73,6 +73,15 @@ class RowSet {
    */
   void Append(char const* row_key) { Append(absl::string_view(row_key)); }
 
+  /**
+   * Modify this object to contain the ranges and keys inside @p range.
+   *
+   * This function removes any rowkeys outside @p range, it removes any row
+   * ranges that do not insersect with @p range, and keeps only the intersection
+   * for those ranges that do intersect @p range.
+   */
+  void Intersect(bigtable::RowRange const& range);
+
   ::google::bigtable::v2::RowSet as_proto() const { return row_set_; }
   ::google::bigtable::v2::RowSet as_proto_move() { return std::move(row_set_); }
 

--- a/bigtable/client/row_set.h
+++ b/bigtable/client/row_set.h
@@ -80,7 +80,7 @@ class RowSet {
    * ranges that do not insersect with @p range, and keeps only the intersection
    * for those ranges that do intersect @p range.
    */
-  void Intersect(bigtable::RowRange const& range);
+  RowSet Intersect(bigtable::RowRange const& range) const;
 
   ::google::bigtable::v2::RowSet as_proto() const { return row_set_; }
   ::google::bigtable::v2::RowSet as_proto_move() { return std::move(row_set_); }

--- a/bigtable/client/row_set_test.cc
+++ b/bigtable/client/row_set_test.cc
@@ -76,3 +76,6 @@ TEST(RowSetTest, VariadicConstructor) {
   EXPECT_EQ("foo", proto.row_keys(0));
   EXPECT_EQ("bar", proto.row_keys(1));
 }
+
+TEST(RowSetTest, IntersectRightOpen) {
+}

--- a/bigtable/client/row_set_test.cc
+++ b/bigtable/client/row_set_test.cc
@@ -80,9 +80,8 @@ TEST(RowSetTest, IntersectRightOpen) {
   using R = bigtable::RowRange;
   bigtable::RowSet row_set(R::Range("a", "b"), "foo", R::LeftOpen("k", "m"),
                            "zzz");
-  row_set.Intersect(R::StartingAt("l"));
 
-  auto proto = row_set.as_proto();
+  auto proto = row_set.Intersect(R::StartingAt("l")).as_proto();
   ASSERT_EQ(1, proto.row_ranges_size());
   EXPECT_EQ(R::Closed("l", "m"), R(proto.row_ranges(0)));
   ASSERT_EQ(1, proto.row_keys_size());


### PR DESCRIPTION
This member function is needed to implement `bigtable::Table::ReadRows()`, it is therefore part of the fixes for #32.