### PR TITLE
Fix bug in scan throughput benchmark.

### DIFF
--- a/bigtable/benchmarks/scan_throughput_benchmark.cc
+++ b/bigtable/benchmarks/scan_throughput_benchmark.cc
@@ -64,7 +64,7 @@ constexpr int kScanSizes[] = {100, 1000, 10000};
 /// Run an iteration of the test.
 BenchmarkResult RunBenchmark(bigtable::benchmarks::Benchmark const& benchmark,
                              std::shared_ptr<bigtable::DataClient> data_client,
-                             std::string const& table_id, long table_size,
+                             long table_size, std::string const& table_id,
                              long scan_size,
                              std::chrono::seconds test_duration);
 }  // anonymous namespace
@@ -86,8 +86,8 @@ int main(int argc, char* argv[]) try {
     std::cout << "# Running benchmark [" << scan_size << "] " << std::flush;
     auto start = std::chrono::steady_clock::now();
     auto combined =
-        RunBenchmark(benchmark, data_client, setup.table_id(), scan_size,
-                     setup.table_size(), setup.test_duration());
+        RunBenchmark(benchmark, data_client, setup.table_size(),
+                     setup.table_id(), scan_size, setup.test_duration());
     using std::chrono::duration_cast;
     combined.elapsed = duration_cast<std::chrono::milliseconds>(
         std::chrono::steady_clock::now() - start);
@@ -118,7 +118,7 @@ int main(int argc, char* argv[]) try {
 namespace {
 BenchmarkResult RunBenchmark(bigtable::benchmarks::Benchmark const& benchmark,
                              std::shared_ptr<bigtable::DataClient> data_client,
-                             std::string const& table_id, long table_size,
+                             long table_size, std::string const& table_id,
                              long scan_size,
                              std::chrono::seconds test_duration) {
   BenchmarkResult result = {};


### PR DESCRIPTION
I made a mistake in the scan throughput benchmark, swapping the
scan_size and table_size parameters. Effectively this meant all
the tests were using the same scan size, and it was absurdly
large (the full table!).  Of course that resulted in fantastic
performance results, but for a different thing than we wanted to
measure.

I changed the function signatures to make it less likely that one
can swap the parameters.