### PR TITLE
Automatically retry when the image creation fails.

### DIFF
--- a/ci/install-linux.sh
+++ b/ci/install-linux.sh
@@ -24,14 +24,14 @@ if [ "${TRAVIS_OS_NAME}" != "linux" ]; then
 fi
 
 readonly IMAGE="cached-${DISTRO}-${DISTRO_VERSION}"
-# Make three attempts to build the Docker image.  From time to time the image
-# creation fails because some apt server times out, and more often than not
+# Make three attempts to build the Docker image.  From time to time, the image
+# creation fails because some apt server times out, and more often than not,
 # restarting the build is successful.
 
-# Initially wait at least 3 minutes (the times are in seconds), because it makes
-# no sense to try faster.  We currently have 20+ minutes of remaining budget to
-# complete a build, and we should be as nice as possible to the servers that
-# provide the packages.
+# Initially, wait at least 3 minutes (the times are in seconds), because it
+# makes no sense to try faster.  We currently have 20+ minutes of remaining
+# budget to complete a build, and we should be as nice as possible to the
+# servers that provide the packages.
 min_wait=180
 for i in 1 2 3; do
   sudo docker build -t "${IMAGE}:tip" \
@@ -42,7 +42,7 @@ for i in 1 2 3; do
   fi
   # Sleep for a few minutes before trying again.
   readonly PERIOD=$[ (${RANDOM} % 60) + min_wait ]
-  echo "Fetch failed trying again in ${PERIOD} seconds"
+  echo "Fetch failed; trying again in ${PERIOD} seconds."
   sleep ${PERIOD}s
   min_wait=$[ min_wait * 2 ]
 done

--- a/ci/install-linux.sh
+++ b/ci/install-linux.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright 2017 Google Inc.
 #
@@ -16,19 +16,33 @@
 
 set -eu
 
+# Create a Docker image with all the dependencies necessary to build the
+# project.
 if [ "${TRAVIS_OS_NAME}" != "linux" ]; then
-  echo "Not a Linux-based build; skipping Docker installation and restore from cache."
+  echo "Not a Linux-based build; skipping Docker image creation."
   exit 0
 fi
 
-if [ "${CI:-}" = "true" ]; then
-  # Running in the CI environment, upgrade Docker.
-  sudo apt-get update
-  sudo apt-get install -y docker-ce
-  sudo docker --version
-fi
-
 readonly IMAGE="cached-${DISTRO}-${DISTRO_VERSION}"
-sudo docker build -t "${IMAGE}:tip" \
-     --build-arg DISTRO_VERSION="${DISTRO_VERSION}" \
-     -f "ci/Dockerfile.${DISTRO}" ci
+# Make three attempts to build the Docker image.  From time to time the image
+# creation fails because some apt server times out, and more often than not
+# restarting the build is successful.
+
+# Initially wait at least 3 minutes (the times are in seconds), because it makes
+# no sense to try faster.  We currently have 20+ minutes of remaining budget to
+# complete a build, and we should be as nice as possible to the servers that
+# provide the packages.
+min_wait=180
+for i in 1 2 3; do
+  sudo docker build -t "${IMAGE}:tip" \
+       --build-arg DISTRO_VERSION="${DISTRO_VERSION}" \
+       -f "ci/Dockerfile.${DISTRO}" ci
+  if [ $? -eq 0 ]; then
+    exit 0
+  fi
+  # Sleep for a few minutes before trying again.
+  readonly PERIOD=$[ (${RANDOM} % 60) + min_wait ]
+  echo "Fetch failed trying again in ${PERIOD} seconds"
+  sleep ${PERIOD}s
+  min_wait=$[ min_wait * 2 ]
+done


### PR DESCRIPTION
From time to time the build fails because we cannot create the
corresponding Docker image.  Often this is just a time out from
some server, and restarting the build succeeds.

Also, Travis has updated the stock Docker version, so we do not
need to upgrade, saves a few seconds per build.
