### PR TITLE
Implement connection pooling.

### DIFF
--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -130,6 +130,7 @@ add_library(bigtable_client
     client/internal/bulk_mutator.h
     client/internal/bulk_mutator.cc
     client/internal/common_client.h
+    client/internal/common_client.cc
     client/internal/conjunction.h
     client/internal/make_unique.h
     client/internal/port_platform.h

--- a/bigtable/admin/admin_client_test.cc
+++ b/bigtable/admin/admin_client_test.cc
@@ -18,7 +18,7 @@
 
 TEST(AdminClientTest, Default) {
   auto admin_client = bigtable::CreateDefaultAdminClient(
-      "test-project", bigtable::ClientOptions());
+      "test-project", bigtable::ClientOptions().set_connection_pool_size(1));
   ASSERT_TRUE(admin_client);
   EXPECT_EQ("test-project", admin_client->project());
 

--- a/bigtable/benchmarks/benchmark.cc
+++ b/bigtable/benchmarks/benchmark.cc
@@ -37,6 +37,8 @@ Benchmark::Benchmark(BenchmarkSetup const& setup)
     client_options_.set_data_endpoint(address);
     client_options_.SetCredentials(grpc::InsecureChannelCredentials());
   }
+  client_options_.set_connection_pool_size(
+      static_cast<std::size_t>(setup_.thread_count()));
 }
 
 Benchmark::~Benchmark() {

--- a/bigtable/client/client_options.cc
+++ b/bigtable/client/client_options.cc
@@ -15,7 +15,7 @@
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-ClientOptions::ClientOptions() {
+ClientOptions::ClientOptions() : connection_pool_size_(1) {
   char const* emulator = std::getenv("BIGTABLE_EMULATOR_HOST");
   if (emulator != nullptr) {
     data_endpoint_ = emulator;

--- a/bigtable/client/client_options.cc
+++ b/bigtable/client/client_options.cc
@@ -13,9 +13,15 @@
 
 #include "bigtable/client/client_options.h"
 
+// Make the default pool size 4 because that is consistent with what Go does.
+#ifndef BIGTABLE_CLIENT_DEFAULT_CONNECTION_POOL_SIZE
+#define BIGTABLE_CLIENT_DEFAULT_CONNECTION_POOL_SIZE 4
+#endif  // BIGTABLE_CLIENT_DEFAULT_CONNECTION_POOL_SIZE
+
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-ClientOptions::ClientOptions() : connection_pool_size_(1) {
+ClientOptions::ClientOptions()
+    : connection_pool_size_(BIGTABLE_CLIENT_DEFAULT_CONNECTION_POOL_SIZE) {
   char const* emulator = std::getenv("BIGTABLE_EMULATOR_HOST");
   if (emulator != nullptr) {
     data_endpoint_ = emulator;

--- a/bigtable/client/client_options.h
+++ b/bigtable/client/client_options.h
@@ -50,6 +50,37 @@ class ClientOptions {
     return *this;
   }
 
+  /**
+   * Set the name of the connection pool.
+   *
+   * gRPC typically opens a single connection for each destination.  To improve
+   * performance, the Cloud Bigtable C++ client can open multiple connections
+   * to a given destination, but these connections are shared by all threads
+   * in the application.  Sometimes the application may want even more
+   * segregation, for example, the application may want to use a different pool
+   * for high-priority requests vs. lower priority ones.  Using different names
+   * creates segregated pools.
+   */
+  ClientOptions& set_connection_pool_name(std::string name) {
+    connection_pool_name_ = std::move(name);
+    return *this;
+  }
+  /// Return the name of the connection pool.
+  std::string const& connection_pool_name() const {
+    return connection_pool_name_;
+  }
+
+  /// Set the size of the connection pool.
+  ClientOptions& set_connection_pool_size(std::size_t size) {
+    if (size == 0) {
+      internal::RaiseRangeError(
+          "ClientOptions::set_connection_pool_size requires size > 0");
+    }
+    connection_pool_size_ = size;
+    return *this;
+  }
+  std::size_t connection_pool_size() const { return connection_pool_size_; }
+
   /// Return the current credentials.
   std::shared_ptr<grpc::ChannelCredentials> credentials() const {
     return credentials_;
@@ -60,9 +91,12 @@ class ClientOptions {
     return *this;
   }
 
+  /// Access all the channel arguments.
   grpc::ChannelArguments channel_arguments() const {
     return channel_arguments_;
   }
+
+  /// Set all the channel arguments.
   ClientOptions& set_channel_arguments(
       grpc::ChannelArguments const& channel_arguments) {
     channel_arguments_ = channel_arguments;
@@ -222,6 +256,8 @@ class ClientOptions {
   std::string admin_endpoint_;
   std::shared_ptr<grpc::ChannelCredentials> credentials_;
   grpc::ChannelArguments channel_arguments_;
+  std::string connection_pool_name_;
+  std::size_t connection_pool_size_;
 };
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/bigtable/client/client_options_test.cc
+++ b/bigtable/client/client_options_test.cc
@@ -33,6 +33,9 @@ TEST(ClientOptionsTest, ClientOptionsDefaultSettings) {
             client_options_object.admin_endpoint());
   EXPECT_EQ(typeid(grpc::GoogleDefaultCredentials()),
             typeid(client_options_object.credentials()));
+
+  EXPECT_EQ("", client_options_object.connection_pool_name());
+  EXPECT_EQ(1UL, client_options_object.connection_pool_size());
 }
 
 namespace {
@@ -90,25 +93,39 @@ TEST_F(ClientOptionsEmulatorTest, Default) {
 }
 
 TEST(ClientOptionsTest, EditDataEndpoint) {
-  bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
+  bigtable::ClientOptions client_options_object;
   client_options_object =
       client_options_object.set_data_endpoint("customendpoint.com");
   EXPECT_EQ("customendpoint.com", client_options_object.data_endpoint());
 }
 
 TEST(ClientOptionsTest, EditAdminEndpoint) {
-  bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
+  bigtable::ClientOptions client_options_object;
   client_options_object =
       client_options_object.set_admin_endpoint("customendpoint.com");
   EXPECT_EQ("customendpoint.com", client_options_object.admin_endpoint());
 }
 
 TEST(ClientOptionsTest, EditCredentials) {
-  bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
+  bigtable::ClientOptions client_options_object;
   client_options_object =
       client_options_object.SetCredentials(grpc::InsecureChannelCredentials());
   EXPECT_EQ(typeid(grpc::InsecureChannelCredentials()),
             typeid(client_options_object.credentials()));
+}
+
+TEST(ClientOptionsTest, EditConnectionPoolName) {
+  bigtable::ClientOptions client_options_object;
+  auto& returned = client_options_object.set_connection_pool_name("foo");
+  EXPECT_EQ(&returned, &client_options_object);
+  EXPECT_EQ("foo", returned.connection_pool_name());
+}
+
+TEST(ClientOptionsTest, EditConnectionPoolSize) {
+  bigtable::ClientOptions client_options_object;
+  auto& returned = client_options_object.set_connection_pool_size(42);
+  EXPECT_EQ(&returned, &client_options_object);
+  EXPECT_EQ(42UL, returned.connection_pool_size());
 }
 
 TEST(ClientOptionsTest, SetGrpclbFallbackTimeoutMS) {

--- a/bigtable/client/client_options_test.cc
+++ b/bigtable/client/client_options_test.cc
@@ -35,7 +35,9 @@ TEST(ClientOptionsTest, ClientOptionsDefaultSettings) {
             typeid(client_options_object.credentials()));
 
   EXPECT_EQ("", client_options_object.connection_pool_name());
-  EXPECT_EQ(1UL, client_options_object.connection_pool_size());
+  // The number of connections should be >= 1, we "know" what the actual value
+  // is, but we do not want a change-detection-test.
+  EXPECT_LE(1UL, client_options_object.connection_pool_size());
 }
 
 namespace {

--- a/bigtable/client/data_client_test.cc
+++ b/bigtable/client/data_client_test.cc
@@ -18,7 +18,8 @@
 
 TEST(DataClientTest, Default) {
   auto data_client = bigtable::CreateDefaultDataClient(
-      "test-project", "test-instance", bigtable::ClientOptions());
+      "test-project", "test-instance",
+      bigtable::ClientOptions().set_connection_pool_size(1));
   ASSERT_TRUE(data_client);
   EXPECT_EQ("test-project", data_client->project_id());
   EXPECT_EQ("test-instance", data_client->instance_id());

--- a/bigtable/client/internal/common_client.cc
+++ b/bigtable/client/internal/common_client.cc
@@ -1,0 +1,38 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+#include "bigtable/client/internal/common_client.h"
+
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
+
+std::vector<std::shared_ptr<grpc::Channel>> CreateChannelPool(
+    std::string const& endpoint, bigtable::ClientOptions const& options) {
+  std::vector<std::shared_ptr<grpc::Channel>> result;
+  for (std::size_t i = 0; i != options.connection_pool_size(); ++i) {
+    auto args = options.channel_arguments();
+    if (not options.connection_pool_name().empty()) {
+      args.SetString("cbt-c++/connection-pool-name",
+                     options.connection_pool_name());
+    }
+    args.SetInt("cbt-c++/connection-pool-id", static_cast<int>(i));
+    result.push_back(
+        grpc::CreateCustomChannel(endpoint, options.credentials(), args));
+  }
+  return result;
+}
+
+}  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable

--- a/bigtable/client/internal/common_client.h
+++ b/bigtable/client/internal/common_client.h
@@ -64,6 +64,11 @@ class CommonClient {
       // a lock for long operations like that is a bad practice.  Releasing
       // the lock here can result in wasted work, but that is a smaller problem
       // than a deadlock or an unbounded priority inversion.
+      // Note that only one connection per application is created by gRPC, even
+      // if multiple threads are calling this function at the same time. gRPC
+      // only opens one socket per destination+attributes combo, we artificially
+      // introduce attributes in the implementation of CreateChannelPool() to
+      // create one socket per element in the pool.
       lk.unlock();
       auto channels = CreateChannelPool(Traits::Endpoint(options_), options_);
       std::vector<StubPtr> tmp;

--- a/bigtable/client/internal/common_client.h
+++ b/bigtable/client/internal/common_client.h
@@ -21,6 +21,11 @@
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
+
+/// Create a pool of grpc::Channel objects based on the client options.
+std::vector<std::shared_ptr<grpc::Channel>> CreateChannelPool(
+    std::string const& endpoint, bigtable::ClientOptions const& options);
+
 /**
  * Refactor implementation of `bigtable::AdminClient` and `bigtable::DataClient`
  *
@@ -32,7 +37,7 @@ template <typename Traits, typename Interface>
 class CommonClient {
  public:
   CommonClient(bigtable::ClientOptions options)
-      : options_(std::move(options)) {}
+      : options_(std::move(options)), current_stub_index_(0) {}
 
   using StubPtr = std::shared_ptr<typename Interface::StubInterface>;
 
@@ -44,25 +49,44 @@ class CommonClient {
    * and/or when the credentials require explicit refresh.
    */
   void reset() {
-    stub_.reset();
-    channel_.reset();
+    std::lock_guard<std::mutex> lk(mu_);
+    stubs_.clear();
   }
 
   StubPtr Stub() {
-    if (not stub_) {
-      auto channel = grpc::CreateCustomChannel(Traits::Endpoint(options_),
-                                               options_.credentials(),
-                                               options_.channel_arguments());
-      stub_ = Interface::NewStub(channel);
-      channel_ = channel;
+    std::unique_lock<std::mutex> lk(mu_);
+    if (stubs_.empty()) {
+      // Release the lock while making remote calls.  gRPC uses the current
+      // thread to make remote connections (and probably authenticate), holding
+      // a lock for long operations like that is a bad practice.  Releasing
+      // the lock here can result in wasted work, but that is a smaller problem
+      // than a deadlock or an unbounded priority inversion.
+      lk.unlock();
+      auto channels = CreateChannelPool(Traits::Endpoint(options_), options_);
+      std::vector<StubPtr> tmp;
+      std::transform(channels.begin(), channels.end(), std::back_inserter(tmp),
+                     [](std::shared_ptr<grpc::Channel> ch) {
+                       return Interface::NewStub(ch);
+                     });
+      lk.lock();
+      if (stubs_.empty()) {
+        tmp.swap(stubs_);
+        current_stub_index_ = 0;
+      }
     }
-    return stub_;
+    auto stub = stubs_[current_stub_index_];
+    // Round robin through the connections.
+    if (++current_stub_index_ >= stubs_.size()) {
+      current_stub_index_ = 0;
+    }
+    return stub;
   }
 
  private:
+  std::mutex mu_;
   ClientOptions options_;
-  std::shared_ptr<grpc::Channel> channel_;
-  StubPtr stub_;
+  std::vector<StubPtr> stubs_;
+  std::size_t current_stub_index_;
 };
 
 }  // namespace internal


### PR DESCRIPTION
This fixes #204.  With this change the application can control
the size of the pool associated with each client using
`ClientOptions::set_connection_pool_size()`.  The default size is,
as one would expect, 1. Note that by default the channels created
by different clients are shared, but the application can override
that using `ClientOptions::set_connection_pool_name()`.  We expect
that to be rarely used.