### PR TITLE
After installing known-good SDK, update to latest.

### DIFF
--- a/ci/Dockerfile.centos
+++ b/ci/Dockerfile.centos
@@ -55,4 +55,5 @@ WORKDIR /var/tmp/install/cbt-components
 RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
 RUN tar x -C /usr/local -f google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
 RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable
-RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components update
+RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components update || \
+    echo "Ignoring update failure for Google Cloud SDK"

--- a/ci/Dockerfile.centos
+++ b/ci/Dockerfile.centos
@@ -51,8 +51,8 @@ RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.
-# TODO(#224) - use the latest and greatest SDK once v188 is fixed.
 WORKDIR /var/tmp/install/cbt-components
 RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
 RUN tar x -C /usr/local -f google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
 RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable
+RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components update

--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -49,4 +49,5 @@ WORKDIR /var/tmp/install/cbt-components
 RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
 RUN tar x -C /usr/local -f google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
 RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable
-RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components update
+RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components update || \
+    echo "Ignoring update failure for Google Cloud SDK"

--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -45,8 +45,8 @@ RUN dnf makecache && dnf install -y \
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.
-# TODO(#224) - use the latest and greatest SDK once v188 is fixed.
 WORKDIR /var/tmp/install/cbt-components
 RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
 RUN tar x -C /usr/local -f google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
 RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable
+RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components update

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -51,4 +51,5 @@ WORKDIR /var/tmp/install/cbt-components
 RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
 RUN tar x -C /usr/local -f google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
 RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable
-RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components update
+RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components update || \
+    echo "Ignoring update failure for Google Cloud SDK"

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -47,8 +47,8 @@ RUN if grep -q 14.04 /etc/lsb-release; then \
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.
-# TODO(#224) - use the latest and greatest SDK once v188 is fixed.
 WORKDIR /var/tmp/install/cbt-components
 RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
 RUN tar x -C /usr/local -f google-cloud-sdk-187.0.0-linux-x86_64.tar.gz
 RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable
+RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components update


### PR DESCRIPTION
This is a fix for #224.  Sometimes the installation of the latest and greatest SDK fails, but it seems that upgrading from a working version is more reliable.  In this PR I propose that we use the known-good version (currently 187.0.0), and then upgrade to the latest and greatest.

Every so often we will need to upgrade the known-good version, but we can do that after we test the changes, so a broken release of the SDK will not break all our builds.
