### PR TITLE
Implement ReadRow integration test case

### DIFF
--- a/bigtable/client/testing/table_integration_test.cc
+++ b/bigtable/client/testing/table_integration_test.cc
@@ -71,21 +71,6 @@ std::vector<bigtable::Cell> TableIntegrationTest::ReadRows(
   return result;
 }
 
-std::unique_ptr<bigtable::Cell> TableIntegrationTest::ReadRow(
-    bigtable::Table& table, std::string row_key, bigtable::Filter filter) {
-  auto row_pair = table.ReadRow(row_key, std::move(filter));
-  if (!row_pair.first) {
-    return nullptr;
-  }
-
-  bigtable::Cell row_cell = row_pair.second.cells().at(0);
-  bigtable::Cell newCell(row_cell.row_key(), row_cell.family_name(),
-                         row_cell.column_qualifier(), row_cell.timestamp(),
-                         row_cell.value(), row_cell.labels());
-
-  return bigtable::internal::make_unique<bigtable::Cell>(newCell);
-}
-
 /// A helper function to create a list of cells.
 void TableIntegrationTest::CreateCells(
     bigtable::Table& table, std::vector<bigtable::Cell> const& cells) {

--- a/bigtable/client/testing/table_integration_test.h
+++ b/bigtable/client/testing/table_integration_test.h
@@ -62,13 +62,16 @@ class TableIntegrationTest : public ::testing::Test {
   std::vector<bigtable::Cell> ReadRows(bigtable::Table& table,
                                        bigtable::Filter filter);
 
+  std::vector<bigtable::Cell> ReadRows(bigtable::Table& table,
+                                       std::int64_t rows_limit,
+                                       bigtable::Filter filter);
+
   /// Return all the cells in @p table that pass @p filter.
   void CreateCells(bigtable::Table& table,
                    std::vector<bigtable::Cell> const& cells);
 
   /**
    * Compare two sets of cells.
-   *
    * Unordered because ReadRows does not guarantee a particular order.
    */
   void CheckEqualUnordered(std::vector<bigtable::Cell> expected,

--- a/bigtable/tests/data_integration_test.cc
+++ b/bigtable/tests/data_integration_test.cc
@@ -175,9 +175,9 @@ TEST_F(DataIntegrationTest, TableReadRowTest) {
       {row_key1, family, "c1", 1000, "v1000", {}}};
 
   CreateCells(*table, created);
-  auto row_cell = ReadRow(*table, row_key1, bigtable::Filter::PassAllFilter());
+  auto row_cell = table->ReadRow(row_key1, bigtable::Filter::PassAllFilter());
   std::vector<bigtable::Cell> actual;
-  actual.emplace_back(*row_cell);
+  actual.emplace_back(row_cell.second.cells().at(0));
   DeleteTable(table_name);
   CheckEqualUnordered(expected, actual);
 }
@@ -192,7 +192,7 @@ TEST_F(DataIntegrationTest, TableReadRowNotExistTest) {
       {row_key1, family, "c1", 1000, "v1000", {}}};
 
   CreateCells(*table, created);
-  auto row_cell = ReadRow(*table, row_key2, bigtable::Filter::PassAllFilter());
+  auto row_cell = table->ReadRow(row_key2, bigtable::Filter::PassAllFilter());
   DeleteTable(table_name);
-  EXPECT_EQ(row_cell, nullptr);
+  EXPECT_FALSE(row_cell.first);
 }


### PR DESCRIPTION
Implemented new wrapper functions to use the following functions
1. RowReader ReadRows(RowSet row_set, std::int64_t rows_limit, Filter filter)
2. std::pair<bool, Row> ReadRow(std::string row_key, Filter filter)
    in table_integration_test.cc
But test case for ReadRow is only implemented in data_integration_test.cc as there are some incomplete tests for the ReadRows functions.

