### PR TITLE
Add a user-agent prefix by default.

### DIFF
--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -98,7 +98,7 @@ else ()
     set(GIT_HEAD_LOG "(unknown-git-commit)")
 endif ()
 string(REPLACE "\n" "" GIT_HEAD ${GIT_HEAD_LOG})
-string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)
+string(TOUPPER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_UPPER)
 configure_file(client/build_info.cc.in client/build_info.cc)
 
 # the client library

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -89,8 +89,22 @@ target_link_libraries(bigtable_protos ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PR
 # Enable unit tests
 enable_testing()
 
+# Capture the compiler version and the git revision into variables, then
+# generate a config file with the values.
+if (IS_DIRECTORY ${PROJECT_SOURCE_DIR}/.git)
+    execute_process(COMMAND git rev-parse --short HEAD
+            OUTPUT_VARIABLE GIT_HEAD_LOG ERROR_VARIABLE GIT_HEAD_LOG)
+else ()
+    set(GIT_HEAD_LOG "(unknown-git-commit)")
+endif ()
+string(REPLACE "\n" "" GIT_HEAD ${GIT_HEAD_LOG})
+string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)
+configure_file(client/build_info.cc.in client/build_info.cc)
+
 # the client library
 add_library(bigtable_client
+    client/build_info.h
+    ${PROJECT_BINARY_DIR}/bigtable/client/build_info.cc
     client/cell.h
     client/client_options.h
     client/client_options.cc
@@ -125,7 +139,8 @@ add_library(bigtable_client
     client/rpc_retry_policy.cc
     client/table.h
     client/table.cc
-    client/version.h)
+    client/version.h
+    client/version.cc)
 target_link_libraries(bigtable_client
     bigtable_protos absl::strings
     ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})

--- a/bigtable/client/build_info.cc.in
+++ b/bigtable/client/build_info.cc.in
@@ -10,25 +10,18 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
+// limitations under the License.
 
-#include "bigtable/client/client_options.h"
+#include "bigtable/client/build_info.h"
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-ClientOptions::ClientOptions() {
-  char const* emulator = std::getenv("BIGTABLE_EMULATOR_HOST");
-  if (emulator != nullptr) {
-    data_endpoint_ = emulator;
-    admin_endpoint_ = emulator;
-    credentials_ = grpc::InsecureChannelCredentials();
-  } else {
-    data_endpoint_ = "bigtable.googleapis.com";
-    admin_endpoint_ = "bigtableadmin.googleapis.com";
-    credentials_ = grpc::GoogleDefaultCredentials();
-  }
-  channel_arguments_ = grpc::ChannelArguments();
-  channel_arguments_.SetUserAgentPrefix("cbt-c++/" + version_string());
-}
+
+char const compiler[] = R"""(@CMAKE_CXX_COMPILER_ID@ @CMAKE_CXX_COMPILER_VERSION@)""";
+
+char const compiler_flags[] = R"""(@CMAKE_CXX_FLAGS@ ${CMAKE_CXX_FLAGS_${BUILD_TYPE_UPPER}})""";
+
+char const gitrev[] = R"""(@GIT_HEAD@)""";
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/bigtable/client/build_info.h
+++ b/bigtable/client/build_info.h
@@ -10,25 +10,25 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
+// limitations under the License.
 
-#include "bigtable/client/client_options.h"
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_BUILD_INFO_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_BUILD_INFO_H_
+
+#include "bigtable/client/version.h"
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-ClientOptions::ClientOptions() {
-  char const* emulator = std::getenv("BIGTABLE_EMULATOR_HOST");
-  if (emulator != nullptr) {
-    data_endpoint_ = emulator;
-    admin_endpoint_ = emulator;
-    credentials_ = grpc::InsecureChannelCredentials();
-  } else {
-    data_endpoint_ = "bigtable.googleapis.com";
-    admin_endpoint_ = "bigtableadmin.googleapis.com";
-    credentials_ = grpc::GoogleDefaultCredentials();
-  }
-  channel_arguments_ = grpc::ChannelArguments();
-  channel_arguments_.SetUserAgentPrefix("cbt-c++/" + version_string());
-}
+/// The git revision at compile time
+extern char const gitrev[];
+
+/// The compiler version
+extern char const compiler[];
+
+/// The compiler flags
+extern char const compiler_flags[];
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_BUILD_INFO_H_

--- a/bigtable/client/client_options.cc
+++ b/bigtable/client/client_options.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 
 #include "bigtable/client/client_options.h"
+#include <absl/strings/str_cat.h>
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
@@ -27,7 +28,8 @@ ClientOptions::ClientOptions() {
     credentials_ = grpc::GoogleDefaultCredentials();
   }
   channel_arguments_ = grpc::ChannelArguments();
-  channel_arguments_.SetUserAgentPrefix("cbt-c++/" + version_string());
+  channel_arguments_.SetUserAgentPrefix(
+      absl::StrCat("cbt-c++/", version_string()));
 }
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/bigtable/client/version.cc
+++ b/bigtable/client/version.cc
@@ -1,0 +1,24 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/client/version.h"
+#include <absl/strings/str_cat.h>
+#include "bigtable/client/build_info.h"
+
+namespace bigtable {
+std::string version_string() {
+  return absl::StrCat("v", version_major(), ".", version_minor(), ".",
+                      version_patch(), "-", gitrev);
+}
+}  // namespace bigtable

--- a/bigtable/client/version.h
+++ b/bigtable/client/version.h
@@ -18,7 +18,7 @@
 #include <string>
 
 #ifndef _MSC_VER
-// Microsoft Vistual Studio does not define __cplusplus correctly for C++11.
+// Microsoft Visual Studio does not define __cplusplus correctly for C++11.
 #if __cplusplus < 201103L
 #error "Bigtable C++ Client requires C++11"
 #endif  // __cplusplus < 201103L

--- a/bigtable/client/version.h
+++ b/bigtable/client/version.h
@@ -15,6 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_VERSION_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_VERSION_H_
 
+#include <string>
+
 #ifndef _MSC_VER
 // Microsoft Vistual Studio does not define __cplusplus correctly for C++11.
 #if __cplusplus < 201103L
@@ -28,6 +30,7 @@
 
 #define BIGTABLE_CLIENT_VERSION_MAJOR 0
 #define BIGTABLE_CLIENT_VERSION_MINOR 1
+#define BIGTABLE_CLIENT_VERSION_PATCH 0
 
 #define BIGTABLE_CLIENT_VCONCAT(Ma, Mi) v##Ma
 #define BIGTABLE_CLIENT_VEVAL(Ma, Mi) BIGTABLE_CLIENT_VCONCAT(Ma, Mi)
@@ -38,8 +41,12 @@
 namespace bigtable {
 int constexpr version_major() { return BIGTABLE_CLIENT_VERSION_MAJOR; }
 int constexpr version_minor() { return BIGTABLE_CLIENT_VERSION_MINOR; }
+int constexpr version_patch() { return BIGTABLE_CLIENT_VERSION_PATCH; }
 /// A single integer representing the Major/Minor version
-int constexpr version() { return 100 * version_major() + version_minor(); }
+int constexpr version() {
+  return 100 * (100 * version_major() + version_minor()) + version_patch();
+}
+std::string version_string();
 }  // namespace bigtable
 
 #endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_VERSION_H_


### PR DESCRIPTION
This fixes #191.  Every grpc::Channel created by the client
library includes the library name (`cbt-c++`) and version as
a user-agent prefix.  The version includes the git commit (the
short form of the SHA-1), which is captured by CMake at
build-time.  I also captured the compiler id, compiler version,
and relevant compiler flags because those will be useful
elsewhere.

There is some overlap with #195, whichever one gets merged first I will resolve the conflicts.
