### PR TITLE
Complete read modify write integration tests

### DIFF
--- a/bigtable/client/table.cc
+++ b/bigtable/client/table.cc
@@ -208,10 +208,10 @@ Row Table::CallReadModifyWriteRowRequest(
         std::vector<std::string> labels;
         std::move(cell.mutable_labels()->begin(), cell.mutable_labels()->end(),
                   std::back_inserter(labels));
-        bigtable::Cell new_cell(
-            std::move(row.key()), std::move(*family.mutable_name()),
-            std::move(*column.mutable_qualifier()), cell.timestamp_micros(),
-            std::move(*cell.mutable_value()), std::move(labels));
+        bigtable::Cell new_cell(row.key(), family.name(), column.qualifier(),
+                                cell.timestamp_micros(),
+                                std::move(*cell.mutable_value()),
+                                std::move(labels));
 
         cells.emplace_back(std::move(new_cell));
       }

--- a/bigtable/client/testing/table_integration_test.cc
+++ b/bigtable/client/testing/table_integration_test.cc
@@ -15,6 +15,7 @@
 #include "bigtable/client/testing/table_integration_test.h"
 #include "bigtable/client/internal/make_unique.h"
 #include <google/protobuf/text_format.h>
+#include <cctype>
 
 namespace bigtable {
 namespace testing {


### PR DESCRIPTION
This fixes #306.  Fixed the implementation for `Table::ReadModifyWriteRow()`
I gave Hemant bad advice about moving data out of the gRPC response:
we can move the cell value and labels, but the row key, column family names,
and column qualifier names need to be copied because `bigtable::Cell` does
not share them.  Something to fix in the future, maybe.
