### PR TITLE
clang-format orders #includes per style-guide.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,15 +7,14 @@ BasedOnStyle: Google
 # so to enforce the consistency:
 PointerAlignment: Left
 
-# These will need to be enabled after we commit the style guide:
-# IncludeCategories:
-# - Regex: '^\"'
-#   Priority: 1000
-# - Regex: '^<grpc/'
-#   Priority: 2000
-# - Regex: '^<google/*'
-#   Priority: 3000
-# - Regex: '^<.*/.*'
-#   Priority: 4000
-# - Regex: '^<[^/]*>'
-#   Priority: 5000
+IncludeCategories:
+- Regex: '^\"'
+  Priority: 1000
+- Regex: '^<grpc/'
+  Priority: 2000
+- Regex: '^<google/*'
+  Priority: 3000
+- Regex: '^<.*/.*'
+  Priority: 4000
+- Regex: '^<[^/]*>'
+  Priority: 5000

--- a/bigtable/admin/instance_admin.h
+++ b/bigtable/admin/instance_admin.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_ADMIN_INSTANCE_ADMIN_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_ADMIN_INSTANCE_ADMIN_H_
 
-#include <memory>
 #include "bigtable/admin/instance_admin_client.h"
 #include "bigtable/client/internal/unary_rpc_utils.h"
+#include <memory>
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {

--- a/bigtable/admin/instance_admin_client.h
+++ b/bigtable/admin/instance_admin_client.h
@@ -15,10 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_ADMIN_INSTANCE_ADMIN_CLIENT_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_ADMIN_INSTANCE_ADMIN_CLIENT_H_
 
+#include "bigtable/client/client_options.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h>
 #include <memory>
 #include <string>
-#include "bigtable/client/client_options.h"
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {

--- a/bigtable/admin/instance_admin_test.cc
+++ b/bigtable/admin/instance_admin_test.cc
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include "bigtable/admin/instance_admin.h"
-#include <gmock/gmock.h>
+#include "bigtable/client/testing/chrono_literals.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin_mock.grpc.pb.h>
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
-#include "bigtable/client/testing/chrono_literals.h"
+#include <gmock/gmock.h>
 
 namespace {
 namespace btproto = ::google::bigtable::admin::v2;

--- a/bigtable/admin/table_admin.h
+++ b/bigtable/admin/table_admin.h
@@ -15,11 +15,11 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_ADMIN_TABLE_ADMIN_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_ADMIN_TABLE_ADMIN_H_
 
-#include <memory>
 #include "bigtable/admin/admin_client.h"
 #include "bigtable/admin/column_family.h"
 #include "bigtable/admin/table_config.h"
 #include "bigtable/client/internal/unary_rpc_utils.h"
+#include <memory>
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {

--- a/bigtable/admin/table_admin_test.cc
+++ b/bigtable/admin/table_admin_test.cc
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 #include "bigtable/admin/table_admin.h"
-#include <gmock/gmock.h>
+#include "bigtable/client/grpc_error.h"
+#include "bigtable/client/testing/chrono_literals.h"
 #include <google/bigtable/admin/v2/bigtable_table_admin_mock.grpc.pb.h>
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
-#include "bigtable/client/grpc_error.h"
-#include "bigtable/client/testing/chrono_literals.h"
+#include <gmock/gmock.h>
 
 namespace {
 namespace btproto = ::google::bigtable::admin::v2;

--- a/bigtable/admin/table_config.h
+++ b/bigtable/admin/table_config.h
@@ -16,9 +16,7 @@
 #define GOOGLE_CLOUD_CPP_BIGTABLE_ADMIN_TABLE_CONFIG_H_
 
 #include "bigtable/admin/column_family.h"
-
 #include <google/bigtable/admin/v2/bigtable_table_admin.pb.h>
-
 #include <map>
 #include <vector>
 

--- a/bigtable/admin/table_config_test.cc
+++ b/bigtable/admin/table_config_test.cc
@@ -13,11 +13,9 @@
 // limitations under the License.
 
 #include "bigtable/admin/table_config.h"
-
-#include <gmock/gmock.h>
-
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
+#include <gmock/gmock.h>
 
 namespace btproto = ::google::bigtable::admin::v2;
 

--- a/bigtable/benchmarks/apply_read_latency_benchmark.cc
+++ b/bigtable/benchmarks/apply_read_latency_benchmark.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "bigtable/benchmarks/benchmark.h"
 #include <cctype>
 #include <chrono>
 #include <future>
 #include <iomanip>
 #include <sstream>
-#include "bigtable/benchmarks/benchmark.h"
 
 /**
  * @file

--- a/bigtable/benchmarks/embedded_server_test.cc
+++ b/bigtable/benchmarks/embedded_server_test.cc
@@ -13,13 +13,10 @@
 // limitations under the License.
 
 #include "bigtable/benchmarks/embedded_server.h"
-
-#include <thread>
-
-#include <gmock/gmock.h>
-
 #include "bigtable/admin/table_admin.h"
 #include "bigtable/client/table.h"
+#include <gmock/gmock.h>
+#include <thread>
 
 using namespace bigtable::benchmarks;
 

--- a/bigtable/benchmarks/endurance_benchmark.cc
+++ b/bigtable/benchmarks/endurance_benchmark.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "bigtable/benchmarks/benchmark.h"
 #include <future>
 #include <iomanip>
 #include <sstream>
-#include "bigtable/benchmarks/benchmark.h"
 
 /**
  * @file

--- a/bigtable/benchmarks/format_duration_test.cc
+++ b/bigtable/benchmarks/format_duration_test.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
 #include "bigtable/benchmarks/benchmark.h"
+#include <gmock/gmock.h>
 
 using namespace bigtable::benchmarks;
 using namespace std::chrono;

--- a/bigtable/benchmarks/random.h
+++ b/bigtable/benchmarks/random.h
@@ -15,10 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_RANDOM_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_RANDOM_H_
 
-#include <algorithm>
-#include <random>
 #include "bigtable/admin/table_admin.h"
 #include "bigtable/client/table.h"
+#include <algorithm>
+#include <random>
 
 namespace bigtable {
 namespace benchmarks {

--- a/bigtable/benchmarks/random_test.cc
+++ b/bigtable/benchmarks/random_test.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "bigtable/benchmarks/random.h"
-#include <gmock/gmock.h>
 #include "bigtable/benchmarks/constants.h"
+#include <gmock/gmock.h>
 
 using namespace bigtable::benchmarks;
 

--- a/bigtable/benchmarks/scan_throughput_benchmark.cc
+++ b/bigtable/benchmarks/scan_throughput_benchmark.cc
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "bigtable/benchmarks/benchmark.h"
 #include <chrono>
 #include <future>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
-
-#include "bigtable/benchmarks/benchmark.h"
 
 /**
  * @file

--- a/bigtable/benchmarks/setup.cc
+++ b/bigtable/benchmarks/setup.cc
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 #include "bigtable/benchmarks/setup.h"
-#include <cctype>
-#include <iomanip>
-#include <sstream>
 #include "bigtable/benchmarks/random.h"
 #include "bigtable/client/build_info.h"
 #include "bigtable/client/internal/throw_delegate.h"
+#include <cctype>
+#include <iomanip>
+#include <sstream>
 
 /// Supporting types and functions to implement `BenchmarkSetup`
 namespace {

--- a/bigtable/benchmarks/setup.h
+++ b/bigtable/benchmarks/setup.h
@@ -15,10 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_BENCHMARK_SETUP_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_BENCHMARK_SETUP_H_
 
+#include "bigtable/benchmarks/constants.h"
 #include <chrono>
 #include <string>
 #include <vector>
-#include "bigtable/benchmarks/constants.h"
 
 namespace bigtable {
 namespace benchmarks {

--- a/bigtable/client/data_client.h
+++ b/bigtable/client/data_client.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_DATA_CLIENT_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_DATA_CLIENT_H_
 
-#include <google/bigtable/v2/bigtable.grpc.pb.h>
 #include "bigtable/client/client_options.h"
+#include <google/bigtable/v2/bigtable.grpc.pb.h>
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {

--- a/bigtable/client/grpc_error.h
+++ b/bigtable/client/grpc_error.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_GRPC_ERROR_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_GRPC_ERROR_H_
 
+#include "bigtable/client/version.h"
 #include <grpc++/grpc++.h>
 #include <stdexcept>
-#include "bigtable/client/version.h"
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {

--- a/bigtable/client/idempotent_mutation_policy.h
+++ b/bigtable/client/idempotent_mutation_policy.h
@@ -17,8 +17,8 @@
 
 #include <bigtable/client/version.h>
 
-#include <memory>
 #include "bigtable/client/mutations.h"
+#include <memory>
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {

--- a/bigtable/client/internal/common_client.h
+++ b/bigtable/client/internal/common_client.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_COMMON_CLIENT_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_COMMON_CLIENT_H_
 
-#include <grpc++/grpc++.h>
 #include "bigtable/client/client_options.h"
+#include <grpc++/grpc++.h>
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {

--- a/bigtable/client/internal/prefix_range_end.h
+++ b/bigtable/client/internal/prefix_range_end.h
@@ -16,7 +16,6 @@
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_PREFIX_RANGE_END_H_
 
 #include "bigtable/client/version.h"
-
 #include <string>
 
 namespace bigtable {

--- a/bigtable/client/internal/prefix_range_end_test.cc
+++ b/bigtable/client/internal/prefix_range_end_test.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "bigtable/client/internal/prefix_range_end.h"
-
 #include <gmock/gmock.h>
 
 TEST(PrefixRangeEndTest, Simple) {

--- a/bigtable/client/internal/readrowsparser.h
+++ b/bigtable/client/internal/readrowsparser.h
@@ -15,11 +15,11 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_READROWSPARSER_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_READROWSPARSER_H_
 
-#include <google/bigtable/v2/bigtable.grpc.pb.h>
-#include <vector>
 #include "bigtable/client/cell.h"
 #include "bigtable/client/internal/make_unique.h"
 #include "bigtable/client/row.h"
+#include <google/bigtable/v2/bigtable.grpc.pb.h>
+#include <vector>
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {

--- a/bigtable/client/internal/readrowsparser_test.cc
+++ b/bigtable/client/internal/readrowsparser_test.cc
@@ -14,11 +14,8 @@
 
 #include "bigtable/client/internal/readrowsparser.h"
 #include "bigtable/client/row.h"
-
 #include <google/protobuf/text_format.h>
-
 #include <gtest/gtest.h>
-
 #include <numeric>
 #include <sstream>
 #include <vector>

--- a/bigtable/client/internal/rowreaderiterator.cc
+++ b/bigtable/client/internal/rowreaderiterator.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "bigtable/client/internal/rowreaderiterator.h"
-
 #include "bigtable/client/row_reader.h"
 
 namespace bigtable {

--- a/bigtable/client/internal/rowreaderiterator.h
+++ b/bigtable/client/internal/rowreaderiterator.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_ROWREADERITERATOR_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_ROWREADERITERATOR_H_
 
-#include <iterator>
 #include "bigtable/client/internal/throw_delegate.h"
 #include "bigtable/client/row.h"
+#include <iterator>
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {

--- a/bigtable/client/internal/throw_delegate.cc
+++ b/bigtable/client/internal/throw_delegate.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "bigtable/client/internal/throw_delegate.h"
-#include <sstream>
 #include "bigtable/client/grpc_error.h"
+#include <sstream>
 
 namespace {
 template <typename Exception>

--- a/bigtable/client/internal/throw_delegate.h
+++ b/bigtable/client/internal/throw_delegate.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_THROW_DELEGATE_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_THROW_DELEGATE_H_
 
-#include <grpc++/grpc++.h>
 #include "bigtable/client/version.h"
+#include <grpc++/grpc++.h>
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {

--- a/bigtable/client/internal/unary_rpc_utils.h
+++ b/bigtable/client/internal/unary_rpc_utils.h
@@ -15,10 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_UNARY_RPC_UTILS_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_UNARY_RPC_UTILS_H_
 
-#include <thread>
 #include "bigtable/client/internal/throw_delegate.h"
 #include "bigtable/client/rpc_backoff_policy.h"
 #include "bigtable/client/rpc_retry_policy.h"
+#include <thread>
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {

--- a/bigtable/client/mutations_test.cc
+++ b/bigtable/client/mutations_test.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "bigtable/client/mutations.h"
-#include <gmock/gmock.h>
 #include <google/rpc/error_details.pb.h>
+#include <gmock/gmock.h>
 
 /// @test Verify that SetCell() works as expected.
 TEST(MutationsTest, SetCell) {

--- a/bigtable/client/read_modify_write_rule.h
+++ b/bigtable/client/read_modify_write_rule.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_READ_MODIFY_WRITE_RULE_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_READ_MODIFY_WRITE_RULE_H_
 
+#include "bigtable/client/version.h"
 #include <google/bigtable/v2/data.pb.h>
 #include <chrono>
-#include "bigtable/client/version.h"
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {

--- a/bigtable/client/row_reader.cc
+++ b/bigtable/client/row_reader.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "bigtable/client/row_reader.h"
-#include <thread>
 #include "bigtable/client/internal/make_unique.h"
 #include "bigtable/client/internal/throw_delegate.h"
+#include <thread>
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {

--- a/bigtable/client/row_reader.h
+++ b/bigtable/client/row_reader.h
@@ -15,10 +15,6 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_ROW_READER_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_ROW_READER_H_
 
-#include <google/bigtable/v2/bigtable.grpc.pb.h>
-#include <grpc++/grpc++.h>
-#include <cinttypes>
-#include <iterator>
 #include "bigtable/client/data_client.h"
 #include "bigtable/client/filters.h"
 #include "bigtable/client/internal/readrowsparser.h"
@@ -27,6 +23,10 @@
 #include "bigtable/client/row_set.h"
 #include "bigtable/client/rpc_backoff_policy.h"
 #include "bigtable/client/rpc_retry_policy.h"
+#include <google/bigtable/v2/bigtable.grpc.pb.h>
+#include <grpc++/grpc++.h>
+#include <cinttypes>
+#include <iterator>
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {

--- a/bigtable/client/table.cc
+++ b/bigtable/client/table.cc
@@ -13,12 +13,10 @@
 // limitations under the License.
 
 #include "bigtable/client/table.h"
-
-#include <bigtable/client/internal/unary_rpc_utils.h>
-#include <thread>
-
 #include "bigtable/client/internal/bulk_mutator.h"
 #include "bigtable/client/internal/make_unique.h"
+#include <bigtable/client/internal/unary_rpc_utils.h>
+#include <thread>
 
 namespace btproto = ::google::bigtable::v2;
 

--- a/bigtable/client/table.h
+++ b/bigtable/client/table.h
@@ -23,7 +23,6 @@
 #include "bigtable/client/row_set.h"
 #include "bigtable/client/rpc_backoff_policy.h"
 #include "bigtable/client/rpc_retry_policy.h"
-
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
 
 namespace bigtable {

--- a/bigtable/client/table_bulk_apply_test.cc
+++ b/bigtable/client/table_bulk_apply_test.cc
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "bigtable/client/table.h"
-
 #include "bigtable/client/internal/make_unique.h"
+#include "bigtable/client/table.h"
 #include "bigtable/client/testing/chrono_literals.h"
 #include "bigtable/client/testing/table_test_fixture.h"
 

--- a/bigtable/client/table_test.cc
+++ b/bigtable/client/table_test.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "bigtable/client/table.h"
-
 #include "bigtable/client/testing/table_test_fixture.h"
 
 /// Define types and functions used in the tests.

--- a/bigtable/client/testing/mock_data_client.h
+++ b/bigtable/client/testing/mock_data_client.h
@@ -16,9 +16,7 @@
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_DATA_CLIENT_H_
 
 #include "bigtable/client/table.h"
-
 #include <google/bigtable/v2/bigtable_mock.grpc.pb.h>
-
 #include <gmock/gmock.h>
 
 namespace bigtable {

--- a/bigtable/client/testing/mock_response_stream.h
+++ b/bigtable/client/testing/mock_response_stream.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_RESPONSE_STREAM_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_RESPONSE_STREAM_H_
 
-#include <gmock/gmock.h>
 #include <google/bigtable/v2/bigtable.pb.h>
+#include <gmock/gmock.h>
 
 namespace bigtable {
 namespace testing {

--- a/bigtable/client/testing/table_integration_test.cc
+++ b/bigtable/client/testing/table_integration_test.cc
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google/protobuf/text_format.h>
-
-#include "bigtable/client/internal/make_unique.h"
 #include "bigtable/client/testing/table_integration_test.h"
+#include "bigtable/client/internal/make_unique.h"
+#include <google/protobuf/text_format.h>
 
 namespace bigtable {
 namespace testing {

--- a/bigtable/client/testing/table_integration_test.h
+++ b/bigtable/client/testing/table_integration_test.h
@@ -15,14 +15,13 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_TABLE_INTEGRATION_TEST_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_TABLE_INTEGRATION_TEST_H_
 
+#include "bigtable/admin/admin_client.h"
+#include "bigtable/admin/table_admin.h"
 #include "bigtable/client/cell.h"
+#include "bigtable/client/data_client.h"
 #include "bigtable/client/table.h"
 #include "bigtable/client/testing/mock_data_client.h"
 #include "bigtable/client/testing/mock_response_stream.h"
-
-#include "bigtable/admin/admin_client.h"
-#include "bigtable/admin/table_admin.h"
-#include "bigtable/client/data_client.h"
 
 namespace bigtable {
 namespace testing {

--- a/bigtable/client/testing/table_test_fixture.cc
+++ b/bigtable/client/testing/table_test_fixture.cc
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 #include "bigtable/client/testing/table_test_fixture.h"
-
-#include <google/protobuf/text_format.h>
-
 #include "bigtable/client/internal/throw_delegate.h"
+#include <google/protobuf/text_format.h>
 
 namespace bigtable {
 namespace testing {

--- a/bigtable/client/version.cc
+++ b/bigtable/client/version.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "bigtable/client/version.h"
-#include <sstream>
 #include "bigtable/client/build_info.h"
+#include <sstream>
 
 namespace bigtable {
 std::string version_string() {

--- a/bigtable/client/version.h
+++ b/bigtable/client/version.h
@@ -15,10 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_VERSION_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_VERSION_H_
 
-#include <string>
-
 #include "bigtable/client/internal/port_platform.h"
 #include "bigtable/client/version_info.h"
+#include <string>
 
 #define BIGTABLE_CLIENT_VCONCAT(Ma, Mi) v##Ma
 #define BIGTABLE_CLIENT_VEVAL(Ma, Mi) BIGTABLE_CLIENT_VCONCAT(Ma, Mi)

--- a/bigtable/tests/admin_integration_test.cc
+++ b/bigtable/tests/admin_integration_test.cc
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
-#include <google/protobuf/text_format.h>
-#include <google/protobuf/util/message_differencer.h>
-
 #include "bigtable/client/internal/make_unique.h"
 #include "bigtable/client/testing/table_integration_test.h"
-
+#include <google/protobuf/text_format.h>
+#include <google/protobuf/util/message_differencer.h>
+#include <gmock/gmock.h>
 #include <string>
 #include <vector>
 

--- a/tests/grpc-crash/client.cc
+++ b/tests/grpc-crash/client.cc
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 #include "echo.grpc.pb.h"
-
-#include <future>
-
 #include <grpc++/grpc++.h>
+#include <future>
 
 void MakeStreamPing(Echo::Stub &echo, std::int32_t count) {
   for (int i = 0; i != 100; ++i) {

--- a/tests/grpc-crash/server.cc
+++ b/tests/grpc-crash/server.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "echo.grpc.pb.h"
-
 #include <grpc++/grpc++.h>
 #include <future>
 #include <iostream>

--- a/tests/grpc-round-robin-freeze/client.cc
+++ b/tests/grpc-round-robin-freeze/client.cc
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 #include "echo.grpc.pb.h"
-
-#include <future>
-
 #include <grpc++/grpc++.h>
+#include <future>
 
 void MakeStreamPing(Echo::Stub &echo, std::int32_t count) {
   for (int i = 0; i != 100; ++i) {

--- a/tests/grpc-round-robin-freeze/server.cc
+++ b/tests/grpc-round-robin-freeze/server.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "echo.grpc.pb.h"
-
 #include <grpc++/grpc++.h>
 #include <future>
 #include <iostream>


### PR DESCRIPTION
Use .clang-format to enforce the right order for #includes.
We should decide if #298 or this PR goes first.