### PR TITLE
Refactor code to retry RPC calls

### DIFF
--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -129,6 +129,7 @@ add_library(bigtable_client
     client/data_client.cc
     client/internal/bulk_mutator.h
     client/internal/bulk_mutator.cc
+    client/internal/call_with_retry.h
     client/internal/common_client.h
     client/internal/common_client.cc
     client/internal/conjunction.h

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -129,7 +129,6 @@ add_library(bigtable_client
     client/data_client.cc
     client/internal/bulk_mutator.h
     client/internal/bulk_mutator.cc
-    client/internal/call_with_retry.h
     client/internal/common_client.h
     client/internal/common_client.cc
     client/internal/conjunction.h
@@ -143,6 +142,7 @@ add_library(bigtable_client
     client/internal/rowreaderiterator.cc
     client/internal/throw_delegate.h
     client/internal/throw_delegate.cc
+    client/internal/unary_rpc_utils.h
     client/filters.h
     client/filters.cc
     client/idempotent_mutation_policy.h

--- a/bigtable/admin/table_admin.cc
+++ b/bigtable/admin/table_admin.cc
@@ -27,7 +27,7 @@ inline namespace BIGTABLE_CLIENT_NS {
   request.set_table_id(std::move(table_id));
 
   auto error_message = "CreateTable(" + request.table_id() + ")";
-  return CallWithRetry::MakeCall(
+  return RpcUtils::CallWithRetry(
       *client_, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
       &StubType::CreateTable, request, error_message.c_str());
 }
@@ -82,7 +82,7 @@ std::vector<::google::bigtable::admin::v2::Table> TableAdmin::ListTables(
   request.set_view(view);
 
   auto error_message = "GetTable(" + request.name() + ")";
-  return CallWithRetry::MakeCall(
+  return RpcUtils::CallWithRetry(
       *client_, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
       &StubType::GetTable, request, error_message.c_str());
 }
@@ -91,7 +91,7 @@ void TableAdmin::DeleteTable(std::string table_id) {
   btproto::DeleteTableRequest request;
   request.set_name(TableName(table_id));
 
-  CallWithRetry::MakeCall(*client_, rpc_retry_policy_->clone(),
+  RpcUtils::CallWithRetry(*client_, rpc_retry_policy_->clone(),
                           rpc_backoff_policy_->clone(), &StubType::DeleteTable,
                           request, "DeleteTable");
 }
@@ -105,7 +105,7 @@ void TableAdmin::DeleteTable(std::string table_id) {
   }
 
   auto error_message = "ModifyColumnFamilies(" + request.name() + ")";
-  return CallWithRetry::MakeCall(
+  return RpcUtils::CallWithRetry(
       *client_, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
       &StubType::ModifyColumnFamilies, request, error_message.c_str());
 }
@@ -116,7 +116,7 @@ void TableAdmin::DropRowsByPrefix(std::string table_id,
   request.set_name(TableName(table_id));
   request.set_row_key_prefix(std::move(row_key_prefix));
 
-  CallWithRetry::MakeCall(*client_, rpc_retry_policy_->clone(),
+  RpcUtils::CallWithRetry(*client_, rpc_retry_policy_->clone(),
                           rpc_backoff_policy_->clone(), &StubType::DropRowRange,
                           request, "DropRowsByPrefix");
 }
@@ -126,7 +126,7 @@ void TableAdmin::DropAllRows(std::string table_id) {
   request.set_name(TableName(table_id));
   request.set_delete_all_data_from_table(true);
 
-  CallWithRetry::MakeCall(*client_, rpc_retry_policy_->clone(),
+  RpcUtils::CallWithRetry(*client_, rpc_retry_policy_->clone(),
                           rpc_backoff_policy_->clone(), &StubType::DropRowRange,
                           request, "DropAllRows");
 }

--- a/bigtable/admin/table_admin.h
+++ b/bigtable/admin/table_admin.h
@@ -19,7 +19,7 @@
 #include "bigtable/admin/admin_client.h"
 #include "bigtable/admin/column_family.h"
 #include "bigtable/admin/table_config.h"
-#include "bigtable/client/internal/call_with_retry.h"
+#include "bigtable/client/internal/unary_rpc_utils.h"
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
@@ -180,8 +180,8 @@ class TableAdmin {
   }
 
   /// Shortcuts to avoid typing long names over and over.
-  using CallWithRetry = bigtable::internal::CallWithRetry<AdminClient>;
-  using StubType = CallWithRetry::StubType;
+  using RpcUtils = bigtable::internal::UnaryRpcUtils<AdminClient>;
+  using StubType = RpcUtils::StubType;
 
  private:
   std::shared_ptr<AdminClient> client_;

--- a/bigtable/admin/table_admin.h
+++ b/bigtable/admin/table_admin.h
@@ -179,12 +179,9 @@ class TableAdmin {
     return instance_name() + "/tables/" + table_id;
   }
 
-  /// A shortcut for the grpc stub this class wraps.
-  using StubType =
-      ::google::bigtable::admin::v2::BigtableTableAdmin::StubInterface;
-
-  using CallWithRetry =
-      bigtable::internal::CallWithRetry<AdminClient, StubType>;
+  /// Shortcuts to avoid typing long names over and over.
+  using CallWithRetry = bigtable::internal::CallWithRetry<AdminClient>;
+  using StubType = CallWithRetry::StubType;
 
  private:
   std::shared_ptr<AdminClient> client_;

--- a/bigtable/client/internal/call_with_retry.h
+++ b/bigtable/client/internal/call_with_retry.h
@@ -60,12 +60,12 @@ struct CallWithRetry {
    *
    * This is the generic case, where the type does not match the expected
    * signature.  The class derives from `std::false_type`, so
-   * `CheckSignature<T>::value` is `false`.
+   * `CheckSignature<T>::%value` is `false`.
    *
    * @tparam T the type to check against the expected signature.
    */
   template <typename T>
-  struct CheckSignature : std::false_type {
+  struct CheckSignature : public std::false_type {
     /// Must define ResponseType because it is used in std::enable_if<>.
     using ResponseType = int;
   };
@@ -75,7 +75,7 @@ struct CallWithRetry {
    * signature for `MakeCall()`.
    *
    * This is the case where the type actually matches the expected signature.
-   * This class derives from `std::true_type`, so `CheckSignature<T>::value` is
+   * This class derives from `std::true_type`, so `CheckSignature<T>::%value` is
    * `true`.  The class also extracts the request and response types used in the
    * implementation of `CallWithRetry()`.
    *

--- a/bigtable/client/internal/call_with_retry.h
+++ b/bigtable/client/internal/call_with_retry.h
@@ -1,0 +1,157 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_CALL_WITH_RETRY_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_CALL_WITH_RETRY_H_
+
+#include <thread>
+#include "bigtable/client/internal/throw_delegate.h"
+#include "bigtable/client/rpc_backoff_policy.h"
+#include "bigtable/client/rpc_retry_policy.h"
+
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
+/**
+ * Helper functions to make (unary) gRPC calls under the right policies.
+ *
+ * Many of the gRPC calls made the the Cloud Bigtable C++ client library are
+ * wrapped in essentially the same loop:
+ *
+ * @code
+ * clone the policies for the call
+ * do {
+ *   make rpc call
+ *   return if successful
+ *   update policies
+ * } while(policies allow retry);
+ * report failure
+ * @endcode
+ *
+ * The loop is not hard to write, but gets tedious, `CallWithRetry` provides a
+ * function that implements this loop.  The code is a bit difficult because the
+ * signature of the gRPC functions look like this:
+ *
+ * @code
+ * grpc::Status (StubType::*)(grpc::ClientContext*, Request const&, Response*);
+ * @endcode
+ *
+ * Where `Request` and `Response` are the protos in the gRPC call.
+ *
+ * @tparam ClientType the type of the client used for the gRPC call.
+ * @tparam StubType the type of the stub returned by Client::Stub().
+ */
+template <typename ClientType, typename StubType>
+struct CallWithRetry {
+  /**
+   * Determine if @p T is a pointer to member function with the expected
+   * signature for `MakeCall()`.
+   *
+   * This is the generic case, where the type does not match the expected
+   * signature.  The class derives from `std::false_type`, so
+   * `CheckSignature<T>::value` is `false`.
+   *
+   * @tparam T the type to check against the expected signature.
+   */
+  template <typename T>
+  struct CheckSignature : std::false_type {
+    /// Must define ResponseType because it is used in std::enable_if<>.
+    using ResponseType = int;
+  };
+
+  /**
+   * Determine if a type is a pointer to member function with the correct
+   * signature for `MakeCall()`.
+   *
+   * This is the case where the type actually matches the expected signature.
+   * This class derives from `std::true_type`, so `CheckSignature<T>::value` is
+   * `true`.  The class also extracts the request and response types used in the
+   * implementation of `CallWithRetry()`.
+   *
+   * @tparam Request the RPC request type.
+   * @tparam Response the RPC response type.
+   */
+  template <typename Request, typename Response>
+  struct CheckSignature<grpc::Status (StubType::*)(grpc::ClientContext *,
+                                                   Request const &, Response *)>
+      : public std::true_type {
+    using RequestType = Request;
+    using ResponseType = Response;
+    using MemberFunctionType = grpc::Status (StubType::*)(grpc::ClientContext *,
+                                                          Request const &,
+                                                          Response *);
+  };
+
+  /**
+   * Call a simple unary RPC with retries.
+   *
+   * Given a pointer to member function in the grpc StubInterface class this
+   * generic function calls it with retries until success or until the RPC
+   * policies determine that this is an error.
+   *
+   * We use std::enable_if<> to stop signature errors at compile-time.  The
+   * `CheckSignature` meta function returns `false` if given a type that is not
+   * a pointer to member with the right signature, that disables this function
+   * altogether, and the developer gets a nice-ish error message.
+   *
+   * @tparam MemberFunction the signature of the member function.
+   * @param client the object that holds the gRPC stub.
+   * @param rpc_policy the policy controlling what failures are retryable.
+   * @param backoff_policy the policy controlling how long to wait before
+   *     retrying.
+   * @param function the pointer to the member function to call.
+   * @param request an initialized request parameter for the RPC.
+   * @param error_message include this message in any exception or error log.
+   * @return the return parameter from the RPC.
+   * @throw std::exception with a description of the last RPC error.
+   */
+  template <typename MemberFunction>
+  // Disable the function if the provided member function does not match the
+  // expected signature.  Compilers also emit nice error messages in this case.
+  static typename std::enable_if<
+      CheckSignature<MemberFunction>::value,
+      typename CheckSignature<MemberFunction>::ResponseType>::type
+  MakeCall(ClientType &client,
+           std::unique_ptr<bigtable::RPCRetryPolicy> rpc_policy,
+           std::unique_ptr<bigtable::RPCBackoffPolicy> backoff_policy,
+           MemberFunction function,
+           typename CheckSignature<MemberFunction>::RequestType const &request,
+           char const *error_message) {
+    typename CheckSignature<MemberFunction>::ResponseType response;
+    while (true) {
+      grpc::ClientContext client_context;
+      rpc_policy->setup(client_context);
+      backoff_policy->setup(client_context);
+      // Call the pointer to member function.
+      grpc::Status status =
+          ((*client.Stub()).*function)(&client_context, request, &response);
+      client.on_completion(status);
+      if (status.ok()) {
+        break;
+      }
+      if (not rpc_policy->on_failure(status)) {
+        RaiseRpcError(status, error_message);
+      }
+      auto delay = backoff_policy->on_completion(status);
+      std::this_thread::sleep_for(delay);
+    }
+    return response;
+  }
+};
+
+}  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_CALL_WITH_RETRY_H_

--- a/bigtable/client/internal/throw_delegate.cc
+++ b/bigtable/client/internal/throw_delegate.cc
@@ -68,7 +68,7 @@ namespace internal {
   RaiseException<std::logic_error>(msg.c_str());
 }
 
-[[noreturn]] void RaiseRpcError(grpc::Status const& status, char const* msg) {
+[[noreturn]] void RaiseRpcError(grpc::Status const &status, char const *msg) {
   // TODO(#119) - raise an exception that stores `status` as a value.
   std::ostringstream os;
   os << "unrecoverable gRPC error or too many gRPC errors in " << msg << ": "
@@ -77,8 +77,8 @@ namespace internal {
   internal::RaiseRuntimeError(os.str());
 }
 
-[[noreturn]] void RaiseRpcError(grpc::Status const& status,
-                                std::string const& msg) {
+[[noreturn]] void RaiseRpcError(grpc::Status const &status,
+                                std::string const &msg) {
   RaiseRpcError(status, msg.c_str());
 }
 

--- a/bigtable/client/internal/throw_delegate.cc
+++ b/bigtable/client/internal/throw_delegate.cc
@@ -14,13 +14,11 @@
 
 #include "bigtable/client/internal/throw_delegate.h"
 
-#include <absl/base/config.h>
-
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 #include <stdexcept>
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 
-#include <iostream>
+#include <sstream>
 
 namespace {
 template <typename Exception>
@@ -68,6 +66,20 @@ namespace internal {
 
 [[noreturn]] void RaiseLogicError(std::string const &msg) {
   RaiseException<std::logic_error>(msg.c_str());
+}
+
+[[noreturn]] void RaiseRpcError(grpc::Status const& status, char const* msg) {
+  // TODO(#119) - raise an exception that stores `status` as a value.
+  std::ostringstream os;
+  os << "unrecoverable gRPC error or too many gRPC errors in " << msg << ": "
+     << status.error_message() << " [" << status.error_code() << "] "
+     << status.error_details();
+  internal::RaiseRuntimeError(os.str());
+}
+
+[[noreturn]] void RaiseRpcError(grpc::Status const& status,
+                                std::string const& msg) {
+  RaiseRpcError(status, msg.c_str());
 }
 
 }  // namespace internal

--- a/bigtable/client/internal/throw_delegate.h
+++ b/bigtable/client/internal/throw_delegate.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_THROW_DELEGATE_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_THROW_DELEGATE_H_
 
+#include <grpc++/grpc++.h>
 #include "bigtable/client/version.h"
 
 namespace bigtable {
@@ -43,6 +44,10 @@ namespace internal {
 
 [[noreturn]] void RaiseLogicError(char const* msg);
 [[noreturn]] void RaiseLogicError(std::string const& msg);
+
+[[noreturn]] void RaiseRpcError(grpc::Status const& status, char const* msg);
+[[noreturn]] void RaiseRpcError(grpc::Status const& status,
+                                std::string const& msg);
 //@}
 
 }  // namespace internal

--- a/bigtable/client/internal/unary_rpc_utils.h
+++ b/bigtable/client/internal/unary_rpc_utils.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_CALL_WITH_RETRY_H_
-#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_CALL_WITH_RETRY_H_
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_UNARY_RPC_UTILS_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_UNARY_RPC_UTILS_H_
 
 #include <thread>
 #include "bigtable/client/internal/throw_delegate.h"
@@ -52,7 +52,7 @@ namespace internal {
  * @tparam ClientType the type of the client used for the gRPC call.
  */
 template <typename ClientType>
-struct CallWithRetry {
+struct UnaryRpcUtils {
   /**
    * Extract the StubType from the type returned by ClientType::Stub().
    *
@@ -155,12 +155,12 @@ struct CallWithRetry {
   static typename std::enable_if<
       CheckSignature<MemberFunction>::value,
       typename CheckSignature<MemberFunction>::ResponseType>::type
-  MakeCall(ClientType &client,
-           std::unique_ptr<bigtable::RPCRetryPolicy> rpc_policy,
-           std::unique_ptr<bigtable::RPCBackoffPolicy> backoff_policy,
-           MemberFunction function,
-           typename CheckSignature<MemberFunction>::RequestType const &request,
-           char const *error_message) {
+  CallWithRetry(
+      ClientType &client, std::unique_ptr<bigtable::RPCRetryPolicy> rpc_policy,
+      std::unique_ptr<bigtable::RPCBackoffPolicy> backoff_policy,
+      MemberFunction function,
+      typename CheckSignature<MemberFunction>::RequestType const &request,
+      char const *error_message) {
     typename CheckSignature<MemberFunction>::ResponseType response;
     while (true) {
       grpc::ClientContext client_context;
@@ -187,4 +187,4 @@ struct CallWithRetry {
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
 
-#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_CALL_WITH_RETRY_H_
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_UNARY_RPC_UTILS_H_


### PR DESCRIPTION
This is part of the fixes for #273.  For background, `bigtable::TableAdmin` had
a nice function to retry RPCs untill success (or until the policies said to stop).
We think this function will be useful to implement #271, #207, and #208, but
those use a different grpc stub and client classes.  This is just a refactoring
PR, the function is still only used in `bigtable::TableAdmin`.
