### PR TITLE
Remove references to Ubuntu-17.04 it is EOL.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,12 +62,12 @@ advised that `clang-format` has been known to generate slightly different
 formatting in different versions, we use version 4.0, use the same version if
 you run into problems.
 
-If you have prepared a Docker image for `ubuntu:17.04` (see below), you can
+If you have prepared a Docker image for `ubuntu:17.10` (see below), you can
 verify and fix the format of your code using:
 
 ```console
 # Run from google-cloud-cpp:
-$ TRAVIS_OS_NAME=linux DISTRO=ubuntu DISTRO_VERSION=17.04 CXX=clang++ CC=clang CHECK_STYLE=yes ./ci/build-linux.sh
+$ TRAVIS_OS_NAME=linux DISTRO=ubuntu DISTRO_VERSION=17.10 CXX=clang++ CC=clang CHECK_STYLE=yes ./ci/build-linux.sh
 ```
 
 ## Advanced Compilation and Testing
@@ -117,7 +117,7 @@ intend to use, for example:
 
 ```console
 # Run from the google-cloud-cpp directory.
-$ TRAVIS_OS_NAME=linux DISTRO=ubuntu DISTRO_VERSION=17.04 ./ci/install-linux.sh
+$ TRAVIS_OS_NAME=linux DISTRO=ubuntu DISTRO_VERSION=17.10 ./ci/install-linux.sh
 ```
 
 Once you create the image for a given combination of `DISTRO` and
@@ -125,7 +125,7 @@ Once you create the image for a given combination of `DISTRO` and
 
 ```console
 # Also run from google-cloud-cpp:
-$ TRAVIS_OS_NAME=linux DISTRO=ubuntu DISTRO_VERSION=17.04 CXX=clang++ CC=clang BUILD_TYPE=Debug ./ci/build-linux.sh
+$ TRAVIS_OS_NAME=linux DISTRO=ubuntu DISTRO_VERSION=17.10 CXX=clang++ CC=clang BUILD_TYPE=Debug ./ci/build-linux.sh
 ```
 
 You can set any of the following environment variables to control the build.
@@ -138,7 +138,7 @@ which combinations are tested regularly.
    * `CXX=clang++ CC=clang` to use Clang.
    * `CXX=g++ CC=gcc` to use GCC.
  * `DISTRO`: the Linux distribution, use `ubuntu`, `fedora`, or `centos`.
- * `DISTRO_VERSION`: the version of the distribution, e.g. `17.04`.
+ * `DISTRO_VERSION`: the version of the distribution, e.g. `16.04`.
  * `CHECK_STYLE`: if set to `yes`, the build fails if the code is different
    than the output from `clang-format(1)`.  Note that this reformats your files,
    that can be useful to keep the formatting clean.

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=17.04
+ARG DISTRO_VERSION=17.10
 FROM ubuntu:${DISTRO_VERSION}
 MAINTAINER "Carlos O'Ryan <coryan@google.com>"
 

--- a/ci/build-docker.sh
+++ b/ci/build-docker.sh
@@ -116,7 +116,7 @@ scan-build detected errors.  Please read the log for details. To
 run scan-build locally and examine the HTML output install and configure Docker,
 then run:
 
-DISTRO=ubuntu DISTRO_VERSION=17.04 SCAN_BUILD=yes NCPU=8 TRAVIS_OS_NAME=linux CXX=clang++ CC=clang ./ci/build-linux.sh
+DISTRO=ubuntu DISTRO_VERSION=16.04 SCAN_BUILD=yes NCPU=8 TRAVIS_OS_NAME=linux CXX=clang++ CC=clang ./ci/build-linux.sh
 
 The HTML output will be copied into the scan-build-output subdirectory.
 ${COLOR_RESET}


### PR DESCRIPTION
We stopped using Ubuntu 17.04 a while ago, and moved to 17.10.
Some of the documentation was not updated at the time.