### PR TITLE
ReadRowsParser fix: move the value of single chunk cells

### DIFF
--- a/bigtable/client/internal/readrowsparser.cc
+++ b/bigtable/client/internal/readrowsparser.cc
@@ -51,7 +51,6 @@ void ReadRowsParser::HandleChunk(ReadRowsResponse_CellChunk chunk) {
   if (cell_first_chunk_) {
     cell_.timestamp = chunk.timestamp_micros();
   }
-  cell_first_chunk_ = false;
 
   std::move(chunk.mutable_labels()->begin(), chunk.mutable_labels()->end(),
             std::back_inserter(cell_.labels));
@@ -62,6 +61,8 @@ void ReadRowsParser::HandleChunk(ReadRowsResponse_CellChunk chunk) {
   } else {
     cell_.value.append(chunk.value());
   }
+
+  cell_first_chunk_ = false;
 
   // This is a hint we get about the total size
   if (chunk.value_size() > 0) {

--- a/bigtable/client/internal/readrowsparser_test.cc
+++ b/bigtable/client/internal/readrowsparser_test.cc
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 #include "bigtable/client/internal/readrowsparser.h"
+#include "bigtable/client/row.h"
 
 #include <absl/strings/str_join.h>
 #include <google/protobuf/text_format.h>
+
 #include <gtest/gtest.h>
 
 #include <numeric>
@@ -117,6 +119,36 @@ TEST(ReadRowsParserTest, NextWithNoDataThrows) {
 
   EXPECT_FALSE(parser.HasNext());
   EXPECT_THROW(parser.Next(), std::exception);
+}
+
+TEST(ReadRowsParserTest, SingleChunkValueIsMoved) {
+  using google::protobuf::TextFormat;
+  ReadRowsParser parser;
+  ReadRowsResponse_CellChunk chunk;
+  std::string chunk1 = R"(
+    row_key: "RK"
+    family_name: < value: "F">
+    qualifier: < value: "C">
+    timestamp_micros: 42
+    commit_row: true
+    )";
+  ASSERT_TRUE(TextFormat::ParseFromString(chunk1, &chunk));
+
+  // This is a bit hacky, we check that the buffer holding the chunk's
+  // value has been moved to the Row created by the parser by matching
+  // the original string data address with the address of the returned
+  // string_view of the Cell's value.
+  std::string value(1024, 'a');  // avoid any small value optimizations
+  auto* data_ptr = value.data();
+  chunk.mutable_value()->swap(value);
+
+  ASSERT_FALSE(parser.HasNext());
+  parser.HandleChunk(std::move(chunk));
+  ASSERT_TRUE(parser.HasNext());
+  bigtable::Row r = parser.Next();
+  ASSERT_EQ(1U, r.cells().size());
+
+  EXPECT_EQ(data_ptr, r.cells().begin()->value().data());
 }
 
 // **** Acceptance tests helpers ****


### PR DESCRIPTION
While admiring coverage results, I noticed a line of dead code, the call that was supposed to reduce copies by moving out the buffer holding cell values in the most common case of the first chunk. This commit adds a test for that case and fixes the blunder.