### PR TITLE
Use milliseconds in bigtable::SetCell

### DIFF
--- a/bigtable/benchmarks/embedded_server_test.cc
+++ b/bigtable/benchmarks/embedded_server_test.cc
@@ -22,6 +22,7 @@
 #include "bigtable/client/table.h"
 
 using namespace bigtable::benchmarks;
+using std::chrono::milliseconds;
 
 TEST(EmbeddedServer, WaitAndShutdown) {
   auto server = CreateEmbeddedServer();
@@ -72,8 +73,8 @@ TEST(EmbeddedServer, TableApply) {
 
   bigtable::SingleRowMutation mutation(
       "row1",
-      {bigtable::SetCell("fam", "col", 0, "val"),
-       bigtable::SetCell("fam", "col", 0, "val")});
+      {bigtable::SetCell("fam", "col", milliseconds(0), "val"),
+       bigtable::SetCell("fam", "col", milliseconds(0), "val")});
 
   EXPECT_EQ(0, server->mutate_row_count());
   table.Apply(std::move(mutation));
@@ -96,9 +97,9 @@ TEST(EmbeddedServer, TableBulkApply) {
 
   bigtable::BulkMutation bulk;
   bulk.emplace_back(bigtable::SingleRowMutation(
-      "row1", {bigtable::SetCell("fam", "col", 0, "val")}));
+      "row1", {bigtable::SetCell("fam", "col", milliseconds(0), "val")}));
   bulk.emplace_back(bigtable::SingleRowMutation(
-      "row2", {bigtable::SetCell("fam", "col", 0, "val")}));
+      "row2", {bigtable::SetCell("fam", "col", milliseconds(0), "val")}));
 
   EXPECT_EQ(0, server->mutate_rows_count());
   table.BulkApply(std::move(bulk));

--- a/bigtable/benchmarks/random.cc
+++ b/bigtable/benchmarks/random.cc
@@ -28,8 +28,8 @@ std::string Sample(DefaultPRNG& gen, int n, std::string const& population) {
 
 bigtable::Mutation MakeRandomMutation(DefaultPRNG& gen, int f) {
   std::string field = "field" + std::to_string(f);
-  return bigtable::SetCell(kColumnFamily, std::move(field), 0,
-                           MakeRandomValue(gen));
+  return bigtable::SetCell(kColumnFamily, std::move(field),
+                           std::chrono::milliseconds(0), MakeRandomValue(gen));
 }
 
 std::string MakeRandomValue(DefaultPRNG& generator) {

--- a/bigtable/client/idempotent_mutation_policy_test.cc
+++ b/bigtable/client/idempotent_mutation_policy_test.cc
@@ -13,38 +13,35 @@
 // limitations under the License.
 
 #include "bigtable/client/idempotent_mutation_policy.h"
-
 #include <gmock/gmock.h>
+#include "bigtable/client/testing/chrono_literals.h"
 
 /// @test Verify that the default policy works as expected.
 TEST(IdempotentMutationPolicyTest, Simple) {
+  using namespace bigtable::chrono_literals;
   auto policy = bigtable::DefaultIdempotentMutationPolicy();
   EXPECT_TRUE(policy->is_idempotent(
       bigtable::DeleteFromColumn("fam", "col", 0, 10).op));
   EXPECT_TRUE(policy->is_idempotent(bigtable::DeleteFromFamily("fam").op));
 
   EXPECT_TRUE(
-      policy->is_idempotent(bigtable::SetCell("fam", "col", 0, "v1").op));
+      policy->is_idempotent(bigtable::SetCell("fam", "col", 0_ms, "v1").op));
   EXPECT_FALSE(policy->is_idempotent(bigtable::SetCell("fam", "c2", "v2").op));
-  EXPECT_FALSE(policy->is_idempotent(
-      bigtable::SetCell("f", "c", bigtable::ServerSetTimestamp(), "v").op));
 }
 
 /// @test Verify that bigtable::AlwaysRetryMutationPolicy works as expected.
 TEST(IdempotentMutationPolicyTest, AlwaysRetry) {
+  using namespace bigtable::chrono_literals;
   bigtable::AlwaysRetryMutationPolicy policy;
   EXPECT_TRUE(
       policy.is_idempotent(bigtable::DeleteFromColumn("fam", "col", 0, 10).op));
   EXPECT_TRUE(policy.is_idempotent(bigtable::DeleteFromFamily("fam").op));
 
   EXPECT_TRUE(
-      policy.is_idempotent(bigtable::SetCell("fam", "col", 0, "v1").op));
+      policy.is_idempotent(bigtable::SetCell("fam", "col", 0_ms, "v1").op));
   EXPECT_TRUE(policy.is_idempotent(bigtable::SetCell("fam", "c2", "v2").op));
-  EXPECT_TRUE(policy.is_idempotent(
-      bigtable::SetCell("f", "c", bigtable::ServerSetTimestamp(), "v").op));
 
   auto clone = policy.clone();
-  EXPECT_TRUE(clone->is_idempotent(
-      bigtable::SetCell("f", "c", bigtable::ServerSetTimestamp(), "v").op));
-  EXPECT_TRUE(clone->is_idempotent(bigtable::SetCell("f", "c", 10, "v").op));
+  EXPECT_TRUE(clone->is_idempotent(bigtable::SetCell("f", "c", "v").op));
+  EXPECT_TRUE(clone->is_idempotent(bigtable::SetCell("f", "c", 10_ms, "v").op));
 }

--- a/bigtable/client/internal/bulk_mutator_test.cc
+++ b/bigtable/client/internal/bulk_mutator_test.cc
@@ -13,10 +13,9 @@
 // limitations under the License.
 
 #include "bigtable/client/internal/bulk_mutator.h"
-
 #include <google/bigtable/v2/bigtable_mock.grpc.pb.h>
-
 #include "bigtable/client/internal/make_unique.h"
+#include "bigtable/client/testing/chrono_literals.h"
 
 /// Define types and functions used in the tests.
 namespace {
@@ -35,12 +34,13 @@ TEST(MultipleRowsMutatorTest, Simple) {
   namespace btproto = ::google::bigtable::v2;
   namespace bt = ::bigtable;
   using namespace ::testing;
+  using namespace bigtable::chrono_literals;
 
   // In this test we create a Mutation for two rows, which succeeds in the
   // first RPC request.  First create the mutation.
   bt::BulkMutation mut(
-      bt::SingleRowMutation("foo", {bt::SetCell("fam", "col", 0, "baz")}),
-      bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0, "qux")}));
+      bt::SingleRowMutation("foo", {bt::SetCell("fam", "col", 0_ms, "baz")}),
+      bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0_ms, "qux")}));
 
   // Prepare the mocks.  The mutator should issue a RPC which must return a
   // stream of responses, we prepare the stream first because it is easier than
@@ -88,12 +88,13 @@ TEST(MultipleRowsMutatorTest, RetryPartialFailure) {
   namespace btproto = ::google::bigtable::v2;
   namespace bt = ::bigtable;
   using namespace ::testing;
+  using namespace bigtable::chrono_literals;
 
   // In this test we create a Mutation for two rows, one of which will fail.
   // First create the mutation.
   bt::BulkMutation mut(
-      bt::SingleRowMutation("foo", {bt::SetCell("fam", "col", 0, "baz")}),
-      bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0, "qux")}));
+      bt::SingleRowMutation("foo", {bt::SetCell("fam", "col", 0_ms, "baz")}),
+      bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0_ms, "qux")}));
 
   // Prepare the mocks for the request.  First create a stream response which
   // indicates a partial failure.
@@ -162,12 +163,13 @@ TEST(MultipleRowsMutatorTest, PermanentFailure) {
   namespace btproto = ::google::bigtable::v2;
   namespace bt = ::bigtable;
   using namespace ::testing;
+  using namespace bigtable::chrono_literals;
 
   // In this test we handle a recoverable and one unrecoverable failures.
   // Create a bulk mutation with two SetCell() mutations.
   bt::BulkMutation mut(
-      bt::SingleRowMutation("foo", {bt::SetCell("fam", "col", 0, "baz")}),
-      bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0, "qux")}));
+      bt::SingleRowMutation("foo", {bt::SetCell("fam", "col", 0_ms, "baz")}),
+      bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0_ms, "qux")}));
 
   // Make the first RPC return one recoverable and one unrecoverable failures.
   auto r1 = bigtable::internal::make_unique<MockReader>();
@@ -237,12 +239,13 @@ TEST(MultipleRowsMutatorTest, PartialStream) {
   namespace btproto = ::google::bigtable::v2;
   namespace bt = ::bigtable;
   using namespace ::testing;
+  using namespace bigtable::chrono_literals;
 
   // We are going to test the case where the stream does not contain a response
   // for all requests.  Create a BulkMutation with two entries.
   bt::BulkMutation mut(
-      bt::SingleRowMutation("foo", {bt::SetCell("fam", "col", 0, "baz")}),
-      bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0, "qux")}));
+      bt::SingleRowMutation("foo", {bt::SetCell("fam", "col", 0_ms, "baz")}),
+      bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0_ms, "qux")}));
 
   // This will be the stream returned by the first request.  It is missing
   // information about one of the mutations.
@@ -305,11 +308,12 @@ TEST(MultipleRowsMutatorTest, RetryOnlyIdempotent) {
   namespace btproto = ::google::bigtable::v2;
   namespace bt = ::bigtable;
   using namespace ::testing;
+  using namespace bigtable::chrono_literals;
 
   // Create a BulkMutation with a non-idempotent mutation.
   bt::BulkMutation mut(
       bt::SingleRowMutation("foo", {bt::SetCell("fam", "col", "baz")}),
-      bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0, "qux")}),
+      bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0_ms, "qux")}),
       bt::SingleRowMutation("baz", {bt::SetCell("fam", "col", "v")}));
 
   // We will setup the mock to return recoverable failures for idempotent

--- a/bigtable/client/mutations.cc
+++ b/bigtable/client/mutations.cc
@@ -17,13 +17,14 @@
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-Mutation SetCell(std::string family, std::string column, std::int64_t timestamp,
-                 std::string value) {
+Mutation SetCell(std::string family, std::string column,
+                 std::chrono::milliseconds timestamp, std::string value) {
   Mutation m;
   auto& set_cell = *m.op.mutable_set_cell();
   set_cell.set_family_name(std::move(family));
   set_cell.set_column_qualifier(std::move(column));
-  set_cell.set_timestamp_micros(timestamp);
+  set_cell.set_timestamp_micros(
+      std::chrono::duration_cast<std::chrono::microseconds>(timestamp).count());
   set_cell.set_value(std::move(value));
   return m;
 }

--- a/bigtable/client/mutations.h
+++ b/bigtable/client/mutations.h
@@ -38,8 +38,8 @@ struct Mutation {
 };
 
 /// Create a mutation to set a cell value.
-Mutation SetCell(std::string family, std::string column, std::int64_t timestamp,
-                 std::string value);
+Mutation SetCell(std::string family, std::string column,
+                 std::chrono::milliseconds timestamp, std::string value);
 
 /**
  * Create a mutation to set a cell value where the server sets the time.

--- a/bigtable/client/table_apply_test.cc
+++ b/bigtable/client/table_apply_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "bigtable/client/table.h"
+#include "bigtable/client/testing/chrono_literals.h"
 #include "bigtable/client/testing/table_test_fixture.h"
 
 /// Define helper types and functions for this test.
@@ -21,6 +22,9 @@ class TableApplyTest : public bigtable::testing::TableTestFixture {};
 }  // anonymous namespace
 
 /// @test Verify that Table::Apply() works in a simplest case.
+
+using namespace bigtable::chrono_literals;
+
 TEST_F(TableApplyTest, Simple) {
   using namespace ::testing;
 
@@ -28,7 +32,7 @@ TEST_F(TableApplyTest, Simple) {
       .WillOnce(Return(grpc::Status::OK));
 
   table_.Apply(bigtable::SingleRowMutation(
-      "bar", {bigtable::SetCell("fam", "col", 0, "val")}));
+      "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}));
 }
 
 /// @test Verify that Table::Apply() raises an exception on permanent failures.
@@ -41,7 +45,7 @@ TEST_F(TableApplyTest, Failure) {
 
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_THROW(table_.Apply(bigtable::SingleRowMutation(
-                   "bar", {bigtable::SetCell("fam", "col", 0, "val")})),
+                   "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")})),
                std::exception);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
@@ -65,7 +69,7 @@ TEST_F(TableApplyTest, Retry) {
       .WillOnce(Return(grpc::Status::OK));
 
   table_.Apply(bigtable::SingleRowMutation(
-      "bar", {bigtable::SetCell("fam", "col", 0, "val")}));
+      "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}));
 }
 
 /// @test Verify that Table::Apply() retries only idempotent mutations.

--- a/bigtable/client/table_apply_test.cc
+++ b/bigtable/client/table_apply_test.cc
@@ -50,7 +50,7 @@ TEST_F(TableApplyTest, Failure) {
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       table_.Apply(bigtable::SingleRowMutation(
-          "bar", {bigtable::SetCell("fam", "col", 0, "val")})),
+          "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")})),
       "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }

--- a/bigtable/client/table_check_and_mutate_row_test.cc
+++ b/bigtable/client/table_check_and_mutate_row_test.cc
@@ -55,8 +55,8 @@ TEST_F(TableCheckAndMutateRowTest, Failure) {
   EXPECT_DEATH_IF_SUPPORTED(
       table_.CheckAndMutateRow(
           "foo", bigtable::Filter::PassAllFilter(),
-          {bigtable::SetCell("fam", "col", 0, "it was true")},
-          {bigtable::SetCell("fam", "col", 0, "it was false")}),
+          {bigtable::SetCell("fam", "col", 0_ms, "it was true")},
+          {bigtable::SetCell("fam", "col", 0_ms, "it was false")}),
       "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }

--- a/bigtable/client/table_check_and_mutate_row_test.cc
+++ b/bigtable/client/table_check_and_mutate_row_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "bigtable/client/table.h"
+#include "bigtable/client/testing/chrono_literals.h"
 #include "bigtable/client/testing/table_test_fixture.h"
 
 /// Define helper types and functions for this test.
@@ -20,6 +21,8 @@ namespace {
 class TableCheckAndMutateRowTest : public bigtable::testing::TableTestFixture {
 };
 }  // anonymous namespace
+
+using namespace bigtable::chrono_literals;
 
 /// @test Verify that Table::CheckAndMutateRow() works in a simplest case.
 TEST_F(TableCheckAndMutateRowTest, Simple) {
@@ -30,8 +33,8 @@ TEST_F(TableCheckAndMutateRowTest, Simple) {
 
   table_.CheckAndMutateRow(
       "foo", bigtable::Filter::PassAllFilter(),
-      {bigtable::SetCell("fam", "col", 0, "it was true")},
-      {bigtable::SetCell("fam", "col", 0, "it was false")});
+      {bigtable::SetCell("fam", "col", 0_ms, "it was true")},
+      {bigtable::SetCell("fam", "col", 0_ms, "it was false")});
 }
 
 /// @test Verify that Table::CheckAndMutateRow() raises an on failures.
@@ -45,8 +48,8 @@ TEST_F(TableCheckAndMutateRowTest, Failure) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_THROW(table_.CheckAndMutateRow(
                    "foo", bigtable::Filter::PassAllFilter(),
-                   {bigtable::SetCell("fam", "col", 0, "it was true")},
-                   {bigtable::SetCell("fam", "col", 0, "it was false")}),
+                   {bigtable::SetCell("fam", "col", 0_ms, "it was true")},
+                   {bigtable::SetCell("fam", "col", 0_ms, "it was false")}),
                std::exception);
 #else
   EXPECT_DEATH_IF_SUPPORTED(

--- a/bigtable/client/testing/table_integration_test.cc
+++ b/bigtable/client/testing/table_integration_test.cc
@@ -76,11 +76,13 @@ void TableIntegrationTest::CreateCells(
     bigtable::Table& table, std::vector<bigtable::Cell> const& cells) {
   std::map<std::string, bigtable::SingleRowMutation> mutations;
   for (auto const& cell : cells) {
+    using namespace std::chrono;
     std::string key = cell.row_key();
     auto inserted = mutations.emplace(key, bigtable::SingleRowMutation(key));
-    inserted.first->second.emplace_back(
-        bigtable::SetCell(cell.family_name(), cell.column_qualifier(),
-                          cell.timestamp(), cell.value()));
+    inserted.first->second.emplace_back(bigtable::SetCell(
+        cell.family_name(), cell.column_qualifier(),
+        duration_cast<milliseconds>(microseconds(cell.timestamp())),
+        cell.value()));
   }
   bigtable::BulkMutation bulk;
   for (auto& kv : mutations) {

--- a/bigtable/examples/quick_start/bigtable_write_row.cc
+++ b/bigtable/examples/quick_start/bigtable_write_row.cc
@@ -36,8 +36,10 @@ int main(int argc, char* argv[]) try {
 
   // Modify (and create if necessary) a row.
   //! [write row]
+  using std::chrono::milliseconds;
   table.Apply(bigtable::SingleRowMutation(
-      "my-key", bigtable::SetCell("family", "value", 0, "Hello World!")));
+      "my-key",
+      bigtable::SetCell("family", "value", milliseconds(0), "Hello World!")));
   //! [write row]
 
   return 0;

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "bigtable/client/testing/chrono_literals.h"
 #include "bigtable/client/testing/table_integration_test.h"
 
 namespace {
@@ -386,6 +387,7 @@ TEST_F(FilterIntegrationTest, CellsRowOffset) {
 }
 
 TEST_F(FilterIntegrationTest, RowSample) {
+  using namespace bigtable::chrono_literals;
   // TODO(#151) - remove workarounds for emulator bug(s).
   if (UsingCloudBigtableEmulator()) {
     return;
@@ -400,7 +402,7 @@ TEST_F(FilterIntegrationTest, RowSample) {
   for (int row = 0; row != row_count; ++row) {
     std::string row_key = prefix + "/" + std::to_string(row);
     bulk.emplace_back(bigtable::SingleRowMutation(
-        row_key, bigtable::SetCell("fam0", "col", 4000, "foo")));
+        row_key, bigtable::SetCell("fam0", "col", 4_ms, "foo")));
   }
   table->BulkApply(std::move(bulk));
 
@@ -597,36 +599,38 @@ namespace {
 void FilterIntegrationTest::CreateComplexRows(bigtable::Table& table,
                                               std::string const& prefix) {
   namespace bt = bigtable;
+  using namespace bigtable::chrono_literals;
+
   bt::BulkMutation mutation;
   // Prepare a set of rows, with different numbers of cells, columns, and
   // column families.
   mutation.emplace_back(bt::SingleRowMutation(
-      prefix + "/one-cell", {bt::SetCell("fam0", "c", 3000, "foo")}));
+      prefix + "/one-cell", {bt::SetCell("fam0", "c", 3_ms, "foo")}));
   mutation.emplace_back(
       bt::SingleRowMutation(prefix + "/two-cells",
-                            {bt::SetCell("fam0", "c", 3000, "foo"),
-                             bt::SetCell("fam0", "c2", 3000, "foo")}));
+                            {bt::SetCell("fam0", "c", 3_ms, "foo"),
+                             bt::SetCell("fam0", "c2", 3_ms, "foo")}));
   mutation.emplace_back(
       bt::SingleRowMutation(prefix + "/many",
-                            {bt::SetCell("fam0", "c", 0, "foo"),
-                             bt::SetCell("fam0", "c", 1000, "foo"),
-                             bt::SetCell("fam0", "c", 2000, "foo"),
-                             bt::SetCell("fam0", "c", 3000, "foo")}));
+                            {bt::SetCell("fam0", "c", 0_ms, "foo"),
+                             bt::SetCell("fam0", "c", 1_ms, "foo"),
+                             bt::SetCell("fam0", "c", 2_ms, "foo"),
+                             bt::SetCell("fam0", "c", 3_ms, "foo")}));
   mutation.emplace_back(
       bt::SingleRowMutation(prefix + "/many-columns",
-                            {bt::SetCell("fam0", "c0", 3000, "foo"),
-                             bt::SetCell("fam0", "c1", 3000, "foo"),
-                             bt::SetCell("fam0", "c2", 3000, "foo"),
-                             bt::SetCell("fam0", "c3", 3000, "foo")}));
+                            {bt::SetCell("fam0", "c0", 3_ms, "foo"),
+                             bt::SetCell("fam0", "c1", 3_ms, "foo"),
+                             bt::SetCell("fam0", "c2", 3_ms, "foo"),
+                             bt::SetCell("fam0", "c3", 3_ms, "foo")}));
   // This one is complicated: create a mutation with several families and
   // columns.
   bt::SingleRowMutation complex(prefix + "/complex");
   for (int i = 0; i != 4; ++i) {
     for (int j = 0; j != 10; ++j) {
       complex.emplace_back(bt::SetCell("fam" + std::to_string(i),
-                                       "col" + std::to_string(j), 3000, "foo"));
+                                       "col" + std::to_string(j), 3_ms, "foo"));
       complex.emplace_back(bt::SetCell("fam" + std::to_string(i),
-                                       "col" + std::to_string(j), 6000, "bar"));
+                                       "col" + std::to_string(j), 6_ms, "bar"));
     }
   }
   mutation.emplace_back(std::move(complex));


### PR DESCRIPTION
This fixes #274.  It makes it impossible for users to accidentally create an invalid
timestamp in the `bigtable::SetCell()` mutations.  In the future, when we support
sub-millisecond timestamps for Cloud Bigtable we will need to add an overload
that accepts `std::chrono::microseconds`. Think of all the kittens saved by
not infuriating users by accepting invalid timestamp values.
