### PR TITLE
Fix namespace for version_* functions.

### DIFF
--- a/bigtable/client/version.cc
+++ b/bigtable/client/version.cc
@@ -17,14 +17,16 @@
 #include "bigtable/client/build_info.h"
 
 namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
 std::string version_string() {
   auto create_version = []() -> std::string {
     std::ostringstream os;
     os << "v" << version_major() << "." << version_minor() << "."
-       << version_patch() << "-" << gitrev;
+       << version_patch() << "+" << gitrev;
     return os.str();
   };
   static std::string const version = create_version();
   return version;
 }
+}  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/bigtable/client/version.h
+++ b/bigtable/client/version.h
@@ -30,15 +30,6 @@
  * Contains all the Cloud Bigtable C++ client APIs.
  */
 namespace bigtable {
-int constexpr version_major() { return BIGTABLE_CLIENT_VERSION_MAJOR; }
-int constexpr version_minor() { return BIGTABLE_CLIENT_VERSION_MINOR; }
-int constexpr version_patch() { return BIGTABLE_CLIENT_VERSION_PATCH; }
-/// A single integer representing the Major/Minor/Patch version
-int constexpr version() {
-  return 100 * (100 * version_major() + version_minor()) + version_patch();
-}
-std::string version_string();
-
 /**
  * The inlined, versioned namespace for the Cloud Bigtable C++ client APIs.
  *
@@ -51,7 +42,37 @@ std::string version_string();
  * Note that, consistent with the semver.org guidelines, the v0 version makes
  * no guarantees with respect to backwards compatibility.
  */
-inline namespace BIGTABLE_CLIENT_NS {}
+inline namespace BIGTABLE_CLIENT_NS {
+/**
+ * The Cloud Bigtable C++ Client major version.
+ *
+ * @see https://semver.org/spec/v2.0.0.html for details.
+ */
+int constexpr version_major() { return BIGTABLE_CLIENT_VERSION_MAJOR; }
+
+/**
+ * The Cloud Bigtable C++ Client minor version.
+ *
+ * @see https://semver.org/spec/v2.0.0.html for details.
+ */
+int constexpr version_minor() { return BIGTABLE_CLIENT_VERSION_MINOR; }
+
+/**
+ * The Cloud Bigtable C++ Client patch version.
+ *
+ * @see https://semver.org/spec/v2.0.0.html for details.
+ */
+int constexpr version_patch() { return BIGTABLE_CLIENT_VERSION_PATCH; }
+
+/// A single integer representing the Major/Minor/Patch version.
+int constexpr version() {
+  return 100 * (100 * version_major() + version_minor()) + version_patch();
+}
+
+/// The version as a string, in MAJOR.MINOR.PATCH+gitrev format.
+std::string version_string();
+
+}  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
 
 #endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_VERSION_H_


### PR DESCRIPTION
These should always have been in the bigtable::v*:: namespace.
Fixed them.  Also took the opportunity to document them, which
helps with #342.  And finally the format of version_string() was
wrong, build info is `+foo`, not `-foo` according to semver.org.