### PR TITLE
Hello world example

### DIFF
--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -367,6 +367,8 @@ target_link_libraries(scan_throughput_benchmark
         bigtable_protos gmock absl::time
         ${GRPCPP_LIBRARIES} ${GRPC_LIBRARIES} ${PROTOBUF_LIBRARIES})
 
+add_subdirectory(examples/quick_start)
+
 # Define the install target
 get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
 if ("${LIB64}" STREQUAL "TRUE")

--- a/bigtable/README.md
+++ b/bigtable/README.md
@@ -1,4 +1,15 @@
 # Google Cloud Bigtable
 
+[![Documentation][doxygen-shield]][doxygen-link]
+
+[doxygen-shield]: https://img.shields.io/badge/documentation-master-brightgreen.svg
+[doxygen-link]: http://GoogleCloudPlatform.github.io/google-cloud-cpp/
+[quickstart-link]: http://GoogleCloudPlatform.github.io/google-cloud-cpp/
+
 This directory contains the implementation of the Google Cloud Bigtable C++
 client. This is a work-in-progress and is not yet suitable for production use.
+
+## Documentation
+
+Full documentation, including a [quick start guide][quickstart-link] 
+is available [online][doxygen-link].

--- a/bigtable/doc/Doxyfile
+++ b/bigtable/doc/Doxyfile
@@ -119,7 +119,7 @@ WARN_LOGFILE           =
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
 
-INPUT                  = README.md doc client admin
+INPUT                  = doc client admin
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.h *.cc *.md *.proto
 RECURSIVE              = YES
@@ -127,7 +127,7 @@ EXCLUDE                = third_party
 EXCLUDE_SYMLINKS       = YES
 EXCLUDE_PATTERNS       =
 EXCLUDE_SYMBOLS        =
-EXAMPLE_PATH           =
+EXAMPLE_PATH           = examples
 EXAMPLE_PATTERNS       = *
 EXAMPLE_RECURSIVE      = YES
 IMAGE_PATH             =
@@ -135,7 +135,7 @@ INPUT_FILTER           =
 FILTER_PATTERNS        =
 FILTER_SOURCE_FILES    = NO
 FILTER_SOURCE_PATTERNS =
-USE_MDFILE_AS_MAINPAGE = ./README.md
+USE_MDFILE_AS_MAINPAGE = ./doc/bigtable-main.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/bigtable/doc/bigtable-main.md
+++ b/bigtable/doc/bigtable-main.md
@@ -1,0 +1,68 @@
+# Cloud Bigtable C++ Client Libraries
+
+## Quick Start
+
+This page explains how to use the Cloud Bigtable C++ library to connect to a
+Cloud Bigtable instance, perform basic administrative tasks, and read and write
+data in a table.
+
+### Before you begin
+
+Please consult the Cloud Bigtable
+[documentation](https://cloud.google.com/bigtable/docs/creating-instance)
+on how to create an instance.
+
+### Create a Table
+
+First connect to Cloud Bigtable C++ using the Admin API:
+
+@snippet quick_start/bigtable_create_table.cc connect
+
+Then define the column families and garbage collection rules for your table:
+
+@snippet quick_start/bigtable_create_table.cc define schema
+
+And then create the table:
+
+@snippet quick_start/bigtable_create_table.cc create table
+
+@see `bigtable::v0::TableAdmin` for additional operations to list, read, modify,
+and delete tables. 
+
+### Write a Row
+
+First connect to Cloud Bigtable C++ using the Data API:
+
+@snippet quick_start/bigtable_write_row.cc connect data
+
+Then write the row.
+
+@snippet quick_start/bigtable_write_row.cc write row
+
+@see `bigtable::v0::Table::BulkApply()` to modify multiple rows in a single
+operation.  In addition to `SetCell()` there
+are functions to delete columns (e.g., `DeleteFromFamily()`) or to delete the
+whole row (`DeleteFromRow()`).
+
+### Read a Table
+
+First connect to Cloud Bigtable C++ using the Data API:
+
+@snippet quick_start/bigtable_read_row.cc connect data
+
+Request the row that you want:
+
+@snippet quick_start/bigtable_read_row.cc read row
+
+In this example we request all the columns, you could filter the column
+families, columns, and timestamps to only obtain a subset. Check the
+`bigtable::v0::Filter` documentation for additional filtering primitives.
+In any case, you should verify if the row really exists:
+
+@snippet quick_start/bigtable_read_row.cc check result
+
+And if it does you can iterate over the returned cells:
+
+@snippet quick_start/bigtable_read_row.cc use value
+
+@see `bigtable::v0::Table::ReadRows()` to iterate over multiple rows.

--- a/bigtable/examples/quick_start/CMakeLists.txt
+++ b/bigtable/examples/quick_start/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# While it is tempting create these targets using a function or a loop, we want
+# to keep this particular file as simple as possible, as it is intended to be
+# part of the examples.
+
+add_executable(bigtable_create_table bigtable_create_table.cc)
+target_link_libraries(bigtable_create_table bigtable_client bigtable_admin_client)
+
+add_executable(bigtable_write_row bigtable_write_row.cc)
+target_link_libraries(bigtable_write_row bigtable_client)
+
+add_executable(bigtable_read_row bigtable_read_row.cc)
+target_link_libraries(bigtable_read_row bigtable_client)

--- a/bigtable/examples/quick_start/bigtable_create_table.cc
+++ b/bigtable/examples/quick_start/bigtable_create_table.cc
@@ -1,0 +1,53 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/admin/table_admin.h"
+#include "bigtable/client/table.h"
+
+int main(int argc, char* argv[]) try {
+  if (argc != 4) {
+    std::string const cmd = argv[0];
+    auto last_slash = std::string(cmd).find_last_of('/');
+    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
+              << " <project_id> <instance_id> <table_id>" << std::endl;
+    return 1;
+  }
+
+  std::string const project_id = argv[0];
+  std::string const instance_id = argv[1];
+  std::string const table_id = argv[2];
+
+  // Connect to the Cloud Bigtable Admin API.
+  //! [connect]
+  bigtable::TableAdmin table_admin(
+      bigtable::CreateDefaultAdminClient(project_id, bigtable::ClientOptions()),
+      instance_id);
+  //! [connect]
+
+  // Define the desired schema for the Table.
+  //! [define schema]
+  auto gc_rule = bigtable::GcRule::MaxNumVersions(1);
+  bigtable::TableConfig schema({{"family", gc_rule}}, {});
+  //! [define schema]
+
+  // Create a table.
+  //! [create table]
+  auto returned_schema = table_admin.CreateTable(table_id, schema);
+  //! [create table]
+
+  return 0;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard C++ exception raised: " << ex.what() << std::endl;
+  return 1;
+}

--- a/bigtable/examples/quick_start/bigtable_create_table.cc
+++ b/bigtable/examples/quick_start/bigtable_create_table.cc
@@ -24,9 +24,9 @@ int main(int argc, char* argv[]) try {
     return 1;
   }
 
-  std::string const project_id = argv[0];
-  std::string const instance_id = argv[1];
-  std::string const table_id = argv[2];
+  std::string const project_id = argv[1];
+  std::string const instance_id = argv[2];
+  std::string const table_id = argv[3];
 
   // Connect to the Cloud Bigtable Admin API.
   //! [connect]

--- a/bigtable/examples/quick_start/bigtable_read_row.cc
+++ b/bigtable/examples/quick_start/bigtable_read_row.cc
@@ -24,9 +24,9 @@ int main(int argc, char* argv[]) try {
     return 1;
   }
 
-  std::string const project_id = argv[0];
-  std::string const instance_id = argv[1];
-  std::string const table_id = argv[2];
+  std::string const project_id = argv[1];
+  std::string const instance_id = argv[2];
+  std::string const table_id = argv[3];
 
   // Create an object to access the Cloud Bigtable Data API.
   //! [connect data]

--- a/bigtable/examples/quick_start/bigtable_read_row.cc
+++ b/bigtable/examples/quick_start/bigtable_read_row.cc
@@ -1,0 +1,65 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/admin/table_admin.h"
+#include "bigtable/client/table.h"
+
+int main(int argc, char* argv[]) try {
+  if (argc != 4) {
+    std::string const cmd = argv[0];
+    auto last_slash = std::string(cmd).find_last_of('/');
+    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
+              << " <project_id> <instance_id> <table_id>" << std::endl;
+    return 1;
+  }
+
+  std::string const project_id = argv[0];
+  std::string const instance_id = argv[1];
+  std::string const table_id = argv[2];
+
+  // Create an object to access the Cloud Bigtable Data API.
+  //! [connect data]
+  bigtable::Table table(bigtable::CreateDefaultDataClient(
+                            project_id, instance_id, bigtable::ClientOptions()),
+                        table_id);
+  //! [connect data]
+
+  // Read a single row.
+  //! [read row]
+  auto result = table.ReadRow("my-key", bigtable::Filter::PassAllFilter());
+  //! [read row]
+
+  // Handle the case where the row does not exist.
+  //! [check result]
+  if (not result.first) {
+    std::cerr << "Cannot find row 'my-key' in the table: " << table.table_name()
+              << std::endl;
+    return 0;
+  }
+  //! [check result]
+
+  // Print the contents of the row.
+  //! [use value]
+  for (auto const& cell : result.second.cells()) {
+    std::cout << cell.family_name() << ":" << cell.column_qualifier()
+              << "    @ " << cell.timestamp() << "\n"
+              << '"' << cell.value() << '"' << std::endl;
+  }
+  //! [use value]
+
+  return 0;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard C++ exception raised: " << ex.what() << std::endl;
+  return 1;
+}

--- a/bigtable/examples/quick_start/bigtable_write_row.cc
+++ b/bigtable/examples/quick_start/bigtable_write_row.cc
@@ -1,0 +1,47 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/client/table.h"
+
+int main(int argc, char* argv[]) try {
+  if (argc != 4) {
+    std::string const cmd = argv[0];
+    auto last_slash = std::string(cmd).find_last_of('/');
+    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
+              << " <project_id> <instance_id> <table_id>" << std::endl;
+    return 1;
+  }
+
+  std::string const project_id = argv[0];
+  std::string const instance_id = argv[1];
+  std::string const table_id = argv[2];
+
+  // Create an object to access the Cloud Bigtable Data API.
+  //! [connect data]
+  bigtable::Table table(bigtable::CreateDefaultDataClient(
+                            project_id, instance_id, bigtable::ClientOptions()),
+                        table_id);
+  //! [connect data]
+
+  // Modify (and create if necessary) a row.
+  //! [write row]
+  table.Apply(bigtable::SingleRowMutation(
+      "my-key", bigtable::SetCell("family", "value", 0, "Hello World!")));
+  //! [write row]
+
+  return 0;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard C++ exception raised: " << ex.what() << std::endl;
+  return 1;
+}

--- a/bigtable/examples/quick_start/bigtable_write_row.cc
+++ b/bigtable/examples/quick_start/bigtable_write_row.cc
@@ -23,9 +23,9 @@ int main(int argc, char* argv[]) try {
     return 1;
   }
 
-  std::string const project_id = argv[0];
-  std::string const instance_id = argv[1];
-  std::string const table_id = argv[2];
+  std::string const project_id = argv[1];
+  std::string const instance_id = argv[2];
+  std::string const table_id = argv[3];
 
   // Create an object to access the Cloud Bigtable Data API.
   //! [connect data]


### PR DESCRIPTION
This fixes #240.  Create 3 super simple examples for the library.
Link these examples from the Doxygen landing page, and link
that from the github `README.md` file.

Unfortunately one cannot see the generated Doxygen until it makes it to master (well, I can see it locally, but I cannot send you a link), so you get a [pdf](https://github.com/GoogleCloudPlatform/google-cloud-cpp/files/1742096/doxygen-output-issue-240.pdf) as a consolation price.  It is kind of neat because the code snippets are taken from programs that actually run.

It think these changes will be useful for #243 also, but more on that later.

