### PR TITLE
Do not raise exceptions in bigtable::DeleteFromColumn()

### DIFF
--- a/bigtable/client/mutations.cc
+++ b/bigtable/client/mutations.cc
@@ -13,12 +13,7 @@
 // limitations under the License.
 
 #include "bigtable/client/mutations.h"
-
 #include <google/protobuf/text_format.h>
-
-#include <sstream>
-
-#include "bigtable/client/internal/throw_delegate.h"
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
@@ -46,18 +41,6 @@ Mutation SetCell(std::string family, std::string column, std::string value) {
 Mutation DeleteFromColumn(std::string family, std::string column,
                           std::int64_t timestamp_begin,
                           std::int64_t timestamp_end) {
-  if (timestamp_end < timestamp_begin) {
-    std::ostringstream os;
-    os << "invalid time range in DeleteFromColumn [" << timestamp_begin << ","
-       << timestamp_end << ")";
-    internal::RaiseRangeError(os.str());
-  }
-  if (timestamp_end == timestamp_begin and timestamp_end != 0) {
-    std::ostringstream os;
-    os << "invalid time range in DeleteFromColumn [" << timestamp_begin << ","
-       << timestamp_end << ")";
-    internal::RaiseRangeError(os.str());
-  }
   Mutation m;
   auto& d = *m.op.mutable_delete_from_column();
   d.set_family_name(std::move(family));

--- a/bigtable/client/mutations.h
+++ b/bigtable/client/mutations.h
@@ -65,9 +65,13 @@ constexpr std::int64_t ServerSetTimestamp() { return -1; }
  * timestamp range.
  *
  * The ending timestamp is exclusive, while the beginning timestamp is
- * inclusive.  Please notice that [a,a) is an invalid range unless
- * a==0.
+ * inclusive.  That is, the interval is [@p timestamp_begin, @p timestamp_end).
+ * The value 0 is special and treated as "unbounded" for both the begin and end
+ * endpoints of the time range.  The Cloud Bigtable server rejects invalid and
+ * empty ranges, i.e., any range where the endpoint is smaller or equal than to
+ * the initial endpoint unless either endpoint is 0.
  */
+
 /// Delete only within the timestamp range provided.
 Mutation DeleteFromColumn(std::string family, std::string column,
                           std::int64_t timestamp_begin,

--- a/bigtable/client/mutations_test.cc
+++ b/bigtable/client/mutations_test.cc
@@ -48,16 +48,13 @@ TEST(MutationsTest, SetCell) {
   EXPECT_EQ(val_data, moved.op.set_cell().value().data());
 }
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-/// @test Verify that DeleteFromColumn() validates inputs as expected.
-TEST(MutationsTest, DeleteFromColumnValidation) {
-  // Invalid ranges should fail.
-  EXPECT_THROW(bigtable::DeleteFromColumn("family", "col", 20, 0),
-               std::range_error);
-  EXPECT_THROW(bigtable::DeleteFromColumn("family", "col", 1000, 1000),
-               std::range_error);
+/// @test Verify that DeleteFromColumn() does not validates inputs.
+TEST(MutationsTest, DeleteFromColumnNoValidation) {
+  auto reversed = bigtable::DeleteFromColumn("family", "col", 20, 0);
+  EXPECT_TRUE(reversed.op.has_delete_from_column());
+  auto empty = bigtable::DeleteFromColumn("family", "col", 1000, 1000);
+  EXPECT_TRUE(empty.op.has_delete_from_column());
 }
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 
 /// @test Verify that DeleteFromColumn() and friends work as expected.
 TEST(MutationsTest, DeleteFromColumn) {

--- a/bigtable/tests/mutations_integration_test.cc
+++ b/bigtable/tests/mutations_integration_test.cc
@@ -210,12 +210,13 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForReversedTimestampRangeTest) {
   };
 
   CreateCells(*table, created_cells);
-// Try to delete the columns with an invalid range:
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  // Try to delete the columns with an invalid range:
+  // TODO(#119) - change the expected exception to the wrapper.
   EXPECT_THROW(
       table->Apply(bigtable::SingleRowMutation(
           key, bigtable::DeleteFromColumn(column_family2, "c2", 4000, 2000))),
-      std::exception);
+      std::runtime_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       table->Apply(bigtable::SingleRowMutation(
@@ -251,12 +252,13 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForEmptyTimestampRangeTest) {
   };
 
   CreateCells(*table, created_cells);
-// Try to delete the columns with an invalid range:
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  // Try to delete the columns with an invalid range:
+  // TODO(#119) - change the expected exception to the wrapper.
   EXPECT_THROW(
       table->Apply(bigtable::SingleRowMutation(
           key, bigtable::DeleteFromColumn(column_family2, "c2", 2000, 2000))),
-      std::exception);
+      std::runtime_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       table->Apply(bigtable::SingleRowMutation(

--- a/bigtable/tests/mutations_integration_test.cc
+++ b/bigtable/tests/mutations_integration_test.cc
@@ -52,6 +52,10 @@ class MutationIntegrationTest : public bigtable::testing::TableIntegrationTest {
     table.BulkApply(std::move(bulk));
   }
 };
+
+bool UsingCloudBigtableEmulator() {
+  return std::getenv("BIGTABLE_EMULATOR_HOST") != nullptr;
+}
 }  // namespace
 
 /**
@@ -184,6 +188,10 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForTimestampRangeTest) {
  * We expect the server (and not the client library) to reject invalid ranges.
  */
 TEST_F(MutationIntegrationTest, DeleteFromColumnForReversedTimestampRangeTest) {
+  // TODO(#151) - remove workarounds for emulator bug(s).
+  if (UsingCloudBigtableEmulator()) {
+    return;
+  }
   std::string const table_name = "table-delete-for-column-time-range-reversed";
 
   auto table = CreateTable(table_name, table_config);
@@ -227,6 +235,10 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForReversedTimestampRangeTest) {
  * We expect the server (and not the client library) to reject invalid ranges.
  */
 TEST_F(MutationIntegrationTest, DeleteFromColumnForEmptyTimestampRangeTest) {
+  // TODO(#151) - remove workarounds for emulator bug(s).
+  if (UsingCloudBigtableEmulator()) {
+    return;
+  }
   std::string const table_name = "table-delete-for-column-time-range-empty";
 
   auto table = CreateTable(table_name, table_config);


### PR DESCRIPTION
This fixes #312.  In general we prefer to push error detection
to the server, to avoid repeating the same checks on both the
client library.
