### PR TITLE
Implement a benchmark for Table::ReadRows()

### DIFF
--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -353,7 +353,7 @@ add_executable(scan_throughput_benchmark
         benchmarks/scan_throughput_benchmark.cc)
 target_link_libraries(scan_throughput_benchmark
         bigtable_benchmark_common bigtable_admin_client bigtable_client
-        bigtable_protos gmock absl::strings absl::time
+        bigtable_protos gmock absl::time
         ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 
 # Define the install target

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -349,6 +349,13 @@ target_sources(bigtable_client_all_tests
     PUBLIC ${bigtable_benchmarks_unit_tests})
 target_link_libraries(bigtable_client_all_tests bigtable_benchmark_common)
 
+add_executable(scan_throughput_benchmark
+        benchmarks/scan_throughput_benchmark.cc)
+target_link_libraries(scan_throughput_benchmark
+        bigtable_benchmark_common bigtable_admin_client bigtable_client
+        bigtable_protos gmock absl::strings absl::time
+        ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+
 # Define the install target
 get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
 if ("${LIB64}" STREQUAL "TRUE")

--- a/bigtable/benchmarks/scan_throughput_benchmark.cc
+++ b/bigtable/benchmarks/scan_throughput_benchmark.cc
@@ -1,0 +1,154 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <absl/time/time.h>
+#include <chrono>
+#include <future>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include "bigtable/benchmarks/benchmark.h"
+
+/**
+ * @file
+ *
+ * Measure the throughput of `bigtable::Table::ReadRows()`.
+ *
+ * This benchmark measures the throughput of `bigtable::Table::ReadRows()` on a
+ * "typical" table used for serving data.  The benchmark:
+ * - Creates a table with 10,000,000 rows, each row with a single column family,
+ *   but with 10 columns.
+ * - Creates a table with 10,000,000 rows, each row with a
+ *   single column family.
+ * - The column family contains 10 columns, each column filled with a random
+ *   100 byte string.
+ * - The name of the table starts with `scant`, followed by random characters.
+ * - If there is a collision on the table name the benchmark aborts immediately.
+ * - The benchmark populates the table during an initial phase.  The benchmark
+ *   uses `BulkApply()` to populate the table, multiple threads to populate
+ *   in parallel, and provides an initial split hint when creating the table.
+ * - The benchmark reports the throughput of this bulk upload phase.
+ *
+ * After successfully uploading the initial data, the main phase of the
+ * benchmark starts. During this phase the benchmark will:
+ *
+ * - Execute the following block with different scan sizes:
+ *   - Execute the following loop for S seconds:
+ *     - Pick one of the 10,000,000 keys at random, with uniform probability.
+ *     - Scan the number rows starting the the key selected above.
+ *     - Go back and pick a new random key.
+ *
+ * The benchmark will report throughput in rows per second for each scans with
+ * 100, 1,000 and 10,000 rows.
+ *
+ * Using a command-line parameter the benchmark can be configured to create a
+ * local gRPC server that implements the Cloud Bigtable APIs used by the
+ * benchmark.  If this parameter is not used, the benchmark uses the default
+ * configuration, that is, a production instance of Cloud Bigtable unless the
+ * CLOUD_BIGTABLE_EMULATOR environment variable is set.
+ */
+
+/// Helper functions and types for the scan_throughput_benchmark.
+namespace {
+using namespace bigtable::benchmarks;
+
+constexpr int kScanSizes[] = {100, 1000, 10000};
+
+/// Run an iteration of the test.
+BenchmarkResult RunBenchmark(bigtable::benchmarks::Benchmark const& benchmark,
+                             std::shared_ptr<bigtable::DataClient> data_client,
+                             std::string const& table_id, long table_size,
+                             long scan_size,
+                             std::chrono::seconds test_duration);
+}  // anonymous namespace
+
+int main(int argc, char* argv[]) try {
+  bigtable::benchmarks::BenchmarkSetup setup("scant", argc, argv);
+
+  Benchmark benchmark(setup);
+
+  // Create and populate the table for the benchmark.
+  benchmark.CreateTable();
+  auto populate_results = benchmark.PopulateTable();
+  benchmark.PrintThroughputResult(std::cout, "scant", "Upload",
+                                  populate_results);
+
+  auto data_client = benchmark.MakeDataClient();
+  std::map<std::string, BenchmarkResult> results_by_size;
+  for (auto scan_size : kScanSizes) {
+    std::cout << "# Running benchmark [" << scan_size << "] " << std::flush;
+    auto start = std::chrono::steady_clock::now();
+    auto combined =
+        RunBenchmark(benchmark, data_client, setup.table_id(), scan_size,
+                     setup.table_size(), setup.test_duration());
+    using std::chrono::duration_cast;
+    combined.elapsed = duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - start);
+    std::cout << " DONE. Elapsed=" << absl::FromChrono(combined.elapsed)
+              << ", Ops=" << combined.operations.size()
+              << ", Rows=" << combined.row_count << std::endl;
+    auto op_name = "Scan(" + std::to_string(scan_size) + ")";
+    benchmark.PrintLatencyResult(std::cout, "scant", op_name, combined);
+    results_by_size[op_name] = std::move(combined);
+  }
+
+  std::cout << bigtable::benchmarks::Benchmark::ResultsCsvHeader() << std::endl;
+  benchmark.PrintResultCsv(std::cout, "scant", "BulkApply()", "Latency",
+                           populate_results);
+  for (auto& kv : results_by_size) {
+    benchmark.PrintResultCsv(std::cout, "scant", kv.first, "IterationTime",
+                             kv.second);
+  }
+
+  benchmark.DeleteTable();
+
+  return 0;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard exception raised: " << ex.what() << std::endl;
+  return 1;
+}
+
+namespace {
+BenchmarkResult RunBenchmark(bigtable::benchmarks::Benchmark const& benchmark,
+                             std::shared_ptr<bigtable::DataClient> data_client,
+                             std::string const& table_id, long table_size,
+                             long scan_size,
+                             std::chrono::seconds test_duration) {
+  BenchmarkResult result = {};
+
+  bigtable::Table table(std::move(data_client), table_id);
+
+  auto generator = MakeDefaultPRNG();
+  std::uniform_int_distribution<long> prng(0, table_size - scan_size - 1);
+
+  auto test_start = std::chrono::steady_clock::now();
+  while (std::chrono::steady_clock::now() < test_start + test_duration) {
+    auto range =
+        bigtable::RowRange::StartingAt(benchmark.MakeKey(prng(generator)));
+
+    long count = 0;
+    auto op = [&count, &table, &scan_size, &range]() {
+      auto reader =
+          table.ReadRows(bigtable::RowSet(std::move(range)), scan_size,
+                         bigtable::Filter::ColumnRangeClosed(
+                             kColumnFamily, "field0", "field9"));
+      count = std::distance(reader.begin(), reader.end());
+    };
+    result.operations.push_back(Benchmark::TimeOperation(op));
+    result.row_count += count;
+  }
+  return result;
+}
+
+}  // anonymous namespace

--- a/bigtable/benchmarks/scan_throughput_benchmark.cc
+++ b/bigtable/benchmarks/scan_throughput_benchmark.cc
@@ -29,10 +29,6 @@
  * "typical" table used for serving data.  The benchmark:
  * - Creates a table with 10,000,000 rows, each row with a single column family,
  *   but with 10 columns.
- * - Creates a table with 10,000,000 rows, each row with a
- *   single column family.
- * - The column family contains 10 columns, each column filled with a random
- *   100 byte string.
  * - The name of the table starts with `scant`, followed by random characters.
  * - If there is a collision on the table name the benchmark aborts immediately.
  * - The benchmark populates the table during an initial phase.  The benchmark

--- a/bigtable/benchmarks/setup.cc
+++ b/bigtable/benchmarks/setup.cc
@@ -91,12 +91,21 @@ BenchmarkSetup::BenchmarkSetup(std::string const& prefix, int& argc,
   if (argc == 1) {
     return;
   }
-  test_duration_ = std::chrono::seconds(std::stol(shift()));
+  long seconds = std::stol(shift());
+  if (seconds <= 0) {
+    throw std::runtime_error("test-duration-seconds should be > 0");
+  }
+  test_duration_ = std::chrono::seconds(seconds);
 
   if (argc == 1) {
     return;
   }
   table_size_ = std::stol(shift());
+  if (table_size_ <= kPopulateShardCount) {
+    std::ostringstream os;
+    os << "table-size parameter should be > " << kPopulateShardCount;
+    throw std::runtime_error(os.str());
+  }
 
   if (argc == 1) {
     return;

--- a/bigtable/benchmarks/setup_test.cc
+++ b/bigtable/benchmarks/setup_test.cc
@@ -124,3 +124,21 @@ TEST(BenchmarkSetup, Test0) {
   int argc = sizeof(argv) / sizeof(argv[0]);
   EXPECT_THROW(BenchmarkSetup("t0", argc, argv), std::exception);
 }
+
+TEST(BenchmarkSetup, TestDuration) {
+  char seconds[] = "0";
+  char* argv[] = {arg0, arg1, arg2, arg3, seconds, arg5, arg6, arg7};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+
+  // Test duration parameter should be >= 0.
+  EXPECT_THROW(BenchmarkSetup("test-duration", argc, argv), std::exception);
+}
+
+TEST(BenchmarkSetup, TableSize) {
+  char table_size[] = "10";
+  char* argv[] = {arg0, arg1, arg2, arg3, arg4, table_size, arg6, arg7};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+
+  // TableSize parameter should be >= 100.
+  EXPECT_THROW(BenchmarkSetup("table-size", argc, argv), std::exception);
+}


### PR DESCRIPTION
This fixes #196.  Implements a benchmark to measure the throughput
of Table::ReadRows() using either production Cloud Bigtable, the
Cloud Bigtable Emulator, or an embedded server.