### PR TITLE
Fix build problems on master.

### DIFF
--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -367,7 +367,9 @@ if (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
             gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
 endif (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
 
-add_subdirectory(examples/quick_start)
+if (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
+    add_subdirectory(examples/quick_start)
+endif (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
 
 # Define the install target
 get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)

--- a/bigtable/examples/quick_start/bigtable_read_row.cc
+++ b/bigtable/examples/quick_start/bigtable_read_row.cc
@@ -43,7 +43,7 @@ int main(int argc, char* argv[]) try {
   // Handle the case where the row does not exist.
   //! [check result]
   if (not result.first) {
-    std::cerr << "Cannot find row 'my-key' in the table: " << table.table_name()
+    std::cout << "Cannot find row 'my-key' in the table: " << table.table_name()
               << std::endl;
     return 0;
   }


### PR DESCRIPTION
The PR merged cleanly in a purely syntactic sense.  Disable the
examples when exceptions are disabled because we want the
examples to be clean code, and therefore do not want ugly
`#if/#endif` blocks in them.
