### PR TITLE
Enable a build with exceptions disabled.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,12 @@ matrix:
       compiler: clang
       env: DISTRO=ubuntu DISTRO_VERSION=16.04 BUILD_TYPE=Debug \
            CMAKE_FLAGS=-DSANITIZE_UNDEFINED=yes
+    - # Compile with clang-tidy enabled.  We use Fedora for this build because
+      # it has a version of cmake(1) that reports clang-tidy errors.
+      os: linux
+      compiler: clang
+      env: DISTRO=fedora DISTRO_VERSION=27 BUILD_TYPE=Debug \
+            CMAKE_FLAGS=-DBIGTABLE_CLIENT_CLANG_TIDY=yes
     - # Generate code coverage information and upload to codecov.io.
       os: linux
       compiler: gcc
@@ -80,16 +86,16 @@ matrix:
       os: linux
       compiler: gcc
       env: DISTRO=fedora DISTRO_VERSION=27
-    - # Compile with clang-tidy enabled.  We use Fedora for this build because
-      # it has a version of cmake(1) that reports clang-tidy errors.
-      os: linux
-      compiler: clang
-      env: DISTRO=fedora DISTRO_VERSION=27 BUILD_TYPE=Debug \
-            CMAKE_FLAGS=-DBIGTABLE_CLIENT_CLANG_TIDY=yes
     - # Compile on CentOS.
       os: linux
       compiler: gcc
       env: DISTRO=centos DISTRO_VERSION=7 BUILD_TYPE=Release
+  allow_failures:
+    - # Compile with exceptions disabled.
+      os: linux
+      compiler: gcc
+      env: DISTRO=ubuntu DISTRO_VERSION=16.04 BUILD_TYPE=Release
+           CMAKE_FLAGS=-DGOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS=no
 
 script:
   - ci/build-linux.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,11 @@ matrix:
       os: linux
       compiler: gcc
       env: DISTRO=ubuntu DISTRO_VERSION=14.04 BUILD_TYPE=Coverage
+    - # Compile with exceptions disabled.
+      os: linux
+      compiler: gcc
+      env: DISTRO=ubuntu DISTRO_VERSION=16.04 BUILD_TYPE=Release
+           CMAKE_FLAGS=-DGOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS=no
     - # Compile on Fedora.
       os: linux
       compiler: gcc
@@ -90,12 +95,6 @@ matrix:
       os: linux
       compiler: gcc
       env: DISTRO=centos DISTRO_VERSION=7 BUILD_TYPE=Release
-  allow_failures:
-    - # Compile with exceptions disabled.
-      os: linux
-      compiler: gcc
-      env: DISTRO=ubuntu DISTRO_VERSION=16.04 BUILD_TYPE=Release
-           CMAKE_FLAGS=-DGOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS=no
 
 script:
   - ci/build-linux.sh

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -133,6 +133,8 @@ add_library(bigtable_client
     client/internal/readrowsparser.cc
     client/internal/rowreaderiterator.h
     client/internal/rowreaderiterator.cc
+    client/internal/throw_delegate.h
+    client/internal/throw_delegate.cc
     client/filters.h
     client/filters.cc
     client/idempotent_mutation_policy.h

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -52,6 +52,9 @@ include(${PROJECT_SOURCE_DIR}/cmake/EnableSanitizers.cmake)
 # Include support for clang-tidy if available
 include(${PROJECT_SOURCE_DIR}/cmake/EnableClangTidy.cmake)
 
+# C++ Exceptions are enabled by default, but allow the user to turn them off.
+include(${PROJECT_SOURCE_DIR}/cmake/EnableCxxExceptions.cmake)
+
 # We use abseil.io .
 set(BUILD_TESTING OFF)
 include(${PROJECT_SOURCE_DIR}/cmake/IncludeAbseil.cmake)
@@ -97,6 +100,7 @@ GRPC_GENERATE_CPP_MOCKS(GRPCPP_SOURCES GRPCPP_HDRS GRPC_MOCK_HDRS
 add_library(bigtable_protos ${PROTO_SOURCES} ${PROTO_HDRS} ${GRPCPP_SOURCES} ${GRPCPP_HDRS})
 target_link_libraries(bigtable_protos ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 target_include_directories(bigtable_protos PUBLIC "${PROJECT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
+target_compile_options(bigtable_protos PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 add_library(bigtable::protos ALIAS bigtable_protos)
 
 # Enable unit tests
@@ -160,6 +164,7 @@ target_link_libraries(bigtable_client
     bigtable_protos absl::strings
     ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 target_include_directories(bigtable_client PUBLIC "${PROJECT_SOURCE_DIR}")
+target_compile_options(bigtable_client PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 add_library(bigtable::client ALIAS bigtable_client)
 
 add_library(bigtable_client_testing
@@ -255,7 +260,6 @@ target_link_libraries(bigtable_client_all_tests
     bigtable_protos gmock absl::strings
     ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 
-
 # List the unit tests, then setup the targets and dependencies.
 set(bigtable_admin_unit_tests
     admin/admin_client_test.cc
@@ -316,6 +320,7 @@ target_link_libraries(filters_integration_test
     ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 add_dependencies(tests-local filters_integration_test)
 
+if (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
 add_library(bigtable_benchmark_common
     benchmarks/benchmark.h
     benchmarks/benchmark.cc
@@ -368,6 +373,7 @@ target_link_libraries(scan_throughput_benchmark
         bigtable_benchmark_common bigtable_admin_client bigtable_client
         bigtable_protos gmock absl::time
         ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+endif (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
 
 # Define the install target
 get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -171,10 +171,10 @@ add_library(bigtable_client_testing
     client/testing/chrono_literals.h
     client/testing/mock_data_client.h
     client/testing/mock_response_stream.h
-    client/testing/table_test_fixture.h
-    client/testing/table_test_fixture.cc
     client/testing/table_integration_test.h
-    client/testing/table_integration_test.cc)
+    client/testing/table_integration_test.cc
+    client/testing/table_test_fixture.h
+    client/testing/table_test_fixture.cc)
 target_link_libraries(bigtable_client_testing
     bigtable_client bigtable_protos absl::strings gmock
     ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
@@ -321,58 +321,49 @@ target_link_libraries(filters_integration_test
 add_dependencies(tests-local filters_integration_test)
 
 if (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
-add_library(bigtable_benchmark_common
-    benchmarks/benchmark.h
-    benchmarks/benchmark.cc
-    benchmarks/constants.h
-    benchmarks/embedded_server.h
-    benchmarks/embedded_server.cc
-    benchmarks/random.h
-    benchmarks/random.cc
-    benchmarks/setup.h
-    benchmarks/setup.cc)
-target_link_libraries(bigtable_benchmark_common
-    absl::time bigtable_admin_client bigtable_client bigtable_protos
-    ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
-
-# List the unit tests, then setup the targets and dependencies.
-set(bigtable_benchmarks_unit_tests
-    benchmarks/benchmark_test.cc
-    benchmarks/embedded_server_test.cc
-    benchmarks/random_test.cc
-    benchmarks/setup_test.cc)
-foreach (fname ${bigtable_benchmarks_unit_tests})
-    string(REPLACE "/" "_" target ${fname})
-    string(REPLACE ".cc" "" target ${target})
-    add_executable(${target} ${fname})
-    get_target_property(tname ${target} NAME)
-    target_link_libraries(${target}
-        bigtable_benchmark_common bigtable_admin_client bigtable_client
-        bigtable_protos gmock absl::strings absl::time
+    add_library(bigtable_benchmark_common
+        benchmarks/benchmark.h
+        benchmarks/benchmark.cc
+        benchmarks/constants.h
+        benchmarks/embedded_server.h
+        benchmarks/embedded_server.cc
+        benchmarks/random.h
+        benchmarks/random.cc
+        benchmarks/setup.h
+        benchmarks/setup.cc)
+    target_link_libraries(bigtable_benchmark_common
+        absl::time bigtable_admin_client bigtable_client bigtable_protos
         ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
-    add_test(NAME ${tname} COMMAND ${target})
-    get_target_property(sources ${target} SOURCES)
-    add_dependencies(tests-local ${target})
-endforeach ()
-target_sources(bigtable_client_all_tests
-    PUBLIC ${bigtable_benchmarks_unit_tests})
-target_link_libraries(bigtable_client_all_tests bigtable_benchmark_common)
 
-# Benchmark for Table::Apply() and Table::ReadRow().
-add_executable(apply_read_latency_benchmark
-benchmarks/apply_read_latency_benchmark.cc)
-target_link_libraries(apply_read_latency_benchmark
-bigtable_benchmark_common bigtable_admin_client bigtable_client
-bigtable_protos gmock absl::strings absl::time
-${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+    # List the unit tests, then setup the targets and dependencies.
+    set(bigtable_benchmarks_unit_tests
+        benchmarks/benchmark_test.cc
+        benchmarks/embedded_server_test.cc
+        benchmarks/random_test.cc
+        benchmarks/setup_test.cc)
+    foreach (fname ${bigtable_benchmarks_unit_tests})
+        string(REPLACE "/" "_" target ${fname})
+        string(REPLACE ".cc" "" target ${target})
+        add_executable(${target} ${fname})
+        get_target_property(tname ${target} NAME)
+        target_link_libraries(${target}
+            bigtable_benchmark_common bigtable_admin_client bigtable_client
+            bigtable_protos gmock absl::strings absl::time
+            ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+        add_test(NAME ${tname} COMMAND ${target})
+        get_target_property(sources ${target} SOURCES)
+        add_dependencies(tests-local ${target})
+    endforeach ()
+    target_sources(bigtable_client_all_tests
+        PUBLIC ${bigtable_benchmarks_unit_tests})
+    target_link_libraries(bigtable_client_all_tests bigtable_benchmark_common)
 
-# Benchmark Table::ReadRows().
-add_executable(scan_throughput_benchmark
-        benchmarks/scan_throughput_benchmark.cc)
-target_link_libraries(scan_throughput_benchmark
-        bigtable_benchmark_common bigtable_admin_client bigtable_client
-        bigtable_protos gmock absl::time
-        ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
+    add_executable(scan_throughput_benchmark
+            benchmarks/scan_throughput_benchmark.cc)
+    target_link_libraries(scan_throughput_benchmark
+            bigtable_benchmark_common bigtable_admin_client bigtable_client
+            bigtable_protos gmock absl::time
+            ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 endif (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
 
 # Define the install target

--- a/bigtable/admin/table_admin.cc
+++ b/bigtable/admin/table_admin.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "bigtable/admin/table_admin.h"
+#include "bigtable/client/internal/throw_delegate.h"
 
 #include <sstream>
 
@@ -133,8 +134,7 @@ void TableAdmin::RaiseError(grpc::Status const& status,
   os << "TableAdmin(" << instance_name() << ") unrecoverable error or too many "
      << " errors in " << error_message << ": " << status.error_message() << " ["
      << status.error_code() << "] " << status.error_details();
-  // TODO(#35) - implement non-throwing version of this class.
-  throw std::runtime_error(os.str());
+  internal::RaiseRuntimeError(os.str());
 }
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/bigtable/admin/table_admin_test.cc
+++ b/bigtable/admin/table_admin_test.cc
@@ -195,9 +195,14 @@ TEST_F(TableAdminTest, ListTablesUnrecoverableFailures) {
   EXPECT_CALL(*client_, on_completion(_)).Times(1);
 
   // After all the setup, make the actual call we want to test.
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_THROW(tested.ListTables(btproto::Table::FULL), std::exception);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(tested.ListTables(btproto::Table::FULL), "failures");
+#endif  // ABSL_HAVE_EXCEPTIONS
 }
 
+#if ABSL_HAVE_EXCEPTIONS
 /**
  * @test Verify that `bigtable::TableAdmin::ListTables` handles too many
  * recoverable failures.
@@ -224,6 +229,7 @@ TEST_F(TableAdminTest, ListTablesTooManyFailures) {
   // After all the setup, make the actual call we want to test.
   EXPECT_THROW(tested.ListTables(btproto::Table::FULL), std::exception);
 }
+#endif  // ABSL_HAVE_EXCEPTIONS
 
 /// @test Verify that `bigtable::TableAdmin::Create` works in the easy case.
 TEST_F(TableAdminTest, CreateTableSimple) {
@@ -264,9 +270,10 @@ initial_splits { key: 'p' }
   bigtable::TableConfig config(
       {{"f1", GC::MaxNumVersions(1)}, {"f2", GC::MaxAge(1_s)}},
       {"a", "c", "p"});
-  EXPECT_NO_THROW(tested.CreateTable("new-table", std::move(config)));
+  tested.CreateTable("new-table", std::move(config));
 }
 
+#if ABSL_HAVE_EXCEPTIONS
 /**
  * @test Verify that `bigtable::TableAdmin::CreateTable` works with
  * unrecoverable failures.
@@ -310,6 +317,7 @@ TEST_F(TableAdminTest, CreateTableTooManyFailures) {
   EXPECT_THROW(tested.CreateTable("other-table", bigtable::TableConfig()),
                std::runtime_error);
 }
+#endif  // ABSL_HAVE_EXCEPTIONS
 
 /// @test Verify that `bigtable::TableAdmin::GetTable` works in the easy case.
 TEST_F(TableAdminTest, GetTableSimple) {
@@ -330,9 +338,10 @@ view: SCHEMA_VIEW
   EXPECT_CALL(*client_, on_completion(_)).Times(2);
 
   // After all the setup, make the actual call we want to test.
-  EXPECT_NO_THROW(tested.GetTable("the-table"));
+  tested.GetTable("the-table");
 }
 
+#if ABSL_HAVE_EXCEPTIONS
 /**
  * @test Verify that `bigtable::TableAdmin::GetTable` reports unrecoverable
  * failures.
@@ -372,6 +381,7 @@ TEST_F(TableAdminTest, GetTableTooManyFailures) {
   // After all the setup, make the actual call we want to test.
   EXPECT_THROW(tested.GetTable("other-table"), std::runtime_error);
 }
+#endif  // ABSL_HAVE_EXCEPTIONS
 
 /// @test Verify that bigtable::TableAdmin::DeleteTable works as expected.
 TEST_F(TableAdminTest, DeleteTable) {

--- a/bigtable/benchmarks/benchmark_test.cc
+++ b/bigtable/benchmarks/benchmark_test.cc
@@ -35,14 +35,13 @@ TEST(BenchmarkTest, Create) {
 
   {
     Benchmark bm(setup);
-    std::string table_id;
     EXPECT_EQ(0, bm.create_table_count());
-    EXPECT_NO_THROW(table_id = bm.CreateTable());
+    std::string table_id = bm.CreateTable();
     EXPECT_EQ(1, bm.create_table_count());
     EXPECT_EQ(std::string("create-"), table_id.substr(0, 7));
 
     EXPECT_EQ(0, bm.delete_table_count());
-    EXPECT_NO_THROW(bm.DeleteTable());
+    bm.DeleteTable();
     EXPECT_EQ(1, bm.delete_table_count());
   }
   SUCCEED() << "Benchmark object successfully destroyed";
@@ -56,7 +55,7 @@ TEST(BenchmarkTest, Populate) {
   Benchmark bm(setup);
   bm.CreateTable();
   EXPECT_EQ(0, bm.mutate_rows_count());
-  EXPECT_NO_THROW(bm.PopulateTable());
+  bm.PopulateTable();
   // The magic 10000 comes from arg5 and we accept 5% error.
   EXPECT_GE(int(10000 * 1.05 / kBulkSize), bm.mutate_rows_count());
   EXPECT_LE(int(10000 * 0.95 / kBulkSize), bm.mutate_rows_count());

--- a/bigtable/benchmarks/embedded_server_test.cc
+++ b/bigtable/benchmarks/embedded_server_test.cc
@@ -48,12 +48,12 @@ TEST(EmbeddedServer, Admin) {
 
   auto gc = bigtable::GcRule::MaxNumVersions(42);
   EXPECT_EQ(0, server->create_table_count());
-  EXPECT_NO_THROW(admin.CreateTable("fake-table-01",
-                                    bigtable::TableConfig({{"fam", gc}}, {})));
+  admin.CreateTable("fake-table-01",
+                                    bigtable::TableConfig({{"fam", gc}}, {}));
   EXPECT_EQ(1, server->create_table_count());
 
   EXPECT_EQ(0, server->delete_table_count());
-  EXPECT_NO_THROW(admin.DeleteTable("fake-table-02"));
+  admin.DeleteTable("fake-table-02");
   EXPECT_EQ(1, server->delete_table_count());
 
   server->Shutdown();
@@ -77,7 +77,7 @@ TEST(EmbeddedServer, TableApply) {
        bigtable::SetCell("fam", "col", 0, "val")});
 
   EXPECT_EQ(0, server->mutate_row_count());
-  EXPECT_NO_THROW(table.Apply(std::move(mutation)));
+  table.Apply(std::move(mutation));
   EXPECT_EQ(1, server->mutate_row_count());
 
   server->Shutdown();
@@ -102,7 +102,7 @@ TEST(EmbeddedServer, TableBulkApply) {
       "row2", {bigtable::SetCell("fam", "col", 0, "val")}));
 
   EXPECT_EQ(0, server->mutate_rows_count());
-  EXPECT_NO_THROW(table.BulkApply(std::move(bulk)));
+  table.BulkApply(std::move(bulk));
   EXPECT_EQ(1, server->mutate_rows_count());
 
   server->Shutdown();

--- a/bigtable/benchmarks/embedded_server_test.cc
+++ b/bigtable/benchmarks/embedded_server_test.cc
@@ -48,8 +48,7 @@ TEST(EmbeddedServer, Admin) {
 
   auto gc = bigtable::GcRule::MaxNumVersions(42);
   EXPECT_EQ(0, server->create_table_count());
-  admin.CreateTable("fake-table-01",
-                                    bigtable::TableConfig({{"fam", gc}}, {}));
+  admin.CreateTable("fake-table-01", bigtable::TableConfig({{"fam", gc}}, {}));
   EXPECT_EQ(1, server->create_table_count());
 
   EXPECT_EQ(0, server->delete_table_count());

--- a/bigtable/benchmarks/setup.cc
+++ b/bigtable/benchmarks/setup.cc
@@ -62,8 +62,7 @@ BenchmarkSetup::BenchmarkSetup(std::string const& prefix, int& argc,
       project_id_(),
       instance_id_(),
       table_id_(MakeRandomTableId(prefix)) {
-
-  auto usage = [argv](char const *msg) {
+  auto usage = [argv](char const* msg) {
     std::string const cmd = argv[0];
     auto last_slash = std::string(argv[0]).find_last_of('/');
     std::cerr << "Usage: " << cmd.substr(last_slash + 1)

--- a/bigtable/client/client_options.h
+++ b/bigtable/client/client_options.h
@@ -86,9 +86,9 @@ class ClientOptions {
    * for the channel.
    *
    * @throws std::range_error if the @p fallback_timeout parameter is too large.
-   *     Currently gRPC uses `int` to represent the timeout in milliseconds, so
-   *     the maximum timeout is `std::numeric_limits<int>::milliseconds()` or
-   *     about 50 days on platforms where `int` is a 32-bit number.
+   *     Currently gRPC uses `int` to represent the timeout, and it is expressed
+   *     in milliseconds. Therefore, the maximum timeout is about 50 days on
+   *     platforms where `int` is a 32-bit number.
    *
    * For example:
    *

--- a/bigtable/client/client_options.h
+++ b/bigtable/client/client_options.h
@@ -19,6 +19,8 @@
 
 #include <grpc++/grpc++.h>
 
+#include "bigtable/client/internal/throw_delegate.h"
+
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -35,14 +37,14 @@ class ClientOptions {
   ClientOptions();
 
   /// Return the current endpoint for data RPCs.
-  const std::string& data_endpoint() const { return data_endpoint_; }
+  std::string const& data_endpoint() const { return data_endpoint_; }
   ClientOptions& set_data_endpoint(std::string endpoint) {
     data_endpoint_ = std::move(endpoint);
     return *this;
   }
 
   /// Return the current endpoint for admin RPCs.
-  const std::string& admin_endpoint() const { return admin_endpoint_; }
+  std::string const& admin_endpoint() const { return admin_endpoint_; }
   ClientOptions& set_admin_endpoint(std::string endpoint) {
     admin_endpoint_ = std::move(endpoint);
     return *this;
@@ -54,16 +56,15 @@ class ClientOptions {
   }
   ClientOptions& SetCredentials(
       std::shared_ptr<grpc::ChannelCredentials> credentials) {
-    credentials_ = credentials;
+    credentials_ = std::move(credentials);
     return *this;
   }
 
-  // TODO(#53) create setter/getter for each channel argument.
-  const grpc::ChannelArguments channel_arguments() const {
+  grpc::ChannelArguments channel_arguments() const {
     return channel_arguments_;
   }
   ClientOptions& set_channel_arguments(
-      grpc::ChannelArguments channel_arguments) {
+      grpc::ChannelArguments const& channel_arguments) {
     channel_arguments_ = channel_arguments;
     return *this;
   }
@@ -84,9 +85,12 @@ class ClientOptions {
    * Set the grpclb fallback timeout with the timestamp @p fallback_timeout
    * for the channel.
    *
-   * This function accepts any instantiation of 'std::chrono::duration<>' for
-   * @p duration parameter convert it into milliseconds and pass it to
-   * channel_arguments. For example:
+   * @throws std::range_error if the @p fallback_timeout parameter is too large.
+   *     Currently gRPC uses `int` to represent the timeout in milliseconds, so
+   *     the maximum timeout is `std::numeric_limits<int>::milliseconds()` or
+   *     about 50 days on platforms where `int` is a 32-bit number.
+   *
+   * For example:
    *
    * @code
    * bigtable::ClientOptions::SetGrpclbFallbackTimeout(
@@ -94,10 +98,6 @@ class ClientOptions {
    * bigtable::ClientOptions::SetGrpclbFallbackTimeout(
    *     std::chrono::seconds(5))
    * @endcode
-   *
-   * The fallback_timeout must not be empty and it should be within the range
-   * of int. The code will throw exception std::out_of_range if range goes
-   * outside of int.
    *
    * @tparam Rep a placeholder to match the Rep tparam for @p fallback_timeout,
    *     the semantics of this template parameter are documented in
@@ -125,24 +125,11 @@ class ClientOptions {
     std::chrono::milliseconds ft_ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(fallback_timeout);
 
-    if (ft_ms.count() > std::numeric_limits<int>::max())
-      throw std::out_of_range("Duration Exceeds Range for int");
-
+    if (ft_ms.count() > std::numeric_limits<int>::max()) {
+      internal::RaiseRangeError("Duration Exceeds Range for int");
+    }
     auto fallback_timeout_ms = static_cast<int>(ft_ms.count());
-
     channel_arguments_.SetGrpclbFallbackTimeout(fallback_timeout_ms);
-  }
-
-  /**
-   * Set Socket Mutator for channel.
-   *
-   * Please see the docs for grpc::ChannelArguments::SetSocketMutator()
-   * on https://grpc.io/grpc/cpp/classgrpc_1_1_channel_arguments.html
-   * for more details.
-   *
-   */
-  void SetSocketMutator(grpc_socket_mutator* mutator) {
-    channel_arguments_.SetSocketMutator(mutator);
   }
 
   /**
@@ -153,7 +140,7 @@ class ClientOptions {
    * for more details.
    *
    */
-  void SetUserAgentPrefix(const grpc::string& user_agent_prefix) {
+  void SetUserAgentPrefix(grpc::string const& user_agent_prefix) {
     channel_arguments_.SetUserAgentPrefix(user_agent_prefix);
   }
 
@@ -165,7 +152,7 @@ class ClientOptions {
    * for more details.
    *
    */
-  void SetResourceQuota(const grpc::ResourceQuota& resource_quota) {
+  void SetResourceQuota(grpc::ResourceQuota const& resource_quota) {
     channel_arguments_.SetResourceQuota(resource_quota);
   }
 
@@ -202,7 +189,7 @@ class ClientOptions {
    * for more details.
    *
    */
-  void SetLoadBalancingPolicyName(const grpc::string& lb_policy_name) {
+  void SetLoadBalancingPolicyName(grpc::string const& lb_policy_name) {
     channel_arguments_.SetLoadBalancingPolicyName(lb_policy_name);
   }
 
@@ -214,7 +201,7 @@ class ClientOptions {
    * for more details.
    *
    */
-  void SetServiceConfigJSON(const grpc::string& service_config_json) {
+  void SetServiceConfigJSON(grpc::string const& service_config_json) {
     channel_arguments_.SetServiceConfigJSON(service_config_json);
   }
 
@@ -226,7 +213,7 @@ class ClientOptions {
    * for more details.
    *
    */
-  void SetSslTargetNameOverride(const grpc::string& name) {
+  void SetSslTargetNameOverride(grpc::string const& name) {
     channel_arguments_.SetSslTargetNameOverride(name);
   }
 

--- a/bigtable/client/client_options_test.cc
+++ b/bigtable/client/client_options_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "bigtable/client/client_options.h"
+#include <absl/base/config.h>
 
 #include <cstdlib>
 #ifdef WIN32
@@ -139,6 +140,7 @@ TEST(ClientOptionsTest, SetGrpclbFallbackTimeoutSec) {
             grpc::string(test_args_second.args[1].key));
 }
 
+#if ABSL_HAVE_EXCEPTIONS
 TEST(ClientOptionsTest, SetGrpclbFallbackTimeoutException) {
   // Test if fallback_timeout exceeds int range then throw out_of_range
   // exception
@@ -146,8 +148,9 @@ TEST(ClientOptionsTest, SetGrpclbFallbackTimeoutException) {
       bigtable::ClientOptions();
   EXPECT_THROW(client_options_object_third.SetGrpclbFallbackTimeout(
                    std::chrono::hours(999)),
-               std::out_of_range);
+               std::range_error);
 }
+#endif  // ABSL_HAVE_EXCEPTIONS
 
 TEST(ClientOptionsTest, SetCompressionAlgorithm) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();

--- a/bigtable/client/internal/conjunction.h
+++ b/bigtable/client/internal/conjunction.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_CONJUNCTION_H_
 
 #include "bigtable/client/version.h"
+
 #include <type_traits>
 
 namespace bigtable {

--- a/bigtable/client/internal/conjunction.h
+++ b/bigtable/client/internal/conjunction.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_CONJUNCTION_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_CONJUNCTION_H_
 
-#include <bigtable/client/version.h>
+#include "bigtable/client/version.h"
 #include <type_traits>
 
 namespace bigtable {

--- a/bigtable/client/internal/readrowsparser.cc
+++ b/bigtable/client/internal/readrowsparser.cc
@@ -25,8 +25,7 @@ void ReadRowsParser::HandleChunk(ReadRowsResponse_CellChunk chunk) {
     RaiseRuntimeError("HandleChunk after end of stream");
   }
   if (HasNext()) {
-    RaiseRuntimeError(
-        "HandleChunk called before taking the previous row");
+    RaiseRuntimeError("HandleChunk called before taking the previous row");
   }
 
   if (not chunk.row_key().empty()) {

--- a/bigtable/client/internal/readrowsparser.cc
+++ b/bigtable/client/internal/readrowsparser.cc
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 #include "bigtable/client/internal/readrowsparser.h"
-
-#include <stdexcept>
+#include "bigtable/client/internal/throw_delegate.h"
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
@@ -23,23 +22,23 @@ using google::bigtable::v2::ReadRowsResponse_CellChunk;
 
 void ReadRowsParser::HandleChunk(ReadRowsResponse_CellChunk chunk) {
   if (end_of_stream_) {
-    throw std::runtime_error("HandleChunk after end of stream");
+    RaiseRuntimeError("HandleChunk after end of stream");
   }
   if (HasNext()) {
-    throw std::runtime_error(
+    RaiseRuntimeError(
         "HandleChunk called before taking the previous row");
   }
 
   if (not chunk.row_key().empty()) {
     if (last_seen_row_key_.compare(chunk.row_key()) >= 0) {
-      throw std::runtime_error("Row keys are expected in increasing order");
+      RaiseRuntimeError("Row keys are expected in increasing order");
     }
     chunk.mutable_row_key()->swap(cell_.row);
   }
 
   if (chunk.has_family_name()) {
     if (not chunk.has_qualifier()) {
-      throw std::runtime_error("New column family must specify qualifier");
+      RaiseRuntimeError("New column family must specify qualifier");
     }
     chunk.mutable_family_name()->mutable_value()->swap(cell_.family);
   }
@@ -73,12 +72,12 @@ void ReadRowsParser::HandleChunk(ReadRowsResponse_CellChunk chunk) {
   if (chunk.value_size() == 0) {
     if (cells_.empty()) {
       if (cell_.row.empty()) {
-        throw std::runtime_error("Missing row key at last chunk in cell");
+        RaiseRuntimeError("Missing row key at last chunk in cell");
       }
       row_key_ = cell_.row;
     } else {
       if (row_key_ != cell_.row) {
-        throw std::runtime_error("Different row key in cell chunk");
+        RaiseRuntimeError("Different row key in cell chunk");
       }
     }
     cells_.emplace_back(MovePartialToCell());
@@ -89,14 +88,14 @@ void ReadRowsParser::HandleChunk(ReadRowsResponse_CellChunk chunk) {
     cells_.clear();
     cell_ = {};
     if (not cell_first_chunk_) {
-      throw std::runtime_error("Reset row with an unfinished cell");
+      RaiseRuntimeError("Reset row with an unfinished cell");
     }
   } else if (chunk.commit_row()) {
     if (not cell_first_chunk_) {
-      throw std::runtime_error("Commit row with an unfinished cell");
+      RaiseRuntimeError("Commit row with an unfinished cell");
     }
     if (cells_.empty()) {
-      throw std::runtime_error("Commit row missing the row key");
+      RaiseRuntimeError("Commit row missing the row key");
     }
     row_ready_ = true;
     last_seen_row_key_ = row_key_;
@@ -106,16 +105,16 @@ void ReadRowsParser::HandleChunk(ReadRowsResponse_CellChunk chunk) {
 
 void ReadRowsParser::HandleEndOfStream() {
   if (end_of_stream_) {
-    throw std::runtime_error("HandleEndOfStream called twice");
+    RaiseRuntimeError("HandleEndOfStream called twice");
   }
   end_of_stream_ = true;
 
   if (not cell_first_chunk_) {
-    throw std::runtime_error("end of stream with unfinished cell");
+    RaiseRuntimeError("end of stream with unfinished cell");
   }
 
   if (cells_.begin() != cells_.end() and not row_ready_) {
-    throw std::runtime_error("end of stream with unfinished row");
+    RaiseRuntimeError("end of stream with unfinished row");
   }
 }
 
@@ -123,7 +122,7 @@ bool ReadRowsParser::HasNext() const { return row_ready_; }
 
 Row ReadRowsParser::Next() {
   if (not row_ready_) {
-    throw std::runtime_error("Next with row not ready");
+    RaiseRuntimeError("Next with row not ready");
   }
   row_ready_ = false;
 

--- a/bigtable/client/internal/readrowsparser_acceptance_tests.inc
+++ b/bigtable/client/internal/readrowsparser_acceptance_tests.inc
@@ -31,7 +31,12 @@ TEST_F(AcceptanceTest, InvalidNoCommit) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_THROW(FeedChunks(chunks), std::exception);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(FeedChunks(chunks), "exceptions");
+  return;
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {};
   EXPECT_EQ(expected_cells, ExtractCells());
@@ -48,7 +53,12 @@ TEST_F(AcceptanceTest, InvalidNoCellKeyBeforeCommit) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_THROW(FeedChunks(chunks), std::exception);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(FeedChunks(chunks), "exceptions");
+  return;
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {};
   EXPECT_EQ(expected_cells, ExtractCells());
@@ -67,7 +77,12 @@ TEST_F(AcceptanceTest, InvalidNoCellKeyBeforeValue) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_THROW(FeedChunks(chunks), std::exception);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(FeedChunks(chunks), "exceptions");
+  return;
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {};
   EXPECT_EQ(expected_cells, ExtractCells());
@@ -95,7 +110,12 @@ TEST_F(AcceptanceTest, InvalidNewColFamilyMustSpecifyQualifier) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_THROW(FeedChunks(chunks), std::exception);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(FeedChunks(chunks), "exceptions");
+  return;
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {};
   EXPECT_EQ(expected_cells, ExtractCells());
@@ -120,7 +140,11 @@ TEST_F(AcceptanceTest, BareCommitImpliesTs) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -156,7 +180,11 @@ TEST_F(AcceptanceTest, SimpleRowWithTimestamp) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -184,7 +212,11 @@ TEST_F(AcceptanceTest, MissingTimestampImpliedTs) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -211,7 +243,11 @@ TEST_F(AcceptanceTest, EmptyCellValue) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -245,7 +281,11 @@ TEST_F(AcceptanceTest, TwoUnsplitCells) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -287,7 +327,11 @@ TEST_F(AcceptanceTest, TwoQualifiers) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -330,7 +374,11 @@ TEST_F(AcceptanceTest, TwoFamilies) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -373,7 +421,11 @@ TEST_F(AcceptanceTest, WithLabels) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -417,7 +469,11 @@ TEST_F(AcceptanceTest, SplitCellBareCommit) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -458,7 +514,11 @@ TEST_F(AcceptanceTest, SplitCell) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -503,7 +563,11 @@ TEST_F(AcceptanceTest, SplitFourWays) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -547,7 +611,11 @@ TEST_F(AcceptanceTest, TwoSplitCells) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -599,7 +667,11 @@ TEST_F(AcceptanceTest, MultiqualifierSplits) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -661,7 +733,11 @@ TEST_F(AcceptanceTest, MultiqualifierMultisplit) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -714,7 +790,11 @@ TEST_F(AcceptanceTest, MultifamilySplit) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -758,7 +838,12 @@ TEST_F(AcceptanceTest, InvalidNoCommitBetweenRows) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_THROW(FeedChunks(chunks), std::exception);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(FeedChunks(chunks), "exceptions");
+  return;
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {};
   EXPECT_EQ(expected_cells, ExtractCells());
@@ -788,7 +873,12 @@ TEST_F(AcceptanceTest, InvalidNoCommitAfterFirstRow) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_THROW(FeedChunks(chunks), std::exception);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(FeedChunks(chunks), "exceptions");
+  return;
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {};
   EXPECT_EQ(expected_cells, ExtractCells());
@@ -818,7 +908,12 @@ TEST_F(AcceptanceTest, InvalidLastRowMissingCommit) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_THROW(FeedChunks(chunks), std::exception);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(FeedChunks(chunks), "exceptions");
+  return;
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK_1\n"
@@ -855,7 +950,12 @@ TEST_F(AcceptanceTest, InvalidDuplicateRowKey) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_THROW(FeedChunks(chunks), std::exception);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(FeedChunks(chunks), "exceptions");
+  return;
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK_1\n"
@@ -889,7 +989,12 @@ TEST_F(AcceptanceTest, InvalidNewRowMissingRowKey) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_THROW(FeedChunks(chunks), std::exception);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(FeedChunks(chunks), "exceptions");
+  return;
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK_1\n"
@@ -926,7 +1031,11 @@ TEST_F(AcceptanceTest, TwoRows) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK_1\n"
@@ -969,7 +1078,11 @@ TEST_F(AcceptanceTest, TwoRowsImplicitTimestamp) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK_1\n"
@@ -1011,7 +1124,11 @@ TEST_F(AcceptanceTest, TwoRowsEmptyValue) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK_1\n"
@@ -1060,7 +1177,11 @@ TEST_F(AcceptanceTest, TwoRowsOneWithMultipleCells) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK_1\n"
@@ -1123,7 +1244,11 @@ TEST_F(AcceptanceTest, TwoRowsMultipleCells) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK_1\n"
@@ -1195,7 +1320,11 @@ TEST_F(AcceptanceTest, TwoRowsMultipleCellsMultipleFamilies) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK_1\n"
@@ -1265,7 +1394,11 @@ TEST_F(AcceptanceTest, TwoRowsFourCellsLabels) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK_1\n"
@@ -1333,7 +1466,11 @@ TEST_F(AcceptanceTest, TwoRowsWithSplitsSameTimestamp) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK_1\n"
@@ -1364,7 +1501,12 @@ TEST_F(AcceptanceTest, InvalidBareReset) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_THROW(FeedChunks(chunks), std::exception);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(FeedChunks(chunks), "exceptions");
+  return;
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {};
   EXPECT_EQ(expected_cells, ExtractCells());
@@ -1389,7 +1531,12 @@ TEST_F(AcceptanceTest, InvalidBadResetNoCommit) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_THROW(FeedChunks(chunks), std::exception);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(FeedChunks(chunks), "exceptions");
+  return;
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {};
   EXPECT_EQ(expected_cells, ExtractCells());
@@ -1419,7 +1566,12 @@ TEST_F(AcceptanceTest, InvalidMissingKeyAfterReset) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_THROW(FeedChunks(chunks), std::exception);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(FeedChunks(chunks), "exceptions");
+  return;
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {};
   EXPECT_EQ(expected_cells, ExtractCells());
@@ -1444,7 +1596,11 @@ TEST_F(AcceptanceTest, NoDataAfterReset) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {};
   EXPECT_EQ(expected_cells, ExtractCells());
@@ -1477,7 +1633,11 @@ TEST_F(AcceptanceTest, SimpleReset) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -1517,7 +1677,11 @@ TEST_F(AcceptanceTest, ResetToNewVal) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -1557,7 +1721,11 @@ TEST_F(AcceptanceTest, ResetToNewQual) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -1602,7 +1770,11 @@ TEST_F(AcceptanceTest, ResetWithSplits) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -1647,7 +1819,11 @@ TEST_F(AcceptanceTest, ResetTwoCells) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -1705,7 +1881,11 @@ TEST_F(AcceptanceTest, TwoResets) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -1751,7 +1931,11 @@ TEST_F(AcceptanceTest, ResetThenTwoCells) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"
@@ -1798,7 +1982,11 @@ TEST_F(AcceptanceTest, ResetToNewRow) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK_2\n"
@@ -1845,7 +2033,11 @@ TEST_F(AcceptanceTest, ResetInBetweenChunks) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK_1\n"
@@ -1881,7 +2073,12 @@ TEST_F(AcceptanceTest, InvalidResetWithChunk) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_THROW(FeedChunks(chunks), std::exception);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(FeedChunks(chunks), "exceptions");
+  return;
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {};
   EXPECT_EQ(expected_cells, ExtractCells());
@@ -1910,7 +2107,12 @@ TEST_F(AcceptanceTest, InvalidCommitWithChunk) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_THROW(FeedChunks(chunks), std::exception);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(FeedChunks(chunks), "exceptions");
+  return;
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {};
   EXPECT_EQ(expected_cells, ExtractCells());
@@ -1938,7 +2140,11 @@ TEST_F(AcceptanceTest, EmptyCellChunk) {
   auto chunks = ConvertChunks(std::move(chunk_strings));
   ASSERT_FALSE(chunks.empty());
 
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_NO_THROW(FeedChunks(chunks));
+#else
+  FeedChunks(chunks);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
   std::vector<std::string> expected_cells = {
       "rk: RK\n"

--- a/bigtable/client/internal/readrowsparser_test.cc
+++ b/bigtable/client/internal/readrowsparser_test.cc
@@ -35,6 +35,7 @@ TEST(ReadRowsParserTest, NoChunksNoRowsSucceeds) {
   EXPECT_FALSE(parser.HasNext());
 }
 
+#if ABSL_HAVE_EXCEPTIONS
 TEST(ReadRowsParserTest, HandleEndOfStreamCalledTwiceThrows) {
   ReadRowsParser parser;
 
@@ -54,6 +55,7 @@ TEST(ReadRowsParserTest, HandleChunkAfterEndOfStreamThrows) {
   EXPECT_THROW(parser.HandleChunk(chunk), std::exception);
   EXPECT_FALSE(parser.HasNext());
 }
+#endif  // ABSL_HAVE_EXCEPTIONS
 
 TEST(ReadRowsParserTest, SingleChunkSucceeds) {
   using google::protobuf::TextFormat;
@@ -111,6 +113,7 @@ TEST(ReadRowsParserTest, NextAfterEndOfStreamSucceeds) {
   EXPECT_FALSE(parser.HasNext());
 }
 
+#if ABSL_HAVE_EXCEPTIONS
 TEST(ReadRowsParserTest, NextWithNoDataThrows) {
   ReadRowsParser parser;
 
@@ -120,6 +123,7 @@ TEST(ReadRowsParserTest, NextWithNoDataThrows) {
   EXPECT_FALSE(parser.HasNext());
   EXPECT_THROW(parser.Next(), std::exception);
 }
+#endif  // ABSL_HAVE_EXCEPTIONS
 
 TEST(ReadRowsParserTest, SingleChunkValueIsMoved) {
   using google::protobuf::TextFormat;

--- a/bigtable/client/internal/readrowsparser_test.cc
+++ b/bigtable/client/internal/readrowsparser_test.cc
@@ -44,6 +44,7 @@ TEST(ReadRowsParserTest, HandleEndOfStreamCalledTwiceThrows) {
   EXPECT_THROW(parser.HandleEndOfStream(), std::exception);
   EXPECT_FALSE(parser.HasNext());
 }
+#endif  // ABSL_HAVE_EXCEPTIONS
 
 TEST(ReadRowsParserTest, HandleChunkAfterEndOfStreamThrows) {
   ReadRowsParser parser;
@@ -52,10 +53,13 @@ TEST(ReadRowsParserTest, HandleChunkAfterEndOfStreamThrows) {
 
   EXPECT_FALSE(parser.HasNext());
   parser.HandleEndOfStream();
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_THROW(parser.HandleChunk(chunk), std::exception);
   EXPECT_FALSE(parser.HasNext());
-}
+#else
+  EXPECT_DEATH_IF_SUPPORTED(parser.HandleChunk(chunk), "exceptions");
 #endif  // ABSL_HAVE_EXCEPTIONS
+}
 
 TEST(ReadRowsParserTest, SingleChunkSucceeds) {
   using google::protobuf::TextFormat;
@@ -113,17 +117,20 @@ TEST(ReadRowsParserTest, NextAfterEndOfStreamSucceeds) {
   EXPECT_FALSE(parser.HasNext());
 }
 
-#if ABSL_HAVE_EXCEPTIONS
 TEST(ReadRowsParserTest, NextWithNoDataThrows) {
   ReadRowsParser parser;
 
   EXPECT_FALSE(parser.HasNext());
   parser.HandleEndOfStream();
 
+
   EXPECT_FALSE(parser.HasNext());
+#if ABSL_HAVE_EXCEPTIONS
   EXPECT_THROW(parser.Next(), std::exception);
-}
+#else
+  ASSERT_DEATH_IF_SUPPORTED(parser.Next(), "exceptions are disabled");
 #endif  // ABSL_HAVE_EXCEPTIONS
+}
 
 TEST(ReadRowsParserTest, SingleChunkValueIsMoved) {
   using google::protobuf::TextFormat;

--- a/bigtable/client/internal/readrowsparser_test.cc
+++ b/bigtable/client/internal/readrowsparser_test.cc
@@ -123,7 +123,6 @@ TEST(ReadRowsParserTest, NextWithNoDataThrows) {
   EXPECT_FALSE(parser.HasNext());
   parser.HandleEndOfStream();
 
-
   EXPECT_FALSE(parser.HasNext());
 #if ABSL_HAVE_EXCEPTIONS
   EXPECT_THROW(parser.Next(), std::exception);

--- a/bigtable/client/internal/throw_delegate.cc
+++ b/bigtable/client/internal/throw_delegate.cc
@@ -38,12 +38,12 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
 
-[[noreturn]] void RaiseRuntimeError(char const* msg) {
-  RaiseException<std::runtime_error>(msg);
+[[noreturn]] void RaiseInvalidArgument(char const* msg) {
+  RaiseException<std::invalid_argument>(msg);
 }
 
-[[noreturn]] void RaiseRuntimeError(std::string const& msg) {
-  RaiseException<std::runtime_error>(msg.c_str());
+[[noreturn]] void RaiseInvalidArgument(std::string const& msg) {
+  RaiseException<std::invalid_argument>(msg.c_str());
 }
 
 [[noreturn]] void RaiseRangeError(char const* msg) {
@@ -53,6 +53,15 @@ namespace internal {
 [[noreturn]] void RaiseRangeError(std::string const& msg) {
   RaiseException<std::range_error>(msg.c_str());
 }
+
+[[noreturn]] void RaiseRuntimeError(char const* msg) {
+  RaiseException<std::runtime_error>(msg);
+}
+
+[[noreturn]] void RaiseRuntimeError(std::string const& msg) {
+  RaiseException<std::runtime_error>(msg.c_str());
+}
+
 
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS

--- a/bigtable/client/internal/throw_delegate.cc
+++ b/bigtable/client/internal/throw_delegate.cc
@@ -62,7 +62,6 @@ namespace internal {
   RaiseException<std::runtime_error>(msg.c_str());
 }
 
-
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/bigtable/client/internal/throw_delegate.cc
+++ b/bigtable/client/internal/throw_delegate.cc
@@ -1,0 +1,59 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/client/internal/throw_delegate.h"
+
+#include <absl/base/config.h>
+
+#if ABSL_HAVE_EXCEPTIONS
+#include <stdexcept>
+#endif  // ABSL_HAVE_EXCEPTIONS
+
+#include <iostream>
+
+namespace {
+template <typename Exception>
+[[noreturn]] void RaiseException(char const* msg) {
+#ifdef ABSL_HAVE_EXCEPTIONS
+  throw Exception(msg);
+#else
+  std::cerr << "Aborting because exceptions are disabled: " << msg << std::endl;
+  std::abort();
+#endif  // ABSL_HAVE_EXCEPTIONS
+}
+}
+
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
+
+[[noreturn]] void RaiseRuntimeError(char const* msg) {
+  RaiseException<std::runtime_error>(msg);
+}
+
+[[noreturn]] void RaiseRuntimeError(std::string const& msg) {
+  RaiseException<std::runtime_error>(msg.c_str());
+}
+
+[[noreturn]] void RaiseRangeError(char const* msg) {
+  RaiseException<std::range_error>(msg);
+}
+
+[[noreturn]] void RaiseRangeError(std::string const& msg) {
+  RaiseException<std::range_error>(msg.c_str());
+}
+
+}  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable

--- a/bigtable/client/internal/throw_delegate.h
+++ b/bigtable/client/internal/throw_delegate.h
@@ -32,11 +32,14 @@ namespace internal {
  * We copied this technique from Abseil.  Unfortunately we cannot use it
  * directly because it is not a public interface for Abseil.
  */
-[[noreturn]] void RaiseRuntimeError(char const* msg);
-[[noreturn]] void RaiseRuntimeError(std::string const& msg);
+[[noreturn]] void RaiseInvalidArgument(char const* msg);
+[[noreturn]] void RaiseInvalidArgument(std::string const& msg);
 
 [[noreturn]] void RaiseRangeError(char const* msg);
 [[noreturn]] void RaiseRangeError(std::string const& msg);
+
+[[noreturn]] void RaiseRuntimeError(char const* msg);
+[[noreturn]] void RaiseRuntimeError(std::string const& msg);
 //@}
 
 }  // namespace internal

--- a/bigtable/client/internal/throw_delegate.h
+++ b/bigtable/client/internal/throw_delegate.h
@@ -1,0 +1,46 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_THROW_DELEGATE_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_THROW_DELEGATE_H_
+
+#include "bigtable/client/version.h"
+
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
+
+//@{
+/**
+ * @name Delete exception raising to hidden functions.
+ *
+ * The following functions raise the corresponding exception, unless the user
+ * has disabled exception handling, in which case they print the error message
+ * to std::cerr and call std::abort().
+ *
+ * We copied this technique from Abseil.  Unfortunately we cannot use it
+ * directly because it is not a public interface for Abseil.
+ */
+[[noreturn]] void RaiseRuntimeError(char const* msg);
+[[noreturn]] void RaiseRuntimeError(std::string const& msg);
+
+[[noreturn]] void RaiseRangeError(char const* msg);
+[[noreturn]] void RaiseRangeError(std::string const& msg);
+//@}
+
+}  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_THROW_DELEGATE_H_

--- a/bigtable/client/mutations.cc
+++ b/bigtable/client/mutations.cc
@@ -17,7 +17,8 @@
 #include <google/protobuf/text_format.h>
 
 #include <sstream>
-#include <stdexcept>
+
+#include "bigtable/client/internal/throw_delegate.h"
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
@@ -49,13 +50,13 @@ Mutation DeleteFromColumn(std::string family, std::string column,
     std::ostringstream os;
     os << "invalid time range in DeleteFromColumn [" << timestamp_begin << ","
        << timestamp_end << ")";
-    throw std::range_error(os.str());
+    internal::RaiseRangeError(os.str());
   }
   if (timestamp_end == timestamp_begin and timestamp_end != 0) {
     std::ostringstream os;
     os << "invalid time range in DeleteFromColumn [" << timestamp_begin << ","
        << timestamp_end << ")";
-    throw std::range_error(os.str());
+    internal::RaiseRangeError(os.str());
   }
   Mutation m;
   auto& d = *m.op.mutable_delete_from_column();

--- a/bigtable/client/mutations_test.cc
+++ b/bigtable/client/mutations_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "bigtable/client/mutations.h"
+#include <absl/base/config.h>
 #include <google/rpc/error_details.pb.h>
 
 #include <gmock/gmock.h>
@@ -49,14 +50,19 @@ TEST(MutationsTest, SetCell) {
   EXPECT_EQ(val_data, moved.op.set_cell().value().data());
 }
 
-/// @test Verify that DeleteFromColumn() and friends work as expected.
-TEST(MutationsTest, DeleteFromColumn) {
+#if ABSL_HAVE_EXCEPTIONS
+/// @test Verify that DeleteFromColumn() validates inputs as expected.
+TEST(MutationsTest, DeleteFromColumnValidation) {
   // Invalid ranges should fail.
   EXPECT_THROW(bigtable::DeleteFromColumn("family", "col", 20, 0),
                std::range_error);
   EXPECT_THROW(bigtable::DeleteFromColumn("family", "col", 1000, 1000),
                std::range_error);
+}
+#endif  // ABSL_HAVE_EXCEPTIONS
 
+/// @test Verify that DeleteFromColumn() and friends work as expected.
+TEST(MutationsTest, DeleteFromColumn) {
   auto actual = bigtable::DeleteFromColumn("family", "col", 1234, 1235);
   ASSERT_TRUE(actual.op.has_delete_from_column());
   {

--- a/bigtable/client/row_reader.cc
+++ b/bigtable/client/row_reader.cc
@@ -157,7 +157,8 @@ void RowReader::Advance(absl::optional<Row>& row) {
     }
 
     if (not status.ok() and not retry_policy_->on_failure(status)) {
-      internal::RaiseRuntimeError("Unretriable error: " + status.error_message());
+      internal::RaiseRuntimeError("Unretriable error: " +
+                                  status.error_message());
     }
 
     auto delay = backoff_policy_->on_completion(status);

--- a/bigtable/client/row_reader.cc
+++ b/bigtable/client/row_reader.cc
@@ -16,6 +16,8 @@
 
 #include <thread>
 
+#include "bigtable/client/internal/throw_delegate.h"
+
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 // RowReader::iterator must satisfy the requirements of an InputIterator.
@@ -64,7 +66,7 @@ RowReader::RowReader(
 
 RowReader::iterator RowReader::begin() {
   if (operation_cancelled_) {
-    throw std::runtime_error("Operation already cancelled.");
+    internal::RaiseRuntimeError("Operation already cancelled.");
   }
   if (not stream_) {
     MakeRequest();
@@ -120,12 +122,16 @@ void RowReader::Advance(absl::optional<Row>& row) {
   while (true) {
     grpc::Status status = grpc::Status::OK;
 
+#if ABSL_HAVE_EXCEPTIONS
     try {
       status = AdvanceOrFail(row);
-    } catch (std::exception ex) {
+    } catch (std::exception const& ex) {
       // Parser exceptions arrive here.
       status = grpc::Status(grpc::INTERNAL, ex.what());
     }
+#else
+    status = AdvanceOrFail(row);
+#endif  // ABSL_HAVE_EXCEPTIONS
 
     if (status.ok()) {
       return;
@@ -151,7 +157,7 @@ void RowReader::Advance(absl::optional<Row>& row) {
     }
 
     if (not status.ok() and not retry_policy_->on_failure(status)) {
-      throw std::runtime_error("Unretriable error: " + status.error_message());
+      internal::RaiseRuntimeError("Unretriable error: " + status.error_message());
     }
 
     auto delay = backoff_policy_->on_completion(status);

--- a/bigtable/client/row_reader_test.cc
+++ b/bigtable/client/row_reader_test.cc
@@ -290,6 +290,7 @@ TEST_F(RowReaderTest, FailedStreamIsRetried) {
   EXPECT_EQ(++it, reader.end());
 }
 
+#if ABSL_HAVE_EXCEPTIONS
 TEST_F(RowReaderTest, FailedStreamWithNoRetryThrows) {
   auto* stream = new MockResponseStream();  // wrapped in unique_ptr by ReadRows
   auto parser = absl::make_unique<ReadRowsParserMock>();
@@ -312,6 +313,7 @@ TEST_F(RowReaderTest, FailedStreamWithNoRetryThrows) {
 
   EXPECT_THROW(reader.begin(), std::exception);
 }
+#endif  // ABSL_HAVE_EXCEPTIONS
 
 TEST_F(RowReaderTest, FailedStreamRetriesSkipAlreadyReadRows) {
   auto* stream = new MockResponseStream();  // wrapped in unique_ptr by ReadRows
@@ -390,6 +392,7 @@ TEST_F(RowReaderTest, FailedParseIsRetried) {
   EXPECT_EQ(++it, reader.end());
 }
 
+#if ABSL_HAVE_EXCEPTIONS
 TEST_F(RowReaderTest, FailedParseWithNoRetryThrows) {
   auto* stream = new MockResponseStream();  // wrapped in unique_ptr by ReadRows
   auto parser = absl::make_unique<ReadRowsParserMock>();
@@ -413,6 +416,7 @@ TEST_F(RowReaderTest, FailedParseWithNoRetryThrows) {
 
   EXPECT_THROW(reader.begin(), std::exception);
 }
+#endif  // ABSL_HAVE_EXCEPTIONS
 
 TEST_F(RowReaderTest, FailedParseRetriesSkipAlreadyReadRows) {
   auto* stream = new MockResponseStream();  // wrapped in unique_ptr by ReadRows
@@ -573,6 +577,7 @@ TEST_F(RowReaderTest, RowLimitIsNotDecreasedToZero) {
   EXPECT_EQ(++it, reader.end());
 }
 
+#if ABSL_HAVE_EXCEPTIONS
 TEST_F(RowReaderTest, BeginThrowsAfterCancelClosesStream) {
   auto parser = absl::make_unique<ReadRowsParserMock>();
   parser->SetRows({"r1"});
@@ -612,6 +617,7 @@ TEST_F(RowReaderTest, BeginThrowsAfterImmediateCancel) {
 
   EXPECT_THROW(reader.begin(), std::runtime_error);
 }
+#endif  // ABSL_HAVE_EXCEPTIONS
 
 TEST_F(RowReaderTest, RowReaderConstructorDoesNotCallRpc) {
   // The RowReader constructor/destructor by themselves should not

--- a/bigtable/client/row_reader_test.cc
+++ b/bigtable/client/row_reader_test.cc
@@ -28,7 +28,6 @@ using testing::Matcher;
 using testing::Property;
 using testing::Return;
 using testing::SetArgPointee;
-using testing::Throw;
 using testing::_;
 
 using google::bigtable::v2::ReadRowsRequest;
@@ -355,6 +354,10 @@ TEST_F(RowReaderTest, FailedStreamRetriesSkipAlreadyReadRows) {
   EXPECT_EQ(++it, reader.end());
 }
 
+#if ABSL_HAVE_EXCEPTIONS
+
+using testing::Throw;
+
 TEST_F(RowReaderTest, FailedParseIsRetried) {
   auto* stream = new MockResponseStream();  // wrapped in unique_ptr by ReadRows
   auto parser = absl::make_unique<ReadRowsParserMock>();
@@ -392,7 +395,6 @@ TEST_F(RowReaderTest, FailedParseIsRetried) {
   EXPECT_EQ(++it, reader.end());
 }
 
-#if ABSL_HAVE_EXCEPTIONS
 TEST_F(RowReaderTest, FailedParseWithNoRetryThrows) {
   auto* stream = new MockResponseStream();  // wrapped in unique_ptr by ReadRows
   auto parser = absl::make_unique<ReadRowsParserMock>();
@@ -416,7 +418,6 @@ TEST_F(RowReaderTest, FailedParseWithNoRetryThrows) {
 
   EXPECT_THROW(reader.begin(), std::exception);
 }
-#endif  // ABSL_HAVE_EXCEPTIONS
 
 TEST_F(RowReaderTest, FailedParseRetriesSkipAlreadyReadRows) {
   auto* stream = new MockResponseStream();  // wrapped in unique_ptr by ReadRows
@@ -458,6 +459,7 @@ TEST_F(RowReaderTest, FailedParseRetriesSkipAlreadyReadRows) {
   EXPECT_EQ(it->row_key(), "r1");
   EXPECT_EQ(++it, reader.end());
 }
+#endif  // ABSL_HAVE_EXCEPTIONS
 
 TEST_F(RowReaderTest, FailedStreamWithAllRequiedRowsSeenShouldNotRetry) {
   auto* stream = new MockResponseStream();  // wrapped in unique_ptr by ReadRows

--- a/bigtable/client/row_reader_test.cc
+++ b/bigtable/client/row_reader_test.cc
@@ -105,7 +105,7 @@ class RetryPolicyMock : public bigtable::RPCRetryPolicy {
  public:
   RetryPolicyMock() {}
   std::unique_ptr<RPCRetryPolicy> clone() const override {
-    throw std::runtime_error("Mocks cannot be copied.");
+    bigtable::internal::RaiseRuntimeError("Mocks cannot be copied.");
   }
 
   MOCK_CONST_METHOD1(setup_impl, void(grpc::ClientContext&));
@@ -125,7 +125,7 @@ class BackoffPolicyMock : public bigtable::RPCBackoffPolicy {
  public:
   BackoffPolicyMock() {}
   std::unique_ptr<RPCBackoffPolicy> clone() const override {
-    throw std::runtime_error("Mocks cannot be copied.");
+    bigtable::internal::RaiseRuntimeError("Mocks cannot be copied.");
   }
   void setup(grpc::ClientContext& context) const override {}
   MOCK_METHOD1(on_completion_impl,

--- a/bigtable/client/table.cc
+++ b/bigtable/client/table.cc
@@ -22,15 +22,14 @@
 namespace btproto = ::google::bigtable::v2;
 
 namespace {
-[[noreturn]] void ReportPermanentFailures(char const* msg, grpc::Status const& status,
-                                          std::vector<bigtable::FailedMutation> failures) {
+[[noreturn]] void ReportPermanentFailures(
+    char const* msg, grpc::Status const& status,
+    std::vector<bigtable::FailedMutation> failures) {
 #if ABSL_HAVE_EXCEPTIONS
-  throw bigtable::PermanentMutationFailure(msg,
-                                 status, std::move(failures));
+  throw bigtable::PermanentMutationFailure(msg, status, std::move(failures));
 #else
-  std::cerr << "Permanent (or too many transient) errors in "
-            << "able::BulkApply()";
-  std::cerr << "Status: " << status.error_message() << " ["
+  std::cerr << msg << "\n"
+            << "Status: " << status.error_message() << " ["
             << status.error_code() << "] - " << status.error_details()
             << std::endl;
   for (auto const& failed : failures) {
@@ -38,10 +37,9 @@ namespace {
               << failed.status().error_message() << " ["
               << failed.status().error_code() << "]" << std::endl;
   }
+  std::cerr << "Aborting because exceptions are disabled." << std::endl;
   std::abort();
 #endif  // ABSL_HAVE_EXCEPTIONS
-
-
 }
 }
 

--- a/bigtable/client/table.cc
+++ b/bigtable/client/table.cc
@@ -145,7 +145,7 @@ RowReader Table::ReadRows(RowSet row_set, Filter filter) {
 RowReader Table::ReadRows(RowSet row_set, std::int64_t rows_limit,
                           Filter filter) {
   if (rows_limit <= 0) {
-    internal::RaiseRuntimeError("rows_limit must be >0");
+    internal::RaiseInvalidArgument("rows_limit must be >0");
   }
   return RowReader(
       client_, table_name(), std::move(row_set), rows_limit, std::move(filter),

--- a/bigtable/client/table_apply_test.cc
+++ b/bigtable/client/table_apply_test.cc
@@ -31,6 +31,7 @@ TEST_F(TableApplyTest, Simple) {
       "bar", {bigtable::SetCell("fam", "col", 0, "val")})));
 }
 
+#if ABSL_HAVE_EXCEPTIONS
 /// @test Verify that Table::Apply() raises an exception on permanent failures.
 TEST_F(TableApplyTest, Failure) {
   using namespace ::testing;
@@ -43,6 +44,7 @@ TEST_F(TableApplyTest, Failure) {
                    "bar", {bigtable::SetCell("fam", "col", 0, "val")})),
                std::exception);
 }
+#endif  // ABSL_HAVE_EXCEPTIONS
 
 /// @test Verify that Table::Apply() retries on partial failures.
 TEST_F(TableApplyTest, Retry) {

--- a/bigtable/client/table_bulk_apply_test.cc
+++ b/bigtable/client/table_bulk_apply_test.cc
@@ -119,6 +119,8 @@ TEST_F(TableBulkApplyTest, RetryPartialFailure) {
                             {bigtable::SetCell("fam", "col", 0, "qux")}))));
 }
 
+// TODO(#234) - this test could be enabled when bug is closed.
+#if ABSL_HAVE_EXCEPTIONS
 /// @test Verify that Table::BulkApply() handles permanent failures.
 TEST_F(TableBulkApplyTest, PermanentFailure) {
   using namespace ::testing;
@@ -155,6 +157,7 @@ TEST_F(TableBulkApplyTest, PermanentFailure) {
           bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0, "qux")}))),
       std::exception);
 }
+#endif  // ABSL_HAVE_EXCEPTIONS
 
 /// @test Verify that Table::BulkApply() handles a terminated stream.
 TEST_F(TableBulkApplyTest, CanceledStream) {
@@ -208,6 +211,8 @@ TEST_F(TableBulkApplyTest, CanceledStream) {
       bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0, "qux")}))));
 }
 
+// TODO(#234) - test should be enabled when bug is closed.
+#if ABSL_HAVE_EXCEPTIONS
 /// @test Verify that Table::BulkApply() reports correctly on too many errors.
 TEST_F(TableBulkApplyTest, TooManyFailures) {
   using namespace ::testing;
@@ -265,6 +270,7 @@ TEST_F(TableBulkApplyTest, TooManyFailures) {
           bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0, "qux")}))),
       std::exception);
 }
+#endif  // ABSL_HAVE_EXCEPTIONS
 
 /// @test Verify that Table::BulkApply() retries only idempotent mutations.
 TEST_F(TableBulkApplyTest, RetryOnlyIdempotent) {

--- a/bigtable/client/table_bulk_apply_test.cc
+++ b/bigtable/client/table_bulk_apply_test.cc
@@ -64,9 +64,10 @@ TEST_F(TableBulkApplyTest, Simple) {
             return reader.release();
           }));
 
-  EXPECT_NO_THROW(table_.BulkApply(bt::BulkMutation(
+  table_.BulkApply(bt::BulkMutation(
       bt::SingleRowMutation("foo", {bt::SetCell("fam", "col", 0, "baz")}),
-      bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0, "qux")}))));
+      bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0, "qux")})));
+  SUCCEED();
 }
 
 /// @test Verify that Table::BulkApply() retries partial failures.
@@ -113,10 +114,11 @@ TEST_F(TableBulkApplyTest, RetryPartialFailure) {
             return r2.release();
           }));
 
-  EXPECT_NO_THROW(table_.BulkApply(bt::BulkMutation(
+  table_.BulkApply(bt::BulkMutation(
       bt::SingleRowMutation("foo", {bigtable::SetCell("fam", "col", 0, "baz")}),
       bt::SingleRowMutation("bar",
-                            {bigtable::SetCell("fam", "col", 0, "qux")}))));
+                            {bigtable::SetCell("fam", "col", 0, "qux")})));
+  SUCCEED();
 }
 
 // TODO(#234) - this test could be enabled when bug is closed.
@@ -206,12 +208,13 @@ TEST_F(TableBulkApplyTest, CanceledStream) {
             return r2.release();
           }));
 
-  EXPECT_NO_THROW(table_.BulkApply(bt::BulkMutation(
+  table_.BulkApply(bt::BulkMutation(
       bt::SingleRowMutation("foo", {bt::SetCell("fam", "col", 0, "baz")}),
-      bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0, "qux")}))));
+      bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0, "qux")})));
+  SUCCEED();
 }
 
-// TODO(#234) - test should be enabled when bug is closed.
+// TODO(#234) - these test should be modified and enabled when bug is closed.
 #if ABSL_HAVE_EXCEPTIONS
 /// @test Verify that Table::BulkApply() reports correctly on too many errors.
 TEST_F(TableBulkApplyTest, TooManyFailures) {
@@ -270,7 +273,6 @@ TEST_F(TableBulkApplyTest, TooManyFailures) {
           bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0, "qux")}))),
       std::exception);
 }
-#endif  // ABSL_HAVE_EXCEPTIONS
 
 /// @test Verify that Table::BulkApply() retries only idempotent mutations.
 TEST_F(TableBulkApplyTest, RetryOnlyIdempotent) {
@@ -357,3 +359,4 @@ TEST_F(TableBulkApplyTest, FailedRPC) {
     FAIL() << "unexpected exception of unknown type raised";
   }
 }
+#endif  // ABSL_HAVE_EXCEPTIONS

--- a/bigtable/client/table_readrows_test.cc
+++ b/bigtable/client/table_readrows_test.cc
@@ -54,6 +54,7 @@ TEST_F(TableReadRowsTest, ReadRowsCanReadOneRow) {
   EXPECT_EQ(++it, reader.end());
 }
 
+#if ABSL_HAVE_EXCEPTIONS
 TEST_F(TableReadRowsTest, ReadRowsFailsForIllegalRowLimit) {
   EXPECT_THROW(
       table_.ReadRows(bigtable::RowSet(), 0, bigtable::Filter::PassAllFilter()),
@@ -62,6 +63,7 @@ TEST_F(TableReadRowsTest, ReadRowsFailsForIllegalRowLimit) {
                                bigtable::Filter::PassAllFilter()),
                std::invalid_argument);
 }
+#endif  // ABSL_HAVE_EXCEPTIONS
 
 TEST_F(TableReadRowsTest, ReadRowsCanReadWithRetries) {
   auto response = bigtable::testing::ReadRowsResponseFromString(R"(
@@ -120,6 +122,7 @@ TEST_F(TableReadRowsTest, ReadRowsCanReadWithRetries) {
   EXPECT_EQ(++it, reader.end());
 }
 
+#if ABSL_HAVE_EXCEPTIONS
 TEST_F(TableReadRowsTest, ReadRowsThrowsWhenTooManyErrors) {
   EXPECT_CALL(*bigtable_stub_, ReadRowsRaw(_, _))
       .WillRepeatedly(testing::WithoutArgs(testing::Invoke([] {
@@ -141,3 +144,4 @@ TEST_F(TableReadRowsTest, ReadRowsThrowsWhenTooManyErrors) {
 
   EXPECT_THROW(reader.begin(), std::exception);
 }
+#endif  // ABSL_HAVE_EXCEPTIONS

--- a/bigtable/client/testing/table_test_fixture.cc
+++ b/bigtable/client/testing/table_test_fixture.cc
@@ -16,6 +16,8 @@
 
 #include <google/protobuf/text_format.h>
 
+#include "bigtable/client/internal/throw_delegate.h"
+
 namespace bigtable {
 namespace testing {
 
@@ -23,7 +25,7 @@ google::bigtable::v2::ReadRowsResponse ReadRowsResponseFromString(
     std::string repr) {
   google::bigtable::v2::ReadRowsResponse response;
   if (!google::protobuf::TextFormat::ParseFromString(repr, &response)) {
-    throw std::runtime_error("Failed to parse " + repr);
+    bigtable::internal::RaiseRuntimeError("Failed to parse " + repr);
   }
   return response;
 }

--- a/bigtable/tests/admin_integration_test.cc
+++ b/bigtable/tests/admin_integration_test.cc
@@ -103,7 +103,7 @@ class AdminIntegrationTest : public bigtable::testing::TableIntegrationTest {
   }
 };
 
-}  // anonymus namespace
+}  // namespace
 
 /***
  * Test case for checking create table
@@ -264,8 +264,9 @@ int main(int argc, char* argv[]) {
   // If Instance is not empty then dont start test cases
   auto table_list = admin.ListTables(admin_proto::Table::NAME_ONLY);
   if (not table_list.empty()) {
-    throw std::runtime_error(
-        "Expected empty instance at the beginning of integration test");
+    std::cerr << "Expected empty instance at the beginning of integration test"
+              << std::endl;
+    return 1;
   }
 
   (void)::testing::AddGlobalTestEnvironment(

--- a/bigtable/tests/admin_integration_test.cc
+++ b/bigtable/tests/admin_integration_test.cc
@@ -14,6 +14,7 @@
 
 #include <absl/memory/memory.h>
 #include <absl/strings/str_join.h>
+
 #include <gmock/gmock.h>
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
@@ -240,7 +241,7 @@ TEST_F(AdminIntegrationTest, CheckModifyTable) {
 }
 // Test Cases Finished
 
-int main(int argc, char* argv[]) try {
+int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
 
   // Check for arguments validity
@@ -271,10 +272,4 @@ int main(int argc, char* argv[]) try {
       new bigtable::testing::TableTestEnvironment(project_id, instance_id));
 
   return RUN_ALL_TESTS();
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << std::endl;
-  return 1;
-} catch (...) {
-  std::cerr << "Unknown exception raised." << std::endl;
-  return 1;
 }

--- a/bigtable/tests/data_integration_test.cc
+++ b/bigtable/tests/data_integration_test.cc
@@ -21,9 +21,9 @@
 #include "bigtable/admin/table_admin.h"
 #include "bigtable/client/cell.h"
 #include "bigtable/client/data_client.h"
+#include "bigtable/client/internal/throw_delegate.h"
 #include "bigtable/client/table.h"
 #include "bigtable/client/testing/table_integration_test.h"
-#include "bigtable/client/internal/throw_delegate.h"
 
 namespace admin_proto = ::google::bigtable::admin::v2;
 
@@ -48,7 +48,7 @@ class DataIntegrationTest : public TableIntegrationTest {
 }  // namespace testing
 }  // namespace bigtable
 
-int main(int argc, char* argv[]) try {
+int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
 
   // Make sure the arguments are valid.
@@ -69,33 +69,15 @@ int main(int argc, char* argv[]) try {
 
   auto table_list = admin.ListTables(admin_proto::Table::NAME_ONLY);
   if (not table_list.empty()) {
-    std::ostringstream os;
-    os << "Expected empty instance at the beginning of integration test";
-    bigtable::internal::RaiseRuntimeError(os.str());
+    std::cerr << "Expected empty instance at the beginning of integration "
+              << "test";
+    return 1;
   }
 
   (void)::testing::AddGlobalTestEnvironment(
       new ::bigtable::testing::TableTestEnvironment(project_id, instance_id));
 
   return RUN_ALL_TESTS();
-
-} catch (bigtable::PermanentMutationFailure const& ex) {
-  std::cerr << "bigtable::PermanentMutationFailure raised: " << ex.what()
-            << " - " << ex.status().error_message() << " ["
-            << ex.status().error_code()
-            << "], details=" << ex.status().error_details() << std::endl;
-  int count = 0;
-  for (auto const& failure : ex.failures()) {
-    std::cerr << "failure[" << count++
-              << "] {key=" << failure.mutation().row_key() << "}" << std::endl;
-  }
-  return 1;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << std::endl;
-  return 1;
-} catch (...) {
-  std::cerr << "Unknown exception raised." << std::endl;
-  return 1;
 }
 
 namespace bigtable {

--- a/bigtable/tests/data_integration_test.cc
+++ b/bigtable/tests/data_integration_test.cc
@@ -23,6 +23,7 @@
 #include "bigtable/client/data_client.h"
 #include "bigtable/client/table.h"
 #include "bigtable/client/testing/table_integration_test.h"
+#include "bigtable/client/internal/throw_delegate.h"
 
 namespace admin_proto = ::google::bigtable::admin::v2;
 
@@ -70,7 +71,7 @@ int main(int argc, char* argv[]) try {
   if (not table_list.empty()) {
     std::ostringstream os;
     os << "Expected empty instance at the beginning of integration test";
-    throw std::runtime_error(os.str());
+    bigtable::internal::RaiseRuntimeError(os.str());
   }
 
   (void)::testing::AddGlobalTestEnvironment(

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -17,7 +17,6 @@
 #include <cmath>
 #include <sstream>
 
-#include <absl/memory/memory.h>
 #include <absl/strings/str_join.h>
 
 #include <gmock/gmock.h>
@@ -28,6 +27,7 @@
 #include "bigtable/client/data_client.h"
 #include "bigtable/client/table.h"
 #include "bigtable/client/testing/table_integration_test.h"
+#include "bigtable/client/internal/throw_delegate.h"
 
 namespace btproto = ::google::bigtable::v2;
 namespace admin_proto = ::google::bigtable::admin::v2;
@@ -109,7 +109,7 @@ int main(int argc, char* argv[]) try {
   if (not table_list.empty()) {
     std::ostringstream os;
     os << "Expected empty instance at the beginning of integration test";
-    throw std::runtime_error(os.str());
+    bigtable::internal::RaiseRuntimeError(os.str());
   }
 
   (void)::testing::AddGlobalTestEnvironment(

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -25,9 +25,9 @@
 #include "bigtable/admin/table_admin.h"
 #include "bigtable/client/cell.h"
 #include "bigtable/client/data_client.h"
+#include "bigtable/client/internal/throw_delegate.h"
 #include "bigtable/client/table.h"
 #include "bigtable/client/testing/table_integration_test.h"
-#include "bigtable/client/internal/throw_delegate.h"
 
 namespace btproto = ::google::bigtable::v2;
 namespace admin_proto = ::google::bigtable::admin::v2;
@@ -87,7 +87,7 @@ bool UsingCloudBigtableEmulator();
 
 }  // anonymous namespace
 
-int main(int argc, char* argv[]) try {
+int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
 
   // Make sure the arguments are valid.
@@ -107,32 +107,15 @@ int main(int argc, char* argv[]) try {
 
   auto table_list = admin.ListTables(admin_proto::Table::NAME_ONLY);
   if (not table_list.empty()) {
-    std::ostringstream os;
-    os << "Expected empty instance at the beginning of integration test";
-    bigtable::internal::RaiseRuntimeError(os.str());
+    std::cerr << "Expected empty instance at the beginning of integration "
+              << "test";
+    return 1;
   }
 
   (void)::testing::AddGlobalTestEnvironment(
       new ::bigtable::testing::TableTestEnvironment(project_id, instance_id));
 
   return RUN_ALL_TESTS();
-} catch (bigtable::PermanentMutationFailure const& ex) {
-  std::cerr << "bigtable::PermanentMutationFailure raised: " << ex.what()
-            << " - " << ex.status().error_message() << " ["
-            << ex.status().error_code()
-            << "], details=" << ex.status().error_details() << std::endl;
-  int count = 0;
-  for (auto const& failure : ex.failures()) {
-    std::cerr << "failure[" << count++
-              << "] {key=" << failure.mutation().row_key() << "}" << std::endl;
-  }
-  return 1;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << std::endl;
-  return 1;
-} catch (...) {
-  std::cerr << "Unknown exception raised." << std::endl;
-  return 1;
 }
 
 namespace bigtable {

--- a/bigtable/tools/convert_acceptance_tests.py
+++ b/bigtable/tools/convert_acceptance_tests.py
@@ -85,9 +85,18 @@ def print_test(t):
         ok = not any([r['error'] for r in t['results']])
 
     if ok:
+        o += '#if ABSL_HAVE_EXCEPTIONS\n'
         o += '  EXPECT_NO_THROW(FeedChunks(chunks));\n'
+        o += '#else\n'
+        o += '  FeedChunks(chunks);\n'
+        o += '#endif  // ABSL_HAVE_EXCEPTIONS\n'
     else:
+        o += '#if ABSL_HAVE_EXCEPTIONS\n'
         o += '  EXPECT_THROW(FeedChunks(chunks), std::exception);\n'
+        o += '#else\n'
+        o += '  EXPECT_DEATH_IF_SUPPORTED(FeedChunks(chunks), "exceptions");\n'
+        o += '  return;\n'
+        o += '#endif  // ABSL_HAVE_EXCEPTIONS\n'
 
     o += '\n'
     o += '  std::vector<std::string> expected_cells = {'

--- a/cmake/EnableCxxExceptions.cmake
+++ b/cmake/EnableCxxExceptions.cmake
@@ -1,0 +1,31 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+option(GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS "Enable C++ Exception Support" ON)
+
+# If the user disabled C++ exceptions we should give them a heads up about the
+# consequences.
+if (NOT GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
+    message(WARNING "C++ Exceptions disabled, any operation that normally"
+            " raises exceptions will instead log the error and call"
+            " std::abort().  In addition, some examples and tests will not be"
+            " compiled.")
+    if (MSVC)
+        set(GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG "/EHs-c-")
+    else ()
+        set(GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG "-fno-exceptions")
+    endif ()
+else ()
+    set(GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG "")
+endif ()


### PR DESCRIPTION
This is part of the fixes for #35.  The changes are (I think) the minimal set of changes to get a build to compile and pass the tests without exception support, but even so, it is a large PR.  There are several changes:

- Introduces a configuration flag in CMake to disable exceptions.
- It creates an automated build using that flag.
- It changes the code to raise exceptions through a delegate function, an idea stolen from Abseil, which aborts on exceptions.  A future PR we will add APIs that return errors instead of crashing.
- It changes the tests to use `EXPECT_DEATH()` when exceptions are disabled instead of EXPECT_THROW().

Some tests are disabled when exceptions are unavailable, and mocking is complicated with `EXPECT_DEATH()` because the side-effects in the mocks are not observable (they happen in a separate process).

