### PR TITLE
Run integration tests vs production

### DIFF
--- a/bigtable/tests/integration_tests_utils.sh
+++ b/bigtable/tests/integration_tests_utils.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file defines common routines and variables to run the integration tests.
+
+readonly CBT_CMD="${CBT:-${GOPATH}/bin/cbt}"
+readonly CBT_EMULATOR_CMD="${CBT_EMULATOR:-${GOPATH}/bin/emulator}"
+
+# Remove all the tables from a Cloud Bigtable instance.
+function delete_all_tables() {
+  local project_id=$1
+  shift
+  local instance_id=$1
+  shift
+
+  # If the instance is not set, just return immediately.
+  if [ -z "${instance_id}" ]; then
+    return 0
+  fi
+  ${CBT_CMD} -project "${project_id}" -instance "${instance_id}" ls |
+      xargs -i ${CBT_CMD} -project "${project_id}" -instance "${instance_id}" deletetable {}
+}
+
+# Run all the integration tests against the emulator or production.
+#
+# This function allows us to keep a single place where all the integration tests
+# are listed. Unfortunately there are some significant differences on how we
+# run the integration tests against production vs. how we run them against the
+# Cloud Bigtable Emulator.  This function hides those details.
+function run_all_integration_tests() {
+  local project_id=$1
+  shift
+
+  # Normally this function rn
+  # Declare the variable, but do not set it at first.
+  local instance_id=
+  if [ "$#" -gt 0 ]; then
+    instance_id=$1
+  fi
+
+  echo
+  echo "Running bigtable::TableAdmin integration test."
+  delete_all_tables "${project_id}" "${instance_id:-}"
+  ./admin_integration_test "${project_id}" "${instance_id:-admin-test}"
+
+  echo
+  echo "Running bigtable::Table integration test."
+  delete_all_tables "${project_id}" "${instance_id:-}"
+  ./data_integration_test "${project_id}" "${instance_id:-data-test}"
+
+  echo
+  echo "Running bigtable::Filters integration tests."
+  delete_all_tables "${project_id}" "${instance_id:-}"
+  ./filters_integration_test "${project_id}" "${instance_id:-filters-test}"
+
+  echo
+  echo "Running Mutation (e.g. DeleteFromColumn, SetCell) integration tests."
+  delete_all_tables "${project_id}" "${instance_id:-}"
+  ./mutations_integration_test "${project_id}" "${instance_id:-mutations-test}"
+}

--- a/bigtable/tests/integration_tests_utils.sh
+++ b/bigtable/tests/integration_tests_utils.sh
@@ -29,8 +29,9 @@ function delete_all_tables() {
   if [ -z "${instance_id}" ]; then
     return 0
   fi
-  ${CBT_CMD} -project "${project_id}" -instance "${instance_id}" ls |
-      xargs -i ${CBT_CMD} -project "${project_id}" -instance "${instance_id}" deletetable {}
+  local args=("-project" "${project_id}" "-instance" "${instance_id}")
+  # TODO(#356) - change the tests so we do not clear the instance.
+  ${CBT_CMD} ${args[*]} ls | xargs -i ${CBT_CMD} ${args[*]} deletetable {}
 }
 
 # Run all the integration tests against the emulator or production.

--- a/bigtable/tests/mutations_integration_test.cc
+++ b/bigtable/tests/mutations_integration_test.cc
@@ -216,7 +216,7 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForReversedTimestampRangeTest) {
   EXPECT_THROW(
       table->Apply(bigtable::SingleRowMutation(
           key, bigtable::DeleteFromColumn(column_family2, "c2", 4000, 2000))),
-      bigtable::GRpcError);
+      bigtable::PermanentMutationFailure);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       table->Apply(bigtable::SingleRowMutation(
@@ -258,7 +258,7 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForEmptyTimestampRangeTest) {
   EXPECT_THROW(
       table->Apply(bigtable::SingleRowMutation(
           key, bigtable::DeleteFromColumn(column_family2, "c2", 2000, 2000))),
-      bigtable::GRpcError);
+      bigtable::PermanentMutationFailure);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       table->Apply(bigtable::SingleRowMutation(

--- a/bigtable/tests/run_integration_tests_emulator.sh
+++ b/bigtable/tests/run_integration_tests_emulator.sh
@@ -22,8 +22,8 @@ function kill_emulator {
   cat emulator.log >&2
 }
 
-readonly CBT_CMD="${CBT:-${GOPATH}/bin/cbt}"
-readonly CBT_EMULATOR_CMD="${CBT_EMULATOR:-${GOPATH}/bin/emulator}"
+readonly BINDIR=$(dirname $0)
+source ${BINDIR}/integration_tests_utils.sh
 
 echo "Launching Cloud Bigtable emulator in the background"
 # The tests typically run in a Docker container, where the ports are largely
@@ -57,25 +57,8 @@ else
   echo "Successfully connected to the Cloud Bigtable emulator."
 fi
 
-# Run the integration tests
-
 # The project and instance do not matter for the Cloud Bigtable emulator.
 # Use a unique project name to allow multiple runs of the test with
 # an externally launched emulator.
-NONCE=$(date +%s)
-
-echo
-echo "Running Table::Apply() integration test."
-./data_integration_test emulated$NONCE data-test 
-
-echo
-echo "Running TableAdmin integration test."
-./admin_integration_test emulated$NONCE admin-test
-
-echo
-echo "Running bigtable::Filters integration tests."
-./filters_integration_test emulated$NONCE filters-test
-
-echo
-echo "Running bigtable::Filters integration tests."
-./mutations_integration_test emulated$NONCE mutations-test
+readonly NONCE=$(date +%s)
+run_all_integration_tests "emulated-${NONCE}"

--- a/bigtable/tests/run_integration_tests_production.sh
+++ b/bigtable/tests/run_integration_tests_production.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+readonly BINDIR=$(dirname $0)
+source ${BINDIR}/integration_tests_utils.sh
+
+# Run the integration tests assuming the CI scripts have setup the PROJECT_ID
+# and INSTANCE_ID environment variables.
+run_all_integration_tests "${PROJECT_ID}" "${INSTANCE_ID}"

--- a/ci/build-docker.sh
+++ b/ci/build-docker.sh
@@ -78,7 +78,7 @@ CTEST_OUTPUT_ON_FAILURE=1 make -j ${NCPU} test
 if [ -r /etc/lsb-release ] && grep -q 14.04 /etc/lsb-release; then
   echo "Skipping integration tests, Go version too old in Ubuntu 14.04."
 else
-  (cd bigtable/tests && ../../../../bigtable/tests/run_integration_tests.sh)
+  (cd bigtable/tests && /v/bigtable/tests/run_integration_tests_emulator.sh)
 fi
 
 # Some of the sanitizers only emit errors and do not change the error code

--- a/ci/build-jenkins.sh
+++ b/ci/build-jenkins.sh
@@ -38,6 +38,9 @@ case ${BENCHMARK} in
     scan)
         bigtable/benchmarks/scan_throughput_benchmark ${PROJECT_ID} ${INSTANCE_ID} 1 1800;
         ;;
+    integration)
+        (cd bigtable/tests && ../../../bigtable/tests/run_integration_tests_production.sh);
+        ;;
     # The following cases are used to test the script when making changes, they are not good
     # benchmarks.
     endurance-quick)


### PR DESCRIPTION
This fixes #270.  Runs the integration builds against production for our Jenkins builds.  Caught a couple of test bugs along the way.