### PR TITLE
Reorder includes using clang-format.

### DIFF
--- a/bigtable/client/internal/throw_delegate_test.cc
+++ b/bigtable/client/internal/throw_delegate_test.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "bigtable/client/internal/throw_delegate.h"
-#include <gtest/gtest.h>
 #include "bigtable/client/grpc_error.h"
+#include <gtest/gtest.h>
 
 using namespace bigtable::internal;
 

--- a/bigtable/client/metadata_update_policy.h
+++ b/bigtable/client/metadata_update_policy.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_METADATA_UPDATE_POLICY_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_METADATA_UPDATE_POLICY_H_
 
+#include "bigtable/client/version.h"
 #include <grpc++/grpc++.h>
 #include <memory>
-#include "bigtable/client/version.h"
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {


### PR DESCRIPTION
The last pass missed a few files added after I started my pass.
And the PR builds do not always catch problems like this: the PR
build caches a version of the destination (typically master)
branch. The cache is not invalidated on commits to master.

So new commits do not participate on the PR build, and if there
are no conflicts you may end up with a broken build :frowning_face: 
