### PR TITLE
Helper class to create an embedded Bigtable server.

### DIFF
--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -326,6 +326,7 @@ target_link_libraries(bigtable_benchmark_common
 
 # List the unit tests, then setup the targets and dependencies.
 set(bigtable_benchmarks_unit_tests
+    benchmarks/embedded_server_test.cc
     benchmarks/random_test.cc
     benchmarks/setup_test.cc)
 foreach (fname ${bigtable_benchmarks_unit_tests})

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -314,6 +314,8 @@ add_dependencies(tests-local filters_integration_test)
 
 add_library(bigtable_benchmark_common
     benchmarks/constants.h
+    benchmarks/embedded_server.h
+    benchmarks/embedded_server.cc
     benchmarks/random.h
     benchmarks/random.cc
     benchmarks/setup.h

--- a/bigtable/benchmarks/embedded_server.cc
+++ b/bigtable/benchmarks/embedded_server.cc
@@ -171,7 +171,7 @@ class DefaultEmbeddedServer : public EmbeddedServer {
     builder_.RegisterService(&bigtable_service_);
     builder_.RegisterService(&admin_service_);
     server_ = builder_.BuildAndStart();
-    address_ = "localhost:" + std::to_string(port);
+    address_ = "ipv4:///localhost:" + std::to_string(port);
   }
 
   std::string address() const override { return address_; }

--- a/bigtable/benchmarks/embedded_server.cc
+++ b/bigtable/benchmarks/embedded_server.cc
@@ -105,27 +105,28 @@ class BigtableImpl final : public btproto::Bigtable::Service {
       std::size_t idx = 0;
       char const* cf = kColumnFamily;
       std::string row_key = "user" + std::to_string(i);
-      for (int i = 0; i != kNumFields; ++i) {
+      for (int j = 0; j != kNumFields; ++j) {
         auto& chunk = *msg.add_chunks();
         // This is neither the real format of the keys, nor the keys requested,
         // but it is good enough for a simulation.
-        chunk.set_row_key(std::move(row_key));
-        row_key = "";
+        chunk.set_row_key(row_key);
         chunk.set_timestamp_micros(0);
         chunk.mutable_family_name()->set_value(cf);
-        chunk.mutable_qualifier()->set_value("field" + std::to_string(i));
+        chunk.mutable_qualifier()->set_value("field" + std::to_string(j));
         chunk.set_value(values_[idx]);
+        chunk.set_value_size(static_cast<std::int32_t>(values_[idx].size()));
         ++idx;
         if (idx >= values_.size()) {
           idx = 0;
         }
         cf = "";
         if (i == kNumFields - 1) {
+          chunk.set_value_size(0);
           chunk.set_commit_row(true);
         }
       }
       if (i != request->rows_limit() - 1) {
-        writer->Write(std::move(msg));
+        writer->Write(msg);
         msg = {};
       }
     }

--- a/bigtable/benchmarks/embedded_server.cc
+++ b/bigtable/benchmarks/embedded_server.cc
@@ -1,0 +1,193 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/benchmarks/embedded_server.h"
+#include "bigtable/benchmarks/random.h"
+#include "bigtable/benchmarks/setup.h"
+#include "google/bigtable/v2/bigtable.grpc.pb.h"
+
+namespace btproto = google::bigtable::v2;
+namespace adminproto = google::bigtable::admin::v2;
+
+namespace bigtable {
+namespace benchmarks {
+/**
+ * Implement the portions of the `google.bigtable.v2.Bigtable` interface
+ * necessary for the benchmarks.
+ *
+ * This is not a Mock (use `google::bigtable;:v2::MockBigtableStub` for that,
+ * nor is this a Fake implementation (use the Cloud Bigtable Emulator for that),
+ * this is an implementation of the interface that returns hardcoded values.
+ * It is suitable for the benchmarks, but for nothing else.
+ */
+class BigtableImpl final : public btproto::Bigtable::Service {
+ public:
+  BigtableImpl() {
+    // Prepare a list of random values to use at run-time.  This is because we
+    // want the overhead of this implementation to be as small as possible.
+    // Using a single value is an option, but compresses too well and makes the
+    // tests a bit unrealistic.
+    auto generator = MakeDefaultPRNG();
+    values_.resize(1000);
+    std::generate(values_.begin(), values_.end(),
+                  [&generator]() { return MakeRandomValue(generator); });
+  }
+
+  grpc::Status MutateRow(grpc::ServerContext* context,
+                         btproto::MutateRowRequest const* request,
+                         btproto::MutateRowResponse* response) override {
+    return grpc::Status::OK;
+  }
+
+  grpc::Status MutateRows(
+      grpc::ServerContext* context, btproto::MutateRowsRequest const* request,
+      grpc::ServerWriter<btproto::MutateRowsResponse>* writer) override {
+    btproto::MutateRowsResponse msg;
+    for (int index = 0; index != request->entries_size(); ++index) {
+      auto& entry = *msg.add_entries();
+      entry.set_index(index);
+      entry.mutable_status()->set_code(grpc::StatusCode::OK);
+    }
+    writer->WriteLast(msg, grpc::WriteOptions());
+    return grpc::Status::OK;
+  }
+
+  grpc::Status ReadRows(
+      grpc::ServerContext* context,
+      google::bigtable::v2::ReadRowsRequest const* request,
+      grpc::ServerWriter<google::bigtable::v2::ReadRowsResponse>* writer)
+      override {
+    if (request->rows_limit() == 0) {
+      return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not-yet");
+    }
+
+    if (request->rows_limit() == 1) {
+      if (request->rows().row_keys_size() != 1) {
+        return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not-yet");
+      }
+      auto const& row_key = request->rows().row_keys(0);
+      btproto::ReadRowsResponse msg;
+      msg.set_last_scanned_row_key(row_key);
+      std::size_t idx = 0;
+      char const* cf = kColumnFamily;
+      for (int i = 0; i != kNumFields; ++i) {
+        auto& chunk = *msg.add_chunks();
+        chunk.set_row_key(row_key);
+        chunk.set_timestamp_micros(0);
+        chunk.mutable_family_name()->set_value(cf);
+        chunk.mutable_qualifier()->set_value("field" + std::to_string(i));
+        chunk.set_value(values_[idx]);
+        ++idx;
+        if (idx >= values_.size()) {
+          idx = 0;
+        }
+        cf = "";
+        if (i == kNumFields - 1) {
+          chunk.set_commit_row(true);
+        }
+      }
+      writer->WriteLast(msg, grpc::WriteOptions());
+      return grpc::Status::OK;
+    }
+    btproto::ReadRowsResponse msg;
+    for (std::int64_t i = 0; i != request->rows_limit(); ++i) {
+      std::size_t idx = 0;
+      char const* cf = kColumnFamily;
+      std::string row_key = "user" + std::to_string(i);
+      for (int i = 0; i != kNumFields; ++i) {
+        auto& chunk = *msg.add_chunks();
+        // This is neither the real format of the keys, nor the keys requested,
+        // but it is good enough for a simulation.
+        chunk.set_row_key(std::move(row_key));
+        row_key = "";
+        chunk.set_timestamp_micros(0);
+        chunk.mutable_family_name()->set_value(cf);
+        chunk.mutable_qualifier()->set_value("field" + std::to_string(i));
+        chunk.set_value(values_[idx]);
+        ++idx;
+        if (idx >= values_.size()) {
+          idx = 0;
+        }
+        cf = "";
+        if (i == kNumFields - 1) {
+          chunk.set_commit_row(true);
+        }
+      }
+      if (i != request->rows_limit() - 1) {
+        writer->Write(std::move(msg));
+        msg = {};
+      }
+    }
+    writer->WriteLast(msg, grpc::WriteOptions());
+    return grpc::Status::OK;
+  }
+
+ private:
+  std::vector<std::string> values_;
+};
+
+/**
+ * Implement the `google.bigtable.admin.v2.BigtableTableAdmin` interface for the
+ * benchmarks.
+ */
+class TableAdminImpl final : public adminproto::BigtableTableAdmin::Service {
+ public:
+  grpc::Status CreateTable(
+      grpc::ServerContext* context,
+      google::bigtable::admin::v2::CreateTableRequest const* request,
+      google::bigtable::admin::v2::Table* response) override {
+    response->set_name(request->parent() + "/tables/" + request->table_id());
+    return grpc::Status::OK;
+  }
+
+  grpc::Status DeleteTable(
+      grpc::ServerContext* context,
+      google::bigtable::admin::v2::DeleteTableRequest const* request,
+      ::google::protobuf::Empty* response) override {
+    return grpc::Status::OK;
+  }
+};
+
+/// The implementation of EmbeddedServer.
+class DefaultEmbeddedServer : public EmbeddedServer {
+ public:
+  explicit DefaultEmbeddedServer() {
+    int port;
+    std::string server_address("localhost:0");
+    builder_.AddListeningPort(server_address, grpc::InsecureServerCredentials(),
+                              &port);
+    builder_.RegisterService(&bigtable_service_);
+    builder_.RegisterService(&admin_service_);
+    server_ = builder_.BuildAndStart();
+    address_ = "localhost:" + std::to_string(port);
+  }
+
+  std::string address() const override { return address_; }
+  void Shutdown() override { server_->Shutdown(); }
+  void Wait() override { server_->Wait(); }
+
+ private:
+  BigtableImpl bigtable_service_;
+  TableAdminImpl admin_service_;
+  grpc::ServerBuilder builder_;
+  std::unique_ptr<grpc::Server> server_;
+  std::string address_;
+};
+
+std::unique_ptr<EmbeddedServer> CreateEmbeddedServer() {
+  return std::unique_ptr<EmbeddedServer>(new DefaultEmbeddedServer);
+}
+
+}  // namespace benchmarks
+}  // namespace bigtable

--- a/bigtable/benchmarks/embedded_server.cc
+++ b/bigtable/benchmarks/embedded_server.cc
@@ -26,7 +26,7 @@ namespace benchmarks {
  * Implement the portions of the `google.bigtable.v2.Bigtable` interface
  * necessary for the benchmarks.
  *
- * This is not a Mock (use `google::bigtable;:v2::MockBigtableStub` for that,
+ * This is not a Mock (use `google::bigtable::v2::MockBigtableStub` for that,
  * nor is this a Fake implementation (use the Cloud Bigtable Emulator for that),
  * this is an implementation of the interface that returns hardcoded values.
  * It is suitable for the benchmarks, but for nothing else.

--- a/bigtable/benchmarks/embedded_server.h
+++ b/bigtable/benchmarks/embedded_server.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_EMBEDDED_SERVER_H_
 
 #include <memory>
+#include <string>
 
 namespace bigtable {
 namespace benchmarks {

--- a/bigtable/benchmarks/embedded_server.h
+++ b/bigtable/benchmarks/embedded_server.h
@@ -25,7 +25,7 @@ namespace benchmarks {
  *
  * Sometimes it is interesting to run performance benchmarks against an
  * embedded server, as this eliminates sources of variation when measuring
- * small changes to the library.  This class is used to run (using Wait()), and
+ * small changes to the library.  This class is used to run (using Wait()) and
  * stop (using Shutdown()) such a server, without exposing the implementation
  * details to the application.
  */

--- a/bigtable/benchmarks/embedded_server.h
+++ b/bigtable/benchmarks/embedded_server.h
@@ -1,0 +1,46 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_EMBEDDED_SERVER_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_EMBEDDED_SERVER_H_
+
+#include <memory>
+
+namespace bigtable {
+namespace benchmarks {
+/**
+ * An abstract class to run and stop the embedded Bigtable server.
+ *
+ * Sometimes it is interesting to run performance benchmarks against an
+ * embedded server, as this eliminates sources of variation when measuring
+ * small changes to the library.  This class is used to run (using Wait()), and
+ * stop (using Shutdown()) such a server, without exposing the implementation
+ * details to the application.
+ */
+class EmbeddedServer {
+ public:
+  virtual ~EmbeddedServer() = default;
+
+  virtual std::string address() const = 0;
+  virtual void Shutdown() = 0;
+  virtual void Wait() = 0;
+};
+
+/// Create an embedded server.
+std::unique_ptr<EmbeddedServer> CreateEmbeddedServer();
+
+}  // namespace benchmarks
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_EMBEDDED_SERVER_H_

--- a/bigtable/benchmarks/embedded_server_test.cc
+++ b/bigtable/benchmarks/embedded_server_test.cc
@@ -1,0 +1,145 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/benchmarks/embedded_server.h"
+
+#include <thread>
+
+#include <gmock/gmock.h>
+
+#include "bigtable/admin/table_admin.h"
+#include "bigtable/client/table.h"
+
+using namespace bigtable::benchmarks;
+
+TEST(EmbeddedServer, WaitAndShutdown) {
+  auto server = CreateEmbeddedServer();
+  EXPECT_FALSE(server->address().empty());
+
+  std::thread wait_thread([&server]() { server->Wait(); });
+  EXPECT_TRUE(wait_thread.joinable());
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  EXPECT_TRUE(wait_thread.joinable());
+  server->Shutdown();
+  wait_thread.join();
+}
+
+TEST(EmbeddedServer, Admin) {
+  auto server = CreateEmbeddedServer();
+  std::thread wait_thread([&server]() { server->Wait(); });
+
+  bigtable::ClientOptions options;
+  options.set_admin_endpoint(server->address());
+  options.SetCredentials(grpc::InsecureChannelCredentials());
+  bigtable::TableAdmin admin(
+      bigtable::CreateDefaultAdminClient("fake-project", options),
+      "fake-instance");
+
+  auto gc = bigtable::GcRule::MaxNumVersions(42);
+  EXPECT_NO_THROW(admin.CreateTable("fake-table-01",
+                                    bigtable::TableConfig({{"fam", gc}}, {})));
+  EXPECT_NO_THROW(admin.DeleteTable("fake-table-02"));
+
+  server->Shutdown();
+  wait_thread.join();
+}
+
+TEST(EmbeddedServer, TableApply) {
+  auto server = CreateEmbeddedServer();
+  std::thread wait_thread([&server]() { server->Wait(); });
+
+  bigtable::ClientOptions options;
+  options.set_data_endpoint(server->address());
+  options.SetCredentials(grpc::InsecureChannelCredentials());
+  bigtable::Table table(bigtable::CreateDefaultDataClient(
+                            "fake-project", "fake-instance", options),
+                        "fake-table");
+
+  bigtable::SingleRowMutation mutation(
+      "row1", {bigtable::SetCell("fam", "col", 0, "val"),
+               bigtable::SetCell("fam", "col", 0, "val")});
+
+  EXPECT_NO_THROW(table.Apply(std::move(mutation)));
+
+  server->Shutdown();
+  wait_thread.join();
+}
+
+TEST(EmbeddedServer, TableBulkApply) {
+  auto server = CreateEmbeddedServer();
+  std::thread wait_thread([&server]() { server->Wait(); });
+
+  bigtable::ClientOptions options;
+  options.set_data_endpoint(server->address());
+  options.SetCredentials(grpc::InsecureChannelCredentials());
+  bigtable::Table table(bigtable::CreateDefaultDataClient(
+                            "fake-project", "fake-instance", options),
+                        "fake-table");
+
+  bigtable::BulkMutation bulk;
+  bulk.emplace_back(bigtable::SingleRowMutation(
+      "row1", {bigtable::SetCell("fam", "col", 0, "val")}));
+  bulk.emplace_back(bigtable::SingleRowMutation(
+      "row2", {bigtable::SetCell("fam", "col", 0, "val")}));
+
+  EXPECT_NO_THROW(table.BulkApply(std::move(bulk)));
+
+  server->Shutdown();
+  wait_thread.join();
+}
+
+TEST(EmbeddedServer, ReadRows1) {
+  auto server = CreateEmbeddedServer();
+  std::thread wait_thread([&server]() { server->Wait(); });
+
+  bigtable::ClientOptions options;
+  options.set_data_endpoint(server->address());
+  options.SetCredentials(grpc::InsecureChannelCredentials());
+  bigtable::Table table(bigtable::CreateDefaultDataClient(
+                            "fake-project", "fake-instance", options),
+                        "fake-table");
+
+  auto reader = table.ReadRows(bigtable::RowSet("row1"), 1,
+                               bigtable::Filter::PassAllFilter());
+  auto count = std::distance(reader.begin(), reader.end());
+  EXPECT_EQ(1, count);
+
+  server->Shutdown();
+  wait_thread.join();
+}
+
+TEST(EmbeddedServer, ReadRows100) {
+  auto server = CreateEmbeddedServer();
+  std::thread wait_thread([&server]() { server->Wait(); });
+
+  bigtable::ClientOptions options;
+  options.set_data_endpoint(server->address());
+  options.SetCredentials(grpc::InsecureChannelCredentials());
+  bigtable::Table table(bigtable::CreateDefaultDataClient(
+                            "fake-project", "fake-instance", options),
+                        "fake-table");
+
+  try {
+    auto reader =
+        table.ReadRows(bigtable::RowSet(bigtable::RowRange::StartingAt("foo")),
+                       100, bigtable::Filter::PassAllFilter());
+    auto count = std::distance(reader.begin(), reader.end());
+    EXPECT_EQ(100, count);
+  } catch(std::exception const& ex) {
+    std::cerr << ex.what() << std::endl;
+  }
+
+  server->Shutdown();
+  wait_thread.join();
+}

--- a/bigtable/benchmarks/embedded_server_test.cc
+++ b/bigtable/benchmarks/embedded_server_test.cc
@@ -67,8 +67,9 @@ TEST(EmbeddedServer, TableApply) {
                         "fake-table");
 
   bigtable::SingleRowMutation mutation(
-      "row1", {bigtable::SetCell("fam", "col", 0, "val"),
-               bigtable::SetCell("fam", "col", 0, "val")});
+      "row1",
+      {bigtable::SetCell("fam", "col", 0, "val"),
+       bigtable::SetCell("fam", "col", 0, "val")});
 
   EXPECT_NO_THROW(table.Apply(std::move(mutation)));
 
@@ -130,15 +131,11 @@ TEST(EmbeddedServer, ReadRows100) {
                             "fake-project", "fake-instance", options),
                         "fake-table");
 
-  try {
-    auto reader =
-        table.ReadRows(bigtable::RowSet(bigtable::RowRange::StartingAt("foo")),
-                       100, bigtable::Filter::PassAllFilter());
-    auto count = std::distance(reader.begin(), reader.end());
-    EXPECT_EQ(100, count);
-  } catch(std::exception const& ex) {
-    std::cerr << ex.what() << std::endl;
-  }
+  auto reader =
+      table.ReadRows(bigtable::RowSet(bigtable::RowRange::StartingAt("foo")),
+                     100, bigtable::Filter::PassAllFilter());
+  auto count = std::distance(reader.begin(), reader.end());
+  EXPECT_EQ(100, count);
 
   server->Shutdown();
   wait_thread.join();


### PR DESCRIPTION
The benchmarks in #199, #196, and #189 will need to run against
the production Bigtable server, against the Cloud Bigtable
Emulator, or against a server running in the same process as the
benchmark.  This class make it easy to create such an embedded
server.

This is the third of probably 4 or 5 PRs related to implementing the benchmarks described in #199, #196, and #189. If you need more context for the review, the full set of changes is at:

https://github.com/GoogleCloudPlatform/google-cloud-cpp/compare/master...coryan:scan-benchmark