### PR TITLE
Helper classes to initialize PRNGs.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,7 @@ pull_requests:
   do_not_increment_build_number: true
 
 image:
-- Visual Studio 2015
+  - Visual Studio 2017
 
 environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,6 +22,7 @@ image:
 
 environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
+  GENERATOR: "Visual Studio 15 2017 Win64"
 
 cache:
   - c:\projects\vcpkg\installed -> ci\install-windows.ps1

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -242,6 +242,15 @@ foreach (fname ${bigtable_client_unit_tests})
     get_target_property(sources ${target} SOURCES)
     add_dependencies(tests-local ${target})
 endforeach ()
+# Create a single executable that rolls up all the tests, this is convenient
+# for CLion and other IDEs.
+add_executable(bigtable_client_all_tests EXCLUDE_FROM_ALL
+    ${bigtable_client_unit_tests})
+target_link_libraries(bigtable_client_all_tests
+    bigtable_client_testing bigtable_client
+    bigtable_protos gmock absl::strings
+    ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+
 
 # List the unit tests, then setup the targets and dependencies.
 set(bigtable_admin_unit_tests
@@ -262,15 +271,8 @@ foreach (fname ${bigtable_admin_unit_tests})
     get_target_property(sources ${target} SOURCES)
     add_dependencies(tests-local ${target})
 endforeach ()
-
-# Create a single executable that rolls up all the tests, this is convenient
-# for CLion and other IDEs.
-add_executable(bigtable_client_all_tests EXCLUDE_FROM_ALL
-    ${bigtable_client_unit_tests} ${bigtable_admin_unit_tests})
-target_link_libraries(bigtable_client_all_tests
-    bigtable_client_testing bigtable_admin_client bigtable_client
-    bigtable_protos gmock absl::strings
-    ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+target_sources(bigtable_client_all_tests PUBLIC ${bigtable_admin_unit_tests})
+target_link_libraries(bigtable_client_all_tests bigtable_admin_client)
 
 option(FORCE_SANITIZER_ERRORS
     "If set, enable tests that force errors detected by the sanitizers."
@@ -309,6 +311,34 @@ target_link_libraries(filters_integration_test
     gmock bigtable_admin_client bigtable_client bigtable_protos
     ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 add_dependencies(tests-local filters_integration_test)
+
+add_library(bigtable_benchmark_common
+    benchmarks/constants.h
+    benchmarks/random.h
+    benchmarks/random.cc)
+target_link_libraries(bigtable_benchmark_common
+    absl::time bigtable_admin_client bigtable_client bigtable_protos
+    ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+
+# List the unit tests, then setup the targets and dependencies.
+set(bigtable_benchmarks_unit_tests
+    benchmarks/random_test.cc)
+foreach (fname ${bigtable_benchmarks_unit_tests})
+    string(REPLACE "/" "_" target ${fname})
+    string(REPLACE ".cc" "" target ${target})
+    add_executable(${target} ${fname})
+    get_target_property(tname ${target} NAME)
+    target_link_libraries(${target}
+        bigtable_benchmark_common bigtable_admin_client bigtable_client
+        bigtable_protos gmock absl::strings absl::time
+        ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+    add_test(NAME ${tname} COMMAND ${target})
+    get_target_property(sources ${target} SOURCES)
+    add_dependencies(tests-local ${target})
+endforeach ()
+target_sources(bigtable_client_all_tests
+    PUBLIC ${bigtable_benchmarks_unit_tests})
+target_link_libraries(bigtable_client_all_tests bigtable_benchmark_common)
 
 # Define the install target
 get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)

--- a/bigtable/benchmarks/constants.h
+++ b/bigtable/benchmarks/constants.h
@@ -1,0 +1,62 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_CONSTANTS_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_CONSTANTS_H_
+
+namespace bigtable {
+/// Supporting classes and functions to implement benchmarks.
+namespace benchmarks {
+
+//@{
+/**
+ * @name Test constants.
+ *
+ * Most of these were requirements in the original bugs (#189, #196).
+ */
+/// The size of the table.
+constexpr long kDefaultTableSize = 10000000;
+
+/// The name of the column family used in the benchmark.
+constexpr char kColumnFamily[] = "cf";
+
+/// The number of fields (aka columns, aka column qualifiers) in each row.
+constexpr int kNumFields = 10;
+
+/// The size of each value.
+constexpr int kFieldSize = 100;
+
+/// The size of each BulkApply request.
+constexpr long kBulkSize = 1000;
+
+/// The number of threads running the latency test.
+constexpr int kDefaultThreads = 8;
+
+/// How long does the test last by default.
+constexpr int kDefaultTestDuration = 30;
+
+/// How many shards are used to populate the table.
+constexpr int kPopulateShardCount = 10;
+
+/// How many times each PopulateTable shard reports progress.
+constexpr int kPopulateShardProgressMarks = 4;
+
+/// How many random bytes in the table id.
+constexpr int kTableIdRandomLetters = 8;
+//@}
+
+}  // namespace benchmarks
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_CONSTANTS_H_

--- a/bigtable/benchmarks/random.cc
+++ b/bigtable/benchmarks/random.cc
@@ -1,0 +1,42 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/benchmarks/random.h"
+#include "bigtable/benchmarks/constants.h"
+
+namespace bigtable {
+namespace benchmarks {
+std::string Sample(DefaultPRNG& gen, int n, std::string const& population) {
+  std::uniform_int_distribution<std::size_t> rd(0, population.size() - 1);
+
+  std::string result(std::size_t(n), '0');
+  std::generate(result.begin(), result.end(),
+                [&rd, &gen, &population]() { return population[rd(gen)]; });
+  return result;
+}
+
+bigtable::Mutation MakeRandomMutation(DefaultPRNG& gen, int f) {
+  std::string field = "field" + std::to_string(f);
+  return bigtable::SetCell(kColumnFamily, std::move(field), 0,
+                           MakeRandomValue(gen));
+}
+
+std::string MakeRandomValue(DefaultPRNG& generator) {
+  static std::string const letters(
+      "ABCDEFGHIJLKMNOPQRSTUVWXYZabcdefghijlkmnopqrstuvwxyz0123456789-/_");
+  return Sample(generator, kFieldSize, letters);
+}
+
+}  // namespace benchmarks
+}  // namespace bigtable

--- a/bigtable/benchmarks/random.h
+++ b/bigtable/benchmarks/random.h
@@ -1,0 +1,90 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_RANDOM_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_RANDOM_H_
+
+#include <algorithm>
+#include <random>
+#include "bigtable/admin/table_admin.h"
+#include "bigtable/client/table.h"
+
+namespace bigtable {
+namespace benchmarks {
+// While std::mt19937_64 is not the best PRNG ever, it is fairly good for
+// most purposes.  Please read:
+//    http://www.pcg-random.org/
+// for a discussion on the topic of PRNGs in general, and the C++ generators
+// in particular.
+using DefaultPRNG = std::mt19937_64;
+
+/**
+ * Initialize any of the C++11 PRNGs in `<random>` using std::random_device.
+ */
+template <typename Generator>
+Generator MakePRNG() {
+  // We use the default C++ random device to generate entropy.  The quality of
+  // this source of entropy is implementation-defined. The version in
+  // Linux with libstdc++ (the most common library on Linux) it is based on
+  // either `/dev/urandom`, or (if available) the RDRAND CPU instruction.
+  //     http://en.cppreference.com/w/cpp/numeric/random/random_device/random_device
+  // On Linux with libc++ it is also based on `/dev/urandom`, but it is not
+  // known if it uses the RDRND CPU instruction (though `/dev/urandom` does).
+  // On Windows the documentation says that the numbers are not deterministic,
+  // and cryptographically secure, but no further details are available:
+  //     https://docs.microsoft.com/en-us/cpp/standard-library/random-device-class
+  // One would want to simply pass this object to the constructor for the
+  // generator, but the C++11 approach is annoying, see this critique for
+  // the details:
+  //     http://www.pcg-random.org/posts/simple-portable-cpp-seed-entropy.html
+  // Instead we will do a lot of work below.
+  std::random_device rd;
+
+  // We need to get enough entropy to fully initialize the PRNG, that depends
+  // on the size of its state.  The size in bits is `Generator::state_size`.
+  // We convert that to the number of `unsigned int` values; as this is what
+  // std::random_device returns.
+  auto const S =
+      Generator::state_size *
+      (Generator::word_size / std::numeric_limits<unsigned int>::digits);
+
+  // Extract the necessary number of entropy bits.
+  std::vector<unsigned int> entropy(S);
+  std::generate(entropy.begin(), entropy.end(), [&rd]() { return rd(); });
+
+  // Finally, put the entropy into the form that the C++11 PRNG classes want.
+  std::seed_seq seq(entropy.begin(), entropy.end());
+  return Generator(seq);
+}
+
+inline DefaultPRNG MakeDefaultPRNG() { return MakePRNG<DefaultPRNG>(); }
+
+/**
+ * Take @p n samples out of @p population, using the @p gen PRNG.
+ *
+ * Note that sampling is done with repetition, the same element from the
+ * population may appear multiple times.
+ */
+std::string Sample(DefaultPRNG& gen, int n, std::string const& population);
+
+/// Create a mutation that changes field @p f to random values.
+bigtable::Mutation MakeRandomMutation(DefaultPRNG& gen, int f);
+
+/// Create a random value to store in a field.
+std::string MakeRandomValue(DefaultPRNG& gen);
+
+}  // namespace benchmarks
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_RANDOM_H_

--- a/bigtable/benchmarks/random_test.cc
+++ b/bigtable/benchmarks/random_test.cc
@@ -1,0 +1,51 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/benchmarks/random.h"
+#include <gmock/gmock.h>
+#include "bigtable/benchmarks/constants.h"
+
+using namespace bigtable::benchmarks;
+
+TEST(BenchmarksRandom, Basic) {
+  // This is not a statistical test for PRNG, basically we want to make
+  // sure that MakeDefaultPRNG uses different seeds, or at least creates
+  // different series:
+  auto gen_string = []() {
+    auto g = MakeDefaultPRNG();
+    return Sample(g, 32, "0123456789abcdefghijklm");
+  };
+  std::string s0 = gen_string();
+  std::string s1 = gen_string();
+  EXPECT_NE(s0, s1);
+}
+
+TEST(BenchmarksRandom, RandomValue) {
+  auto g = MakeDefaultPRNG();
+  std::string val = MakeRandomValue(g);
+  EXPECT_EQ(static_cast<std::size_t>(kFieldSize), val.size());
+  std::string val2 = MakeRandomValue(g);
+  EXPECT_NE(val, val2);
+}
+
+TEST(BenchmarksRandom, RandomMutation) {
+  auto g = MakeDefaultPRNG();
+  auto m = MakeRandomMutation(g, 0).op;
+
+  ASSERT_TRUE(m.has_set_cell());
+  EXPECT_EQ(kColumnFamily, m.set_cell().family_name());
+  EXPECT_EQ("field0", m.set_cell().column_qualifier());
+  EXPECT_EQ(0, m.set_cell().timestamp_micros());
+  EXPECT_EQ(static_cast<std::size_t>(kFieldSize), m.set_cell().value().size());
+}

--- a/ci/build-windows.ps1
+++ b/ci/build-windows.ps1
@@ -30,7 +30,9 @@ if ($LASTEXITCODE) {
 
 mkdir build
 cd build
-cmake -DCMAKE_TOOLCHAIN_FILE="$dir\vcpkg\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x86-windows-static .. -DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=package
+cmake -DCMAKE_TOOLCHAIN_FILE="$dir\vcpkg\scripts\buildsystems\vcpkg.cmake" `
+    -DVCPKG_TARGET_TRIPLET=x64-windows-static `
+    -DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=package ..
 if ($LASTEXITCODE) {
   throw "cmake failed with exit code $LASTEXITCODE"
 }

--- a/ci/build-windows.ps1
+++ b/ci/build-windows.ps1
@@ -32,7 +32,8 @@ mkdir build
 cd build
 cmake -DCMAKE_TOOLCHAIN_FILE="$dir\vcpkg\scripts\buildsystems\vcpkg.cmake" `
     -DVCPKG_TARGET_TRIPLET=x64-windows-static `
-    -DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=package ..
+    -DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=package `
+    -G $env:GENERATOR ..
 if ($LASTEXITCODE) {
   throw "cmake failed with exit code $LASTEXITCODE"
 }

--- a/ci/install-windows.ps1
+++ b/ci/install-windows.ps1
@@ -55,9 +55,9 @@ if ($LASTEXITCODE) {
 # time in the AppVeyor build the cache is at least partially refreshed, a
 # rebuild will start with some dependencies already cached, and likely
 # complete before the AppVeyor build time limit.
-$packages = @("zlib:x86-windows-static", "openssl:x86-windows-static",
-              "protobuf:x86-windows-static", "c-ares:x86-windows-static",
-              "grpc:x86-windows-static")
+$packages = @("zlib:x64-windows-static", "openssl:x64-windows-static",
+              "protobuf:x64-windows-static", "c-ares:x64-windows-static",
+              "grpc:x64-windows-static")
 foreach ($pkg in $packages) {
   $cmd = ".\vcpkg.exe install $pkg"
   Invoke-Expression $cmd


### PR DESCRIPTION
The benchmarks in #199, #196, and #189 will require good
pseudo-random number generators (PRNGs).  Unfortunately C++11
PRNGs are notoriously hard to initialize, and Abseil does
not offer a solution either.  We also introduce some
helper functions to create random strings in the benchmarks.

This is the first of probably 4 or 5 PRs related to implementing the benchmarks described in #199, #196, and #189.  If you need more context for the review, the full set of changes is at:

https://github.com/GoogleCloudPlatform/google-cloud-cpp/compare/master...coryan:scan-benchmark