### PR TITLE
Update to current gRPC branch (v1.9.x)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,3 +111,5 @@ enable_testing()
 
 # Add subprojects here.
 add_subdirectory(bigtable)
+
+add_subdirectory(tests/grpc-crash EXCLUDE_FROM_ALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,4 +112,4 @@ enable_testing()
 # Add subprojects here.
 add_subdirectory(bigtable)
 
-add_subdirectory(tests/grpc-crash EXCLUDE_FROM_ALL)
+add_subdirectory(tests/grpc-crash)

--- a/tests/grpc-crash/CMakeLists.txt
+++ b/tests/grpc-crash/CMakeLists.txt
@@ -1,0 +1,87 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.5)
+project(grpc-crash CXX C)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if (MSVC)
+    include(CheckCXXCompilerFlag)
+    CHECK_CXX_COMPILER_FLAG("/std:c++latest" _cpp_latest_flag_supported)
+    if (_cpp_latest_flag_supported)
+        add_compile_options("/std:c++latest")
+    endif ()
+endif ()
+
+if (NOT GOOGLE_CLOUD_CPP_GRPC_PROVIDER)
+    if (NOT GRPC_ROOT_DIR)
+        set(GRPC_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ext/grpc)
+    endif ()
+    if (NOT EXISTS "${GRPC_ROOT_DIR}/CMakeLists.txt")
+        message(ERROR "GRPC_ROOT_DIR does not have a CMake file.")
+    endif ()
+    add_subdirectory(${GRPC_ROOT_DIR} ext/grpc EXCLUDE_FROM_ALL)
+    set(GRPCPP_LIBRARIES grpc++)
+    set(GRPC_LIBRARIES grpc)
+    set(PROTOBUF_LIBRARIES libprotobuf)
+    set(GRPC_BINDIR "${PROJECT_BINARY_DIR}/ext/grpc")
+    set(GRPC_INCLUDE_DIRS ${GRPC_ROOT_DIR}/include)
+    set(GRPCPP_INCLUDE_DIRS ${GRPC_ROOT_DIR}/include)
+    set(PROTOBUF_INCLUDE_DIRS ${GRPC_ROOT_DIR}/third_party/protobuf/include)
+    set(PROTOBUF_PROTOC_EXECUTABLE "${GRPC_BINDIR}/third_party/protobuf/protoc")
+    mark_as_advanced(PROTOBUF_PROTOC_EXECUTABLE)
+    set(PROTOC_GRPCPP_PLUGIN_EXECUTABLE "${GRPC_BINDIR}/grpc_cpp_plugin")
+    mark_as_advanced(PROTOC_GRPCPP_PLUGIN_EXECUTABLE)
+endif ()
+
+# Create a library with the protos for the test.
+add_custom_command(
+        OUTPUT "echo.pb.h" "echo.pb.cc"
+        COMMAND "${PROTOBUF_PROTOC_EXECUTABLE}"
+        ARGS
+        --cpp_out=${CMAKE_CURRENT_BINARY_DIR}
+        -I${CMAKE_CURRENT_SOURCE_DIR}
+        echo.proto
+        DEPENDS
+        echo.proto
+        "${PROTOBUF_PROTOC_EXECUTABLE}"
+        COMMENT "Running (local) C++ protocol buffer compiler on ${FIL}"
+        VERBATIM )
+add_custom_command(
+        OUTPUT "echo.grpc.pb.h" "echo.grpc.pb.cc"
+        COMMAND "${PROTOBUF_PROTOC_EXECUTABLE}"
+        ARGS
+            --plugin=protoc-gen-grpc=${PROTOC_GRPCPP_PLUGIN_EXECUTABLE}
+            --grpc_out=${CMAKE_CURRENT_BINARY_DIR}
+            --cpp_out=${CMAKE_CURRENT_BINARY_DIR}
+            -I${CMAKE_CURRENT_SOURCE_DIR}
+            echo.proto
+        DEPENDS
+            echo.proto
+            "${PROTOBUF_PROTOC_EXECUTABLE}" "${PROTOC_GRPCPP_PLUGIN_EXECUTABLE}"
+        COMMENT "Running (local) C++ protocol buffer compiler on ${FIL}"
+        VERBATIM )
+add_library(echo_protos
+        "echo.pb.h" "echo.pb.cc"
+        "echo.grpc.pb.h" "echo.grpc.pb.cc")
+target_link_libraries(echo_protos ${GRPC_LIBRARIES} ${GRPCPP_LIBRARIES} ${PROTOBUF_LIBRARIES})
+target_include_directories(echo_protos PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
+
+add_executable(server server.cc)
+target_link_libraries(server echo_protos)
+
+add_executable(client client.cc)
+target_link_libraries(client echo_protos)

--- a/tests/grpc-crash/README.md
+++ b/tests/grpc-crash/README.md
@@ -1,0 +1,42 @@
+# Reproduce multi-threaded client crash in gRPC.
+
+These programs were used to reproduce the crash described in
+[#211](https://github.com/GoogleCloudPlatform/google-cloud-cpp/issues/211).
+These programs can be compiled with the grpc submodule included in the overall
+project, or you can treat this directory as a top-level CMake project.
+
+### Compiling as a top-level project.
+
+First clone the version of grpc you are interested in:
+
+```console
+$ git clone https://github.com/grpc/grpc.git ext/grpc
+# optionally: (cd extp/grpc ; git checkout branch/sha-1/etc )
+```
+
+Then compile as usual:
+
+```console
+mkdir .build
+cd .build
+cmake ..
+```
+
+### Running the test
+
+Run the server on a port of your choosing, with enough threads to reproduce the
+problem quickly, for example, use 128 threads on port 9876:
+
+```console
+./server 9876 128
+```
+
+Then run the client against this server for a few hours:
+
+```console
+./client localhost:9876 100 600
+```
+
+It may take several hours for the client to crash with a segmentation violation,
+be patient.
+

--- a/tests/grpc-crash/client.cc
+++ b/tests/grpc-crash/client.cc
@@ -1,0 +1,103 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "echo.grpc.pb.h"
+
+#include <future>
+
+#include <grpc++/grpc++.h>
+
+void MakeStreamPing(Echo::Stub &echo, std::int32_t count) {
+  for (int i = 0; i != 100; ++i) {
+    grpc::ClientContext context;
+    Request request;
+    request.set_value(count);
+    auto stream = echo.StreamPing(&context, request);
+
+    Response response;
+    while (stream->Read(&response)) {
+    }
+    auto status = stream->Finish();
+    if (status.ok()) {
+      return;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  std::cerr << "Error making StreamPing request" << std::endl;
+}
+
+void MakePing(Echo::Stub &echo, std::int32_t count) {
+  for (int i = 0; i != 100; ++i) {
+    grpc::ClientContext context;
+    Request request;
+    request.set_value(count);
+    Response response;
+    auto status = echo.Ping(&context, request, &response);
+    if (status.ok()) {
+      return;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  std::cerr << "Error making Ping request" << std::endl;
+}
+
+void RunClient(std::string const &server_address, std::chrono::minutes duration,
+               int id) {
+  grpc::ChannelArguments arguments;
+  arguments.SetInt("foo-bar-baz", id);
+
+  auto channel = grpc::CreateCustomChannel(
+      server_address, grpc::InsecureChannelCredentials(), arguments);
+  auto echo = Echo::NewStub(channel);
+
+  auto deadline = std::chrono::system_clock::now() + duration;
+  std::int32_t count = 0;
+  while (std::chrono::system_clock::now() < deadline) {
+    MakeStreamPing(*echo, count);
+    MakeStreamPing(*echo, count);
+    MakePing(*echo, count);
+    if (++count % 100000 == 0) {
+      std::cout << "." << std::flush;
+    }
+  }
+}
+
+int main(int argc, char *argv[]) try {
+  if (argc < 4) {
+    std::cerr << "Usage: client <address> <thread-count>"
+              << " <test-duration-in-minutes>" << std::endl;
+    return 1;
+  }
+
+  std::string const server_address = argv[1];
+  int const thread_count = std::stoi(argv[2]);
+  auto test_duration = std::chrono::minutes(std::stol(argv[3]));
+
+  std::cout << "Running client threads: " << std::flush;
+  std::vector<std::future<void>> tasks;
+  for (int i = 0; i != thread_count; ++i) {
+    tasks.emplace_back(std::async(std::launch::async, RunClient, server_address,
+                                  test_duration, i));
+  }
+
+  for (auto &t : tasks) {
+    t.get();
+  }
+  std::cout << " DONE." << std::endl;
+
+  return 0;
+} catch (std::exception const &ex) {
+  std::cerr << "Standard C++ exception raised: " << ex.what() << std::endl;
+  return 1;
+}

--- a/tests/grpc-crash/echo.proto
+++ b/tests/grpc-crash/echo.proto
@@ -1,0 +1,32 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+/// Define a simple interface to ping/pong messages.
+service Echo {
+    /// Respond with a single Response message.
+    rpc Ping(Request) returns (Response) {}
+
+    /// Respond with a stream of Response messages.
+    rpc StreamPing(Request) returns (stream Response) {}
+}
+
+message Request {
+    int32 value = 1;
+}
+
+message Response {
+    int32 value = 1;
+}

--- a/tests/grpc-crash/server.cc
+++ b/tests/grpc-crash/server.cc
@@ -48,9 +48,7 @@ int main(int argc, char *argv[]) try {
 
   EchoImpl echo_impl;
 
-  auto start = std::chrono::system_clock::now();
-  auto end = start + std::chrono::hours(24);
-  for (auto now = start; now < end; now = std::chrono::system_clock::now()) {
+  while (true) {
     grpc::ServerBuilder builder;
     builder.AddListeningPort(address, grpc::InsecureServerCredentials());
     builder.RegisterService(&echo_impl);

--- a/tests/grpc-crash/server.cc
+++ b/tests/grpc-crash/server.cc
@@ -1,0 +1,76 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "echo.grpc.pb.h"
+
+#include <grpc++/grpc++.h>
+#include <future>
+#include <iostream>
+
+class EchoImpl : public Echo::Service {
+ public:
+  EchoImpl() {}
+
+  grpc::Status Ping(grpc::ServerContext *context, Request const *request,
+                    Response *response) override {
+    response->set_value(request->value());
+    return grpc::Status::OK;
+  }
+
+  virtual grpc::Status StreamPing(
+      grpc::ServerContext *context, Request const *request,
+      grpc::ServerWriter<Response> *writer) override {
+    Response response;
+    writer->WriteLast(response, grpc::WriteOptions());
+    return grpc::Status::OK;
+  }
+};
+
+int main(int argc, char *argv[]) try {
+  if (argc < 3) {
+    std::cerr << "Usage: server <port> <thread-count>" << std::endl;
+    return 1;
+  }
+
+  std::string const address = "localhost:" + std::string(argv[1]);
+  int const thread_count = std::stoi(argv[2]);
+
+  EchoImpl echo_impl;
+
+  auto start = std::chrono::system_clock::now();
+  auto end = start + std::chrono::hours(24);
+  for (auto now = start; now < end; now = std::chrono::system_clock::now()) {
+    grpc::ServerBuilder builder;
+    builder.AddListeningPort(address, grpc::InsecureServerCredentials());
+    builder.RegisterService(&echo_impl);
+    auto server = builder.BuildAndStart();
+
+    std::vector<std::future<void>> tasks;
+    for (int i = 0; i != thread_count; ++i) {
+      tasks.emplace_back(
+          std::async(std::launch::async, [&server]() { server->Wait(); }));
+    }
+    std::this_thread::sleep_for(std::chrono::seconds(20));
+    server->Shutdown();
+    for (auto &t : tasks) {
+      t.get();
+    }
+    std::cout << "Shutdown completed." << std::endl;
+  }
+
+  return 0;
+} catch (std::exception const &ex) {
+  std::cerr << "Standard C++ exception raised: " << ex.what() << std::endl;
+  return 1;
+}


### PR DESCRIPTION
This fixes #211, at least the crashes are not common when using a newer version of gRPC.  I have introduced tests to reproduce this in the future, but they are not part of the CI builds because it takes hours for the tests to reproduce the problem. 

There are dozens of bugs and PRs in gRPC that could have fixed this issue.  This one is particularly relevant because the stack traces look similar:

https://github.com/grpc/grpc/issues/13581

Fixed by:

https://github.com/grpc/grpc/pull/12829

But there are many more:

https://github.com/grpc/grpc/pulls?page=3&q=is%3Apr+is%3Aclosed+updated%3A%3E%3D2017-11-01+crash&utf8=%E2%9C%93
https://github.com/grpc/grpc/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+crash+updated%3A%3E%3D2017-11-01
