### PR TITLE
Ubuntu Zesty (17.04) is EOL, upgrade to Artful (17.10).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
     - # Compile against an installed version of gRPC.
       os: linux
       compiler: clang
-      env: DISTRO=ubuntu-with-grpc DISTRO_VERSION=17.04 BUILD_TYPE=Release \
+      env: DISTRO=ubuntu-with-grpc DISTRO_VERSION=17.10 BUILD_TYPE=Release \
             CMAKE_FLAGS=-DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=package
       install:
         - # First build the usual Ubuntu image, then use that to build an image
@@ -61,7 +61,7 @@ matrix:
       # documentation.
       os: linux
       compiler: gcc
-      env: DISTRO=ubuntu DISTRO_VERSION=17.04 CHECK_STYLE=yes GENERATE_DOCS=yes
+      env: DISTRO=ubuntu DISTRO_VERSION=17.10 CHECK_STYLE=yes GENERATE_DOCS=yes
     - # Build with the AddressSanitizer.
       os: linux
       compiler: clang


### PR DESCRIPTION
That, the builds broke because Zesty became EOL on 2018-01-13.  A couple of PRs are failing the tests because of this.

