### PR TITLE
Fix #35 Refactor wrappers without exceptions to separate namespace.

### DIFF
--- a/bigtable/CMakeLists.txt
+++ b/bigtable/CMakeLists.txt
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 # This should be included from the top level CMakeLists file
-set(BIGTABLE_CLIENT_VERSION_MAJOR 0)
-set(BIGTABLE_CLIENT_VERSION_MINOR 1)
-set(BIGTABLE_CLIENT_VERSION_PATCH 0)
 
 # Configure the Compiler options, we will be using C++11 features.
 set(CMAKE_CXX_STANDARD 11)
@@ -110,6 +107,12 @@ configure_file(client/build_info.cc.in client/build_info.cc)
 
 include(${PROJECT_SOURCE_DIR}/cmake/IncludeGMock.cmake)
 
+# Generate the version information from the CMake values.
+set(BIGTABLE_CLIENT_VERSION_MAJOR 0)
+set(BIGTABLE_CLIENT_VERSION_MINOR 1)
+set(BIGTABLE_CLIENT_VERSION_PATCH 0)
+configure_file(client/version_info.h.in client/version_info.h)
+
 if (${CMAKE_VERSION} VERSION_LESS "3.9")
     # Old versions of CMake have really poor support for Doxygen generation.
     message(STATUS "Doxygen generation only enabled for cmake 3.9 and higher")
@@ -132,36 +135,309 @@ else ()
     endif ()
 endif ()
 
-# Define custom targets to simplify the scan-build static analysis scripts: we
-# want to compile these targets without static analysis, as they are not part
-# of this project, and we also do not want to list all the dependencies in the
-# scripts and here.  So we create a target to build the dependencies, build that
-# without static analysis, and then build "all" with static analysis.
+# the client library
+add_library(bigtable_client
+    ${PROJECT_BINARY_DIR}/bigtable/client/build_info.cc
+    ${PROJECT_BINARY_DIR}/bigtable/client/version_info.h
+    client/build_info.h
+    client/cell.h
+    client/client_options.h
+    client/client_options.cc
+    client/data_client.h
+    client/data_client.cc
+    client/internal/bulk_mutator.h
+    client/internal/bulk_mutator.cc
+    client/internal/common_client.h
+    client/internal/common_client.cc
+    client/internal/conjunction.h
+    client/internal/make_unique.h
+    client/internal/port_platform.h
+    client/internal/prefix_range_end.h
+    client/internal/prefix_range_end.cc
+    client/internal/readrowsparser.h
+    client/internal/readrowsparser.cc
+    client/internal/rowreaderiterator.h
+    client/internal/rowreaderiterator.cc
+    client/internal/throw_delegate.h
+    client/internal/throw_delegate.cc
+    client/internal/unary_rpc_utils.h
+    client/internal/table.h
+    client/internal/table.cc
+    client/filters.h
+    client/filters.cc
+    client/idempotent_mutation_policy.h
+    client/idempotent_mutation_policy.cc
+    client/mutations.h
+    client/mutations.cc
+    client/row.h
+    client/row_range.h
+    client/row_range.cc
+    client/row_reader.h
+    client/row_reader.cc
+    client/row_set.h
+    client/row_set.cc
+    client/rpc_backoff_policy.h
+    client/rpc_backoff_policy.cc
+    client/rpc_retry_policy.h
+    client/rpc_retry_policy.cc
+    client/table.h
+    client/table.cc
+    client/version.h
+    client/version.cc)
+target_link_libraries(bigtable_client
+    bigtable_protos
+    gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
+target_include_directories(bigtable_client PUBLIC "${PROJECT_SOURCE_DIR}" "${PROJECT_BINARY_DIR}")
+target_compile_options(bigtable_client PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+add_library(bigtable::client ALIAS bigtable_client)
+
+add_library(bigtable_client_testing
+    client/testing/chrono_literals.h
+    client/testing/mock_data_client.h
+    client/testing/mock_response_stream.h
+    client/testing/table_integration_test.h
+    client/testing/table_integration_test.cc
+    client/testing/table_test_fixture.h
+    client/testing/table_test_fixture.cc
+    client/testing/internal_table_test_fixture.h
+    client/testing/internal_table_test_fixture.cc)
+target_link_libraries(bigtable_client_testing
+    bigtable_client bigtable_protos
+    gmock gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
+
+# the admin library
+add_library(bigtable_admin_client
+    admin/admin_client.h
+    admin/admin_client.cc
+    admin/column_family.h
+    admin/instance_admin_client.h
+    admin/instance_admin_client.cc
+    admin/instance_admin.h
+    admin/instance_admin.cc
+    admin/table_admin.h
+    admin/table_admin.cc
+    admin/table_config.h
+    admin/table_config.cc)
+target_link_libraries(bigtable_admin_client bigtable_client bigtable_protos
+    gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
+target_include_directories(bigtable_admin_client PUBLIC "${PROJECT_SOURCE_DIR}")
+add_library(bigtable::admin_client ALIAS bigtable_admin_client)
+
+option(BIGTABLE_CLIENT_CLANG_TIDY
+    "If set compiles the Cloud Bigtable client with clang-tidy."
+    "")
+if (CLANG_TIDY_EXE AND BIGTABLE_CLIENT_CLANG_TIDY)
+    message(STATUS "clang-tidy build enabled.")
+    set_target_properties(
+        bigtable_client PROPERTIES
+        CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
+    )
+    set_target_properties(
+        bigtable_admin_client PROPERTIES
+        CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
+    )
+endif ()
+
+# Define custom targets to simplify the scan-build scripts.
 add_custom_target(depends-local)
 add_dependencies(depends-local gmock bigtable_protos)
 
 # All tests get added to this target below.
 add_custom_target(tests-local)
-add_subdirectory(client)
-add_subdirectory(admin)
-add_subdirectory(tests)
+
+# List the unit tests, then setup the targets and dependencies.
+set(bigtable_client_unit_tests
+    client/cell_test.cc
+    client/client_options_test.cc
+    client/data_client_test.cc
+    client/filters_test.cc
+    client/force_sanitizer_failures_test.cc
+    client/idempotent_mutation_policy_test.cc
+    client/internal/bulk_mutator_test.cc
+    client/internal/prefix_range_end_test.cc
+    client/internal/readrowsparser_test.cc
+    client/internal/table_test.cc
+    client/mutations_test.cc
+    client/table_apply_test.cc
+    client/table_bulk_apply_test.cc
+    client/table_readrow_test.cc
+    client/table_readrows_test.cc
+    client/table_test.cc
+    client/row_reader_test.cc
+    client/row_test.cc
+    client/row_range_test.cc
+    client/row_set_test.cc
+    client/rpc_backoff_policy_test.cc
+    client/rpc_retry_policy_test.cc)
+foreach (fname ${bigtable_client_unit_tests})
+    string(REPLACE "/" "_" target ${fname})
+    string(REPLACE ".cc" "" target ${target})
+    add_executable(${target} ${fname})
+    get_target_property(tname ${target} NAME)
+    target_link_libraries(${target}
+        bigtable_client_testing bigtable_client bigtable_protos
+        gmock gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
+    add_test(NAME ${tname} COMMAND ${target})
+    get_target_property(sources ${target} SOURCES)
+    add_dependencies(tests-local ${target})
+endforeach ()
+# Create a single executable that rolls up all the tests, this is convenient
+# for CLion and other IDEs.
+add_executable(bigtable_client_all_tests EXCLUDE_FROM_ALL
+    ${bigtable_client_unit_tests})
+target_link_libraries(bigtable_client_all_tests
+    bigtable_client_testing bigtable_client bigtable_protos
+    gmock gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
+
+# List the unit tests, then setup the targets and dependencies.
+set(bigtable_admin_unit_tests
+    admin/admin_client_test.cc
+    admin/column_family_test.cc
+    admin/instance_admin_client_test.cc
+    admin/instance_admin_test.cc
+    admin/table_admin_test.cc
+    admin/table_config_test.cc)
+foreach (fname ${bigtable_admin_unit_tests})
+    string(REPLACE "/" "_" target ${fname})
+    string(REPLACE ".cc" "" target ${target})
+    add_executable(${target} ${fname})
+    get_target_property(tname ${target} NAME)
+    target_link_libraries(${target}
+        bigtable_client_testing bigtable_admin_client bigtable_client
+        bigtable_protos
+        gmock gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
+    add_test(NAME ${tname} COMMAND ${target})
+    get_target_property(sources ${target} SOURCES)
+    add_dependencies(tests-local ${target})
+endforeach ()
+target_sources(bigtable_client_all_tests PUBLIC ${bigtable_admin_unit_tests})
+target_link_libraries(bigtable_client_all_tests bigtable_admin_client)
+
+option(FORCE_SANITIZER_ERRORS
+    "If set, enable tests that force errors detected by the sanitizers."
+    "")
+if (FORCE_SANITIZER_ERRORS)
+    target_compile_definitions(client_force_sanitizer_failures_test
+            PRIVATE -DBIGTABLE_CLIENT_FORCE_SANITIZER_ERRORS)
+endif (FORCE_SANITIZER_ERRORS)
+
+option(FORCE_STATIC_ANALYZER_ERRORS
+    "If set, enable tests that force errors detected by the static analyzer."
+    "")
+if (FORCE_STATIC_ANALYZER_ERRORS)
+    target_compile_definitions(client_force_sanitizer_failures_test
+        PRIVATE -DBIGTABLE_CLIENT_FORCE_STATIC_ANALYZER_ERRORS)
+endif (FORCE_STATIC_ANALYZER_ERRORS)
+
+# The integration tests, these are simply programs that connect to the
+# Cloud Bigtable emulator.
+add_executable(data_integration_test tests/data_integration_test.cc)
+target_link_libraries(data_integration_test
+    gmock bigtable_admin_client bigtable_client bigtable_client_testing bigtable_protos
+    gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
+add_dependencies(tests-local data_integration_test)
+
+# An integration test for bigtable::TableAdmin.
+add_executable(admin_integration_test tests/admin_integration_test.cc)
+target_link_libraries(admin_integration_test
+    gmock bigtable_admin_client bigtable_client bigtable_client_testing bigtable_protos
+    gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
+add_dependencies(tests-local admin_integration_test)
+
+# An integration test for bigtable::Filter.
+add_executable(filters_integration_test tests/filters_integration_test.cc)
+target_link_libraries(filters_integration_test
+    bigtable_admin_client bigtable_client bigtable_client_testing bigtable_protos
+    gmock gRPC::grpc protobuf::libprotobuf)
+add_dependencies(tests-local filters_integration_test)
+
+# An integration test for bigtable::Mutations.
+add_executable(mutations_integration_test tests/mutations_integration_test.cc)
+target_link_libraries(mutations_integration_test
+    bigtable_admin_client bigtable_client bigtable_client_testing bigtable_protos
+    gmock gRPC::grpc protobuf::libprotobuf)
+add_dependencies(tests-local mutations_integration_test)
 
 if (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
-    add_subdirectory(benchmarks)
+    add_library(bigtable_benchmark_common
+        benchmarks/benchmark.h
+        benchmarks/benchmark.cc
+        benchmarks/constants.h
+        benchmarks/embedded_server.h
+        benchmarks/embedded_server.cc
+        benchmarks/random.h
+        benchmarks/random.cc
+        benchmarks/setup.h
+        benchmarks/setup.cc)
+    target_link_libraries(bigtable_benchmark_common
+        bigtable_admin_client bigtable_client bigtable_protos
+        gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
+
+    # List the unit tests, then setup the targets and dependencies.
+    set(bigtable_benchmarks_unit_tests
+        benchmarks/benchmark_test.cc
+        benchmarks/embedded_server_test.cc
+        benchmarks/format_duration_test.cc
+        benchmarks/random_test.cc
+        benchmarks/setup_test.cc)
+    foreach (fname ${bigtable_benchmarks_unit_tests})
+        string(REPLACE "/" "_" target ${fname})
+        string(REPLACE ".cc" "" target ${target})
+        add_executable(${target} ${fname})
+        get_target_property(tname ${target} NAME)
+        target_link_libraries(${target}
+            bigtable_benchmark_common bigtable_admin_client bigtable_client
+            bigtable_protos
+            gmock gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
+        add_test(NAME ${tname} COMMAND ${target})
+        get_target_property(sources ${target} SOURCES)
+        add_dependencies(tests-local ${target})
+    endforeach ()
+    target_sources(bigtable_client_all_tests
+        PUBLIC ${bigtable_benchmarks_unit_tests})
+    target_link_libraries(bigtable_client_all_tests bigtable_benchmark_common)
+
+    # Benchmark Table::ReadRows().
+    add_executable(scan_throughput_benchmark
+            benchmarks/scan_throughput_benchmark.cc)
+    target_link_libraries(scan_throughput_benchmark
+            bigtable_benchmark_common bigtable_admin_client bigtable_client
+            bigtable_protos
+            gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
+
+    # Benchmark for Table::Apply() and Table::ReadRow().
+    add_executable(apply_read_latency_benchmark
+            benchmarks/apply_read_latency_benchmark.cc)
+    target_link_libraries(apply_read_latency_benchmark
+            bigtable_benchmark_common bigtable_admin_client bigtable_client
+            bigtable_protos
+            gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
+
+    # A benchmark to measure performance of long running programs.
+    add_executable(endurance_benchmark benchmarks/endurance_benchmark.cc)
+    target_link_libraries(endurance_benchmark bigtable_benchmark_common
+            bigtable_admin_client bigtable_client bigtable_protos
+            gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
+endif (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
+
+if (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_subdirectory(examples/quick_start)
 endif (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
 
-option(BIGTABLE_CLIENT_CLANG_TIDY
-        "If set compiles the Cloud Bigtable client with clang-tidy."
-        "")
-if (CLANG_TIDY_EXE AND BIGTABLE_CLIENT_CLANG_TIDY)
-    message(STATUS "clang-tidy build enabled.")
-    set_target_properties(
-            bigtable_client PROPERTIES
-            CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
-    )
-    set_target_properties(
-            bigtable_admin_client PROPERTIES
-            CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
-    )
-endif ()
+# Define the install target
+get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
+if ("${LIB64}" STREQUAL "TRUE")
+    set(LIBSUFFIX 64)
+else()
+    set(LIBSUFFIX "")
+endif()
+set(INSTALL_LIB_DIR lib${LIBSUFFIX} CACHE PATH "Installation directory for libraries")
+install(TARGETS bigtable_admin_client bigtable_client bigtable_protos
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION ${INSTALL_LIB_DIR}
+    ARCHIVE DESTINATION ${INSTALL_LIB_DIR})
+install(DIRECTORY client/ DESTINATION include/bigtable/client FILES_MATCHING PATTERN "*.h")
+install(DIRECTORY admin/ DESTINATION include/bigtable/admin FILES_MATCHING PATTERN "*.h")
+install(DIRECTORY ../third_party/abseil/absl DESTINATION include/bigtable FILES_MATCHING PATTERN "*.h")
+install(DIRECTORY ../third_party/abseil/absl DESTINATION include/bigtable FILES_MATCHING PATTERN "*.inc")
+install(DIRECTORY ${CMAKE_BINARY_DIR}/bigtable/google/ DESTINATION include/bigtable/google FILES_MATCHING PATTERN "*.h")

--- a/bigtable/client/CMakeLists.txt
+++ b/bigtable/client/CMakeLists.txt
@@ -1,134 +1,116 @@
-# Copyright 2018 Google Inc.
+#Copyright 2018 Google Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+#Licensed under the Apache License, Version 2.0(the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#http:  // www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
 
-# Generate the version information from the CMake values.
+#Generate the version information from the CMake values.
 configure_file(version_info.h.in version_info.h)
 
-# the client library
-add_library(bigtable_client
-        ${PROJECT_BINARY_DIR}/bigtable/client/build_info.cc
-        ${PROJECT_BINARY_DIR}/bigtable/client/version_info.h
-        build_info.h
-        cell.h
-        client_options.h
-        client_options.cc
-        data_client.h
-        data_client.cc
-        internal/bulk_mutator.h
-        internal/bulk_mutator.cc
-        internal/common_client.h
-        internal/common_client.cc
-        internal/conjunction.h
-        internal/make_unique.h
-        internal/port_platform.h
-        internal/prefix_range_end.h
-        internal/prefix_range_end.cc
-        internal/readrowsparser.h
-        internal/readrowsparser.cc
-        internal/rowreaderiterator.h
-        internal/rowreaderiterator.cc
-        internal/throw_delegate.h
-        internal/throw_delegate.cc
-        internal/unary_rpc_utils.h
-        filters.h
-        filters.cc
-        idempotent_mutation_policy.h
-        idempotent_mutation_policy.cc
-        mutations.h
-        mutations.cc
-        row.h
-        row_range.h
-        row_range.cc
-        row_reader.h
-        row_reader.cc
-        row_set.h
-        row_set.cc
-        rpc_backoff_policy.h
-        rpc_backoff_policy.cc
-        rpc_retry_policy.h
-        rpc_retry_policy.cc
-        table.h
-        table.cc
-        version.h
-        version.cc)
-target_link_libraries(bigtable_client
-        bigtable_protos
-        gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
-target_include_directories(bigtable_client PUBLIC "${PROJECT_SOURCE_DIR}" "${PROJECT_BINARY_DIR}")
-target_compile_options(bigtable_client PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
-add_library(bigtable::client ALIAS bigtable_client)
+#the client library
+    add_library(
+        bigtable_client ${PROJECT_BINARY_DIR} / bigtable / client /
+        build_info.cc ${PROJECT_BINARY_DIR} / bigtable / client /
+        version_info.h build_info.h cell.h client_options.h client_options
+            .cc data_client.h data_client.cc internal /
+        bulk_mutator.h internal / bulk_mutator.cc internal /
+        common_client.h internal / common_client.cc internal /
+        conjunction.h internal / make_unique.h internal /
+        port_platform.h internal / prefix_range_end.h internal /
+        prefix_range_end.cc internal / readrowsparser.h internal /
+        readrowsparser.cc internal / rowreaderiterator.h internal /
+        rowreaderiterator.cc internal / throw_delegate.h internal /
+        throw_delegate.cc internal / unary_rpc_utils.h internal /
+        table.h internal /
+        table.cc filters.h filters.cc idempotent_mutation_policy
+            .h idempotent_mutation_policy.cc mutations.h mutations.cc row
+            .h row_range.h row_range.cc row_reader.h row_reader.cc row_set
+            .h row_set.cc rpc_backoff_policy.h rpc_backoff_policy
+            .cc rpc_retry_policy.h rpc_retry_policy.cc table.h table.cc version
+            .h version.cc) target_link_libraries(bigtable_client bigtable_protos
+                                                     gRPC::grpc++ gRPC::grpc
+                                                         protobuf::libprotobuf)
+        target_include_directories(
+            bigtable_client PUBLIC
+            "${PROJECT_SOURCE_DIR}"
+            "${PROJECT_BINARY_DIR}") target_compile_options(bigtable_client PUBLIC ${
+            GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG}) add_library(bigtable::client ALIAS
+                                                               bigtable_client)
 
-add_library(bigtable_client_testing
-        testing/chrono_literals.h
-        testing/mock_data_client.h
-        testing/mock_response_stream.h
-        testing/table_integration_test.h
-        testing/table_integration_test.cc
-        testing/table_test_fixture.h
-        testing/table_test_fixture.cc)
-target_link_libraries(bigtable_client_testing
-        bigtable_client bigtable_protos
-        gmock gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
+            add_library(bigtable_client_testing testing /
+                        chrono_literals.h testing / mock_data_client.h testing /
+                        mock_response_stream.h testing /
+                        table_integration_test.h testing /
+                        table_integration_test.cc testing /
+                        table_test_fixture.h testing /
+                        table_test_fixture.cc testing /
+                        internal_table_test_fixture.h testing /
+                        internal_table_test_fixture.cc)
+                target_link_libraries(
+                    bigtable_client_testing bigtable_client bigtable_protos
+                        gmock gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
 
-# List the unit tests, then setup the targets and dependencies.
-set(bigtable_client_unit_tests
-        cell_test.cc
-        client_options_test.cc
-        data_client_test.cc
-        filters_test.cc
-        force_sanitizer_failures_test.cc
-        idempotent_mutation_policy_test.cc
-        internal/bulk_mutator_test.cc
-        internal/prefix_range_end_test.cc
-        internal/readrowsparser_test.cc
-        mutations_test.cc
-        table_apply_test.cc
-        table_bulk_apply_test.cc
-        table_readrow_test.cc
-        table_readrows_test.cc
-        table_test.cc
-        row_reader_test.cc
-        row_test.cc
-        row_range_test.cc
-        row_set_test.cc
-        rpc_backoff_policy_test.cc
-        rpc_retry_policy_test.cc)
+#List the unit tests, then setup the targets and dependencies.
+                    set(bigtable_client_unit_tests cell_test
+                            .cc client_options_test.cc data_client_test
+                            .cc filters_test.cc force_sanitizer_failures_test
+                            .cc idempotent_mutation_policy_test.cc internal /
+                        bulk_mutator_test.cc internal /
+                        prefix_range_end_test.cc internal /
+                        readrowsparser_test.cc internal /
+                        table_test.cc mutations_test.cc table_apply_test
+                            .cc table_bulk_apply_test.cc table_readrow_test
+                            .cc table_readrows_test.cc table_test
+                            .cc row_reader_test.cc row_test.cc row_range_test
+                            .cc row_set_test.cc rpc_backoff_policy_test
+                            .cc rpc_retry_policy_test.cc)
 
-foreach (fname ${bigtable_client_unit_tests})
-    string(REPLACE "/" "_" target ${fname})
-    string(REPLACE ".cc" "" target ${target})
-    set(target "bigtable_client_${target}")
-    add_executable(${target} ${fname})
-    target_link_libraries(${target} PRIVATE
-            bigtable_client_testing bigtable_client bigtable_protos
-            gmock gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
-    add_test(NAME ${target} COMMAND ${target})
-    add_dependencies(tests-local ${target})
-endforeach ()
+                        foreach (fname ${bigtable_client_unit_tests}) string(
+                            REPLACE
+                            "/"
+                            "_" target ${fname}) string(REPLACE
+                                                        ".cc"
+                                                        "" target ${target})
+                            set(target
+                                "bigtable_client_${target}") add_executable(${
+                                target} ${fname})
+                                target_link_libraries(
+                                    ${target} PRIVATE bigtable_client_testing
+                                        bigtable_client bigtable_protos gmock
+                                            gRPC::grpc++ gRPC::grpc protobuf::
+                                                libprotobuf) add_test(NAME ${
+                                    target} COMMAND ${
+                                    target}) add_dependencies(tests -
+                                                              local ${
+                                                                  target}) endforeach()
 
-option(FORCE_SANITIZER_ERRORS
-        "If set, enable tests that force errors detected by the sanitizers."
-        "")
-if (FORCE_SANITIZER_ERRORS)
-    target_compile_definitions(bigtable_client_force_sanitizer_failures_test
-            PRIVATE -DBIGTABLE_CLIENT_FORCE_SANITIZER_ERRORS)
-endif (FORCE_SANITIZER_ERRORS)
+                                    option(FORCE_SANITIZER_ERRORS
+                                           "If set, enable tests that force "
+                                           "errors detected by the sanitizers."
+                                           "") if (FORCE_SANITIZER_ERRORS)
+                                        target_compile_definitions(
+                                            bigtable_client_force_sanitizer_failures_test
+                                                PRIVATE -
+                                            DBIGTABLE_CLIENT_FORCE_SANITIZER_ERRORS)
+                                            endif(FORCE_SANITIZER_ERRORS)
 
-option(FORCE_STATIC_ANALYZER_ERRORS
-        "If set, enable tests that force errors detected by the static analyzer."
-        "")
-if (FORCE_STATIC_ANALYZER_ERRORS)
-    target_compile_definitions(bigtable_client_force_sanitizer_failures_test
-            PRIVATE -DBIGTABLE_CLIENT_FORCE_STATIC_ANALYZER_ERRORS)
-endif (FORCE_STATIC_ANALYZER_ERRORS)
+                                                option(
+                                                    FORCE_STATIC_ANALYZER_ERRORS
+                                                    "If set, enable tests that "
+                                                    "force errors detected by "
+                                                    "the static analyzer."
+                                                    "") if (FORCE_STATIC_ANALYZER_ERRORS)
+                                                    target_compile_definitions(
+                                                        bigtable_client_force_sanitizer_failures_test
+                                                            PRIVATE -
+                                                        DBIGTABLE_CLIENT_FORCE_STATIC_ANALYZER_ERRORS)
+                                                        endif(
+                                                            FORCE_STATIC_ANALYZER_ERRORS)

--- a/bigtable/client/internal/readrowsparser.h
+++ b/bigtable/client/internal/readrowsparser.h
@@ -68,7 +68,8 @@ class ReadRowsParser {
    * @throws std::runtime_error if validation failed.
    */
   virtual void HandleChunk(
-      google::bigtable::v2::ReadRowsResponse_CellChunk chunk);
+      google::bigtable::v2::ReadRowsResponse_CellChunk chunk,
+      grpc::Status &status);
 
   /**
    * Signal that the input stream reached the end.
@@ -76,7 +77,7 @@ class ReadRowsParser {
    * @throws std::runtime_error if more data was expected to finish
    * the current row.
    */
-  virtual void HandleEndOfStream();
+  virtual void HandleEndOfStream(grpc::Status &status);
 
   /**
    * True if the data parsed so far yielded a Row.
@@ -92,7 +93,7 @@ class ReadRowsParser {
    *
    * @throws std::runtime_error if HasNext() is false.
    */
-  virtual Row Next();
+  virtual Row Next(grpc::Status &status);
 
  private:
   /// Holds partially formed data until a full Row is ready.

--- a/bigtable/client/internal/table.cc
+++ b/bigtable/client/internal/table.cc
@@ -1,0 +1,161 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/client/internal/table.h"
+
+#include <thread>
+
+#include "bigtable/client/internal/bulk_mutator.h"
+#include "bigtable/client/internal/make_unique.h"
+
+namespace btproto = ::google::bigtable::v2;
+
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace noex {
+
+// Call the `google.bigtable.v2.Bigtable.MutateRow` RPC repeatedly until
+// successful, or until the policies in effect tell us to stop.
+std::vector<FailedMutation> Table::Apply(SingleRowMutation&& mut) {
+  // Copy the policies in effect for this operation.  Many policy classes change
+  // their state as the operation makes progress (or fails to make progress), so
+  // we need fresh instances.
+  auto rpc_policy = rpc_retry_policy_->clone();
+  auto backoff_policy = rpc_backoff_policy_->clone();
+  auto idempotent_policy = idempotent_mutation_policy_->clone();
+
+  // Build the RPC request, try to minimize copying.
+  btproto::MutateRowRequest request;
+  request.set_table_name(table_name_);
+  mut.MoveTo(request);
+
+  bool const is_idempotent =
+      std::all_of(request.mutations().begin(), request.mutations().end(),
+                  [&idempotent_policy](btproto::Mutation const& m) {
+                    return idempotent_policy->is_idempotent(m);
+                  });
+
+  btproto::MutateRowResponse response;
+  std::vector<FailedMutation> failures;
+  grpc::Status status;
+  while (true) {
+    grpc::ClientContext client_context;
+    rpc_policy->setup(client_context);
+    backoff_policy->setup(client_context);
+    status = client_->Stub()->MutateRow(&client_context, request, &response);
+    if (status.ok()) {
+      return failures;
+    }
+    // It is up to the policy to terminate this loop, it could run
+    // forever, but that would be a bad policy (pun intended).
+    if (not rpc_policy->on_failure(status) or not is_idempotent) {
+      google::rpc::Status rpc_status;
+      rpc_status.set_code(status.error_code());
+      rpc_status.set_message(status.error_message());
+      failures.emplace_back(SingleRowMutation(std::move(request)), rpc_status,
+                            0);
+      // TODO(#234) - just return the failures instead
+      status = grpc::Status(
+          status.error_code(),
+          "Permanent (or too many transient) errors in Table::Apply()");
+      return failures;
+    }
+    auto delay = backoff_policy->on_completion(status);
+    std::this_thread::sleep_for(delay);
+  }
+}
+
+// Call the `google.bigtable.v2.Bigtable.MutateRows` RPC repeatedly until
+// successful, or until the policies in effect tell us to stop.  When the RPC
+// is partially successful, this function retries only the mutations that did
+// not succeed.
+std::vector<FailedMutation> Table::BulkApply(BulkMutation&& mut,
+                                             grpc::Status& status) {
+  // Copy the policies in effect for this operation.  Many policy classes change
+  // their state as the operation makes progress (or fails to make progress), so
+  // we need fresh instances.
+  auto backoff_policy = rpc_backoff_policy_->clone();
+  auto retry_policy = rpc_retry_policy_->clone();
+  auto idemponent_policy = idempotent_mutation_policy_->clone();
+
+  internal::BulkMutator mutator(table_name_, *idemponent_policy,
+                                std::forward<BulkMutation>(mut));
+  while (mutator.HasPendingMutations()) {
+    grpc::ClientContext client_context;
+    backoff_policy->setup(client_context);
+    retry_policy->setup(client_context);
+
+    status = mutator.MakeOneRequest(*client_->Stub(), client_context);
+    if (not status.ok() and not retry_policy->on_failure(status)) {
+      break;
+    }
+    auto delay = backoff_policy->on_completion(status);
+    std::this_thread::sleep_for(delay);
+  }
+  auto failures = mutator.ExtractFinalFailures();
+  if (not status.ok()) {
+    return failures;
+  }
+  if (not failures.empty()) {
+    // TODO(#234) - just return the failures instead
+    status = grpc::Status(
+        grpc::StatusCode::INTERNAL,
+        "Permanent (or too many transient) errors in Table::BulkApply()");
+  }
+  return failures;
+}
+
+RowReader Table::ReadRows(RowSet row_set, Filter filter, bool raise_on_error) {
+  return RowReader(client_, table_name(), std::move(row_set),
+                   RowReader::NO_ROWS_LIMIT, std::move(filter),
+                   rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
+                   bigtable::internal::make_unique<
+                       bigtable::internal::ReadRowsParserFactory>(),
+                   raise_on_error);
+}
+
+RowReader Table::ReadRows(RowSet row_set, std::int64_t rows_limit,
+                          Filter filter, bool raise_on_error) {
+  return RowReader(client_, table_name(), std::move(row_set), rows_limit,
+                   std::move(filter), rpc_retry_policy_->clone(),
+                   rpc_backoff_policy_->clone(),
+                   bigtable::internal::make_unique<
+                       bigtable::internal::ReadRowsParserFactory>(),
+                   raise_on_error);
+}
+
+std::pair<bool, Row> Table::ReadRow(std::string row_key, Filter filter,
+                                    grpc::Status& status) {
+  RowSet row_set(std::move(row_key));
+  std::int64_t const rows_limit = 1;
+  RowReader reader =
+      ReadRows(std::move(row_set), rows_limit, std::move(filter));
+  auto it = reader.begin();
+  if (it == reader.end()) {
+    status = reader.Finish();
+    return std::make_pair(false, Row("", {}));
+  }
+  auto result = std::make_pair(true, std::move(*it));
+  if (++it != reader.end()) {
+    status =
+        grpc::Status(grpc::StatusCode::INTERNAL,
+                     "internal error - RowReader returned 2 rows in ReadRow()");
+    return std::make_pair(false, Row("", {}));
+  }
+  return result;
+}
+
+}  // namespace noex
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable

--- a/bigtable/client/internal/table.h
+++ b/bigtable/client/internal/table.h
@@ -1,0 +1,108 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_TABLE_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_TABLE_H_
+
+#include "bigtable/client/data_client.h"
+#include "bigtable/client/filters.h"
+#include "bigtable/client/idempotent_mutation_policy.h"
+#include "bigtable/client/mutations.h"
+#include "bigtable/client/row_reader.h"
+#include "bigtable/client/row_set.h"
+#include "bigtable/client/rpc_backoff_policy.h"
+#include "bigtable/client/rpc_retry_policy.h"
+
+#include <google/bigtable/v2/bigtable.grpc.pb.h>
+
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+/**
+ * Return the full table name.
+ *
+ * The full table name is:
+ *
+ * `projects/<PROJECT_ID>/instances/<INSTANCE_ID>/tables/<table_id>`
+ *
+ * Where the project id and instance id come from the @p client parameter.
+ */
+inline std::string TableName(std::shared_ptr<DataClient> client,
+                             std::string const& table_id) {
+  return InstanceName(std::move(client)) + "/tables/" + table_id;
+}
+
+/**
+ * This namespace contains implementations of the API that do not raise
+ * exceptions. It is subject to change without notice, and therefore, not
+ * recommended for direct use by applications.
+ */
+namespace noex {
+class Table {
+ public:
+  Table(std::shared_ptr<DataClient> client, std::string const& table_id)
+      : client_(std::move(client)),
+        table_name_(TableName(client_, table_id)),
+        rpc_retry_policy_(bigtable::DefaultRPCRetryPolicy()),
+        rpc_backoff_policy_(bigtable::DefaultRPCBackoffPolicy()),
+        idempotent_mutation_policy_(
+            bigtable::DefaultIdempotentMutationPolicy()) {}
+
+  template <typename RPCRetryPolicy, typename RPCBackoffPolicy,
+            typename IdempotentMutationPolicy>
+  Table(std::shared_ptr<DataClient> client, std::string const& table_id,
+        RPCRetryPolicy retry_policy, RPCBackoffPolicy backoff_policy,
+        IdempotentMutationPolicy idempotent_mutation_policy)
+      : client_(std::move(client)),
+        table_name_(TableName(client_, table_id)),
+        rpc_retry_policy_(retry_policy.clone()),
+        rpc_backoff_policy_(backoff_policy.clone()),
+        idempotent_mutation_policy_(idempotent_mutation_policy.clone()) {}
+
+  std::string const& table_name() const { return table_name_; }
+
+  //@{
+  /**
+   * @name No exception versions of Table::*
+   *
+   * These functions provide the same functionality as their counterparts in the
+   * `bigtable::Table` class, but do not raise exceptions on errors, instead
+   * they return the error on the status parameter.
+   */
+  std::vector<FailedMutation> Apply(SingleRowMutation&& mut);
+
+  std::vector<FailedMutation> BulkApply(BulkMutation&& mut,
+                                        grpc::Status& status);
+
+  RowReader ReadRows(RowSet row_set, Filter filter,
+                     bool raise_on_error = false);
+
+  RowReader ReadRows(RowSet row_set, std::int64_t rows_limit, Filter filter,
+                     bool raise_on_error = false);
+
+  std::pair<bool, Row> ReadRow(std::string row_key, Filter filter,
+                               grpc::Status& status);
+  //@}
+
+ private:
+  std::shared_ptr<DataClient> client_;
+  std::string table_name_;
+  std::unique_ptr<RPCRetryPolicy> rpc_retry_policy_;
+  std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy_;
+  std::unique_ptr<IdempotentMutationPolicy> idempotent_mutation_policy_;
+};
+}  // namespace noex
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_TABLE_H_

--- a/bigtable/client/internal/table_test.cc
+++ b/bigtable/client/internal/table_test.cc
@@ -1,0 +1,688 @@
+
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/client/table.h"
+
+#include "bigtable/client/testing/chrono_literals.h"
+#include "bigtable/client/testing/internal_table_test_fixture.h"
+
+using testing::_;
+using testing::Return;
+using testing::SetArgPointee;
+
+/// Define types and functions used in the tests.
+namespace {
+class TableTest : public bigtable::testing::internal::TableTestFixture {};
+class TableReadRowTest : public bigtable::testing::internal::TableTestFixture {
+};
+class TableReadRowsTest : public bigtable::testing::internal::TableTestFixture {
+};
+class TableApplyTest : public bigtable::testing::internal::TableTestFixture {};
+class MockReader : public grpc::ClientReaderInterface<
+                       ::google::bigtable::v2::MutateRowsResponse> {
+ public:
+  MOCK_METHOD0(WaitForInitialMetadata, void());
+  MOCK_METHOD0(Finish, grpc::Status());
+  MOCK_METHOD1(NextMessageSize, bool(std::uint32_t *));
+  MOCK_METHOD1(Read, bool(::google::bigtable::v2::MutateRowsResponse *));
+};
+
+class TableBulkApplyTest
+    : public bigtable::testing::internal::TableTestFixture {};
+}  // anonymous namespace
+
+TEST_F(TableTest, ClientProjectId) {
+  EXPECT_EQ(kProjectId, client_->project_id());
+}
+
+TEST_F(TableTest, ClientInstanceId) {
+  EXPECT_EQ(kInstanceId, client_->instance_id());
+}
+
+TEST_F(TableTest, StandaloneInstanceName) {
+  EXPECT_EQ(kInstanceName, bigtable::InstanceName(client_));
+}
+
+TEST_F(TableTest, StandaloneTableName) {
+  EXPECT_EQ(kTableName, bigtable::TableName(client_, kTableId));
+}
+
+TEST_F(TableTest, TableName) {
+  // clang-format: you are drunk, placing this short function in a single line
+  // is not nice.
+  EXPECT_EQ(kTableName, table_.table_name());
+}
+
+TEST_F(TableTest, TableConstructor) {
+  std::string const kOtherTableId = "my-table";
+  std::string const kOtherTableName =
+      bigtable::TableName(client_, kOtherTableId);
+  bigtable::Table table(client_, kOtherTableId);
+  EXPECT_EQ(kOtherTableName, table.table_name());
+}
+
+TEST_F(TableReadRowTest, ReadRowSimple) {
+  using namespace ::testing;
+  namespace btproto = ::google::bigtable::v2;
+  grpc::Status status;
+  auto response =
+      bigtable::testing::internal::ReadRowsResponseFromString(R"(
+                                                                  chunks {
+                                                                  row_key: "r1"
+                                                                      family_name { value: "fam" }
+                                                                      qualifier { value: "col" }
+                                                                  timestamp_micros: 42000
+                                                                  value: "value"
+                                                                  commit_row: true
+                                                                  }
+                                                                  )",
+                                                              status);
+  EXPECT_TRUE(status.ok());
+
+  auto stream =
+      bigtable::internal::make_unique<bigtable::testing::MockResponseStream>();
+  EXPECT_CALL(*stream, Read(_))
+      .WillOnce(Invoke([&response](btproto::ReadRowsResponse *r) {
+        *r = response;
+        return true;
+      }))
+      .WillOnce(Return(false));
+  EXPECT_CALL(*stream, Finish()).WillOnce(Return(grpc::Status::OK));
+
+  EXPECT_CALL(*bigtable_stub_, ReadRowsRaw(_, _))
+      .WillOnce(Invoke([&stream, this](grpc::ClientContext *,
+                                       btproto::ReadRowsRequest const &req) {
+        EXPECT_EQ(1, req.rows().row_keys_size());
+        EXPECT_EQ("r1", req.rows().row_keys(0));
+        EXPECT_EQ(1, req.rows_limit());
+        EXPECT_EQ(table_.table_name(), req.table_name());
+        return stream.release();
+      }));
+
+  auto result = table_.ReadRow("r1", bigtable::Filter::PassAllFilter(), status);
+  EXPECT_TRUE(status.ok());
+  EXPECT_TRUE(std::get<0>(result));
+  auto row = std::get<1>(result);
+  EXPECT_EQ("r1", row.row_key());
+}
+
+TEST_F(TableReadRowTest, ReadRowMissing) {
+  using namespace ::testing;
+  namespace btproto = ::google::bigtable::v2;
+
+  auto stream =
+      bigtable::internal::make_unique<bigtable::testing::MockResponseStream>();
+  EXPECT_CALL(*stream, Read(_)).WillOnce(Return(false));
+  EXPECT_CALL(*stream, Finish()).WillOnce(Return(grpc::Status::OK));
+
+  EXPECT_CALL(*bigtable_stub_, ReadRowsRaw(_, _))
+      .WillOnce(Invoke([&stream, this](grpc::ClientContext *,
+                                       btproto::ReadRowsRequest const &req) {
+        EXPECT_EQ(1, req.rows().row_keys_size());
+        EXPECT_EQ("r1", req.rows().row_keys(0));
+        EXPECT_EQ(1, req.rows_limit());
+        EXPECT_EQ(table_.table_name(), req.table_name());
+        return stream.release();
+      }));
+  grpc::Status status;
+  auto result = table_.ReadRow("r1", bigtable::Filter::PassAllFilter(), status);
+  EXPECT_TRUE(status.ok());
+  EXPECT_FALSE(std::get<0>(result));
+}
+
+TEST_F(TableReadRowTest, ReadRowError) {
+  using namespace ::testing;
+  namespace btproto = ::google::bigtable::v2;
+
+  auto stream =
+      bigtable::internal::make_unique<bigtable::testing::MockResponseStream>();
+  EXPECT_CALL(*stream, Read(_)).WillOnce(Return(false));
+  EXPECT_CALL(*stream, Finish())
+      .WillOnce(
+          Return(grpc::Status(grpc::StatusCode::INTERNAL, "Internal Error")));
+
+  EXPECT_CALL(*bigtable_stub_, ReadRowsRaw(_, _))
+      .WillOnce(Invoke([&stream, this](grpc::ClientContext *,
+                                       btproto::ReadRowsRequest const &req) {
+        EXPECT_EQ(1, req.rows().row_keys_size());
+        EXPECT_EQ("r1", req.rows().row_keys(0));
+        EXPECT_EQ(1, req.rows_limit());
+        EXPECT_EQ(table_.table_name(), req.table_name());
+        return stream.release();
+      }));
+  grpc::Status status;
+  auto result = table_.ReadRow("r1", bigtable::Filter::PassAllFilter(), status);
+  EXPECT_FALSE(status.ok());
+  EXPECT_FALSE(std::get<0>(result));
+}
+
+TEST_F(TableReadRowsTest, ReadRowsCanReadOneRow) {
+  grpc::Status status;
+  auto response =
+      bigtable::testing::internal::ReadRowsResponseFromString(R"(
+                                                                  chunks {
+                                                                  row_key: "r1"
+                                                                      family_name { value: "fam" }
+                                                                      qualifier { value: "qual" }
+                                                                  timestamp_micros: 42000
+                                                                  value: "value"
+                                                                  commit_row: true
+                                                                  }
+                                                                  )",
+                                                              status);
+  EXPECT_TRUE(status.ok());
+
+  // must be a new pointer, it is wrapped in unique_ptr by ReadRows
+  auto stream = new bigtable::testing::MockResponseStream;
+  EXPECT_CALL(*bigtable_stub_, ReadRowsRaw(_, _)).WillOnce(Return(stream));
+  EXPECT_CALL(*stream, Read(testing::_))
+      .WillOnce(DoAll(SetArgPointee<0>(response), Return(true)))
+      .WillOnce(Return(false));
+  EXPECT_CALL(*stream, Finish()).WillOnce(Return(grpc::Status::OK));
+
+  auto reader =
+      table_.ReadRows(bigtable::RowSet(), bigtable::Filter::PassAllFilter());
+
+  auto it = reader.begin();
+  EXPECT_NE(it, reader.end());
+  EXPECT_EQ(it->row_key(), "r1");
+  EXPECT_EQ(++it, reader.end());
+  status = reader.Finish();
+  EXPECT_TRUE(status.ok());
+}
+
+TEST_F(TableReadRowsTest, ReadRowsCanReadWithRetries) {
+  grpc::Status status;
+  auto response =
+      bigtable::testing::internal::ReadRowsResponseFromString(R"(
+                                                                  chunks {
+                                                                  row_key: "r1"
+                                                                      family_name { value: "fam" }
+                                                                      qualifier { value: "qual" }
+                                                                  timestamp_micros: 42000
+                                                                  value: "value"
+                                                                  commit_row: true
+                                                                  }
+                                                                  )",
+                                                              status);
+  EXPECT_TRUE(status.ok());
+
+  auto response_retry =
+      bigtable::testing::internal::ReadRowsResponseFromString(R"(
+                                                                        chunks {
+                                                                        row_key: "r2"
+                                                                            family_name { value: "fam" }
+                                                                            qualifier { value: "qual" }
+                                                                        timestamp_micros: 42000
+                                                                        value: "value"
+                                                                        commit_row: true
+                                                                        }
+                                                                        )",
+                                                              status);
+  EXPECT_TRUE(status.ok());
+
+  // must be a new pointer, it is wrapped in unique_ptr by ReadRows
+  auto stream = new bigtable::testing::MockResponseStream;
+  auto stream_retry = new bigtable::testing::MockResponseStream;
+
+  EXPECT_CALL(*bigtable_stub_, ReadRowsRaw(_, _))
+      .WillOnce(Return(stream))
+      .WillOnce(Return(stream_retry));
+
+  EXPECT_CALL(*stream, Read(_))
+      .WillOnce(DoAll(SetArgPointee<0>(response), Return(true)))
+      .WillOnce(Return(false));
+
+  EXPECT_CALL(*stream, Finish())
+      .WillOnce(
+          Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
+
+  EXPECT_CALL(*stream_retry, Read(_))
+      .WillOnce(DoAll(SetArgPointee<0>(response_retry), Return(true)))
+      .WillOnce(Return(false));
+
+  EXPECT_CALL(*stream_retry, Finish()).WillOnce(Return(grpc::Status::OK));
+
+  auto reader =
+      table_.ReadRows(bigtable::RowSet(), bigtable::Filter::PassAllFilter());
+
+  auto it = reader.begin();
+  EXPECT_NE(it, reader.end());
+  EXPECT_EQ(it->row_key(), "r1");
+  ++it;
+  EXPECT_NE(it, reader.end());
+  EXPECT_EQ(it->row_key(), "r2");
+  EXPECT_EQ(++it, reader.end());
+  status = reader.Finish();
+  EXPECT_TRUE(status.ok());
+}
+
+TEST_F(TableReadRowsTest, ReadRowsThrowsWhenTooManyErrors) {
+  EXPECT_CALL(*bigtable_stub_, ReadRowsRaw(_, _))
+      .WillRepeatedly(testing::WithoutArgs(testing::Invoke([] {
+        auto stream = new bigtable::testing::MockResponseStream;
+        EXPECT_CALL(*stream, Read(_)).WillOnce(Return(false));
+        EXPECT_CALL(*stream, Finish())
+            .WillOnce(
+                Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "broken")));
+        return stream;
+      })));
+
+  auto table = bigtable::noex::Table(
+      client_, "table_id", bigtable::LimitedErrorCountRetryPolicy(3),
+      bigtable::ExponentialBackoffPolicy(std::chrono::seconds(0),
+                                         std::chrono::seconds(0)),
+      bigtable::SafeIdempotentMutationPolicy());
+  auto reader =
+      table.ReadRows(bigtable::RowSet(), bigtable::Filter::PassAllFilter());
+
+  EXPECT_NO_THROW(reader.begin());
+  grpc::Status status = reader.Finish();
+  EXPECT_FALSE(status.ok());
+}
+
+/// @test Verify that Table::Apply() works in a simplest case.
+TEST_F(TableApplyTest, Simple) {
+  using namespace ::testing;
+
+  EXPECT_CALL(*bigtable_stub_, MutateRow(_, _, _))
+      .WillOnce(Return(grpc::Status::OK));
+
+  auto result = table_.Apply(bigtable::SingleRowMutation(
+      "bar", {bigtable::SetCell("fam", "col", 0, "val")}));
+  EXPECT_TRUE(result.empty());
+}
+
+/// @test Verify that Table::Apply() raises an exception on permanent failures.
+TEST_F(TableApplyTest, Failure) {
+  using namespace ::testing;
+
+  EXPECT_CALL(*bigtable_stub_, MutateRow(_, _, _))
+      .WillRepeatedly(
+          Return(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "uh-oh")));
+  std::vector<bigtable::FailedMutation> result;
+  EXPECT_NO_THROW(result = table_.Apply(bigtable::SingleRowMutation(
+                      "bar", {bigtable::SetCell("fam", "col", 0, "val")})));
+  EXPECT_FALSE(result.empty());
+  EXPECT_EQ(1, result.size());
+  EXPECT_FALSE(result.front().status().ok());
+}
+
+/// @test Verify that Table::Apply() retries on partial failures.
+TEST_F(TableApplyTest, Retry) {
+  using namespace ::testing;
+
+  EXPECT_CALL(*bigtable_stub_, MutateRow(_, _, _))
+      .WillOnce(
+          Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")))
+      .WillOnce(
+          Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")))
+      .WillOnce(
+          Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")))
+      .WillOnce(Return(grpc::Status::OK));
+  std::vector<bigtable::FailedMutation> result;
+  EXPECT_NO_THROW(result = table_.Apply(bigtable::SingleRowMutation(
+                      "bar", {bigtable::SetCell("fam", "col", 0, "val")})));
+  EXPECT_TRUE(result.empty());
+}
+
+/// @test Verify that Table::Apply() retries only idempotent mutations.
+TEST_F(TableApplyTest, RetryIdempotent) {
+  using namespace ::testing;
+
+  EXPECT_CALL(*bigtable_stub_, MutateRow(_, _, _))
+      .WillRepeatedly(
+          Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
+  std::vector<bigtable::FailedMutation> result;
+  EXPECT_NO_THROW(
+      result = table_.Apply(bigtable::SingleRowMutation(
+          "not-idempotent", {bigtable::SetCell("fam", "col", "val")})));
+  EXPECT_FALSE(result.empty());
+  EXPECT_EQ(1, result.size());
+  EXPECT_FALSE(result.front().status().ok());
+}
+
+/// @test Verify that Table::BulkApply() works in the easy case.
+TEST_F(TableBulkApplyTest, Simple) {
+  using namespace ::testing;
+  namespace btproto = ::google::bigtable::v2;
+  namespace bt = ::bigtable;
+
+  auto reader = bigtable::internal::make_unique<MockReader>();
+  EXPECT_CALL(*reader, Read(_))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse *r) {
+        {
+          auto &e = *r->add_entries();
+          e.set_index(0);
+          e.mutable_status()->set_code(grpc::OK);
+        }
+        {
+          auto &e = *r->add_entries();
+          e.set_index(1);
+          e.mutable_status()->set_code(grpc::OK);
+        }
+        return true;
+      }))
+      .WillOnce(Return(false));
+  EXPECT_CALL(*reader, Finish()).WillOnce(Return(grpc::Status::OK));
+
+  EXPECT_CALL(*bigtable_stub_, MutateRowsRaw(_, _))
+      .WillOnce(Invoke(
+          [&reader](grpc::ClientContext *, btproto::MutateRowsRequest const &) {
+            return reader.release();
+          }));
+  grpc::Status status;
+  EXPECT_NO_THROW(table_.BulkApply(
+      bt::BulkMutation(
+          bt::SingleRowMutation("foo", {bt::SetCell("fam", "col", 0, "baz")}),
+          bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0, "qux")})),
+      status));
+  EXPECT_TRUE(status.ok());
+  SUCCEED();
+}
+
+/// @test Verify that Table::BulkApply() retries partial failures.
+TEST_F(TableBulkApplyTest, RetryPartialFailure) {
+  using namespace ::testing;
+  namespace btproto = ::google::bigtable::v2;
+  namespace bt = ::bigtable;
+
+  auto r1 = bigtable::internal::make_unique<MockReader>();
+  EXPECT_CALL(*r1, Read(_))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse *r) {
+        // Simulate a partial (recoverable) failure.
+        auto &e0 = *r->add_entries();
+        e0.set_index(0);
+        e0.mutable_status()->set_code(grpc::UNAVAILABLE);
+        auto &e1 = *r->add_entries();
+        e1.set_index(1);
+        e1.mutable_status()->set_code(grpc::OK);
+        return true;
+      }))
+      .WillOnce(Return(false));
+  EXPECT_CALL(*r1, Finish()).WillOnce(Return(grpc::Status::OK));
+
+  auto r2 = bigtable::internal::make_unique<MockReader>();
+  EXPECT_CALL(*r2, Read(_))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse *r) {
+        {
+          auto &e = *r->add_entries();
+          e.set_index(0);
+          e.mutable_status()->set_code(grpc::OK);
+        }
+        return true;
+      }))
+      .WillOnce(Return(false));
+  EXPECT_CALL(*r2, Finish()).WillOnce(Return(grpc::Status::OK));
+
+  EXPECT_CALL(*bigtable_stub_, MutateRowsRaw(_, _))
+      .WillOnce(Invoke(
+          [&r1](grpc::ClientContext *, btproto::MutateRowsRequest const &) {
+            return r1.release();
+          }))
+      .WillOnce(Invoke(
+          [&r2](grpc::ClientContext *, btproto::MutateRowsRequest const &) {
+            return r2.release();
+          }));
+  grpc::Status status;
+  EXPECT_NO_THROW(table_.BulkApply(
+      bt::BulkMutation(bt::SingleRowMutation(
+                           "foo", {bigtable::SetCell("fam", "col", 0, "baz")}),
+                       bt::SingleRowMutation(
+                           "bar", {bigtable::SetCell("fam", "col", 0, "qux")})),
+      status));
+  EXPECT_TRUE(status.ok());
+  SUCCEED();
+}
+
+// TODO(#234) - this test could be enabled when bug is closed.
+/// @test Verify that Table::BulkApply() handles permanent failures.
+TEST_F(TableBulkApplyTest, PermanentFailure) {
+  using namespace ::testing;
+  namespace btproto = ::google::bigtable::v2;
+  namespace bt = ::bigtable;
+
+  auto r1 = bigtable::internal::make_unique<MockReader>();
+  EXPECT_CALL(*r1, Read(_))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse *r) {
+        {
+          auto &e = *r->add_entries();
+          e.set_index(0);
+          e.mutable_status()->set_code(grpc::OK);
+        }
+        {
+          auto &e = *r->add_entries();
+          e.set_index(1);
+          e.mutable_status()->set_code(grpc::OUT_OF_RANGE);
+        }
+        return true;
+      }))
+      .WillOnce(Return(false));
+  EXPECT_CALL(*r1, Finish()).WillOnce(Return(grpc::Status::OK));
+
+  EXPECT_CALL(*bigtable_stub_, MutateRowsRaw(_, _))
+      .WillOnce(Invoke(
+          [&r1](grpc::ClientContext *, btproto::MutateRowsRequest const &) {
+            return r1.release();
+          }));
+  grpc::Status status;
+  EXPECT_NO_THROW(table_.BulkApply(
+      bt::BulkMutation(
+          bt::SingleRowMutation("foo", {bt::SetCell("fam", "col", 0, "baz")}),
+          bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0, "qux")})),
+      status));
+  EXPECT_FALSE(status.ok());
+}
+
+/// @test Verify that Table::BulkApply() handles a terminated stream.
+TEST_F(TableBulkApplyTest, CanceledStream) {
+  using namespace ::testing;
+  namespace btproto = ::google::bigtable::v2;
+  namespace bt = ::bigtable;
+
+  // Simulate a stream that returns one success and then terminates.  We expect
+  // the BulkApply() operation to retry the request, because the mutation is in
+  // an undetermined state.  Well, it should retry assuming it is idempotent,
+  // which happens to be the case in this test.
+  auto r1 = bigtable::internal::make_unique<MockReader>();
+  EXPECT_CALL(*r1, Read(_))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse *r) {
+        {
+          auto &e = *r->add_entries();
+          e.set_index(0);
+          e.mutable_status()->set_code(grpc::OK);
+        }
+        return true;
+      }))
+      .WillOnce(Return(false));
+  EXPECT_CALL(*r1, Finish()).WillOnce(Return(grpc::Status::OK));
+
+  // Create a second stream returned by the mocks when the client retries.
+  auto r2 = bigtable::internal::make_unique<MockReader>();
+  EXPECT_CALL(*r2, Read(_))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse *r) {
+        {
+          auto &e = *r->add_entries();
+          e.set_index(0);
+          e.mutable_status()->set_code(grpc::OK);
+        }
+        return true;
+      }))
+      .WillOnce(Return(false));
+  EXPECT_CALL(*r2, Finish()).WillOnce(Return(grpc::Status::OK));
+
+  EXPECT_CALL(*bigtable_stub_, MutateRowsRaw(_, _))
+      .WillOnce(Invoke(
+          [&r1](grpc::ClientContext *, btproto::MutateRowsRequest const &) {
+            return r1.release();
+          }))
+      .WillOnce(Invoke(
+          [&r2](grpc::ClientContext *, btproto::MutateRowsRequest const &) {
+            return r2.release();
+          }));
+  grpc::Status status;
+  EXPECT_NO_THROW(table_.BulkApply(
+      bt::BulkMutation(
+          bt::SingleRowMutation("foo", {bt::SetCell("fam", "col", 0, "baz")}),
+          bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0, "qux")})),
+      status));
+  EXPECT_TRUE(status.ok());
+  SUCCEED();
+}
+
+/// @test Verify that Table::BulkApply() reports correctly on too many errors.
+TEST_F(TableBulkApplyTest, TooManyFailures) {
+  using namespace ::testing;
+  namespace btproto = ::google::bigtable::v2;
+  namespace bt = ::bigtable;
+  namespace btnoex = ::bigtable::noex;
+
+  using namespace bigtable::chrono_literals;
+  // Create a table with specific policies so we can test the behavior
+  // without having to depend on timers expiring.  In this case tolerate only
+  // 3 failures.
+  btnoex::Table custom_table(
+      client_, "foo_table",
+      // Configure the Table to stop at 3 failures.
+      bt::LimitedErrorCountRetryPolicy(2),
+      // Use much shorter backoff than the default to test faster.
+      bt::ExponentialBackoffPolicy(10_us, 40_us),
+      // TODO(#66) - it is annoying to set a policy we do not care about.
+      bt::SafeIdempotentMutationPolicy());
+
+  // Setup the mocks to fail more than 3 times.
+  auto r1 = bigtable::internal::make_unique<MockReader>();
+  EXPECT_CALL(*r1, Read(_))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse *r) {
+        {
+          auto &e = *r->add_entries();
+          e.set_index(0);
+          e.mutable_status()->set_code(grpc::OK);
+        }
+        return true;
+      }))
+      .WillOnce(Return(false));
+  EXPECT_CALL(*r1, Finish())
+      .WillOnce(Return(grpc::Status(grpc::StatusCode::ABORTED, "")));
+
+  auto create_cancelled_stream = [&](grpc::ClientContext *,
+                                     btproto::MutateRowsRequest const &) {
+    auto stream = bigtable::internal::make_unique<MockReader>();
+    EXPECT_CALL(*stream, Read(_)).WillOnce(Return(false));
+    EXPECT_CALL(*stream, Finish())
+        .WillOnce(Return(grpc::Status(grpc::StatusCode::ABORTED, "")));
+    return stream.release();
+  };
+
+  EXPECT_CALL(*bigtable_stub_, MutateRowsRaw(_, _))
+      .WillOnce(Invoke(
+          [&r1](grpc::ClientContext *, btproto::MutateRowsRequest const &) {
+            return r1.release();
+          }))
+      .WillOnce(Invoke(create_cancelled_stream))
+      .WillOnce(Invoke(create_cancelled_stream));
+  grpc::Status status;
+  EXPECT_NO_THROW(custom_table.BulkApply(
+      bt::BulkMutation(
+          bt::SingleRowMutation("foo", {bt::SetCell("fam", "col", 0, "baz")}),
+          bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0, "qux")})),
+      status));
+  EXPECT_FALSE(status.ok());
+}
+
+/// @test Verify that Table::BulkApply() retries only idempotent mutations.
+TEST_F(TableBulkApplyTest, RetryOnlyIdempotent) {
+  using namespace ::testing;
+  namespace btproto = ::google::bigtable::v2;
+  namespace bt = ::bigtable;
+
+  // We will send both idempotent and non-idempotent mutations.  We prepare the
+  // mocks to return an empty stream in the first RPC request.  That will force
+  // the client to only retry the idempotent mutations.
+  auto r1 = bigtable::internal::make_unique<MockReader>();
+  EXPECT_CALL(*r1, Read(_)).WillOnce(Return(false));
+  EXPECT_CALL(*r1, Finish()).WillOnce(Return(grpc::Status::OK));
+
+  auto r2 = bigtable::internal::make_unique<MockReader>();
+  EXPECT_CALL(*r2, Read(_))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse *r) {
+        {
+          auto &e = *r->add_entries();
+          e.set_index(0);
+          e.mutable_status()->set_code(grpc::OK);
+        }
+        return true;
+      }))
+      .WillOnce(Return(false));
+  EXPECT_CALL(*r2, Finish()).WillOnce(Return(grpc::Status::OK));
+
+  EXPECT_CALL(*bigtable_stub_, MutateRowsRaw(_, _))
+      .WillOnce(Invoke(
+          [&r1](grpc::ClientContext *, btproto::MutateRowsRequest const &) {
+            return r1.release();
+          }))
+      .WillOnce(Invoke(
+          [&r2](grpc::ClientContext *, btproto::MutateRowsRequest const &) {
+            return r2.release();
+          }));
+  std::vector<bigtable::FailedMutation> result;
+  grpc::Status status;
+  EXPECT_NO_THROW(
+      result = table_.BulkApply(
+          bt::BulkMutation(
+              bt::SingleRowMutation("is-idempotent",
+                                    {bt::SetCell("fam", "col", 0, "qux")}),
+              bt::SingleRowMutation("not-idempotent",
+                                    {bt::SetCell("fam", "col", "baz")})),
+          status));
+  EXPECT_FALSE(status.ok());
+  EXPECT_FALSE(result.empty());
+  EXPECT_EQ(1, result.size());
+  EXPECT_EQ(1, result[0].original_index());
+  EXPECT_EQ("not-idempotent", result[0].mutation().row_key());
+}
+
+/// @test Verify that Table::BulkApply() works when the RPC fails.
+TEST_F(TableBulkApplyTest, FailedRPC) {
+  using namespace ::testing;
+  namespace btproto = ::google::bigtable::v2;
+  namespace bt = ::bigtable;
+
+  auto reader = bigtable::internal::make_unique<MockReader>();
+  EXPECT_CALL(*reader, Read(_)).WillOnce(Return(false));
+  EXPECT_CALL(*reader, Finish())
+      .WillOnce(Return(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
+                                    "no such table")));
+
+  EXPECT_CALL(*bigtable_stub_, MutateRowsRaw(_, _))
+      .WillOnce(Invoke(
+          [&reader](grpc::ClientContext *, btproto::MutateRowsRequest const &) {
+            return reader.release();
+          }));
+  std::vector<bigtable::FailedMutation> result;
+  grpc::Status status;
+  EXPECT_NO_THROW(
+      result = table_.BulkApply(
+          bt::BulkMutation(bt::SingleRowMutation(
+                               "foo", {bt::SetCell("fam", "col", 0, "baz")}),
+                           bt::SingleRowMutation(
+                               "bar", {bt::SetCell("fam", "col", 0, "qux")})),
+          status));
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(grpc::StatusCode::FAILED_PRECONDITION, status.error_code());
+  EXPECT_EQ("no such table", status.error_message());
+  EXPECT_FALSE(result.empty());
+  EXPECT_EQ(2, result.size());
+}

--- a/bigtable/client/mutations.h
+++ b/bigtable/client/mutations.h
@@ -155,7 +155,7 @@ class SingleRowMutation {
     entry->set_row_key(std::move(row_key_));
     entry->mutable_mutations()->Swap(&ops_);
   }
-
+  /// Transfer the contents to @p request.
   void MoveTo(google::bigtable::v2::MutateRowRequest& request) {
     request.set_row_key(std::move(row_key_));
     request.mutable_mutations()->Swap(&ops_);

--- a/bigtable/client/mutations.h
+++ b/bigtable/client/mutations.h
@@ -155,6 +155,7 @@ class SingleRowMutation {
     entry->set_row_key(std::move(row_key_));
     entry->mutable_mutations()->Swap(&ops_);
   }
+
   /// Transfer the contents to @p request.
   void MoveTo(google::bigtable::v2::MutateRowRequest& request) {
     request.set_row_key(std::move(row_key_));

--- a/bigtable/client/mutations.h
+++ b/bigtable/client/mutations.h
@@ -156,6 +156,11 @@ class SingleRowMutation {
     entry->mutable_mutations()->Swap(&ops_);
   }
 
+  void MoveTo(google::bigtable::v2::MutateRowRequest& request) {
+    request.set_row_key(std::move(row_key_));
+    request.mutable_mutations()->Swap(&ops_);
+  }
+
  private:
   /// Add multiple mutations to single row
   template <typename... M>

--- a/bigtable/client/row_reader.cc
+++ b/bigtable/client/row_reader.cc
@@ -129,10 +129,10 @@ void RowReader::Advance(internal::OptionalRow& row) {
 
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
     try {
-      status = AdvanceOrFail(row);
+      status_ = status = AdvanceOrFail(row);
     } catch (std::exception const& ex) {
       // Parser exceptions arrive here.
-      status = grpc::Status(grpc::INTERNAL, ex.what());
+      status_ = status = grpc::Status(grpc::INTERNAL, ex.what());
     }
 #else
     status_ = status = AdvanceOrFail(row);

--- a/bigtable/client/row_reader.cc
+++ b/bigtable/client/row_reader.cc
@@ -162,8 +162,12 @@ void RowReader::Advance(internal::OptionalRow& row) {
     }
 
     if (not status.ok() and not retry_policy_->on_failure(status)) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
       internal::RaiseRuntimeError("Unretriable error: " +
                                   status.error_message());
+#else
+      return;
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
     }
 
     auto delay = backoff_policy_->on_completion(status);

--- a/bigtable/client/row_reader.h
+++ b/bigtable/client/row_reader.h
@@ -50,6 +50,12 @@ class RowReader {
             std::unique_ptr<RPCRetryPolicy> retry_policy,
             std::unique_ptr<RPCBackoffPolicy> backoff_policy,
             std::unique_ptr<internal::ReadRowsParserFactory> parser_factory);
+  RowReader(std::shared_ptr<DataClient> client, std::string table_name,
+            RowSet row_set, std::int64_t rows_limit, Filter filter,
+            std::unique_ptr<RPCRetryPolicy> retry_policy,
+            std::unique_ptr<RPCBackoffPolicy> backoff_policy,
+            std::unique_ptr<internal::ReadRowsParserFactory> parser_factory,
+            bool raise_on_error);
   RowReader(RowReader&& rhs) noexcept = default;
 
   ~RowReader();
@@ -84,7 +90,10 @@ class RowReader {
    */
   void Cancel();
 
-  grpc::Status finish() const { return status_; }
+  grpc::Status Finish() {
+    error_retrieved_ = true;
+    return status_;
+  }
 
  private:
   /**
@@ -144,6 +153,8 @@ class RowReader {
   /// Holds the last read row key, for retries.
   std::string last_read_row_key_;
   grpc::Status status_;
+  bool raise_on_error_;
+  bool error_retrieved_;
 };
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/bigtable/client/row_reader.h
+++ b/bigtable/client/row_reader.h
@@ -84,6 +84,8 @@ class RowReader {
    */
   void Cancel();
 
+  grpc::Status finish() const { return status_; }
+
  private:
   /**
    * Read and parse the next row in the response.
@@ -141,6 +143,7 @@ class RowReader {
   std::int64_t rows_count_;
   /// Holds the last read row key, for retries.
   std::string last_read_row_key_;
+  grpc::Status status_;
 };
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/bigtable/client/table.cc
+++ b/bigtable/client/table.cc
@@ -14,12 +14,12 @@
 
 #include "bigtable/client/table.h"
 
-#include <thread>
-
-#include "bigtable/client/internal/bulk_mutator.h"
-#include "bigtable/client/internal/make_unique.h"
-
-namespace btproto = ::google::bigtable::v2;
+//#include <thread>
+//
+//#include "bigtable/client/internal/bulk_mutator.h"
+//#include "bigtable/client/internal/make_unique.h"
+//
+// namespace btproto = ::google::bigtable::v2;
 
 namespace {
 [[noreturn]] void ReportPermanentFailures(
@@ -45,140 +45,6 @@ namespace {
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-namespace noex {
-
-// Call the `google.bigtable.v2.Bigtable.MutateRow` RPC repeatedly until
-// successful, or until the policies in effect tell us to stop.
-std::vector<FailedMutation> Table::Apply(SingleRowMutation&& mut) {
-  // Copy the policies in effect for this operation.  Many policy classes change
-  // their state as the operation makes progress (or fails to make progress), so
-  // we need fresh instances.
-  auto rpc_policy = rpc_retry_policy_->clone();
-  auto backoff_policy = rpc_backoff_policy_->clone();
-  auto idempotent_policy = idempotent_mutation_policy_->clone();
-
-  // Build the RPC request, try to minimize copying.
-  btproto::MutateRowRequest request;
-  request.set_table_name(table_name_);
-  mut.MoveTo(request);
-  //            request.set_row_key(std::move(mut.row_key()));
-  //            request.mutable_mutations()->Swap(mut.ops());
-  bool const is_idempotent =
-      std::all_of(request.mutations().begin(), request.mutations().end(),
-                  [&idempotent_policy](btproto::Mutation const& m) {
-                    return idempotent_policy->is_idempotent(m);
-                  });
-
-  btproto::MutateRowResponse response;
-  std::vector<FailedMutation> failures;
-  grpc::Status status;
-  while (true) {
-    grpc::ClientContext client_context;
-    rpc_policy->setup(client_context);
-    backoff_policy->setup(client_context);
-    status = client_->Stub()->MutateRow(&client_context, request, &response);
-    if (status.ok()) {
-      return failures;
-    }
-    // It is up to the policy to terminate this loop, it could run
-    // forever, but that would be a bad policy (pun intended).
-    if (not rpc_policy->on_failure(status) or not is_idempotent) {
-      google::rpc::Status rpc_status;
-      rpc_status.set_code(status.error_code());
-      rpc_status.set_message(status.error_message());
-      failures.emplace_back(SingleRowMutation(std::move(request)), rpc_status,
-                            0);
-      // TODO(#234) - just return the failures instead
-      status = grpc::Status(
-          status.error_code(),
-          "Permanent (or too many transient) errors in Table::Apply()");
-      return failures;
-    }
-    auto delay = backoff_policy->on_completion(status);
-    std::this_thread::sleep_for(delay);
-  }
-}
-
-// Call the `google.bigtable.v2.Bigtable.MutateRows` RPC repeatedly until
-// successful, or until the policies in effect tell us to stop.  When the RPC
-// is partially successful, this function retries only the mutations that did
-// not succeed.
-std::vector<FailedMutation> Table::BulkApply(BulkMutation&& mut,
-                                             grpc::Status& status) {
-  // Copy the policies in effect for this operation.  Many policy classes change
-  // their state as the operation makes progress (or fails to make progress), so
-  // we need fresh instances.
-  auto backoff_policy = rpc_backoff_policy_->clone();
-  auto retry_policy = rpc_retry_policy_->clone();
-  auto idemponent_policy = idempotent_mutation_policy_->clone();
-
-  internal::BulkMutator mutator(table_name_, *idemponent_policy,
-                                std::forward<BulkMutation>(mut));
-  while (mutator.HasPendingMutations()) {
-    grpc::ClientContext client_context;
-    backoff_policy->setup(client_context);
-    retry_policy->setup(client_context);
-
-    status = mutator.MakeOneRequest(*client_->Stub(), client_context);
-    if (not status.ok() and not retry_policy->on_failure(status)) {
-      break;
-    }
-    auto delay = backoff_policy->on_completion(status);
-    std::this_thread::sleep_for(delay);
-  }
-  auto failures = mutator.ExtractFinalFailures();
-  if (not status.ok()) {
-    return failures;
-  }
-  if (not failures.empty()) {
-    // TODO(#234) - just return the failures instead
-    status = grpc::Status(
-        grpc::StatusCode::INTERNAL,
-        "Permanent (or too many transient) errors in Table::BulkApply()");
-  }
-  return failures;
-}
-
-RowReader Table::ReadRows(RowSet row_set, Filter filter) {
-  return RowReader(client_, table_name(), std::move(row_set),
-                   RowReader::NO_ROWS_LIMIT, std::move(filter),
-                   rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
-                   bigtable::internal::make_unique<
-                       bigtable::internal::ReadRowsParserFactory>());
-}
-
-RowReader Table::ReadRows(RowSet row_set, std::int64_t rows_limit,
-                          Filter filter) {
-  return RowReader(client_, table_name(), std::move(row_set), rows_limit,
-                   std::move(filter), rpc_retry_policy_->clone(),
-                   rpc_backoff_policy_->clone(),
-                   bigtable::internal::make_unique<
-                       bigtable::internal::ReadRowsParserFactory>());
-}
-
-std::pair<bool, Row> Table::ReadRow(std::string row_key, Filter filter,
-                                    grpc::Status& status) {
-  RowSet row_set(std::move(row_key));
-  std::int64_t const rows_limit = 1;
-  RowReader reader =
-      ReadRows(std::move(row_set), rows_limit, std::move(filter));
-  auto it = reader.begin();
-  if (it == reader.end()) {
-    grpc::Status status = reader.finish();
-    return std::make_pair(false, Row("", {}));
-  }
-  auto result = std::make_pair(true, std::move(*it));
-  if (++it != reader.end()) {
-    status =
-        grpc::Status(grpc::StatusCode::INTERNAL,
-                     "internal error - RowReader returned 2 rows in ReadRow()");
-    return std::make_pair(false, Row("", {}));
-  }
-  return result;
-}
-
-}  // namespace noex
-
 void Table::Apply(SingleRowMutation&& mut) {
   std::vector<FailedMutation> failures = impl_.Apply(std::move(mut));
   if (not failures.empty()) {
@@ -197,12 +63,13 @@ void Table::BulkApply(BulkMutation&& mut) {
 }
 
 RowReader Table::ReadRows(RowSet row_set, Filter filter) {
-  return impl_.ReadRows(std::move(row_set), std::move(filter));
+  return impl_.ReadRows(std::move(row_set), std::move(filter), true);
 }
 
 RowReader Table::ReadRows(RowSet row_set, std::int64_t rows_limit,
                           Filter filter) {
-  return impl_.ReadRows(std::move(row_set), rows_limit, std::move(filter));
+  return impl_.ReadRows(std::move(row_set), rows_limit, std::move(filter),
+                        true);
 }
 
 std::pair<bool, Row> Table::ReadRow(std::string row_key, Filter filter) {

--- a/bigtable/client/table.h
+++ b/bigtable/client/table.h
@@ -76,11 +76,9 @@ class Table {
    * `bigtable::Table` class, but do not raise exceptions on errors, instead
    * they return the error on the status parameter.
    */
-  std::vector<FailedMutation> Apply(SingleRowMutation&& mut,
-                                    grpc::Status& status);
+  std::vector<FailedMutation> Apply(SingleRowMutation&& mut);
 
-  std::vector<FailedMutation> BulkApply(BulkMutation&& mut,
-                                        grpc::Status& status);
+  std::vector<FailedMutation> BulkApply(BulkMutation&& mut);
 
   RowReader ReadRows(RowSet row_set, Filter filter);
 

--- a/bigtable/client/table.h
+++ b/bigtable/client/table.h
@@ -15,89 +15,20 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TABLE_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TABLE_H_
 
-#include "bigtable/client/data_client.h"
-#include "bigtable/client/filters.h"
-#include "bigtable/client/idempotent_mutation_policy.h"
-#include "bigtable/client/mutations.h"
-#include "bigtable/client/row_reader.h"
-#include "bigtable/client/row_set.h"
-#include "bigtable/client/rpc_backoff_policy.h"
-#include "bigtable/client/rpc_retry_policy.h"
-
-#include <google/bigtable/v2/bigtable.grpc.pb.h>
+//#include "bigtable/client/data_client.h"
+//#include "bigtable/client/filters.h"
+//#include "bigtable/client/idempotent_mutation_policy.h"
+//#include "bigtable/client/mutations.h"
+//#include "bigtable/client/row_reader.h"
+//#include "bigtable/client/row_set.h"
+//#include "bigtable/client/rpc_backoff_policy.h"
+//#include "bigtable/client/rpc_retry_policy.h"
+//
+//#include <google/bigtable/v2/bigtable.grpc.pb.h>
+#include "bigtable/client/internal/table.h"
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-/**
- * Return the full table name.
- *
- * The full table name is:
- *
- * `projects/<PROJECT_ID>/instances/<INSTANCE_ID>/tables/<table_id>`
- *
- * Where the project id and instance id come from the @p client parameter.
- */
-inline std::string TableName(std::shared_ptr<DataClient> client,
-                             std::string const& table_id) {
-  return InstanceName(std::move(client)) + "/tables/" + table_id;
-}
-/**
- * No Exception namespace contains the public version of interface without
- * exception. This is not for public use.
- */
-namespace noex {
-class Table {
- public:
-  Table(std::shared_ptr<DataClient> client, std::string const& table_id)
-      : client_(std::move(client)),
-        table_name_(TableName(client_, table_id)),
-        rpc_retry_policy_(bigtable::DefaultRPCRetryPolicy()),
-        rpc_backoff_policy_(bigtable::DefaultRPCBackoffPolicy()),
-        idempotent_mutation_policy_(
-            bigtable::DefaultIdempotentMutationPolicy()) {}
-
-  template <typename RPCRetryPolicy, typename RPCBackoffPolicy,
-            typename IdempotentMutationPolicy>
-  Table(std::shared_ptr<DataClient> client, std::string const& table_id,
-        RPCRetryPolicy retry_policy, RPCBackoffPolicy backoff_policy,
-        IdempotentMutationPolicy idempotent_mutation_policy)
-      : client_(std::move(client)),
-        table_name_(TableName(client_, table_id)),
-        rpc_retry_policy_(retry_policy.clone()),
-        rpc_backoff_policy_(backoff_policy.clone()),
-        idempotent_mutation_policy_(idempotent_mutation_policy.clone()) {}
-
-  std::string const& table_name() const { return table_name_; }
-  //@{
-  /**
-   * @name No exception versions of Table::*
-   *
-   * These functions provide the same functionality as their counterparts in the
-   * `bigtable::Table` class, but do not raise exceptions on errors, instead
-   * they return the error on the status parameter.
-   */
-  std::vector<FailedMutation> Apply(SingleRowMutation&& mut);
-
-  std::vector<FailedMutation> BulkApply(BulkMutation&& mut,
-                                        grpc::Status& status);
-
-  RowReader ReadRows(RowSet row_set, Filter filter);
-
-  RowReader ReadRows(RowSet row_set, std::int64_t rows_limit, Filter filter);
-
-  std::pair<bool, Row> ReadRow(std::string row_key, Filter filter,
-                               grpc::Status& status);
-  //@}
-
- private:
-  std::shared_ptr<DataClient> client_;
-  std::string table_name_;
-  std::unique_ptr<RPCRetryPolicy> rpc_retry_policy_;
-  std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy_;
-  std::unique_ptr<IdempotentMutationPolicy> idempotent_mutation_policy_;
-};
-}  // namespace noex
-
 /**
  * The main interface to interact with data in a Cloud Bigtable table.
  *
@@ -176,8 +107,9 @@ class Table {
   Table(std::shared_ptr<DataClient> client, std::string const& table_id,
         RPCRetryPolicy retry_policy, RPCBackoffPolicy backoff_policy,
         IdempotentMutationPolicy idempotent_mutation_policy)
-      : impl_(std::move(client), table_id, retry_policy, backoff_policy,
-              idempotent_mutation_policy) {}
+      : impl_(std::move(client), table_id, std::move(retry_policy),
+              std::move(backoff_policy),
+              std::move(idempotent_mutation_policy)) {}
 
   std::string const& table_name() const { return impl_.table_name(); }
 

--- a/bigtable/client/table.h
+++ b/bigtable/client/table.h
@@ -78,7 +78,8 @@ class Table {
    */
   std::vector<FailedMutation> Apply(SingleRowMutation&& mut);
 
-  std::vector<FailedMutation> BulkApply(BulkMutation&& mut);
+  std::vector<FailedMutation> BulkApply(BulkMutation&& mut,
+                                        grpc::Status& status);
 
   RowReader ReadRows(RowSet row_set, Filter filter);
 

--- a/bigtable/client/table.h
+++ b/bigtable/client/table.h
@@ -82,10 +82,9 @@ class Table {
   std::vector<FailedMutation> BulkApply(BulkMutation&& mut,
                                         grpc::Status& status);
 
-  RowReader ReadRows(RowSet row_set, Filter filter, grpc::Status& status);
+  RowReader ReadRows(RowSet row_set, Filter filter);
 
-  RowReader ReadRows(RowSet row_set, std::int64_t rows_limit, Filter filter,
-                     grpc::Status& ret_status);
+  RowReader ReadRows(RowSet row_set, std::int64_t rows_limit, Filter filter);
 
   std::pair<bool, Row> ReadRow(std::string row_key, Filter filter,
                                grpc::Status& status);

--- a/bigtable/client/table_readrows_test.cc
+++ b/bigtable/client/table_readrows_test.cc
@@ -15,10 +15,10 @@
 #include "bigtable/client/table.h"
 #include "bigtable/client/testing/table_test_fixture.h"
 
+using testing::_;
 using testing::DoAll;
 using testing::Return;
 using testing::SetArgPointee;
-using testing::_;
 
 /// Define helper types and functions for this test.
 namespace {
@@ -53,17 +53,6 @@ TEST_F(TableReadRowsTest, ReadRowsCanReadOneRow) {
   EXPECT_EQ(it->row_key(), "r1");
   EXPECT_EQ(++it, reader.end());
 }
-
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-TEST_F(TableReadRowsTest, ReadRowsFailsForIllegalRowLimit) {
-  EXPECT_THROW(
-      table_.ReadRows(bigtable::RowSet(), 0, bigtable::Filter::PassAllFilter()),
-      std::invalid_argument);
-  EXPECT_THROW(table_.ReadRows(bigtable::RowSet(), -1,
-                               bigtable::Filter::PassAllFilter()),
-               std::invalid_argument);
-}
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 
 TEST_F(TableReadRowsTest, ReadRowsCanReadWithRetries) {
   auto response = bigtable::testing::ReadRowsResponseFromString(R"(

--- a/bigtable/client/testing/internal_table_test_fixture.cc
+++ b/bigtable/client/testing/internal_table_test_fixture.cc
@@ -1,0 +1,47 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/client/testing/internal_table_test_fixture.h"
+
+#include <google/protobuf/text_format.h>
+
+#include "bigtable/client/internal/throw_delegate.h"
+
+namespace bigtable {
+namespace testing {
+namespace internal {
+
+google::bigtable::v2::ReadRowsResponse ReadRowsResponseFromString(
+    std::string repr, grpc::Status &status) {
+  google::bigtable::v2::ReadRowsResponse response;
+  if (!google::protobuf::TextFormat::ParseFromString(repr, &response)) {
+    status = grpc::Status(grpc::StatusCode::INTERNAL, "can not parse");
+  }
+  return response;
+}
+
+std::shared_ptr<MockDataClient> TableTestFixture::SetupMockClient() {
+  auto client = std::make_shared<MockDataClient>();
+  EXPECT_CALL(*client, project_id())
+      .WillRepeatedly(::testing::ReturnRef(project_id_));
+  EXPECT_CALL(*client, instance_id())
+      .WillRepeatedly(::testing::ReturnRef(instance_id_));
+  EXPECT_CALL(*client, Stub())
+      .WillRepeatedly(::testing::Return(bigtable_stub_));
+  return client;
+}
+
+}  // namespace internal
+}  // namespace testing
+}  // namespace bigtable

--- a/bigtable/client/testing/internal_table_test_fixture.h
+++ b/bigtable/client/testing/internal_table_test_fixture.h
@@ -1,0 +1,59 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_INTERNAL_TABLE_TEST_FIXTURE_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_INTERNAL_TABLE_TEST_FIXTURE_H_
+
+#include "bigtable/client/internal/table.h"
+#include "bigtable/client/testing/mock_data_client.h"
+#include "bigtable/client/testing/mock_response_stream.h"
+
+namespace bigtable {
+namespace testing {
+namespace internal {
+
+/// Common fixture for the bigtable::Table tests.
+class TableTestFixture : public ::testing::Test {
+ protected:
+  TableTestFixture() {}
+
+  std::shared_ptr<MockDataClient> SetupMockClient();
+
+  std::string const kProjectId = "foo-project";
+  std::string const kInstanceId = "bar-instance";
+  std::string const kTableId = "baz-table";
+
+  // These are hardcoded, and not computed, because we want to test the
+  // computation.
+  std::string const kInstanceName =
+      "projects/foo-project/instances/bar-instance";
+  std::string const kTableName =
+      "projects/foo-project/instances/bar-instance/tables/baz-table";
+
+  std::string project_id_ = kProjectId;
+  std::string instance_id_ = kInstanceId;
+  std::shared_ptr<::google::bigtable::v2::MockBigtableStub> bigtable_stub_ =
+      std::make_shared<::google::bigtable::v2::MockBigtableStub>();
+  std::shared_ptr<MockDataClient> client_ = SetupMockClient();
+  bigtable::noex::Table table_ = bigtable::noex::Table(client_, kTableId);
+};
+
+google::bigtable::v2::ReadRowsResponse ReadRowsResponseFromString(
+    std::string repr, grpc::Status &status);
+
+}  // namespace internal
+}  // namespace testing
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_INTERNAL_TABLE_TEST_FIXTURE_H_


### PR DESCRIPTION
Fix #35 Refactor wrappers without exceptions to separate namespace.

This contains change related to table interface. PTAL and provide feedback.