### PR TITLE
Wrap grpc status with exception

### DIFF
--- a/bigtable/admin/table_admin_test.cc
+++ b/bigtable/admin/table_admin_test.cc
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include "bigtable/admin/table_admin.h"
-#include <bigtable/client/grpc_error.h>
 #include <gmock/gmock.h>
 #include <google/bigtable/admin/v2/bigtable_table_admin_mock.grpc.pb.h>
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
+#include "bigtable/client/grpc_error.h"
 #include "bigtable/client/testing/chrono_literals.h"
 
 namespace {
@@ -56,25 +56,26 @@ class TableAdminTest : public ::testing::Test {
 auto create_list_tables_lambda = [](std::string expected_token,
                                     std::string returned_token,
                                     std::vector<std::string> table_names) {
-  return [expected_token, returned_token, table_names](
-      grpc::ClientContext* ctx, btproto::ListTablesRequest const& request,
-      btproto::ListTablesResponse* response) {
-    auto const instance_name =
-        "projects/" + kProjectId + "/instances/" + kInstanceId;
-    EXPECT_EQ(instance_name, request.parent());
-    EXPECT_EQ(btproto::Table::FULL, request.view());
-    EXPECT_EQ(expected_token, request.page_token());
+  return
+      [expected_token, returned_token, table_names](
+          grpc::ClientContext* ctx, btproto::ListTablesRequest const& request,
+          btproto::ListTablesResponse* response) {
+        auto const instance_name =
+            "projects/" + kProjectId + "/instances/" + kInstanceId;
+        EXPECT_EQ(instance_name, request.parent());
+        EXPECT_EQ(btproto::Table::FULL, request.view());
+        EXPECT_EQ(expected_token, request.page_token());
 
-    EXPECT_NE(nullptr, response);
-    for (auto const& table_name : table_names) {
-      auto& table = *response->add_tables();
-      table.set_name(instance_name + "/tables/" + table_name);
-      table.set_granularity(btproto::Table::MILLIS);
-    }
-    // Return the right token.
-    response->set_next_page_token(returned_token);
-    return grpc::Status::OK;
-  };
+        EXPECT_NE(nullptr, response);
+        for (auto const& table_name : table_names) {
+          auto& table = *response->add_tables();
+          table.set_name(instance_name + "/tables/" + table_name);
+          table.set_granularity(btproto::Table::MILLIS);
+        }
+        // Return the right token.
+        response->set_next_page_token(returned_token);
+        return grpc::Status::OK;
+      };
 };
 
 /**

--- a/bigtable/admin/table_admin_test.cc
+++ b/bigtable/admin/table_admin_test.cc
@@ -56,26 +56,25 @@ class TableAdminTest : public ::testing::Test {
 auto create_list_tables_lambda = [](std::string expected_token,
                                     std::string returned_token,
                                     std::vector<std::string> table_names) {
-  return
-      [expected_token, returned_token, table_names](
-          grpc::ClientContext* ctx, btproto::ListTablesRequest const& request,
-          btproto::ListTablesResponse* response) {
-        auto const instance_name =
-            "projects/" + kProjectId + "/instances/" + kInstanceId;
-        EXPECT_EQ(instance_name, request.parent());
-        EXPECT_EQ(btproto::Table::FULL, request.view());
-        EXPECT_EQ(expected_token, request.page_token());
+  return [expected_token, returned_token, table_names](
+      grpc::ClientContext* ctx, btproto::ListTablesRequest const& request,
+      btproto::ListTablesResponse* response) {
+    auto const instance_name =
+        "projects/" + kProjectId + "/instances/" + kInstanceId;
+    EXPECT_EQ(instance_name, request.parent());
+    EXPECT_EQ(btproto::Table::FULL, request.view());
+    EXPECT_EQ(expected_token, request.page_token());
 
-        EXPECT_NE(nullptr, response);
-        for (auto const& table_name : table_names) {
-          auto& table = *response->add_tables();
-          table.set_name(instance_name + "/tables/" + table_name);
-          table.set_granularity(btproto::Table::MILLIS);
-        }
-        // Return the right token.
-        response->set_next_page_token(returned_token);
-        return grpc::Status::OK;
-      };
+    EXPECT_NE(nullptr, response);
+    for (auto const& table_name : table_names) {
+      auto& table = *response->add_tables();
+      table.set_name(instance_name + "/tables/" + table_name);
+      table.set_granularity(btproto::Table::MILLIS);
+    }
+    // Return the right token.
+    response->set_next_page_token(returned_token);
+    return grpc::Status::OK;
+  };
 };
 
 /**

--- a/bigtable/admin/table_admin_test.cc
+++ b/bigtable/admin/table_admin_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "bigtable/admin/table_admin.h"
+#include <bigtable/client/grpc_error.h>
 #include <gmock/gmock.h>
 #include <google/bigtable/admin/v2/bigtable_table_admin_mock.grpc.pb.h>
 #include <google/protobuf/text_format.h>
@@ -294,7 +295,7 @@ TEST_F(TableAdminTest, CreateTableFailure) {
   EXPECT_CALL(*client_, on_completion(_)).Times(1);
   // After all the setup, make the actual call we want to test.
   EXPECT_THROW(tested.CreateTable("other-table", bigtable::TableConfig()),
-               std::runtime_error);
+               bigtable::GRpcError);
 #else
   // Death tests happen on a separate process, so we do not get to observe the
   // calls to on_completion().
@@ -343,7 +344,7 @@ TEST_F(TableAdminTest, GetTableUnrecoverableFailures) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_CALL(*client_, on_completion(_)).Times(1);
   // After all the setup, make the actual call we want to test.
-  EXPECT_THROW(tested.GetTable("other-table"), std::runtime_error);
+  EXPECT_THROW(tested.GetTable("other-table"), bigtable::GRpcError);
 #else
   // Death tests happen on a separate process, so we do not get to observe the
   // calls to on_completion().
@@ -375,7 +376,7 @@ TEST_F(TableAdminTest, GetTableTooManyFailures) {
   EXPECT_CALL(*client_, on_completion(_)).Times(4);
 
   // After all the setup, make the actual call we want to test.
-  EXPECT_THROW(tested.GetTable("other-table"), std::runtime_error);
+  EXPECT_THROW(tested.GetTable("other-table"), bigtable::GRpcError);
 #else
   // Death tests happen on a separate process, so we do not get to observe the
   // calls to on_completion().
@@ -421,7 +422,7 @@ TEST_F(TableAdminTest, DeleteTableFailure) {
   EXPECT_CALL(*client_, on_completion(_)).Times(1);
   // After all the setup, make the actual call we want to test.
   EXPECT_THROW(tested.CreateTable("other-table", bigtable::TableConfig()),
-               std::runtime_error);
+               bigtable::GRpcError);
 #else
   // Death tests happen on a separate process, so we do not get to observe the
   // calls to on_completion().
@@ -491,7 +492,7 @@ TEST_F(TableAdminTest, ModifyColumnFamiliesFailure) {
   EXPECT_CALL(*client_, on_completion(_)).Times(1);
   // After all the setup, make the actual call we want to test.
   EXPECT_THROW(tested.ModifyColumnFamilies("other-table", std::move(changes)),
-               std::runtime_error);
+               bigtable::GRpcError);
 #else
   // Death tests happen on a separate process, so we do not get to observe the
   // calls to on_completion().
@@ -539,7 +540,7 @@ TEST_F(TableAdminTest, DropRowsByPrefixFailure) {
   EXPECT_CALL(*client_, on_completion(_)).Times(1);
   // After all the setup, make the actual call we want to test.
   EXPECT_THROW(tested.DropRowsByPrefix("other-table", "prefix"),
-               std::runtime_error);
+               bigtable::GRpcError);
 #else
   // Death tests happen on a separate process, so we do not get to observe the
   // calls to on_completion().
@@ -585,7 +586,7 @@ TEST_F(TableAdminTest, DropAllRowsFailure) {
   // failed.
   EXPECT_CALL(*client_, on_completion(_)).Times(1);
   // After all the setup, make the actual call we want to test.
-  EXPECT_THROW(tested.DropAllRows("other-table"), std::runtime_error);
+  EXPECT_THROW(tested.DropAllRows("other-table"), bigtable::GRpcError);
 #else
   // Death tests happen on a separate process, so we do not get to observe the
   // calls to on_completion().

--- a/bigtable/client/CMakeLists.txt
+++ b/bigtable/client/CMakeLists.txt
@@ -25,6 +25,10 @@ add_library(bigtable_client
         client_options.cc
         data_client.h
         data_client.cc
+        filters.h
+        filters.cc
+        grpc_error.h
+        grpc_error.cc
         internal/bulk_mutator.h
         internal/bulk_mutator.cc
         internal/common_client.h
@@ -41,8 +45,6 @@ add_library(bigtable_client
         internal/throw_delegate.h
         internal/throw_delegate.cc
         internal/unary_rpc_utils.h
-        filters.h
-        filters.cc
         idempotent_mutation_policy.h
         idempotent_mutation_policy.cc
         mutations.h
@@ -93,6 +95,7 @@ set(bigtable_client_unit_tests
         data_client_test.cc
         filters_test.cc
         force_sanitizer_failures_test.cc
+        grpc_error_test.cc
         idempotent_mutation_policy_test.cc
         internal/bulk_mutator_test.cc
         internal/prefix_range_end_test.cc

--- a/bigtable/client/grpc_error.cc
+++ b/bigtable/client/grpc_error.cc
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2018 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/bigtable/client/grpc_error.cc
+++ b/bigtable/client/grpc_error.cc
@@ -1,0 +1,63 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/client/grpc_error.h"
+#include <sstream>
+
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+constexpr char const* kKnownCodes[] = {
+    "OK",
+    "CANCELLED",
+    "UNKNOWN",
+    "INVALID_ARGUMENT",
+    "DEADLINE_EXCEEDED",
+    "NOT_FOUND",
+    "ALREADY_EXISTS",
+    "PERMISSION_DENIED",
+    "RESOURCE_EXHAUSTED",
+    "FAILED_PRECONDITION",
+    "ABORTED",
+    "OUT_OF_RANGE",
+    "UNIMPLEMENTED",
+    "INTERNAL",
+    "UNAVAILABLE",
+    "DATA_LOSS",
+    "UNAUTHENTICATED",
+};
+constexpr int kKnownCodesSize = sizeof(kKnownCodes) / sizeof(kKnownCodes[0]);
+
+GRpcError::GRpcError(char const* what, grpc::Status const& status)
+    : std::runtime_error(CreateWhatString(what, status)),
+      error_code_(status.error_code()),
+      error_message_(status.error_message()),
+      error_details_(status.error_details()) {}
+
+std::string GRpcError::CreateWhatString(char const* what,
+                                        grpc::Status const& status) {
+  std::ostringstream os;
+  os << what << ": " << status.error_message() << " [" << status.error_code()
+     << "=";
+  int const index = status.error_code();
+  if (0 <= index and index < kKnownCodesSize) {
+    os << kKnownCodes[status.error_code()];
+  } else {
+    os << "(UNKNOWN CODE)";
+  }
+  os << "] - " << status.error_details();
+  return os.str();
+}
+
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable

--- a/bigtable/client/grpc_error.h
+++ b/bigtable/client/grpc_error.h
@@ -1,0 +1,60 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_GRPC_ERROR_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_GRPC_ERROR_H_
+
+#include <grpc++/grpc++.h>
+#include <stdexcept>
+#include "bigtable/client/version.h"
+
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+/**
+ * Wrap gRPC errors is a C++ exception.
+ *
+ * It is customary, though not required, for C++ libraries and applications
+ * to use classes in the `std::exception` hierarchy to report errors. Meanwhile,
+ * gRPC reports errors using the `grpc::Status` class. This class wraps the
+ * contents of a `grpc::Status` in an exception class.  If the application is
+ * interested in the details of the exception it can catch it and examine all
+ * fields.  If the application developers simply want to log all exceptions they
+ * can catch `std::exception` and log the contents of `what()`.
+ */
+class GRpcError : public std::runtime_error {
+ public:
+  explicit GRpcError(char const* what, grpc::Status const& status);
+
+  //@{
+  /// @name accessors.
+  grpc::StatusCode error_code() const { return error_code_; }
+  std::string const& error_message() const { return error_message_; }
+  std::string const& error_details() const { return error_details_; }
+  //@}
+
+ private:
+  /// Return the what() string given @p status.
+  static std::string CreateWhatString(char const* what,
+                                      grpc::Status const& status);
+
+ private:
+  grpc::StatusCode error_code_;
+  std::string error_message_;
+  std::string error_details_;
+};
+
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_GRPC_ERROR_H_

--- a/bigtable/client/grpc_error.h
+++ b/bigtable/client/grpc_error.h
@@ -24,6 +24,13 @@ inline namespace BIGTABLE_CLIENT_NS {
 /**
  * Wrap gRPC errors is a C++ exception.
  *
+ * Applications that only wish to log errors can (and should) catch
+ * `std::exception` or `std::runtime_error`. The string returned by `what()`
+ * contains all the necessary information.  If the application wants to handle
+ * errors raised by the gRPC library, they can catch this exception type, and
+ * use the `error_code()` member function to implement whatever error handling
+ * strategy they need.
+ *
  * It is customary, though not required, for C++ libraries and applications
  * to use classes in the `std::exception` hierarchy to report errors. Meanwhile,
  * gRPC reports errors using the `grpc::Status` class. This class wraps the

--- a/bigtable/client/grpc_error_test.cc
+++ b/bigtable/client/grpc_error_test.cc
@@ -1,0 +1,56 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/client/grpc_error.h"
+#include <gmock/gmock.h>
+
+TEST(GRpcErrorTest, Simple) {
+  bigtable::GRpcError cancelled("Test()", grpc::Status::CANCELLED);
+  EXPECT_EQ(grpc::Status::CANCELLED.error_code(), cancelled.error_code());
+  EXPECT_EQ(grpc::Status::CANCELLED.error_message(), cancelled.error_message());
+  EXPECT_EQ(grpc::Status::CANCELLED.error_details(), cancelled.error_details());
+
+  bigtable::GRpcError test("Test()", grpc::Status(grpc::StatusCode::UNAVAILABLE,
+                                                  "try-again", "too-busy"));
+  EXPECT_EQ(grpc::StatusCode::UNAVAILABLE, test.error_code());
+  EXPECT_EQ("try-again", test.error_message());
+  EXPECT_EQ("too-busy", test.error_details());
+
+  std::string what(test.what());
+  EXPECT_NE(std::string::npos, what.find("Test()"));
+  EXPECT_NE(std::string::npos, what.find("try-again"));
+  EXPECT_NE(std::string::npos, what.find("too-busy"));
+  EXPECT_NE(std::string::npos, what.find("UNAVAILABLE"));
+}
+
+TEST(GRpcErrorTest, KnownCode_UNAUTHENTICATED) {
+  bigtable::GRpcError ex(
+      "T()", grpc::Status(grpc::StatusCode::UNAUTHENTICATED, "", ""));
+  EXPECT_EQ(grpc::StatusCode::UNAUTHENTICATED, ex.error_code());
+  EXPECT_NE(std::string::npos, std::string(ex.what()).find("UNAUTHENTICATED"));
+}
+
+TEST(GRpcErrorTest, KnownCode_DATA_LOSS) {
+  bigtable::GRpcError ex("T()",
+                         grpc::Status(grpc::StatusCode::DATA_LOSS, "", ""));
+  EXPECT_EQ(grpc::StatusCode::DATA_LOSS, ex.error_code());
+  EXPECT_NE(std::string::npos, std::string(ex.what()).find("DATA_LOSS"));
+}
+
+TEST(GRpcErrorTest, KnownCode_NOT_FOUND) {
+  bigtable::GRpcError ex("T()",
+                         grpc::Status(grpc::StatusCode::NOT_FOUND, "", ""));
+  EXPECT_EQ(grpc::StatusCode::NOT_FOUND, ex.error_code());
+  EXPECT_NE(std::string::npos, std::string(ex.what()).find("NOT_FOUND"));
+}

--- a/bigtable/client/internal/throw_delegate.cc
+++ b/bigtable/client/internal/throw_delegate.cc
@@ -23,6 +23,7 @@ template <typename Exception>
   throw Exception(msg);
 #else
   std::cerr << "Aborting because exceptions are disabled: " << msg << std::endl;
+  // TODO(#327) - make the call to std::abort() configurable.
   std::abort();
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
@@ -71,6 +72,7 @@ namespace internal {
   bigtable::GRpcError ex(msg, status);
   std::cerr << "Aborting because exceptions are disabled: " << ex.what()
             << std::endl;
+  // TODO(#327) - make the call to std::abort() configurable.
   std::abort();
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }

--- a/bigtable/client/internal/throw_delegate.cc
+++ b/bigtable/client/internal/throw_delegate.cc
@@ -13,12 +13,8 @@
 // limitations under the License.
 
 #include "bigtable/client/internal/throw_delegate.h"
-
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-#include <stdexcept>
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-
 #include <sstream>
+#include "bigtable/client/grpc_error.h"
 
 namespace {
 template <typename Exception>
@@ -69,12 +65,14 @@ namespace internal {
 }
 
 [[noreturn]] void RaiseRpcError(grpc::Status const &status, char const *msg) {
-  // TODO(#119) - raise an exception that stores `status` as a value.
-  std::ostringstream os;
-  os << "unrecoverable gRPC error or too many gRPC errors in " << msg << ": "
-     << status.error_message() << " [" << status.error_code() << "] "
-     << status.error_details();
-  internal::RaiseRuntimeError(os.str());
+#ifdef GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  throw bigtable::GRpcError(msg, status);
+#else
+  bigtable::GRpcError ex(msg, status);
+  std::cerr << "Aborting because exceptions are disabled: " << ex.what()
+            << std::endl;
+  std::abort();
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 [[noreturn]] void RaiseRpcError(grpc::Status const &status,

--- a/bigtable/client/row_reader.cc
+++ b/bigtable/client/row_reader.cc
@@ -156,8 +156,7 @@ void RowReader::Advance(internal::OptionalRow& row) {
     }
 
     if (not status.ok() and not retry_policy_->on_failure(status)) {
-      internal::RaiseRuntimeError("Unretriable error: " +
-                                  status.error_message());
+      internal::RaiseRpcError(status, "RowReader::Advance()");
     }
 
     auto delay = backoff_policy_->on_completion(status);

--- a/bigtable/tests/mutations_integration_test.cc
+++ b/bigtable/tests/mutations_integration_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "bigtable/client/grpc_error.h"
 #include "bigtable/client/testing/table_integration_test.h"
 
 namespace {
@@ -212,11 +213,10 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForReversedTimestampRangeTest) {
   CreateCells(*table, created_cells);
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   // Try to delete the columns with an invalid range:
-  // TODO(#119) - change the expected exception to the wrapper.
   EXPECT_THROW(
       table->Apply(bigtable::SingleRowMutation(
           key, bigtable::DeleteFromColumn(column_family2, "c2", 4000, 2000))),
-      std::runtime_error);
+      bigtable::GRpcError);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       table->Apply(bigtable::SingleRowMutation(
@@ -258,7 +258,7 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForEmptyTimestampRangeTest) {
   EXPECT_THROW(
       table->Apply(bigtable::SingleRowMutation(
           key, bigtable::DeleteFromColumn(column_family2, "c2", 2000, 2000))),
-      std::runtime_error);
+      bigtable::GRpcError);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       table->Apply(bigtable::SingleRowMutation(


### PR DESCRIPTION
This fixes #119.  Instead of raising a plain `std::runtime_error`
exception with the information in the `what()` string the
library now raises `bigtble::GRpcError` with the relevant
`grpc::Status` fields (error code, error message, and error details).
The class is derived from `std::runtime_error` because that is
the exception that one should use to, well, represent run-time
errors, which these are.