### PR TITLE
Do not return absl::string_view objects.

### DIFF
--- a/bigtable/admin/table_admin_test.cc
+++ b/bigtable/admin/table_admin_test.cc
@@ -141,7 +141,7 @@ TEST_F(TableAdminTest, ListTables) {
 
   // After all the setup, make the actual call we want to test.
   auto actual = tested.ListTables(btproto::Table::FULL);
-  std::string instance_name = static_cast<std::string>(tested.instance_name());
+  std::string instance_name = tested.instance_name();
   ASSERT_EQ(2UL, actual.size());
   EXPECT_EQ(instance_name + "/tables/t0", actual[0].name());
   EXPECT_EQ(instance_name + "/tables/t1", actual[1].name());
@@ -171,7 +171,7 @@ TEST_F(TableAdminTest, ListTablesRecoverableFailures) {
 
   // After all the setup, make the actual call we want to test.
   auto actual = tested.ListTables(btproto::Table::FULL);
-  std::string instance_name = static_cast<std::string>(tested.instance_name());
+  std::string instance_name = tested.instance_name();
   ASSERT_EQ(4UL, actual.size());
   EXPECT_EQ(instance_name + "/tables/t0", actual[0].name());
   EXPECT_EQ(instance_name + "/tables/t1", actual[1].name());

--- a/bigtable/client/cell.h
+++ b/bigtable/client/cell.h
@@ -31,10 +31,7 @@ inline namespace BIGTABLE_CLIENT_NS {
  * storage is sparse, column families, columns, and timestamps might contain
  * zero cells.
  *
- * The Cell class owns all its data. Its string accessors return
- * absl::string_view, which is a lightweight pointer to the string contained in
- * Cell and does not actually hold any data. If those values are needed beyond
- * the lifetime of the Cell object itself, they need to be copied.
+ * The Cell class owns all its data.
  */
 class Cell {
  public:
@@ -51,22 +48,22 @@ class Cell {
 
   /// Return the row key this cell belongs to. The returned value is not valid
   /// after this object is deleted.
-  absl::string_view row_key() const { return row_key_; }
+  std::string const& row_key() const { return row_key_; }
 
   /// Return the family this cell belongs to. The returned value is not valid
   /// after this object is deleted.
-  absl::string_view family_name() const { return family_name_; }
+  std::string const& family_name() const { return family_name_; }
 
   /// Return the column this cell belongs to. The returned value is not valid
   /// after this object is deleted.
-  absl::string_view column_qualifier() const { return column_qualifier_; }
+  std::string const& column_qualifier() const { return column_qualifier_; }
 
   /// Return the timestamp of this cell.
   int64_t timestamp() const { return timestamp_; }
 
   /// Return the contents of this cell. The returned value is not valid after
   /// this object is deleted.
-  absl::string_view value() const { return value_; }
+  std::string const& value() const { return value_; }
 
   /// Return the labels applied to this cell by label transformer read filters.
   std::vector<std::string> const& labels() const { return labels_; }

--- a/bigtable/client/row.h
+++ b/bigtable/client/row.h
@@ -39,7 +39,7 @@ class Row {
 
   /// Return the row key. The returned value is not valid
   /// after this object is deleted.
-  absl::string_view row_key() const { return row_key_; }
+  std::string const& row_key() const { return row_key_; }
 
   /// Return all cells.
   std::vector<Cell> const& cells() const { return cells_; }

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -690,10 +690,9 @@ void FilterIntegrationTest::CreateCells(
   for (auto const& cell : cells) {
     std::string key = cell.row_key();
     auto inserted = mutations.emplace(key, bigtable::SingleRowMutation(key));
-    inserted.first->second.emplace_back(bigtable::SetCell(
-        cell.family_name(),
-        cell.column_qualifier(), cell.timestamp(),
-        cell.value()));
+    inserted.first->second.emplace_back(
+        bigtable::SetCell(cell.family_name(), cell.column_qualifier(),
+                          cell.timestamp(), cell.value()));
   }
   bigtable::BulkMutation bulk;
   for (auto& kv : mutations) {
@@ -710,22 +709,19 @@ void FilterIntegrationTest::CreateComplexRows(bigtable::Table& table,
   // column families.
   mutation.emplace_back(bt::SingleRowMutation(
       prefix + "/one-cell", {bt::SetCell("fam0", "c", 3000, "foo")}));
-  mutation.emplace_back(
-      bt::SingleRowMutation(prefix + "/two-cells",
-                            {bt::SetCell("fam0", "c", 3000, "foo"),
-                             bt::SetCell("fam0", "c2", 3000, "foo")}));
-  mutation.emplace_back(
-      bt::SingleRowMutation(prefix + "/many",
-                            {bt::SetCell("fam0", "c", 0, "foo"),
-                             bt::SetCell("fam0", "c", 1000, "foo"),
-                             bt::SetCell("fam0", "c", 2000, "foo"),
-                             bt::SetCell("fam0", "c", 3000, "foo")}));
-  mutation.emplace_back(
-      bt::SingleRowMutation(prefix + "/many-columns",
-                            {bt::SetCell("fam0", "c0", 3000, "foo"),
-                             bt::SetCell("fam0", "c1", 3000, "foo"),
-                             bt::SetCell("fam0", "c2", 3000, "foo"),
-                             bt::SetCell("fam0", "c3", 3000, "foo")}));
+  mutation.emplace_back(bt::SingleRowMutation(
+      prefix + "/two-cells", {bt::SetCell("fam0", "c", 3000, "foo"),
+                              bt::SetCell("fam0", "c2", 3000, "foo")}));
+  mutation.emplace_back(bt::SingleRowMutation(
+      prefix + "/many", {bt::SetCell("fam0", "c", 0, "foo"),
+                         bt::SetCell("fam0", "c", 1000, "foo"),
+                         bt::SetCell("fam0", "c", 2000, "foo"),
+                         bt::SetCell("fam0", "c", 3000, "foo")}));
+  mutation.emplace_back(bt::SingleRowMutation(
+      prefix + "/many-columns", {bt::SetCell("fam0", "c0", 3000, "foo"),
+                                 bt::SetCell("fam0", "c1", 3000, "foo"),
+                                 bt::SetCell("fam0", "c2", 3000, "foo"),
+                                 bt::SetCell("fam0", "c3", 3000, "foo")}));
   // This one is complicated: create a mutation with several families and
   // columns.
   bt::SingleRowMutation complex(prefix + "/complex");

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -423,7 +423,7 @@ TEST_F(FilterIntegrationTest, CellsRowLimit) {
 
   std::map<std::string, int> actual;
   for (auto const& c : result) {
-    auto ins = actual.emplace(static_cast<std::string>(c.row_key()), 0);
+    auto ins = actual.emplace(c.row_key(), 0);
     ins.first->second++;
   }
   std::map<std::string, int> expected{{prefix + "/one-cell", 1},
@@ -446,7 +446,7 @@ TEST_F(FilterIntegrationTest, CellsRowOffset) {
 
   std::map<std::string, int> actual;
   for (auto const& c : result) {
-    auto ins = actual.emplace(static_cast<std::string>(c.row_key()), 0);
+    auto ins = actual.emplace(c.row_key(), 0);
     ins.first->second++;
   }
   std::map<std::string, int> expected{{prefix + "/many", 2},
@@ -688,12 +688,12 @@ void FilterIntegrationTest::CreateCells(
     bigtable::Table& table, std::vector<bigtable::Cell> const& cells) {
   std::map<std::string, bigtable::SingleRowMutation> mutations;
   for (auto const& cell : cells) {
-    std::string key = static_cast<std::string>(cell.row_key());
+    std::string key = cell.row_key();
     auto inserted = mutations.emplace(key, bigtable::SingleRowMutation(key));
     inserted.first->second.emplace_back(bigtable::SetCell(
-        static_cast<std::string>(cell.family_name()),
-        static_cast<std::string>(cell.column_qualifier()), cell.timestamp(),
-        static_cast<std::string>(cell.value())));
+        cell.family_name(),
+        cell.column_qualifier(), cell.timestamp(),
+        cell.value()));
   }
   bigtable::BulkMutation bulk;
   for (auto& kv : mutations) {

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -709,19 +709,22 @@ void FilterIntegrationTest::CreateComplexRows(bigtable::Table& table,
   // column families.
   mutation.emplace_back(bt::SingleRowMutation(
       prefix + "/one-cell", {bt::SetCell("fam0", "c", 3000, "foo")}));
-  mutation.emplace_back(bt::SingleRowMutation(
-      prefix + "/two-cells", {bt::SetCell("fam0", "c", 3000, "foo"),
-                              bt::SetCell("fam0", "c2", 3000, "foo")}));
-  mutation.emplace_back(bt::SingleRowMutation(
-      prefix + "/many", {bt::SetCell("fam0", "c", 0, "foo"),
-                         bt::SetCell("fam0", "c", 1000, "foo"),
-                         bt::SetCell("fam0", "c", 2000, "foo"),
-                         bt::SetCell("fam0", "c", 3000, "foo")}));
-  mutation.emplace_back(bt::SingleRowMutation(
-      prefix + "/many-columns", {bt::SetCell("fam0", "c0", 3000, "foo"),
-                                 bt::SetCell("fam0", "c1", 3000, "foo"),
-                                 bt::SetCell("fam0", "c2", 3000, "foo"),
-                                 bt::SetCell("fam0", "c3", 3000, "foo")}));
+  mutation.emplace_back(
+      bt::SingleRowMutation(prefix + "/two-cells",
+                            {bt::SetCell("fam0", "c", 3000, "foo"),
+                             bt::SetCell("fam0", "c2", 3000, "foo")}));
+  mutation.emplace_back(
+      bt::SingleRowMutation(prefix + "/many",
+                            {bt::SetCell("fam0", "c", 0, "foo"),
+                             bt::SetCell("fam0", "c", 1000, "foo"),
+                             bt::SetCell("fam0", "c", 2000, "foo"),
+                             bt::SetCell("fam0", "c", 3000, "foo")}));
+  mutation.emplace_back(
+      bt::SingleRowMutation(prefix + "/many-columns",
+                            {bt::SetCell("fam0", "c0", 3000, "foo"),
+                             bt::SetCell("fam0", "c1", 3000, "foo"),
+                             bt::SetCell("fam0", "c2", 3000, "foo"),
+                             bt::SetCell("fam0", "c3", 3000, "foo")}));
   // This one is complicated: create a mutation with several families and
   // columns.
   bt::SingleRowMutation complex(prefix + "/complex");


### PR DESCRIPTION
They are not that useful because one has to explicitly convert
them to std::string to use them with most C++ classes, for
example, the std::string constructor does not accept
absl::string_view (in C++17 it would accept std::string_view, but
that is not the version we use).  Same problems with
std::istringstream, or with protos.

This is part of the fixes for #32.
