### PR TITLE
 Complete implementation of install target

### DIFF
--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -89,7 +89,10 @@ GRPC_GENERATE_CPP_MOCKS(GRPCPP_SOURCES GRPCPP_HDRS GRPC_MOCK_HDRS
 # Create a library with the generated files from the relevant protos.
 add_library(bigtable_protos ${PROTO_SOURCES} ${PROTO_HDRS} ${GRPCPP_SOURCES} ${GRPCPP_HDRS})
 target_link_libraries(bigtable_protos gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
-target_include_directories(bigtable_protos PUBLIC "${PROJECT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
+target_include_directories(bigtable_protos PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>)
 target_compile_options(bigtable_protos PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 add_library(bigtable::protos ALIAS bigtable_protos)
 

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -165,3 +165,49 @@ if (CLANG_TIDY_EXE AND BIGTABLE_CLIENT_CLANG_TIDY)
             CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
     )
 endif ()
+
+# The install target can only be enabled if all the dependencies are installed.
+# CMake tries to install the submodules, and gRPC has complex configuration for
+# getting installed.  It is easier to just compile + install gRPC and then
+# compile this project.
+if (NOT ${GOOGLE_CLOUD_CPP_GRPC_PROVIDER} STREQUAL "module")
+    # Install the libraries and headers in the locations determined by
+    # GNUInstallDirs
+    include(GNUInstallDirs)
+    install(TARGETS bigtable_admin_client bigtable_client bigtable_protos
+        EXPORT bigtable-targets
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(DIRECTORY client/ DESTINATION include/bigtable/client FILES_MATCHING PATTERN "*.h")
+    install(DIRECTORY admin/ DESTINATION include/bigtable/admin FILES_MATCHING PATTERN "*.h")
+    install(DIRECTORY ${CMAKE_BINARY_DIR}/bigtable/google/ DESTINATION include/google FILES_MATCHING PATTERN "*.h")
+    # Export the CMake targets to make it easy to create configuration files.
+    install(EXPORT bigtable-targets DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake)
+
+    # Install the pkg-config files.
+    configure_file("client/config.pc.in" "bigtable_client.pc" @ONLY)
+    install(FILES "${CMAKE_BINARY_DIR}/bigtable/bigtable_client.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+    configure_file("admin/config.pc.in" "bigtable_admin.pc" @ONLY)
+    install(FILES "${CMAKE_BINARY_DIR}/bigtable/bigtable_admin.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+
+    # Install the cmake -config.cmake files.
+    configure_file("client/config.cmake.in"
+        "bigtable_client-config.cmake" @ONLY)
+    configure_file("admin/config.cmake.in"
+        "bigtable_admin_client-config.cmake" @ONLY)
+    configure_file("client/config-version.cmake.in"
+        "bigtable_client-config-version.cmake" @ONLY)
+    configure_file("client/config-version.cmake.in"
+        "bigtable_admin_client-config-version.cmake" @ONLY)
+    install(FILES
+        "${CMAKE_BINARY_DIR}/bigtable/bigtable_client-config.cmake"
+        "${CMAKE_BINARY_DIR}/bigtable/bigtable_client-config-version.cmake"
+        "${CMAKE_BINARY_DIR}/bigtable/bigtable_admin_client-config.cmake"
+        "${CMAKE_BINARY_DIR}/bigtable/bigtable_admin_client-config-version.cmake"
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake)
+    export(TARGETS bigtable_admin_client bigtable_client bigtable_protos
+        FILE "bigtable-exports.cmake")
+endif ()

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -64,6 +64,9 @@ if(GRPC_ROOT_DIR)
     list(INSERT PROTOBUF_IMPORT_DIRS 0 "${GRPC_ROOT_DIR}/third_party/protobuf/src")
 endif(GRPC_ROOT_DIR)
 
+# Get the destination directories based on the GNU recommendations.
+include(GNUInstallDirs)
+
 # Include the functions to compile proto files.
 include(${PROJECT_SOURCE_DIR}/cmake/CompileProtos.cmake)
 PROTOBUF_GENERATE_CPP(PROTO_SOURCES PROTO_HDRS
@@ -176,41 +179,19 @@ endif ()
 if (NOT ${GOOGLE_CLOUD_CPP_GRPC_PROVIDER} STREQUAL "module")
     # Install the libraries and headers in the locations determined by
     # GNUInstallDirs
-    include(GNUInstallDirs)
-    install(TARGETS bigtable_admin_client bigtable_client bigtable_protos
+    install(TARGETS bigtable_protos
         EXPORT bigtable-targets
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-    install(DIRECTORY client/ DESTINATION include/bigtable/client FILES_MATCHING PATTERN "*.h")
-    install(DIRECTORY admin/ DESTINATION include/bigtable/admin FILES_MATCHING PATTERN "*.h")
+
+    # Install proto generated files into bigtable/google.
     install(DIRECTORY ${CMAKE_BINARY_DIR}/bigtable/google/ DESTINATION include/google FILES_MATCHING PATTERN "*.h")
+
     # Export the CMake targets to make it easy to create configuration files.
     install(EXPORT bigtable-targets DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake)
 
-    # Install the pkg-config files.
-    configure_file("client/config.pc.in" "bigtable_client.pc" @ONLY)
-    install(FILES "${CMAKE_BINARY_DIR}/bigtable/bigtable_client.pc"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
-    configure_file("admin/config.pc.in" "bigtable_admin.pc" @ONLY)
-    install(FILES "${CMAKE_BINARY_DIR}/bigtable/bigtable_admin.pc"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
-
     # Install the cmake -config.cmake files.
-    configure_file("client/config.cmake.in"
-        "bigtable_client-config.cmake" @ONLY)
-    configure_file("admin/config.cmake.in"
-        "bigtable_admin_client-config.cmake" @ONLY)
-    configure_file("client/config-version.cmake.in"
-        "bigtable_client-config-version.cmake" @ONLY)
-    configure_file("client/config-version.cmake.in"
-        "bigtable_admin_client-config-version.cmake" @ONLY)
-    install(FILES
-        "${CMAKE_BINARY_DIR}/bigtable/bigtable_client-config.cmake"
-        "${CMAKE_BINARY_DIR}/bigtable/bigtable_client-config-version.cmake"
-        "${CMAKE_BINARY_DIR}/bigtable/bigtable_admin_client-config.cmake"
-        "${CMAKE_BINARY_DIR}/bigtable/bigtable_admin_client-config-version.cmake"
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake)
     export(TARGETS bigtable_admin_client bigtable_client bigtable_protos
         FILE "bigtable-exports.cmake")
 endif ()

--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -172,26 +172,24 @@ if (CLANG_TIDY_EXE AND BIGTABLE_CLIENT_CLANG_TIDY)
     )
 endif ()
 
-# The install target can only be enabled if all the dependencies are installed.
-# CMake tries to install the submodules, and gRPC has complex configuration for
-# getting installed.  It is easier to just compile + install gRPC and then
-# compile this project.
+# Install the libraries and headers in the locations determined by
+# GNUInstallDirs
+install(TARGETS bigtable_protos
+    EXPORT bigtable-targets
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+# Install proto generated files into bigtable/google.
+install(DIRECTORY ${CMAKE_BINARY_DIR}/bigtable/google/ DESTINATION include/google FILES_MATCHING PATTERN "*.h")
+
+# The exports can only be installed if all the dependencies are installed.
+# CMake needs to know where the submodules will be installed from,
 if (NOT ${GOOGLE_CLOUD_CPP_GRPC_PROVIDER} STREQUAL "module")
-    # Install the libraries and headers in the locations determined by
-    # GNUInstallDirs
-    install(TARGETS bigtable_protos
-        EXPORT bigtable-targets
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-
-    # Install proto generated files into bigtable/google.
-    install(DIRECTORY ${CMAKE_BINARY_DIR}/bigtable/google/ DESTINATION include/google FILES_MATCHING PATTERN "*.h")
-
     # Export the CMake targets to make it easy to create configuration files.
     install(EXPORT bigtable-targets DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake)
 
-    # Install the cmake -config.cmake files.
+    # Install the cmake -exports.cmake files.
     export(TARGETS bigtable_admin_client bigtable_client bigtable_protos
         FILE "bigtable-exports.cmake")
 endif ()

--- a/bigtable/admin/CMakeLists.txt
+++ b/bigtable/admin/CMakeLists.txt
@@ -52,26 +52,24 @@ foreach (fname ${bigtable_admin_unit_tests})
     add_dependencies(tests-local ${target})
 endforeach ()
 
-if (NOT ${GOOGLE_CLOUD_CPP_GRPC_PROVIDER} STREQUAL "module")
-    install(TARGETS bigtable_admin_client
-        EXPORT bigtable-targets
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-    install(DIRECTORY admin/ DESTINATION include/bigtable/admin FILES_MATCHING PATTERN "*.h")
+install(TARGETS bigtable_admin_client
+    EXPORT bigtable-targets
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(DIRECTORY admin/ DESTINATION include/bigtable/admin FILES_MATCHING PATTERN "*.h")
 
-    # Install the pkg-config files.
-    configure_file("config.pc.in" "bigtable_admin.pc" @ONLY)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/bigtable_admin.pc"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+# Install the pkg-config files.
+configure_file("config.pc.in" "bigtable_admin.pc" @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/bigtable_admin.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
-    # Install the CMake configuration files.
-    configure_file("config.cmake.in"
-        "bigtable_admin_client-config.cmake" @ONLY)
-    configure_file("config-version.cmake.in"
-        "bigtable_admin_client-config-version.cmake" @ONLY)
-    install(FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/bigtable_admin_client-config.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/bigtable_admin_client-config-version.cmake"
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake)
-endif ()
+# Install the CMake configuration files.
+configure_file("config.cmake.in"
+    "bigtable_admin_client-config.cmake" @ONLY)
+configure_file("config-version.cmake.in"
+    "bigtable_admin_client-config-version.cmake" @ONLY)
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/bigtable_admin_client-config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/bigtable_admin_client-config-version.cmake"
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake)

--- a/bigtable/admin/CMakeLists.txt
+++ b/bigtable/admin/CMakeLists.txt
@@ -26,7 +26,10 @@ add_library(bigtable_admin_client
         table_config.cc)
 target_link_libraries(bigtable_admin_client bigtable_client bigtable_protos
         gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
-target_include_directories(bigtable_admin_client PUBLIC "${PROJECT_SOURCE_DIR}")
+target_include_directories(bigtable_admin_client PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+    $<INSTALL_INTERFACE:include>)
 add_library(bigtable::admin_client ALIAS bigtable_admin_client)
 
 # List the unit tests, then setup the targets and dependencies.

--- a/bigtable/admin/CMakeLists.txt
+++ b/bigtable/admin/CMakeLists.txt
@@ -51,3 +51,27 @@ foreach (fname ${bigtable_admin_unit_tests})
     add_test(NAME ${target} COMMAND ${target})
     add_dependencies(tests-local ${target})
 endforeach ()
+
+if (NOT ${GOOGLE_CLOUD_CPP_GRPC_PROVIDER} STREQUAL "module")
+    install(TARGETS bigtable_admin_client
+        EXPORT bigtable-targets
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(DIRECTORY admin/ DESTINATION include/bigtable/admin FILES_MATCHING PATTERN "*.h")
+
+    # Install the pkg-config files.
+    configure_file("config.pc.in" "bigtable_admin.pc" @ONLY)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/bigtable_admin.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+
+    # Install the CMake configuration files.
+    configure_file("config.cmake.in"
+        "bigtable_admin_client-config.cmake" @ONLY)
+    configure_file("config-version.cmake.in"
+        "bigtable_admin_client-config-version.cmake" @ONLY)
+    install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/bigtable_admin_client-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/bigtable_admin_client-config-version.cmake"
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake)
+endif ()

--- a/bigtable/admin/config-version.cmake.in
+++ b/bigtable/admin/config-version.cmake.in
@@ -1,0 +1,37 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(PACKAGE_VERSION @BIGTABLE_CLIENT_VERSION@)
+
+if (@BIGTABLE_CLIENT_VERSION_MAJOR@ EQUAL 0)
+    # Only exact matches for the 0.x.y releases, i.e., no backwards
+    # compatibility guarantees.
+    if (("${PACKAGE_FIND_VERSION_MAJOR}" EQUAL "@BIGTABLE_CLIENT_VERSION_MAJOR@")
+         AND ("${PACKAGE_FIND_VERSION_MINOR}" EQUAL "@BIGTABLE_CLIENT_VERSION_MINOR@"))
+        set(PACKAGE_VERSION_EXACT TRUE)
+    else ()
+        set(PACKAGE_VERSION_UNSUITABLE TRUE)
+    endif ()
+elseif ("${PACKAGE_FIND_VERSION_MAJOR}" EQUAL "@BIGTABLE_CLIENT_VERSION_MAJOR@")
+    # For versions after 1.x.y we will require backwards compatibility.
+    if ("${PACKAGE_FIND_VERSION_MINOR}" EQUAL "@BIGTABLE_CLIENT_VERSION_MINOR@")
+        set(PACKAGE_VERSION_EXACT TRUE)
+    elseif("${PACKAGE_FIND_VERSION_MINOR}" LESS "@BIGTABLE_CLIENT_VERSION_MINOR@")
+        set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    else ()
+        set(PACKAGE_VERSION_UNSUITABLE TRUE)
+    endif ()
+else ()
+    set(PACKAGE_VERSION_UNSUITABLE TRUE)
+endif ()

--- a/bigtable/admin/config.cmake.in
+++ b/bigtable/admin/config.cmake.in
@@ -1,0 +1,19 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include("${CMAKE_CURRENT_LIST_DIR}/bigtable-targets.cmake")
+
+add_library(bigtable::admin_client IMPORTED INTERFACE)
+set_target_properties(bigtable::admin_client PROPERTIES
+    INTERFACE_LINK_LIBRARIES "bigtable_admin_client;bigtable::client;bigtable::protos")

--- a/bigtable/admin/config.pc.in
+++ b/bigtable/admin/config.pc.in
@@ -1,0 +1,25 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}/@CMAKE_INSTALL_BINDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: The Cloud Bigtable C++ Admin Client Library
+Description: Provides C++ APIs to access the Cloud Bigtable Admin interfaces.
+Version: @PROJECT_VERSION@
+
+Libs: -L${libdir} -lbigtable_admin_client -lbigtable_client -lbigtable_protos
+Cflags: -I${includedir}

--- a/bigtable/client/CMakeLists.txt
+++ b/bigtable/client/CMakeLists.txt
@@ -136,27 +136,25 @@ if (FORCE_STATIC_ANALYZER_ERRORS)
             PRIVATE -DBIGTABLE_CLIENT_FORCE_STATIC_ANALYZER_ERRORS)
 endif (FORCE_STATIC_ANALYZER_ERRORS)
 
-if (NOT ${GOOGLE_CLOUD_CPP_GRPC_PROVIDER} STREQUAL "module")
-    install(TARGETS bigtable_client
-        EXPORT bigtable-targets
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-    install(DIRECTORY . DESTINATION include/bigtable/client
-            FILES_MATCHING PATTERN "*.h"
-            PATTERN "testing/*" EXCLUDE)
+install(TARGETS bigtable_client
+    EXPORT bigtable-targets
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(DIRECTORY . DESTINATION include/bigtable/client
+        FILES_MATCHING PATTERN "*.h"
+        PATTERN "testing/*" EXCLUDE)
 
-    # Install the pkg-config files.
-    configure_file("config.pc.in" "bigtable_client.pc" @ONLY)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/bigtable_client.pc"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+# Install the pkg-config files.
+configure_file("config.pc.in" "bigtable_client.pc" @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/bigtable_client.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
-    # Install the CMake configuration files.
-    configure_file("config.cmake.in" "bigtable_client-config.cmake" @ONLY)
-    configure_file("config-version.cmake.in"
-        "bigtable_client-config-version.cmake" @ONLY)
-    install(FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/bigtable_client-config.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/bigtable_client-config-version.cmake"
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake)
-endif ()
+# Install the CMake configuration files.
+configure_file("config.cmake.in" "bigtable_client-config.cmake" @ONLY)
+configure_file("config-version.cmake.in"
+    "bigtable_client-config-version.cmake" @ONLY)
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/bigtable_client-config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/bigtable_client-config-version.cmake"
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake)

--- a/bigtable/client/CMakeLists.txt
+++ b/bigtable/client/CMakeLists.txt
@@ -142,7 +142,9 @@ if (NOT ${GOOGLE_CLOUD_CPP_GRPC_PROVIDER} STREQUAL "module")
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-    install(DIRECTORY . DESTINATION include/bigtable/client FILES_MATCHING PATTERN "*.h")
+    install(DIRECTORY . DESTINATION include/bigtable/client
+            FILES_MATCHING PATTERN "*.h"
+            PATTERN "testing/*" EXCLUDE)
 
     # Install the pkg-config files.
     configure_file("config.pc.in" "bigtable_client.pc" @ONLY)

--- a/bigtable/client/CMakeLists.txt
+++ b/bigtable/client/CMakeLists.txt
@@ -135,3 +135,26 @@ if (FORCE_STATIC_ANALYZER_ERRORS)
     target_compile_definitions(bigtable_client_force_sanitizer_failures_test
             PRIVATE -DBIGTABLE_CLIENT_FORCE_STATIC_ANALYZER_ERRORS)
 endif (FORCE_STATIC_ANALYZER_ERRORS)
+
+if (NOT ${GOOGLE_CLOUD_CPP_GRPC_PROVIDER} STREQUAL "module")
+    install(TARGETS bigtable_client
+        EXPORT bigtable-targets
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(DIRECTORY . DESTINATION include/bigtable/client FILES_MATCHING PATTERN "*.h")
+
+    # Install the pkg-config files.
+    configure_file("config.pc.in" "bigtable_client.pc" @ONLY)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/bigtable_client.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+
+    # Install the CMake configuration files.
+    configure_file("config.cmake.in" "bigtable_client-config.cmake" @ONLY)
+    configure_file("config-version.cmake.in"
+        "bigtable_client-config-version.cmake" @ONLY)
+    install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/bigtable_client-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/bigtable_client-config-version.cmake"
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake)
+endif ()

--- a/bigtable/client/CMakeLists.txt
+++ b/bigtable/client/CMakeLists.txt
@@ -65,7 +65,10 @@ add_library(bigtable_client
 target_link_libraries(bigtable_client
         bigtable_protos
         gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
-target_include_directories(bigtable_client PUBLIC "${PROJECT_SOURCE_DIR}" "${PROJECT_BINARY_DIR}")
+target_include_directories(bigtable_client PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+    $<INSTALL_INTERFACE:include>)
 target_compile_options(bigtable_client PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 add_library(bigtable::client ALIAS bigtable_client)
 

--- a/bigtable/client/config-version.cmake.in
+++ b/bigtable/client/config-version.cmake.in
@@ -1,0 +1,37 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(PACKAGE_VERSION @BIGTABLE_CLIENT_VERSION@)
+
+if (@BIGTABLE_CLIENT_VERSION_MAJOR@ EQUAL 0)
+    # Only exact matches for the 0.x.y releases, i.e., no backwards
+    # compatibility guarantees.
+    if (("${PACKAGE_FIND_VERSION_MAJOR}" EQUAL "@BIGTABLE_CLIENT_VERSION_MAJOR@")
+         AND ("${PACKAGE_FIND_VERSION_MINOR}" EQUAL "@BIGTABLE_CLIENT_VERSION_MINOR@"))
+        set(PACKAGE_VERSION_EXACT TRUE)
+    else ()
+        set(PACKAGE_VERSION_UNSUITABLE TRUE)
+    endif ()
+elseif ("${PACKAGE_FIND_VERSION_MAJOR}" EQUAL "@BIGTABLE_CLIENT_VERSION_MAJOR@")
+    # For versions after 1.x.y we will require backwards compatibility.
+    if ("${PACKAGE_FIND_VERSION_MINOR}" EQUAL "@BIGTABLE_CLIENT_VERSION_MINOR@")
+        set(PACKAGE_VERSION_EXACT TRUE)
+    elseif("${PACKAGE_FIND_VERSION_MINOR}" LESS "@BIGTABLE_CLIENT_VERSION_MINOR@")
+        set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    else ()
+        set(PACKAGE_VERSION_UNSUITABLE TRUE)
+    endif ()
+else ()
+    set(PACKAGE_VERSION_UNSUITABLE TRUE)
+endif ()

--- a/bigtable/client/config.cmake.in
+++ b/bigtable/client/config.cmake.in
@@ -1,0 +1,23 @@
+# Copyright 201\8 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include("${CMAKE_CURRENT_LIST_DIR}/bigtable-targets.cmake")
+
+add_library(bigtable::protos IMPORTED INTERFACE)
+set_target_properties(bigtable::protos PROPERTIES
+    INTERFACE_LINK_LIBRARIES "bigtable_protos")
+
+add_library(bigtable::client IMPORTED INTERFACE)
+set_target_properties(bigtable::client PROPERTIES
+    INTERFACE_LINK_LIBRARIES "bigtable_client")

--- a/bigtable/client/config.pc.in
+++ b/bigtable/client/config.pc.in
@@ -1,0 +1,25 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}/@CMAKE_INSTALL_BINDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: The Cloud Bigtable C++ Client Library
+Description: Provides C++ APIs to access the Cloud Bigtable.
+Version: @PROJECT_VERSION@
+
+Libs: -L${libdir} -lbigtable_client -lbigtable_protos
+Cflags: -I${includedir}

--- a/ci/Dockerfile.ubuntu-with-grpc
+++ b/ci/Dockerfile.ubuntu-with-grpc
@@ -32,3 +32,6 @@ FROM cached-${DISTRO}-${DISTRO_VERSION}:tip
 COPY --from=staging /usr/local/include /usr/local/include
 COPY --from=staging /usr/local/bin /usr/local/bin
 COPY --from=staging /usr/local/lib /usr/local/lib
+
+# Update the dynamic loader cache because we changed /usr/local/lib.
+RUN ldconfig

--- a/ci/build-docker.sh
+++ b/ci/build-docker.sh
@@ -95,6 +95,22 @@ else
   echo "no sanitizer errors found."
 fi
 
+# Test the install rule and that the installation works.
+if [ "${TEST_INSTALL}" = "yes" ]; then
+  echo
+  echo "${COLOR_YELLOW}Testing install rule.${COLOR_RESET}"
+  make install
+  echo
+  echo "${COLOR_YELLOW}Test installed libraries using make(1).${COLOR_RESET}"
+  make -C /v/ci/test-install all
+  echo
+  echo "${COLOR_YELLOW}Test installed libraries using cmake(1).${COLOR_RESET}"
+  # Ignore mkdir errors in development environment.
+  mkdir /v/ci/test-install/.build || /bin/true
+  cd /v/ci/test-install/.build
+  CMAKE_PREFIX_PATH=/usr/local/share cmake .. && make
+fi
+
 # If document generation is enabled, run it now.
 if [ "${GENERATE_DOCS}" = "yes" ]; then
   make doxygen-docs

--- a/ci/test-install/CMakeLists.txt
+++ b/ci/test-install/CMakeLists.txt
@@ -1,0 +1,61 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A minimal CMakeList.txt to *test* the install Cloud Bigtable C++ client.
+#
+# This is not intended to be a demonstration of how to write good CMakeList.txt
+# files, nor is it a general solution to create CMake files for
+# google-cloud-cpp. It is simply a minimal CMake file to verify that (a) the
+# installed libraries contain all required headers, and (b) the installed CMake
+# configuration files are usable.
+
+cmake_minimum_required(VERSION 3.5)
+project(google-cloud-cpp-install-integration-test CXX C)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Threads REQUIRED)
+
+find_package(bigtable_client 0.1.0 REQUIRED)
+find_package(bigtable_admin_client 0.1.0 REQUIRED)
+
+# The dependencies are hard-coded because we just want to test the
+# google-cloud-cpp installed files.  A real application would use find_package()
+# for them too, but we do not install the CMake config files as part of the
+# continous integration build.
+
+# With cmake-3.9 and higher this can be simplified to:
+#    find_package(Protobuf REQUIRED)
+add_library(protobuf::libprotobuf INTERFACE IMPORTED)
+set_target_properties(protobuf::libprotobuf PROPERTIES
+        INTERFACE_LINK_LIBRARIES "/usr/local/lib/libprotobuf.a;Threads::Threads"
+        INTERFACE_INCLUDE_DIRECTORIES "/usr/local/include")
+
+# Ideally these are provided by grpc-config.cmake (or gRPCConfig.cmake), and
+# that file is installed by the gRPC cmake, but the continuous integration build
+# does not install (yet) those files.
+add_library(gRPC::grpc INTERFACE IMPORTED)
+set_target_properties(gRPC::grpc PROPERTIES
+        INTERFACE_LINK_LIBRARIES "/usr/local/lib/libgrpc.so;protobuf::libprotobuf"
+        INTERFACE_INCLUDE_DIRECTORIES "/usr/local/include")
+
+add_library(gRPC::grpc++ INTERFACE IMPORTED)
+set_target_properties(gRPC::grpc++ PROPERTIES
+        INTERFACE_LINK_LIBRARIES "/usr/local/lib/libgrpc++.so;gRPC::grpc++"
+        INTERFACE_INCLUDE_DIRECTORIES "/usr/local/include")
+
+# Defining new targets should be easy.
+add_executable(install_integration_test install_integration_test.cc)
+target_link_libraries(install_integration_test bigtable::admin_client bigtable::client)

--- a/ci/test-install/Makefile
+++ b/ci/test-install/Makefile
@@ -1,0 +1,37 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A simple makefile to test the `install` target.
+#
+# This is not intended to be a demonstration of how to write good Makefiles,
+# nor is it a general solution on how to build Makefiles for google-cloud-cpp.
+# It is simply a minimal file to test the installed pkg-config support files.
+
+DEPS=bigtable_client bigtable_admin grpc++ grpc protobuf
+CXXFLAGS=$(shell pkg-config $(DEPS) --cflags)
+CXXLDFLAGS=$(shell pkg-config $(DEPS) --libs-only-L)
+LIBS=$(shell pkg-config $(DEPS) --libs-only-l)
+
+# This is hard-coded because it is intended for a test, applications are
+# expected to configure the files themselves.
+CXX=clang++ -std=c++11
+CXXLD=$(CXX)
+
+all: echo install_integration_test
+
+install_integration_test: install_integration_test.cc
+	$(CXXLD) $(CXXFLAGS) $(CXXLDFLAGS) -o $@ $^ $(LIBS)
+
+echo:
+	echo $(DEPS)

--- a/ci/test-install/install_integration_test.cc
+++ b/ci/test-install/install_integration_test.cc
@@ -1,0 +1,94 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/client/data_client.h"
+#include "bigtable/client/table.h"
+
+#include <sstream>
+
+#include <google/protobuf/text_format.h>
+
+#include "bigtable/admin/admin_client.h"
+#include "bigtable/admin/table_admin.h"
+
+int main(int argc, char* argv[]) try {
+  // Make sure the arguments are valid.
+  if (argc != 4) {
+    std::string const cmd = argv[0];
+    auto last_slash = std::string(argv[0]).find_last_of("/");
+    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
+              << " <project> <instance> <table>" << std::endl;
+    return 1;
+  }
+  std::string const project_id = argv[1];
+  std::string const instance_id = argv[2];
+  std::string const table_name = argv[3];
+  std::string const family = "fam";
+
+  auto admin_client =
+      bigtable::CreateDefaultAdminClient(project_id, bigtable::ClientOptions());
+  bigtable::TableAdmin admin(admin_client, instance_id);
+
+  auto created_table = admin.CreateTable(
+      table_name, bigtable::TableConfig(
+                      {{family, bigtable::GcRule::MaxNumVersions(1)}}, {}));
+  std::cout << table_name << " created successfully" << std::endl;
+
+  auto client = bigtable::CreateDefaultDataClient(project_id, instance_id,
+                                                  bigtable::ClientOptions());
+  bigtable::Table table(client, table_name);
+
+  bigtable::BulkMutation bulk{
+      bigtable::SingleRowMutation("row-key-0",
+                                  {bigtable::SetCell(family, "c0", 0, "v0"),
+                                   bigtable::SetCell(family, "c1", 0, "v1")}),
+      bigtable::SingleRowMutation("row-key-1",
+                                  {bigtable::SetCell(family, "c0", 0, "v2"),
+                                   bigtable::SetCell(family, "c1", 0, "v3")}),
+  };
+  table.BulkApply(std::move(bulk));
+  std::cout << "bulk mutation successful" << std::endl;
+
+  auto row0 = table.ReadRow("row-key-0", bigtable::Filter::PassAllFilter());
+  if (not row0.first) {
+    std::cout << "Cannot find row-key-0" << std::endl;
+  } else {
+    for (auto const& cell : row0.second.cells()) {
+      std::cout << cell.row_key() << ": " << cell.family_name() << ":"
+                << cell.column_qualifier() << " = " << cell.value()
+                << std::endl;
+    }
+  }
+  auto row1 = table.ReadRow("row-key-1", bigtable::Filter::PassAllFilter());
+  if (not row0.first) {
+    std::cout << "Cannot find row-key-0" << std::endl;
+  } else {
+    for (auto const& cell : row1.second.cells()) {
+      std::cout << cell.row_key() << ": " << cell.family_name() << ":"
+                << cell.column_qualifier() << " = " << cell.value()
+                << std::endl;
+    }
+  }
+
+  return 0;
+} catch (bigtable::PermanentMutationFailure const& ex) {
+  std::cerr << "bigtable::PermanentMutationFailure raised: " << ex.what()
+            << " - " << ex.status().error_message() << " ["
+            << ex.status().error_code()
+            << "], details=" << ex.status().error_details() << std::endl;
+  return 1;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard exception raised: " << ex.what() << std::endl;
+  return 1;
+}


### PR DESCRIPTION
This fixes #24, it contains an example to test 'make install' as
part of the continuous integration build.  It also fixes #44, it
creates and installs the pkg-config support files.  Finally it
fixes #45, it creates and installs the CMake configuration files
to use find_package() when the libraries are installed.

Apologies for making so many fixes in one commit, but otherwise
the commits need to create pkg-config files (or CMake config
files) that are not tested, or I need to introduce tests that
have everything hardcoded without the config files.
