### PR TITLE
Use a different ClientContext for each RPC.

### DIFF
--- a/bigtable/client/row_reader.cc
+++ b/bigtable/client/row_reader.cc
@@ -94,7 +94,7 @@ void RowReader::MakeRequest() {
     request.set_rows_limit(rows_limit_ - rows_count_);
   }
 
-  context_.reset(new grpc::ClientContext);
+  context_ = absl::make_unique<grpc::ClientContext>();
   retry_policy_->setup(*context_);
   backoff_policy_->setup(*context_);
   stream_ = client_->Stub()->ReadRows(context_.get(), request);

--- a/bigtable/client/row_reader.cc
+++ b/bigtable/client/row_reader.cc
@@ -55,7 +55,7 @@ RowReader::RowReader(
       filter_(std::move(filter)),
       retry_policy_(std::move(retry_policy)),
       backoff_policy_(std::move(backoff_policy)),
-      context_(absl::make_unique<grpc::ClientContext>()),
+      context_(),
       parser_factory_(std::move(parser_factory)),
       stream_is_open_(false),
       operation_cancelled_(false),
@@ -94,6 +94,7 @@ void RowReader::MakeRequest() {
     request.set_rows_limit(rows_limit_ - rows_count_);
   }
 
+  context_.reset(new grpc::ClientContext);
   retry_policy_->setup(*context_);
   backoff_policy_->setup(*context_);
   stream_ = client_->Stub()->ReadRows(context_.get(), request);

--- a/bigtable/client/row_reader_test.cc
+++ b/bigtable/client/row_reader_test.cc
@@ -107,7 +107,9 @@ class RetryPolicyMock : public bigtable::RPCRetryPolicy {
   std::unique_ptr<RPCRetryPolicy> clone() const override {
     throw std::runtime_error("Mocks cannot be copied.");
   }
-  void setup(grpc::ClientContext& context) const override {}
+
+  MOCK_CONST_METHOD1(setup, void(grpc::ClientContext&));
+
   MOCK_METHOD1(on_failure_impl, bool(grpc::Status const& status));
   bool on_failure(grpc::Status const& status) override {
     return on_failure_impl(status);
@@ -618,4 +620,52 @@ TEST_F(RowReaderTest, RowReaderConstructorDoesNotCallRpc) {
       client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
       bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
       std::move(backoff_policy_), std::move(parser_factory_));
+}
+
+TEST_F(RowReaderTest, FailedStreamRetryNewContext) {
+  using namespace ::testing;
+  // Every retry should use a new ClientContext object.
+  auto* stream = new MockResponseStream();  // wrapped in unique_ptr by ReadRows
+  auto parser = absl::make_unique<ReadRowsParserMock>();
+  parser->SetRows({"r1"});
+
+  void* previous_context = nullptr;
+  EXPECT_CALL(*retry_policy_, setup(_))
+      .Times(2)
+      .WillRepeatedly(Invoke([&previous_context](grpc::ClientContext& context) {
+        // This is a big hack, we want to make sure the context is new,
+        // but there is no easy way to check that, so we compare addresses.
+        EXPECT_NE(previous_context, &context);
+        previous_context = &context;
+      }));
+
+  {
+    testing::InSequence s;
+    EXPECT_CALL(*bigtable_stub_, ReadRowsRaw(_, _)).WillOnce(Return(stream));
+    EXPECT_CALL(*stream, Read(_)).WillOnce(Return(false));
+    EXPECT_CALL(*stream, Finish())
+        .WillOnce(Return(grpc::Status(grpc::INTERNAL, "retry")));
+
+    EXPECT_CALL(*retry_policy_, on_failure_impl(_)).WillOnce(Return(true));
+    EXPECT_CALL(*backoff_policy_, on_completion_impl(_))
+        .WillOnce(Return(std::chrono::milliseconds(0)));
+
+    auto stream_retry = new MockResponseStream;  // the stub will free it
+    EXPECT_CALL(*bigtable_stub_, ReadRowsRaw(_, _))
+        .WillOnce(Return(stream_retry));
+    EXPECT_CALL(*stream_retry, Read(_)).WillOnce(Return(true));
+    EXPECT_CALL(*stream_retry, Read(_)).WillOnce(Return(false));
+    EXPECT_CALL(*stream_retry, Finish()).WillOnce(Return(grpc::Status::OK));
+  }
+
+  parser_factory_->AddParser(std::move(parser));
+  bigtable::RowReader reader(
+      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
+      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
+      std::move(backoff_policy_), std::move(parser_factory_));
+
+  auto it = reader.begin();
+  EXPECT_NE(it, reader.end());
+  EXPECT_EQ(it->row_key(), "r1");
+  EXPECT_EQ(++it, reader.end());
 }


### PR DESCRIPTION
gRPC requires a new grpc::ClientContext for each RPC, but the
bigtable::RowReader class was reusing them.  Since this is only
a problem on retries it was mostly a non-issue.