### PR TITLE
Helper class to configure the benchmarks.

### DIFF
--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -315,14 +315,17 @@ add_dependencies(tests-local filters_integration_test)
 add_library(bigtable_benchmark_common
     benchmarks/constants.h
     benchmarks/random.h
-    benchmarks/random.cc)
+    benchmarks/random.cc
+    benchmarks/setup.h
+    benchmarks/setup.cc)
 target_link_libraries(bigtable_benchmark_common
     absl::time bigtable_admin_client bigtable_client bigtable_protos
     ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 
 # List the unit tests, then setup the targets and dependencies.
 set(bigtable_benchmarks_unit_tests
-    benchmarks/random_test.cc)
+    benchmarks/random_test.cc
+    benchmarks/setup_test.cc)
 foreach (fname ${bigtable_benchmarks_unit_tests})
     string(REPLACE "/" "_" target ${fname})
     string(REPLACE ".cc" "" target ${target})

--- a/bigtable/benchmarks/setup.cc
+++ b/bigtable/benchmarks/setup.cc
@@ -14,6 +14,7 @@
 
 #include "bigtable/benchmarks/setup.h"
 #include <absl/strings/str_cat.h>
+#include <cctype>
 #include <iomanip>
 #include <sstream>
 #include "bigtable/benchmarks/random.h"

--- a/bigtable/benchmarks/setup.cc
+++ b/bigtable/benchmarks/setup.cc
@@ -1,0 +1,109 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/benchmarks/setup.h"
+#include <absl/strings/str_cat.h>
+#include <iomanip>
+#include <sstream>
+#include "bigtable/benchmarks/random.h"
+#include "bigtable/client/build_info.h"
+
+/// Supporting types and functions to implement `BenchmarkSetup`
+namespace {
+std::string FormattedStartTime() {
+  auto start = std::chrono::system_clock::now();
+  std::time_t start_c = std::chrono::system_clock::to_time_t(start);
+  std::string formatted("YYYY-MM-DDTHH:SS:MMZ");
+  std::strftime(&formatted[0], formatted.size(), "%FT%TZ",
+                std::gmtime(&start_c));
+  return formatted;
+}
+
+std::string FormattedAnnotations() {
+  std::string notes =
+      absl::StrCat(bigtable::version_string(), ";", bigtable::compiler, ";",
+                   bigtable::compiler_flags);
+  std::transform(notes.begin(), notes.end(), notes.begin(),
+                 [](char c) { return c == '\n' ? ';' : c; });
+  return notes;
+}
+
+std::string MakeRandomTableId(std::string const& prefix) {
+  static std::string const table_id_chars(
+      "ABCDEFGHIJLKMNOPQRSTUVWXYZabcdefghijlkmnopqrstuvwxyz0123456789_");
+  auto gen = bigtable::benchmarks::MakeDefaultPRNG();
+  return absl::StrCat(
+      prefix, "-",
+      bigtable::benchmarks::Sample(
+          gen, bigtable::benchmarks::kTableIdRandomLetters, table_id_chars));
+}
+}  // anonymous namespace
+
+namespace bigtable {
+namespace benchmarks {
+BenchmarkSetup::BenchmarkSetup(std::string const& prefix, int& argc,
+                               char* argv[])
+    : start_time_(FormattedStartTime()),
+      notes_(FormattedAnnotations()),
+      project_id_(),
+      instance_id_(),
+      table_id_(MakeRandomTableId(prefix)) {
+  if (argc < 3) {
+    std::string const cmd = argv[0];
+    auto last_slash = std::string(argv[0]).find_last_of('/');
+    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
+              << " <project> <instance>"
+              << " [thread-count (" << kDefaultThreads << ")]"
+              << " [test-duration-seconds (" << kDefaultTestDuration << "min)]"
+              << " [table-size (" << kDefaultTableSize << ")]"
+              << " [use-embedded-server (false)]" << std::endl;
+    throw std::runtime_error("too few arguments for program.");
+  }
+
+  auto shift = [&argc, &argv]() {
+    char* r = argv[1];
+    std::copy(argv + 2, argv + argc, argv + 1);
+    --argc;
+    return r;
+  };
+
+  project_id_ = shift();
+  instance_id_ = shift();
+
+  if (argc == 1) {
+    return;
+  }
+  thread_count_ = std::stoi(shift());
+
+  if (argc == 1) {
+    return;
+  }
+  test_duration_ = std::chrono::seconds(std::stol(shift()));
+
+  if (argc == 1) {
+    return;
+  }
+  table_size_ = std::stol(shift());
+
+  if (argc == 1) {
+    return;
+  }
+  std::string value = shift();
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](char x) { return std::tolower(x); });
+  use_embedded_server_ = value == "true";
+}
+
+}  // namespace benchmarks
+}  // namespace bigtable

--- a/bigtable/benchmarks/setup.h
+++ b/bigtable/benchmarks/setup.h
@@ -1,0 +1,63 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_BENCHMARK_SETUP_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_BENCHMARK_SETUP_H_
+
+#include <chrono>
+#include <string>
+#include <vector>
+#include "bigtable/benchmarks/constants.h"
+
+namespace bigtable {
+namespace benchmarks {
+/**
+ * The configuration for a benchmark.
+ */
+class BenchmarkSetup {
+ public:
+  BenchmarkSetup(std::string const& prefix, int& argc, char* argv[]);
+
+  /// When did the benchmark start, this is used in reporting the results.
+  std::string const& start_time() const { return start_time_; }
+  /// Benchmark annotations, e.g., compiler version and flags.
+  std::string const& notes() const { return notes_; }
+  std::string const& project_id() const { return project_id_; }
+  std::string const& instance_id() const { return instance_id_; }
+
+  /// The randomly generated table id for the benchmark.
+  std::string const& table_id() const { return table_id_; }
+
+  long table_size() const { return table_size_; }
+  int thread_count() const { return thread_count_; }
+  std::chrono::seconds test_duration() const { return test_duration_; }
+  bool use_embedded_server() const { return use_embedded_server_; }
+
+ private:
+  std::string start_time_;
+  std::string notes_;
+  std::string project_id_;
+  std::string instance_id_;
+  std::string table_id_;
+  int thread_count_ = kDefaultThreads;
+  long table_size_ = kDefaultTableSize;
+  std::chrono::seconds test_duration_ =
+      std::chrono::seconds(kDefaultTestDuration * 60);
+  bool use_embedded_server_ = false;
+};
+
+}  // namespace benchmarks
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_BENCHMARK_SETUP_H_

--- a/bigtable/benchmarks/setup_test.cc
+++ b/bigtable/benchmarks/setup_test.cc
@@ -1,0 +1,126 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/benchmarks/setup.h"
+#include <gmock/gmock.h>
+
+using namespace bigtable::benchmarks;
+
+namespace {
+char arg0[] = "program";
+char arg1[] = "foo";
+char arg2[] = "bar";
+char arg3[] = "4";
+char arg4[] = "300";
+char arg5[] = "10000";
+char arg6[] = "True";
+char arg7[] = "Unused";
+}  // anonymous namespace
+
+TEST(BenchmarksSetup, Basic) {
+  char* argv[] = {arg0, arg1, arg2};
+  int argc = 3;
+  BenchmarkSetup setup("pre", argc, argv);
+  EXPECT_EQ("foo", setup.project_id());
+  EXPECT_EQ("bar", setup.instance_id());
+  EXPECT_EQ(0U, setup.table_id().find("pre"));
+  std::size_t expected = 4 + bigtable::benchmarks::kTableIdRandomLetters;
+  EXPECT_EQ(expected, setup.table_id().size());
+
+  EXPECT_EQ(kDefaultTableSize, setup.table_size());
+  EXPECT_EQ(kDefaultTestDuration * 60, setup.test_duration().count());
+  EXPECT_FALSE(setup.use_embedded_server());
+}
+
+TEST(BenchmarksSetup, Different) {
+  char arg0[] = "program";
+  char arg1[] = "foo";
+  char arg2[] = "bar";
+  char* argv_0[] = {arg0, arg1, arg2};
+  int argc_0 = sizeof(argv_0) / sizeof(argv_0[0]);
+  char* argv_1[] = {arg0, arg1, arg2};
+  int argc_1 = sizeof(argv_1) / sizeof(argv_1[0]);
+  BenchmarkSetup s0("pre", argc_0, argv_0);
+  BenchmarkSetup s1("pre", argc_1, argv_1);
+  // The probability of this test failing is tiny, but if it does, run it again.
+  // Sorry for the flakiness, but randomness is hard.
+  EXPECT_NE(s0.table_id(), s1.table_id());
+}
+
+TEST(BenchmarkSetup, Parse) {
+  char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  BenchmarkSetup setup("pre", argc, argv);
+
+  EXPECT_EQ(2, argc);
+  EXPECT_EQ(std::string("program"), argv[0]);
+  EXPECT_EQ(std::string("Unused"), argv[1]);
+
+  EXPECT_EQ("foo", setup.project_id());
+  EXPECT_EQ("bar", setup.instance_id());
+  EXPECT_EQ(4, setup.thread_count());
+  EXPECT_EQ(300, setup.test_duration().count());
+  EXPECT_EQ(10000, setup.table_size());
+  EXPECT_TRUE(setup.use_embedded_server());
+}
+
+TEST(BenchmarkSetup, Test6) {
+  char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  BenchmarkSetup setup("t6", argc, argv);
+  EXPECT_TRUE(setup.use_embedded_server());
+}
+
+TEST(BenchmarkSetup, Test5) {
+  char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  BenchmarkSetup setup("t5", argc, argv);
+  EXPECT_EQ(10000, setup.table_size());
+  EXPECT_FALSE(setup.use_embedded_server());
+}
+
+TEST(BenchmarkSetup, Test4) {
+  char* argv[] = {arg0, arg1, arg2, arg3, arg4};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  BenchmarkSetup setup("t4", argc, argv);
+  EXPECT_EQ(300, setup.test_duration().count());
+}
+
+TEST(BenchmarkSetup, Test3) {
+  char* argv[] = {arg0, arg1, arg2, arg3};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  BenchmarkSetup setup("t3", argc, argv);
+  EXPECT_EQ(4, setup.thread_count());
+}
+
+TEST(BenchmarkSetup, Test2) {
+  char* argv[] = {arg0, arg1, arg2};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  BenchmarkSetup setup("t2", argc, argv);
+  EXPECT_EQ("foo", setup.project_id());
+  EXPECT_EQ("bar", setup.instance_id());
+  EXPECT_EQ(kDefaultThreads, setup.thread_count());
+}
+
+TEST(BenchmarkSetup, Test1) {
+  char* argv[] = {arg0, arg1};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  EXPECT_THROW(BenchmarkSetup("t1", argc, argv), std::exception);
+}
+
+TEST(BenchmarkSetup, Test0) {
+  char* argv[] = {arg0};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  EXPECT_THROW(BenchmarkSetup("t0", argc, argv), std::exception);
+}


### PR DESCRIPTION
The benchmarks in #199, #196, and #189 will need to parse
the command-line to determine the project_id, instance_id,
the duration of the benchmark, etc. There is enough
commonality that we can refactor that code to a class.

This is the first of probably 4 or 5 PRs related to implementing the benchmarks described in #199, #196, and #189. If you need more context for the review, the full set of changes is at:

master...coryan:scan-benchmark