### PR TITLE
A class with the common code for the benchmarks.

### DIFF
--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -313,6 +313,8 @@ target_link_libraries(filters_integration_test
 add_dependencies(tests-local filters_integration_test)
 
 add_library(bigtable_benchmark_common
+    benchmarks/benchmark.h
+    benchmarks/benchmark.cc
     benchmarks/constants.h
     benchmarks/embedded_server.h
     benchmarks/embedded_server.cc
@@ -326,6 +328,7 @@ target_link_libraries(bigtable_benchmark_common
 
 # List the unit tests, then setup the targets and dependencies.
 set(bigtable_benchmarks_unit_tests
+    benchmarks/benchmark_test.cc
     benchmarks/embedded_server_test.cc
     benchmarks/random_test.cc
     benchmarks/setup_test.cc)

--- a/bigtable/benchmarks/benchmark.cc
+++ b/bigtable/benchmarks/benchmark.cc
@@ -1,0 +1,291 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/benchmarks/benchmark.h"
+
+#include <future>
+#include <iomanip>
+#include <sstream>
+
+#include <absl/time/time.h>
+
+namespace {
+double const kResultPercentiles[] = {0, 50, 90, 95, 99, 99.9, 100};
+}  // anonymous namespace
+
+namespace bigtable {
+namespace benchmarks {
+Benchmark::Benchmark(BenchmarkSetup const& setup)
+    : setup_(setup), key_width_(KeyWidth()) {
+  if (setup_.use_embedded_server()) {
+    server_ = CreateEmbeddedServer();
+    std::string address = server_->address();
+    std::cout << "Running embedded Cloud Bigtable server at " << address
+              << std::endl;
+    server_thread_ = std::thread([this]() { server_->Wait(); });
+
+    client_options_.set_admin_endpoint(address);
+    client_options_.set_data_endpoint(address);
+    client_options_.SetCredentials(grpc::InsecureChannelCredentials());
+  }
+}
+
+Benchmark::~Benchmark() {
+  if (not server_) {
+    return;
+  }
+  server_->Shutdown();
+  if (not server_thread_.joinable()) {
+    return;
+  }
+  server_thread_.join();
+}
+
+std::string Benchmark::CreateTable() {
+  // Create the table, with an initial split.
+  bigtable::TableAdmin admin(
+      bigtable::CreateDefaultAdminClient(setup_.project_id(), client_options_),
+      setup_.instance_id());
+
+  std::vector<std::string> splits{"user0", "user1", "user2", "user3", "user4",
+                                  "user5", "user6", "user7", "user8", "user9"};
+  (void)admin.CreateTable(
+      setup_.table_id(),
+      bigtable::TableConfig(
+          {{kColumnFamily, bigtable::GcRule::MaxNumVersions(1)}}, splits));
+  return setup_.table_id();
+}
+
+void Benchmark::DeleteTable() {
+  bigtable::TableAdmin admin(
+      bigtable::CreateDefaultAdminClient(setup_.project_id(), client_options_),
+      setup_.instance_id());
+  admin.DeleteTable(setup_.table_id());
+}
+
+std::shared_ptr<bigtable::DataClient> Benchmark::MakeDataClient() {
+  return bigtable::CreateDefaultDataClient(
+      setup_.project_id(), setup_.instance_id(), client_options_);
+}
+
+BenchmarkResult Benchmark::PopulateTable() {
+  bigtable::Table table(MakeDataClient(), setup_.table_id());
+  std::cout << "Populating table " << setup_.table_id() << " " << std::flush;
+  std::vector<std::future<BenchmarkResult>> tasks;
+  auto upload_start = std::chrono::steady_clock::now();
+  auto table_size = setup_.table_size();
+  long shard_start = 0;
+  for (int i = 0; i != kPopulateShardCount; ++i) {
+    long end =
+        std::min(table_size, shard_start + table_size / kPopulateShardCount);
+    tasks.emplace_back(std::async(std::launch::async,
+                                  &Benchmark::PopulateTableShard, this,
+                                  std::ref(table), shard_start, end));
+    shard_start = end;
+  }
+
+  BenchmarkResult result{};
+  result.row_count = 0;
+  int count = 0;
+  for (auto& t : tasks) {
+    try {
+      auto shard_result = t.get();
+      result.row_count += shard_result.row_count;
+      result.operations.insert(result.operations.end(),
+                               shard_result.operations.begin(),
+                               shard_result.operations.end());
+    } catch (std::exception const& ex) {
+      std::cerr << "Exception raised by PopulateTask/" << count << ": "
+                << ex.what() << std::endl;
+    }
+    ++count;
+  }
+  using std::chrono::duration_cast;
+  result.elapsed = duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - upload_start);
+  std::cout << " DONE. Elapsed=" << absl::FromChrono(result.elapsed)
+            << ", Ops=" << result.operations.size()
+            << ", Rows=" << result.row_count << std::endl;
+  return result;
+}
+
+std::string Benchmark::MakeRandomKey(DefaultPRNG& gen) const {
+  std::uniform_int_distribution<long> prng_user(0, setup_.table_size() - 1);
+  return MakeKey(prng_user(gen));
+}
+
+std::string Benchmark::MakeKey(long id) const {
+  std::ostringstream os;
+  os << "user" << std::setw(key_width_) << std::setfill('0') << id;
+  return os.str();
+}
+
+void Benchmark::PrintThroughputResult(std::ostream& os,
+                                      std::string const& test_name,
+                                      std::string const& phase,
+                                      BenchmarkResult const& result) const {
+  auto row_throughput = 1000 * result.row_count / result.elapsed.count();
+  os << "# " << phase << " row throughput=" << row_throughput << " rows/s\n";
+  auto ops_throughput =
+      1000 * result.operations.size() / result.elapsed.count();
+  os << "# " << phase << " op throughput=" << ops_throughput << " ops/s"
+     << std::endl;
+}
+
+void Benchmark::PrintLatencyResult(std::ostream& os,
+                                   std::string const& test_name,
+                                   std::string const& operation,
+                                   BenchmarkResult& result) const {
+  std::sort(result.operations.begin(), result.operations.end(),
+            [](OperationResult const& lhs, OperationResult const& rhs) {
+              return lhs.latency < rhs.latency;
+            });
+  auto const nsamples = result.operations.size();
+  auto ops_throughput = 1000 * nsamples / result.elapsed.count();
+  os << "# Test=" << test_name << ", " << operation
+     << " Throughput = " << ops_throughput << " ops/s, Latency: ";
+  char const* sep = "";
+  for (double p : kResultPercentiles) {
+    auto index =
+        static_cast<std::size_t>(std::round((nsamples - 1) * p / 100.0));
+    auto i = result.operations.begin();
+    std::advance(i, index);
+    os << sep << "p" << std::setprecision(3) << p << "=" << std::setprecision(2)
+       << absl::FromChrono(i->latency);
+    sep = ", ";
+  }
+  os << std::endl;
+}
+
+std::string Benchmark::ResultsCsvHeader() {
+  return "name,start,op.name,measurement,nsamples,min,p50,p90,p95,p99,p99.9,max"
+         ",units,throughput.rows,throughput.ops,notes";
+}
+
+void Benchmark::PrintResultCsv(std::ostream& os, std::string const& test_name,
+                               std::string const& op_name,
+                               std::string const& measurement,
+                               BenchmarkResult& result) const {
+  std::sort(result.operations.begin(), result.operations.end(),
+            [](OperationResult const& lhs, OperationResult const& rhs) {
+              return lhs.latency < rhs.latency;
+            });
+  auto const nsamples = result.operations.size();
+  os << test_name << "," << setup_.start_time() << "," << op_name << ","
+     << measurement << "," << nsamples;
+  for (double p : kResultPercentiles) {
+    auto index =
+        static_cast<std::size_t>(std::round((nsamples - 1) * p / 100.0));
+    auto i = result.operations.begin();
+    std::advance(i, index);
+    os << "," << i->latency.count();
+  }
+  auto row_throughput = 1000 * result.row_count / result.elapsed.count();
+  auto ops_throughput =
+      1000 * result.operations.size() / result.elapsed.count();
+
+  os << ",us," << row_throughput << "," << ops_throughput << ","
+     << setup_.notes() << "\n";
+}
+
+int Benchmark::create_table_count() const {
+  if (not server_) {
+    return 0;
+  }
+  return server_->create_table_count();
+}
+
+int Benchmark::delete_table_count() const {
+  if (not server_) {
+    return 0;
+  }
+  return server_->delete_table_count();
+}
+
+int Benchmark::mutate_row_count() const {
+  if (not server_) {
+    return 0;
+  }
+  return server_->mutate_row_count();
+}
+
+int Benchmark::mutate_rows_count() const {
+  if (not server_) {
+    return 0;
+  }
+  return server_->mutate_rows_count();
+}
+
+int Benchmark::read_rows_count() const {
+  if (not server_) {
+    return 0;
+  }
+  return server_->read_rows_count();
+}
+
+BenchmarkResult Benchmark::PopulateTableShard(bigtable::Table& table,
+                                              long begin, long end) {
+  auto start = std::chrono::steady_clock::now();
+  BenchmarkResult result{};
+  result.row_count = 0;
+
+  auto generator = MakeDefaultPRNG();
+  int bulk_size = 0;
+  bigtable::BulkMutation bulk;
+
+  long progress_period = (end - begin) / kPopulateShardProgressMarks;
+  if (progress_period == 0) {
+    progress_period = (end - begin);
+  }
+  for (long idx = begin; idx != end; ++idx) {
+    bigtable::SingleRowMutation mutation(MakeKey(idx));
+    std::vector<bigtable::Mutation> columns;
+    for (int f = 0; f != kNumFields; ++f) {
+      mutation.emplace_back(MakeRandomMutation(generator, f));
+    }
+    bulk.emplace_back(std::move(mutation));
+    if (++bulk_size >= kBulkSize) {
+      auto t = TimeOperation(
+          [&table, &bulk]() { table.BulkApply(std::move(bulk)); });
+      result.row_count += bulk_size;
+      result.operations.emplace_back(t);
+      bulk = {};
+      bulk_size = 0;
+    }
+    long count = idx - begin + 1;
+    if (count % progress_period == 0) {
+      std::cout << "." << std::flush;
+    }
+  }
+  if (bulk_size != 0) {
+    auto t =
+        TimeOperation([&table, &bulk]() { table.BulkApply(std::move(bulk)); });
+    result.row_count += bulk_size;
+    result.operations.emplace_back(t);
+  }
+  using std::chrono::duration_cast;
+  result.elapsed = duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - start);
+  return result;
+}
+
+int Benchmark::KeyWidth() const {
+  int r = 1;
+  for (auto tsize = setup_.table_size(); tsize > 0; tsize /= 10, ++r) {
+  }
+  return r;
+}
+
+}  // namespace benchmarks
+}  // namespace bigtable

--- a/bigtable/benchmarks/benchmark.h
+++ b/bigtable/benchmarks/benchmark.h
@@ -1,0 +1,139 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_BENCHMARK_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_BENCHMARK_H_
+
+#include "bigtable/benchmarks/embedded_server.h"
+#include "bigtable/benchmarks/random.h"
+#include "bigtable/benchmarks/setup.h"
+
+namespace bigtable {
+namespace benchmarks {
+/// The result of a single operation.
+struct OperationResult {
+  bool successful;
+  std::chrono::microseconds latency;
+};
+
+struct BenchmarkResult {
+  std::chrono::milliseconds elapsed;
+  std::vector<OperationResult> operations;
+  long row_count;
+};
+
+/**
+ * Common code used by the Cloud Bigtable C++ Client benchmarks.
+ */
+class Benchmark {
+ public:
+  explicit Benchmark(BenchmarkSetup const& setup);
+  ~Benchmark();
+
+  Benchmark(Benchmark const&) = delete;
+  Benchmark& operator=(Benchmark const&) = delete;
+
+  /// Create a table for the benchmark, return the table_id.
+  std::string CreateTable();
+
+  /// Delete the table used in the benchmark.
+  void DeleteTable();
+
+  /// Populate the table with initial data.
+  BenchmarkResult PopulateTable();
+
+  /// Return a `bigtable::DataClient` configured for this benchmark.
+  std::shared_ptr<bigtable::DataClient> MakeDataClient();
+
+  /// Create a random key.
+  std::string MakeRandomKey(DefaultPRNG& gen) const;
+
+  /// Return the key for row @p id.
+  std::string MakeKey(long id) const;
+
+  /// Measure the time to compute an operation.
+  template <typename Operation>
+  static OperationResult TimeOperation(Operation&& op) {
+    auto start = std::chrono::steady_clock::now();
+    bool successful = false;
+    try {
+      op();
+      successful = true;
+    } catch (...) {
+    }
+    using std::chrono::duration_cast;
+    auto elapsed = duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now() - start);
+    return OperationResult{successful, elapsed};
+  }
+
+  /// Print the result of a throughput test in human readable form.
+  void PrintThroughputResult(std::ostream& os, std::string const& test_name,
+                             std::string const& phase,
+                             BenchmarkResult const& result) const;
+
+  /// Print the result of a latency test in human readable form.
+  void PrintLatencyResult(std::ostream& os, std::string const& test_name,
+                          std::string const& operation,
+                          BenchmarkResult& result) const;
+
+  /// Return the header for CSV results.
+  static std::string ResultsCsvHeader();
+
+  /// Print the result of a benchmark as a CSV line.
+  void PrintResultCsv(std::ostream& os, std::string const& test_name,
+                      std::string const& op_name,
+                      std::string const& measurement,
+                      BenchmarkResult& result) const;
+
+  //@{
+  /**
+   * @name Embedded server counter accessors.
+   *
+   * Return 0 if there is no embedded server, or the value from the
+   * corresponding embedded server counter.  This class is tested largely by
+   * observing how many calls it makes on the embedded server.  Because the
+   * embedded server has no memory, that is the only observable effect when
+   * unit testing the class.
+   */
+  int create_table_count() const;
+  int delete_table_count() const;
+  int mutate_row_count() const;
+  int mutate_rows_count() const;
+  int read_rows_count() const;
+  //@}
+
+ private:
+  /// Populate the table rows in the range [@p begin, @p end)
+  BenchmarkResult PopulateTableShard(bigtable::Table& table, long begin,
+                                     long end);
+
+  /**
+   * Return how much space to reserve for digits if the table has @p table_size
+   * elements.
+   */
+  int KeyWidth() const;
+
+ private:
+  BenchmarkSetup setup_;
+  int key_width_;
+  bigtable::ClientOptions client_options_;
+  std::unique_ptr<EmbeddedServer> server_;
+  std::thread server_thread_;
+};
+
+}  // namespace benchmarks
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_BENCHMARK_H_

--- a/bigtable/benchmarks/benchmark_test.cc
+++ b/bigtable/benchmarks/benchmark_test.cc
@@ -1,0 +1,187 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/benchmarks/benchmark.h"
+#include <bigtable/client/build_info.h>
+#include <gmock/gmock.h>
+
+using namespace bigtable::benchmarks;
+
+namespace {
+char arg0[] = "program";
+char arg1[] = "foo";
+char arg2[] = "bar";
+char arg3[] = "4";
+char arg4[] = "300";
+char arg5[] = "10000";
+char arg6[] = "True";
+}  // anonymous namespace
+
+TEST(BenchmarkTest, Create) {
+  char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  BenchmarkSetup setup("create", argc, argv);
+
+  {
+    Benchmark bm(setup);
+    std::string table_id;
+    EXPECT_EQ(0, bm.create_table_count());
+    EXPECT_NO_THROW(table_id = bm.CreateTable());
+    EXPECT_EQ(1, bm.create_table_count());
+    EXPECT_EQ(std::string("create-"), table_id.substr(0, 7));
+
+    EXPECT_EQ(0, bm.delete_table_count());
+    EXPECT_NO_THROW(bm.DeleteTable());
+    EXPECT_EQ(1, bm.delete_table_count());
+  }
+  SUCCEED() << "Benchmark object successfully destroyed";
+}
+
+TEST(BenchmarkTest, Populate) {
+  char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  BenchmarkSetup setup("populate", argc, argv);
+
+  Benchmark bm(setup);
+  bm.CreateTable();
+  EXPECT_EQ(0, bm.mutate_rows_count());
+  EXPECT_NO_THROW(bm.PopulateTable());
+  // The magic 10000 comes from arg5, and we accept 5% error.
+  EXPECT_GE(int(10000 * 1.05 / kBulkSize), bm.mutate_rows_count());
+  EXPECT_LE(int(10000 * 0.95 / kBulkSize), bm.mutate_rows_count());
+  bm.DeleteTable();
+}
+
+TEST(BenchmarkTest, MakeRandomKey) {
+  char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  BenchmarkSetup setup("key", argc, argv);
+
+  Benchmark bm(setup);
+  auto gen = MakeDefaultPRNG();
+
+  // First make sure that the keys are not always the same:
+  auto make_some_keys = [&bm, &gen]() {
+    std::vector<std::string> keys(100);
+    std::generate(keys.begin(), keys.end(),
+                  [&bm, &gen]() { return bm.MakeRandomKey(gen); });
+    return keys;
+  };
+  auto round0 = make_some_keys();
+  auto round1 = make_some_keys();
+  EXPECT_NE(round0, round1);
+
+  // Also make sure the keys have the right format:
+  for (auto const& k : round0) {
+    EXPECT_EQ("user", k.substr(0, 4));
+    std::string suffix = k.substr(5);
+    EXPECT_FALSE(suffix.empty());
+    EXPECT_EQ(std::string::npos, suffix.find_first_not_of("0123456789"));
+  }
+}
+
+TEST(BenchmarkTest, PrintThroughputResult) {
+  char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  BenchmarkSetup setup("throughput", argc, argv);
+
+  Benchmark bm(setup);
+  BenchmarkResult result{};
+  result.elapsed = std::chrono::milliseconds(10000);
+  result.row_count = 1230;
+  result.operations.resize(3450);
+
+  std::ostringstream os;
+  bm.PrintThroughputResult(os, "foo", "bar", result);
+  std::string output = os.str();
+
+  // We do not want a change detector test, we only expect:
+  // The output includes "XX ops/s" where XX is the operations count:
+  EXPECT_NE(std::string::npos, output.find("345 ops/s"));
+  // The output includes "YY rows/s" where YY is the row count.
+  EXPECT_NE(std::string::npos, output.find("123 rows/s"));
+}
+
+TEST(BenchmarkTest, PrintLatencyResult) {
+  char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  BenchmarkSetup setup("latency", argc, argv);
+
+  Benchmark bm(setup);
+  BenchmarkResult result{};
+  result.elapsed = std::chrono::milliseconds(1000);
+  result.row_count = 100;
+  result.operations.resize(100);
+  int count = 0;
+  std::generate(result.operations.begin(), result.operations.end(), [&count]() {
+    return OperationResult{true, std::chrono::microseconds(++count * 100)};
+  });
+
+  std::ostringstream os;
+  bm.PrintLatencyResult(os, "foo", "bar", result);
+  std::string output = os.str();
+
+  // We do not want a change detector test, we only expect:
+  // The output includes "XX ops/s" where XX is the operations count:
+  EXPECT_NE(std::string::npos, output.find("100 ops/s"));
+  // And the percentiles are easy to estimate for the generated data. Note that
+  // this test depends on the duration formatting as specified by the absl::time
+  // library.
+  EXPECT_NE(std::string::npos, output.find("p0=100us"));
+  EXPECT_NE(std::string::npos, output.find("p95=9.5ms"));
+  EXPECT_NE(std::string::npos, output.find("p100=10ms"));
+}
+
+TEST(BenchmarkTest, PrintCsv) {
+  char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  BenchmarkSetup setup("latency", argc, argv);
+
+  Benchmark bm(setup);
+  BenchmarkResult result{};
+  result.elapsed = std::chrono::milliseconds(1000);
+  result.row_count = 123;
+  result.operations.resize(100);
+  int count = 0;
+  std::generate(result.operations.begin(), result.operations.end(), [&count]() {
+    return OperationResult{true, std::chrono::microseconds(++count * 100)};
+  });
+
+  std::string header = bm.ResultsCsvHeader();
+  auto const field_count = std::count(header.begin(), header.end(), ',');
+
+  std::ostringstream os;
+  bm.PrintResultCsv(os, "foo", "bar", "latency", result);
+  std::string output = os.str();
+
+  auto const actual_count = std::count(output.begin(), output.end(), ',');
+  EXPECT_EQ(field_count, actual_count);
+
+  // We do not want a change detector test, we only expect:
+  // The output includes the version and compiler info.
+  EXPECT_NE(std::string::npos, output.find(bigtable::version_string()));
+  EXPECT_NE(std::string::npos, output.find(bigtable::compiler));
+  EXPECT_NE(std::string::npos, output.find(bigtable::compiler_flags));
+
+  // The output includes the latency results:
+  EXPECT_NE(std::string::npos, output.find(",100,"));    // p0
+  EXPECT_NE(std::string::npos, output.find(",9500,"));   // p95
+  EXPECT_NE(std::string::npos, output.find(",10000,"));  // p100
+
+  // The output includes the throughput
+  EXPECT_NE(std::string::npos, output.find(",123,"));
+
+  std::cout << header << std::endl;
+  std::cout << output << std::endl;
+}

--- a/bigtable/benchmarks/benchmark_test.cc
+++ b/bigtable/benchmarks/benchmark_test.cc
@@ -57,7 +57,7 @@ TEST(BenchmarkTest, Populate) {
   bm.CreateTable();
   EXPECT_EQ(0, bm.mutate_rows_count());
   EXPECT_NO_THROW(bm.PopulateTable());
-  // The magic 10000 comes from arg5, and we accept 5% error.
+  // The magic 10000 comes from arg5 and we accept 5% error.
   EXPECT_GE(int(10000 * 1.05 / kBulkSize), bm.mutate_rows_count());
   EXPECT_LE(int(10000 * 0.95 / kBulkSize), bm.mutate_rows_count());
   bm.DeleteTable();
@@ -71,7 +71,7 @@ TEST(BenchmarkTest, MakeRandomKey) {
   Benchmark bm(setup);
   auto gen = MakeDefaultPRNG();
 
-  // First make sure that the keys are not always the same:
+  // First make sure that the keys are not always the same.
   auto make_some_keys = [&bm, &gen]() {
     std::vector<std::string> keys(100);
     std::generate(keys.begin(), keys.end(),
@@ -82,7 +82,7 @@ TEST(BenchmarkTest, MakeRandomKey) {
   auto round1 = make_some_keys();
   EXPECT_NE(round0, round1);
 
-  // Also make sure the keys have the right format:
+  // Also make sure the keys have the right format.
   for (auto const& k : round0) {
     EXPECT_EQ("user", k.substr(0, 4));
     std::string suffix = k.substr(5);
@@ -106,9 +106,12 @@ TEST(BenchmarkTest, PrintThroughputResult) {
   bm.PrintThroughputResult(os, "foo", "bar", result);
   std::string output = os.str();
 
-  // We do not want a change detector test, we only expect:
-  // The output includes "XX ops/s" where XX is the operations count:
+  // We do not want a change detector test, so the following assertions are
+  // fairly minimal.
+
+  // The output includes "XX ops/s" where XX is the operations count.
   EXPECT_NE(std::string::npos, output.find("345 ops/s"));
+
   // The output includes "YY rows/s" where YY is the row count.
   EXPECT_NE(std::string::npos, output.find("123 rows/s"));
 }
@@ -132,9 +135,12 @@ TEST(BenchmarkTest, PrintLatencyResult) {
   bm.PrintLatencyResult(os, "foo", "bar", result);
   std::string output = os.str();
 
-  // We do not want a change detector test, we only expect:
-  // The output includes "XX ops/s" where XX is the operations count:
+  // We do not want a change detector test, so the following assertions are
+  // fairly minimal.
+
+  // The output includes "XX ops/s" where XX is the operations count.
   EXPECT_NE(std::string::npos, output.find("100 ops/s"));
+
   // And the percentiles are easy to estimate for the generated data. Note that
   // this test depends on the duration formatting as specified by the absl::time
   // library.
@@ -168,20 +174,19 @@ TEST(BenchmarkTest, PrintCsv) {
   auto const actual_count = std::count(output.begin(), output.end(), ',');
   EXPECT_EQ(field_count, actual_count);
 
-  // We do not want a change detector test, we only expect:
+  // We do not want a change detector test, so the following assertions are
+  // fairly minimal.
+
   // The output includes the version and compiler info.
   EXPECT_NE(std::string::npos, output.find(bigtable::version_string()));
   EXPECT_NE(std::string::npos, output.find(bigtable::compiler));
   EXPECT_NE(std::string::npos, output.find(bigtable::compiler_flags));
 
-  // The output includes the latency results:
+  // The output includes the latency results.
   EXPECT_NE(std::string::npos, output.find(",100,"));    // p0
   EXPECT_NE(std::string::npos, output.find(",9500,"));   // p95
   EXPECT_NE(std::string::npos, output.find(",10000,"));  // p100
 
-  // The output includes the throughput
+  // The output includes the throughput.
   EXPECT_NE(std::string::npos, output.find(",123,"));
-
-  std::cout << header << std::endl;
-  std::cout << output << std::endl;
 }

--- a/bigtable/benchmarks/embedded_server.h
+++ b/bigtable/benchmarks/embedded_server.h
@@ -36,6 +36,12 @@ class EmbeddedServer {
   virtual std::string address() const = 0;
   virtual void Shutdown() = 0;
   virtual void Wait() = 0;
+
+  virtual int create_table_count() const = 0;
+  virtual int delete_table_count() const = 0;
+  virtual int mutate_row_count() const = 0;
+  virtual int mutate_rows_count() const = 0;
+  virtual int read_rows_count() const = 0;
 };
 
 /// Create an embedded server.

--- a/bigtable/benchmarks/setup.cc
+++ b/bigtable/benchmarks/setup.cc
@@ -26,8 +26,9 @@ std::string FormattedStartTime() {
   auto start = std::chrono::system_clock::now();
   std::time_t start_c = std::chrono::system_clock::to_time_t(start);
   std::string formatted("YYYY-MM-DDTHH:SS:MMZ");
-  std::strftime(&formatted[0], formatted.size(), "%FT%TZ",
-                std::gmtime(&start_c));
+  auto s = std::strftime(&formatted[0], formatted.size() + 1, "%FT%TZ",
+                         std::gmtime(&start_c));
+  formatted[s] = '\0';
   return formatted;
 }
 


### PR DESCRIPTION
When implementing the benchmarks described in #189, #196, and #189
I found myself repeating the same code to create a table, populate
the table, and then report the results.  Refactored the code to
a class, it is not the cleanest design ever, but it serves its
purpose.


This is the fourth PR in a series of 5 or 6 PRs to implement the benchmarks.
The complete changes can be see at:

https://github.com/GoogleCloudPlatform/google-cloud-cpp/compare/master...coryan:scan-benchmark
