### PR TITLE
Use std::chrono::duration in bigtable::ClientOptions::SetGrpclbFallbackTimeout

### DIFF
--- a/bigtable/client/client_options.h
+++ b/bigtable/client/client_options.h
@@ -93,6 +93,27 @@ class ClientOptions {
   }
 
   /**
+   * Set the grpclb fallback timeout (std::chrono::duration<> duration) for the
+   * channel.
+   *
+   * Please see the docs for grpc::ChannelArguments::SetGrpclbFallbackTimeout()
+   * on https://grpc.io/grpc/cpp/classgrpc_1_1_channel_arguments.html
+   * for more details.
+   *
+   */
+  template <typename Rep, typename Period>
+  void SetGrpclbFallbackTimeout(
+      std::chrono::duration<Rep, Period> fallback_timeout) {
+    int fallback_timeout_ms = 0;
+
+    std::chrono::milliseconds ft_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(fallback_timeout);
+    fallback_timeout_ms = static_cast<std::int32_t>(ft_ms.count());
+
+    channel_arguments_.SetGrpclbFallbackTimeout(fallback_timeout_ms);
+  }
+
+  /**
    * Set Socket Mutator for channel.
    *
    * Please see the docs for grpc::ChannelArguments::SetSocketMutator()

--- a/bigtable/client/client_options.h
+++ b/bigtable/client/client_options.h
@@ -105,11 +105,10 @@ class ClientOptions {
    *     used to store the number of ticks), for our purposes it is simply a
    *     formal parameter.
    * @tparam Period a placeholder to match the Period tparam for @p
-   * fallback_timeout
-   *     , the semantics of this template parameter are documented in
-   *     `std::chrono::duration<>` (in brief, the length of the tick in seconds,
-   *     expressed as a `std::ratio<>`), for our purposes it is simply a formal
-   *     parameter.
+   *     fallback_timeout, the semantics of this template parameter are
+   *     documented in `std::chrono::duration<>` (in brief, the length of the
+   *     tick in seconds, expressed as a `std::ratio<>`), for our purposes it
+   *     is simply a formal parameter.
    *
    * @see
    * [std::chrono::duration<>](http://en.cppreference.com/w/cpp/chrono/duration)

--- a/bigtable/client/client_options.h
+++ b/bigtable/client/client_options.h
@@ -15,7 +15,6 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_CLIENT_OPTIONS_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_CLIENT_OPTIONS_H_
 
-#include "absl/base/internal/throw_delegate.h"
 #include "bigtable/client/version.h"
 
 #include <grpc++/grpc++.h>
@@ -82,7 +81,7 @@ class ClientOptions {
   }
 
   /**
-   * Set the grpclb fallback timeout with the timestamp [@p fallback_timeout)
+   * Set the grpclb fallback timeout with the timestamp @p fallback_timeout
    * for the channel.
    *
    * This function accepts any instantiation of 'std::chrono::duration<>' for
@@ -90,14 +89,15 @@ class ClientOptions {
    * channel_arguments. For example:
    *
    * @code
-   * using namespace std::chrono_literals; // C++14
-   * bigtable::ClientOptions::SetGrpclbFallbackTimeout(std::chrono::milliseconds(5000))
-   * bigtable::ClientOptions::SetGrpclbFallbackTimeout(std::chrono::seconds(5))
+   * bigtable::ClientOptions::SetGrpclbFallbackTimeout(
+   *     std::chrono::milliseconds(5000))
+   * bigtable::ClientOptions::SetGrpclbFallbackTimeout(
+   *     std::chrono::seconds(5))
    * @endcode
    *
    * The fallback_timeout must not be empty and it should be within the range
-   * of int32. The code will throw exception std::out_of_range if range goes
-   * outside of int32.
+   * of int. The code will throw exception std::out_of_range if range goes
+   * outside of int.
    *
    * @tparam Rep a placeholder to match the Rep tparam for @p fallback_timeout,
    *     the semantics of this template parameter are documented in
@@ -126,10 +126,10 @@ class ClientOptions {
     std::chrono::milliseconds ft_ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(fallback_timeout);
 
-    if (ft_ms.count() > std::numeric_limits<int32_t>::max())
-      absl::base_internal::ThrowStdOutOfRange("Duration Exceeds Range for int");
+    if (ft_ms.count() > std::numeric_limits<int>::max())
+      throw std::out_of_range("Duration Exceeds Range for int");
 
-    int32_t fallback_timeout_ms = static_cast<std::int32_t>(ft_ms.count());
+    auto fallback_timeout_ms = static_cast<int>(ft_ms.count());
 
     channel_arguments_.SetGrpclbFallbackTimeout(fallback_timeout_ms);
   }

--- a/bigtable/client/client_options.h
+++ b/bigtable/client/client_options.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_CLIENT_OPTIONS_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_CLIENT_OPTIONS_H_
 
+#include "absl/base/internal/throw_delegate.h"
 #include "bigtable/client/version.h"
 
 #include <grpc++/grpc++.h>
@@ -81,20 +82,38 @@ class ClientOptions {
   }
 
   /**
-   * Set the grpclb fallback timeout (in ms) for the channel.
+   * Set the grpclb fallback timeout with the timestamp [@p fallback_timeout)
+   * for the channel.
    *
-   * Please see the docs for grpc::ChannelArguments::SetGrpclbFallbackTimeout()
-   * on https://grpc.io/grpc/cpp/classgrpc_1_1_channel_arguments.html
-   * for more details.
+   * This function accepts any instantiation of 'std::chrono::duration<>' for
+   * @p duration parameter convert it into milliseconds and pass it to
+   * channel_arguments. For example:
    *
-   */
-  void SetGrpclbFallbackTimeout(int fallback_timeout) {
-    channel_arguments_.SetGrpclbFallbackTimeout(fallback_timeout);
-  }
-
-  /**
-   * Set the grpclb fallback timeout (std::chrono::duration<> duration) for the
-   * channel.
+   * @code
+   * using namespace std::chrono_literals; // C++14
+   * bigtable::ClientOptions::SetGrpclbFallbackTimeout(std::chrono::milliseconds(5000))
+   * bigtable::ClientOptions::SetGrpclbFallbackTimeout(std::chrono::seconds(5))
+   * @endcode
+   *
+   * The fallback_timeout must not be empty and it should be within the range
+   * of int32. The code will throw exception std::out_of_range if range goes
+   * outside of int32.
+   *
+   * @tparam Rep a placeholder to match the Rep tparam for @p fallback_timeout,
+   *     the semantics of this template parameter are documented in
+   *     `std::chrono::duration<>` (in brief, the underlying arithmetic type
+   *     used to store the number of ticks), for our purposes it is simply a
+   *     formal parameter.
+   * @tparam Period a placeholder to match the Period tparam for @p
+   * fallback_timeout
+   *     , the semantics of this template parameter are documented in
+   *     `std::chrono::duration<>` (in brief, the length of the tick in seconds,
+   *     expressed as a `std::ratio<>`), for our purposes it is simply a formal
+   *     parameter.
+   *
+   * @see
+   * [std::chrono::duration<>](http://en.cppreference.com/w/cpp/chrono/duration)
+   *     for more details.
    *
    * Please see the docs for grpc::ChannelArguments::SetGrpclbFallbackTimeout()
    * on https://grpc.io/grpc/cpp/classgrpc_1_1_channel_arguments.html
@@ -104,11 +123,13 @@ class ClientOptions {
   template <typename Rep, typename Period>
   void SetGrpclbFallbackTimeout(
       std::chrono::duration<Rep, Period> fallback_timeout) {
-    int fallback_timeout_ms = 0;
-
     std::chrono::milliseconds ft_ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(fallback_timeout);
-    fallback_timeout_ms = static_cast<std::int32_t>(ft_ms.count());
+
+    if (ft_ms.count() > std::numeric_limits<int32_t>::max())
+      absl::base_internal::ThrowStdOutOfRange("Duration Exceeds Range for int");
+
+    int32_t fallback_timeout_ms = static_cast<std::int32_t>(ft_ms.count());
 
     channel_arguments_.SetGrpclbFallbackTimeout(fallback_timeout_ms);
   }

--- a/bigtable/client/client_options_test.cc
+++ b/bigtable/client/client_options_test.cc
@@ -112,7 +112,7 @@ TEST(ClientOptionsTest, EditCredentials) {
 
 TEST(ClientOptionsTest, SetGrpclbFallbackTimeout) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
-  client_options_object.SetGrpclbFallbackTimeout(5);
+  client_options_object.SetGrpclbFallbackTimeout(std::chrono::milliseconds(5));
   grpc::ChannelArguments c_args = client_options_object.channel_arguments();
   grpc_channel_args test_args = c_args.c_channel_args();
   ASSERT_EQ(2UL, test_args.num_args);

--- a/bigtable/client/client_options_test.cc
+++ b/bigtable/client/client_options_test.cc
@@ -110,7 +110,7 @@ TEST(ClientOptionsTest, EditCredentials) {
             typeid(client_options_object.credentials()));
 }
 
-TEST(ClientOptionsTest, SetGrpclbFallbackTimeout) {
+TEST(ClientOptionsTest, SetGrpclbFallbackTimeoutMS) {
   // Test milliseconds are set properly to channel_arguments
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   client_options_object.SetGrpclbFallbackTimeout(std::chrono::milliseconds(5));
@@ -123,7 +123,9 @@ TEST(ClientOptionsTest, SetGrpclbFallbackTimeout) {
   // 2nd element of test_args.
   EXPECT_EQ(GRPC_ARG_GRPCLB_FALLBACK_TIMEOUT_MS,
             grpc::string(test_args.args[1].key));
+}
 
+TEST(ClientOptionsTest, SetGrpclbFallbackTimeoutSec) {
   // Test seconds are converted into milliseconds
   bigtable::ClientOptions client_options_object_second =
       bigtable::ClientOptions();
@@ -135,8 +137,10 @@ TEST(ClientOptionsTest, SetGrpclbFallbackTimeout) {
   ASSERT_EQ(2UL, test_args_second.num_args);
   EXPECT_EQ(GRPC_ARG_GRPCLB_FALLBACK_TIMEOUT_MS,
             grpc::string(test_args_second.args[1].key));
+}
 
-  // Test if fallback_timeout exceeds int32_t range then throw out_of_range
+TEST(ClientOptionsTest, SetGrpclbFallbackTimeoutException) {
+  // Test if fallback_timeout exceeds int range then throw out_of_range
   // exception
   bigtable::ClientOptions client_options_object_third =
       bigtable::ClientOptions();

--- a/bigtable/client/client_options_test.cc
+++ b/bigtable/client/client_options_test.cc
@@ -111,6 +111,7 @@ TEST(ClientOptionsTest, EditCredentials) {
 }
 
 TEST(ClientOptionsTest, SetGrpclbFallbackTimeout) {
+  // Test milliseconds are set properly to channel_arguments
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   client_options_object.SetGrpclbFallbackTimeout(std::chrono::milliseconds(5));
   grpc::ChannelArguments c_args = client_options_object.channel_arguments();
@@ -122,6 +123,26 @@ TEST(ClientOptionsTest, SetGrpclbFallbackTimeout) {
   // 2nd element of test_args.
   EXPECT_EQ(GRPC_ARG_GRPCLB_FALLBACK_TIMEOUT_MS,
             grpc::string(test_args.args[1].key));
+
+  // Test seconds are converted into milliseconds
+  bigtable::ClientOptions client_options_object_second =
+      bigtable::ClientOptions();
+  client_options_object_second.SetGrpclbFallbackTimeout(
+      std::chrono::seconds(5));
+  grpc::ChannelArguments c_args_second =
+      client_options_object_second.channel_arguments();
+  grpc_channel_args test_args_second = c_args_second.c_channel_args();
+  ASSERT_EQ(2UL, test_args_second.num_args);
+  EXPECT_EQ(GRPC_ARG_GRPCLB_FALLBACK_TIMEOUT_MS,
+            grpc::string(test_args_second.args[1].key));
+
+  // Test if fallback_timeout exceeds int32_t range then throw out_of_range
+  // exception
+  bigtable::ClientOptions client_options_object_third =
+      bigtable::ClientOptions();
+  EXPECT_THROW(client_options_object_third.SetGrpclbFallbackTimeout(
+                   std::chrono::hours(999)),
+               std::out_of_range);
 }
 
 TEST(ClientOptionsTest, SetCompressionAlgorithm) {


### PR DESCRIPTION
Changed Test case to use the duration instead of int in method SetGrpclbFallbackTimeout