### PR TITLE
Workaround breakage in Google Cloud SDK v188

### DIFF
--- a/ci/Dockerfile.centos
+++ b/ci/Dockerfile.centos
@@ -51,6 +51,7 @@ RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.
+# TODO(#224) - use the latest and greatest SDK once v188 is fixed.
 WORKDIR /var/tmp/install/cbt-components
 RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
 RUN tar x -C /usr/local -f google-cloud-sdk-187.0.0-linux-x86_64.tar.gz

--- a/ci/Dockerfile.centos
+++ b/ci/Dockerfile.centos
@@ -52,5 +52,6 @@ RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.
 WORKDIR /var/tmp/install/cbt-components
-RUN curl https://sdk.cloud.google.com | bash -s -- --disable-prompts --install-dir=/usr/local
+RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
+RUN tar x -C /usr/local -f google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
 RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable

--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -46,5 +46,6 @@ RUN dnf makecache && dnf install -y \
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.
 WORKDIR /var/tmp/install/cbt-components
-RUN curl https://sdk.cloud.google.com | bash -s -- --disable-prompts --install-dir=/usr/local
+RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
+RUN tar x -C /usr/local -f google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
 RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable

--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -45,6 +45,7 @@ RUN dnf makecache && dnf install -y \
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.
+# TODO(#224) - use the latest and greatest SDK once v188 is fixed.
 WORKDIR /var/tmp/install/cbt-components
 RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
 RUN tar x -C /usr/local -f google-cloud-sdk-187.0.0-linux-x86_64.tar.gz

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -48,5 +48,6 @@ RUN if grep -q 14.04 /etc/lsb-release; then \
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.
 WORKDIR /var/tmp/install/cbt-components
-RUN curl https://sdk.cloud.google.com | bash -s -- --disable-prompts --install-dir=/usr/local
+RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
+RUN tar x -C /usr/local -f google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
 RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -47,6 +47,7 @@ RUN if grep -q 14.04 /etc/lsb-release; then \
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.
+# TODO(#224) - use the latest and greatest SDK once v188 is fixed.
 WORKDIR /var/tmp/install/cbt-components
 RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
 RUN tar x -C /usr/local -f google-cloud-sdk-187.0.0-linux-x86_64.tar.gz


### PR DESCRIPTION
The breakage is documented in the external issue tracker:

https://issuetracker.google.com/issues/73044966

Install v187 until we know 188 works.
