### PR TITLE
Fix pointer alignment once and for all

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,9 +2,9 @@
 BasedOnStyle: Google
 
 # Some folks prefer to write "int& foo" while others prefer "int &foo".  The
-# Google Style Guide only asks for consistency within a project, we have
-# (mostly) been using "int& foo", but clang-format(1) sometimes guesses wrong,
-# so to enforce the consistency:
+# Google Style Guide only asks for consistency within a project, we chose
+# "int& foo" for this project:
+DerivePointerAlignment: false
 PointerAlignment: Left
 
 IncludeCategories:

--- a/bigtable/client/internal/throw_delegate.cc
+++ b/bigtable/client/internal/throw_delegate.cc
@@ -18,7 +18,7 @@
 
 namespace {
 template <typename Exception>
-[[noreturn]] void RaiseException(char const *msg) {
+[[noreturn]] void RaiseException(char const* msg) {
 #ifdef GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   throw Exception(msg);
 #else
@@ -33,39 +33,39 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
 
-[[noreturn]] void RaiseInvalidArgument(char const *msg) {
+[[noreturn]] void RaiseInvalidArgument(char const* msg) {
   RaiseException<std::invalid_argument>(msg);
 }
 
-[[noreturn]] void RaiseInvalidArgument(std::string const &msg) {
+[[noreturn]] void RaiseInvalidArgument(std::string const& msg) {
   RaiseException<std::invalid_argument>(msg.c_str());
 }
 
-[[noreturn]] void RaiseRangeError(char const *msg) {
+[[noreturn]] void RaiseRangeError(char const* msg) {
   RaiseException<std::range_error>(msg);
 }
 
-[[noreturn]] void RaiseRangeError(std::string const &msg) {
+[[noreturn]] void RaiseRangeError(std::string const& msg) {
   RaiseException<std::range_error>(msg.c_str());
 }
 
-[[noreturn]] void RaiseRuntimeError(char const *msg) {
+[[noreturn]] void RaiseRuntimeError(char const* msg) {
   RaiseException<std::runtime_error>(msg);
 }
 
-[[noreturn]] void RaiseRuntimeError(std::string const &msg) {
+[[noreturn]] void RaiseRuntimeError(std::string const& msg) {
   RaiseException<std::runtime_error>(msg.c_str());
 }
 
-[[noreturn]] void RaiseLogicError(char const *msg) {
+[[noreturn]] void RaiseLogicError(char const* msg) {
   RaiseException<std::logic_error>(msg);
 }
 
-[[noreturn]] void RaiseLogicError(std::string const &msg) {
+[[noreturn]] void RaiseLogicError(std::string const& msg) {
   RaiseException<std::logic_error>(msg.c_str());
 }
 
-[[noreturn]] void RaiseRpcError(grpc::Status const &status, char const *msg) {
+[[noreturn]] void RaiseRpcError(grpc::Status const& status, char const* msg) {
 #ifdef GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   throw bigtable::GRpcError(msg, status);
 #else
@@ -77,8 +77,8 @@ namespace internal {
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
-[[noreturn]] void RaiseRpcError(grpc::Status const &status,
-                                std::string const &msg) {
+[[noreturn]] void RaiseRpcError(grpc::Status const& status,
+                                std::string const& msg) {
   RaiseRpcError(status, msg.c_str());
 }
 

--- a/bigtable/client/internal/unary_rpc_utils.h
+++ b/bigtable/client/internal/unary_rpc_utils.h
@@ -117,14 +117,14 @@ struct UnaryRpcUtils {
    * @tparam Response the RPC response type.
    */
   template <typename Request, typename Response>
-  struct CheckSignature<grpc::Status (StubType::*)(grpc::ClientContext *,
-                                                   Request const &, Response *)>
+  struct CheckSignature<grpc::Status (StubType::*)(grpc::ClientContext*,
+                                                   Request const&, Response*)>
       : public std::true_type {
     using RequestType = Request;
     using ResponseType = Response;
-    using MemberFunctionType = grpc::Status (StubType::*)(grpc::ClientContext *,
-                                                          Request const &,
-                                                          Response *);
+    using MemberFunctionType = grpc::Status (StubType::*)(grpc::ClientContext*,
+                                                          Request const&,
+                                                          Response*);
   };
 
   /**
@@ -159,12 +159,12 @@ struct UnaryRpcUtils {
       CheckSignature<MemberFunction>::value,
       typename CheckSignature<MemberFunction>::ResponseType>::type
   CallWithRetry(
-      ClientType &client, std::unique_ptr<bigtable::RPCRetryPolicy> rpc_policy,
+      ClientType& client, std::unique_ptr<bigtable::RPCRetryPolicy> rpc_policy,
       std::unique_ptr<bigtable::RPCBackoffPolicy> backoff_policy,
       bigtable::MetadataUpdatePolicy const &metadata_update_policy,
       MemberFunction function,
-      typename CheckSignature<MemberFunction>::RequestType const &request,
-      char const *error_message) {
+      typename CheckSignature<MemberFunction>::RequestType const& request,
+      char const* error_message) {
     return CallWithRetryBorrow(client, *rpc_policy, *backoff_policy,
                                metadata_update_policy, function, request,
                                error_message);
@@ -198,12 +198,12 @@ struct UnaryRpcUtils {
       CheckSignature<MemberFunction>::value,
       typename CheckSignature<MemberFunction>::ResponseType>::type
   CallWithRetryBorrow(
-      ClientType &client, bigtable::RPCRetryPolicy &rpc_policy,
-      bigtable::RPCBackoffPolicy &backoff_policy,
-      bigtable::MetadataUpdatePolicy const &metadata_update_policy,
+      ClientType& client, bigtable::RPCRetryPolicy& rpc_policy,
+      bigtable::RPCBackoffPolicy& backoff_policy,
+      bigtable::MetadataUpdatePolicy const& metadata_update_policy,
       MemberFunction function,
-      typename CheckSignature<MemberFunction>::RequestType const &request,
-      char const *error_message) {
+      typename CheckSignature<MemberFunction>::RequestType const& request,
+      char const* error_message) {
     typename CheckSignature<MemberFunction>::ResponseType response;
     while (true) {
       grpc::ClientContext client_context;
@@ -256,11 +256,11 @@ struct UnaryRpcUtils {
       CheckSignature<MemberFunction>::value,
       typename CheckSignature<MemberFunction>::ResponseType>::type
   CallWithoutRetry(
-      ClientType &client, std::unique_ptr<bigtable::RPCRetryPolicy> rpc_policy,
+      ClientType& client, std::unique_ptr<bigtable::RPCRetryPolicy> rpc_policy,
       bigtable::MetadataUpdatePolicy const &metadata_update_policy,
       MemberFunction function,
-      typename CheckSignature<MemberFunction>::RequestType const &request,
-      char const *error_message) {
+      typename CheckSignature<MemberFunction>::RequestType const& request,
+      char const* error_message) {
     typename CheckSignature<MemberFunction>::ResponseType response;
 
     grpc::ClientContext client_context;

--- a/bigtable/client/internal/unary_rpc_utils.h
+++ b/bigtable/client/internal/unary_rpc_utils.h
@@ -161,7 +161,7 @@ struct UnaryRpcUtils {
   CallWithRetry(
       ClientType& client, std::unique_ptr<bigtable::RPCRetryPolicy> rpc_policy,
       std::unique_ptr<bigtable::RPCBackoffPolicy> backoff_policy,
-      bigtable::MetadataUpdatePolicy const &metadata_update_policy,
+      bigtable::MetadataUpdatePolicy const& metadata_update_policy,
       MemberFunction function,
       typename CheckSignature<MemberFunction>::RequestType const& request,
       char const* error_message) {
@@ -257,7 +257,7 @@ struct UnaryRpcUtils {
       typename CheckSignature<MemberFunction>::ResponseType>::type
   CallWithoutRetry(
       ClientType& client, std::unique_ptr<bigtable::RPCRetryPolicy> rpc_policy,
-      bigtable::MetadataUpdatePolicy const &metadata_update_policy,
+      bigtable::MetadataUpdatePolicy const& metadata_update_policy,
       MemberFunction function,
       typename CheckSignature<MemberFunction>::RequestType const& request,
       char const* error_message) {

--- a/bigtable/client/table_bulk_apply_test.cc
+++ b/bigtable/client/table_bulk_apply_test.cc
@@ -25,8 +25,8 @@ class MockReader : public grpc::ClientReaderInterface<
  public:
   MOCK_METHOD0(WaitForInitialMetadata, void());
   MOCK_METHOD0(Finish, grpc::Status());
-  MOCK_METHOD1(NextMessageSize, bool(std::uint32_t *));
-  MOCK_METHOD1(Read, bool(::google::bigtable::v2::MutateRowsResponse *));
+  MOCK_METHOD1(NextMessageSize, bool(std::uint32_t*));
+  MOCK_METHOD1(Read, bool(::google::bigtable::v2::MutateRowsResponse*));
 };
 
 class TableBulkApplyTest : public bigtable::testing::TableTestFixture {};
@@ -42,14 +42,14 @@ namespace bt = bigtable;
 TEST_F(TableBulkApplyTest, Simple) {
   auto reader = bigtable::internal::make_unique<MockReader>();
   EXPECT_CALL(*reader, Read(_))
-      .WillOnce(Invoke([](btproto::MutateRowsResponse *r) {
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
-          auto &e = *r->add_entries();
+          auto& e = *r->add_entries();
           e.set_index(0);
           e.mutable_status()->set_code(grpc::OK);
         }
         {
-          auto &e = *r->add_entries();
+          auto& e = *r->add_entries();
           e.set_index(1);
           e.mutable_status()->set_code(grpc::OK);
         }
@@ -60,7 +60,7 @@ TEST_F(TableBulkApplyTest, Simple) {
 
   EXPECT_CALL(*bigtable_stub_, MutateRowsRaw(_, _))
       .WillOnce(Invoke(
-          [&reader](grpc::ClientContext *, btproto::MutateRowsRequest const &) {
+          [&reader](grpc::ClientContext*, btproto::MutateRowsRequest const&) {
             return reader.release();
           }));
 
@@ -74,12 +74,12 @@ TEST_F(TableBulkApplyTest, Simple) {
 TEST_F(TableBulkApplyTest, RetryPartialFailure) {
   auto r1 = bigtable::internal::make_unique<MockReader>();
   EXPECT_CALL(*r1, Read(_))
-      .WillOnce(Invoke([](btproto::MutateRowsResponse *r) {
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         // Simulate a partial (recoverable) failure.
-        auto &e0 = *r->add_entries();
+        auto& e0 = *r->add_entries();
         e0.set_index(0);
         e0.mutable_status()->set_code(grpc::UNAVAILABLE);
-        auto &e1 = *r->add_entries();
+        auto& e1 = *r->add_entries();
         e1.set_index(1);
         e1.mutable_status()->set_code(grpc::OK);
         return true;
@@ -89,9 +89,9 @@ TEST_F(TableBulkApplyTest, RetryPartialFailure) {
 
   auto r2 = bigtable::internal::make_unique<MockReader>();
   EXPECT_CALL(*r2, Read(_))
-      .WillOnce(Invoke([](btproto::MutateRowsResponse *r) {
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
-          auto &e = *r->add_entries();
+          auto& e = *r->add_entries();
           e.set_index(0);
           e.mutable_status()->set_code(grpc::OK);
         }
@@ -102,11 +102,11 @@ TEST_F(TableBulkApplyTest, RetryPartialFailure) {
 
   EXPECT_CALL(*bigtable_stub_, MutateRowsRaw(_, _))
       .WillOnce(Invoke(
-          [&r1](grpc::ClientContext *, btproto::MutateRowsRequest const &) {
+          [&r1](grpc::ClientContext*, btproto::MutateRowsRequest const&) {
             return r1.release();
           }))
       .WillOnce(Invoke(
-          [&r2](grpc::ClientContext *, btproto::MutateRowsRequest const &) {
+          [&r2](grpc::ClientContext*, btproto::MutateRowsRequest const&) {
             return r2.release();
           }));
 
@@ -124,14 +124,14 @@ TEST_F(TableBulkApplyTest, RetryPartialFailure) {
 TEST_F(TableBulkApplyTest, PermanentFailure) {
   auto r1 = bigtable::internal::make_unique<MockReader>();
   EXPECT_CALL(*r1, Read(_))
-      .WillOnce(Invoke([](btproto::MutateRowsResponse *r) {
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
-          auto &e = *r->add_entries();
+          auto& e = *r->add_entries();
           e.set_index(0);
           e.mutable_status()->set_code(grpc::OK);
         }
         {
-          auto &e = *r->add_entries();
+          auto& e = *r->add_entries();
           e.set_index(1);
           e.mutable_status()->set_code(grpc::OUT_OF_RANGE);
         }
@@ -142,7 +142,7 @@ TEST_F(TableBulkApplyTest, PermanentFailure) {
 
   EXPECT_CALL(*bigtable_stub_, MutateRowsRaw(_, _))
       .WillOnce(Invoke(
-          [&r1](grpc::ClientContext *, btproto::MutateRowsRequest const &) {
+          [&r1](grpc::ClientContext*, btproto::MutateRowsRequest const&) {
             return r1.release();
           }));
 
@@ -163,9 +163,9 @@ TEST_F(TableBulkApplyTest, CanceledStream) {
   // which happens to be the case in this test.
   auto r1 = bigtable::internal::make_unique<MockReader>();
   EXPECT_CALL(*r1, Read(_))
-      .WillOnce(Invoke([](btproto::MutateRowsResponse *r) {
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
-          auto &e = *r->add_entries();
+          auto& e = *r->add_entries();
           e.set_index(0);
           e.mutable_status()->set_code(grpc::OK);
         }
@@ -177,9 +177,9 @@ TEST_F(TableBulkApplyTest, CanceledStream) {
   // Create a second stream returned by the mocks when the client retries.
   auto r2 = bigtable::internal::make_unique<MockReader>();
   EXPECT_CALL(*r2, Read(_))
-      .WillOnce(Invoke([](btproto::MutateRowsResponse *r) {
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
-          auto &e = *r->add_entries();
+          auto& e = *r->add_entries();
           e.set_index(0);
           e.mutable_status()->set_code(grpc::OK);
         }
@@ -190,11 +190,11 @@ TEST_F(TableBulkApplyTest, CanceledStream) {
 
   EXPECT_CALL(*bigtable_stub_, MutateRowsRaw(_, _))
       .WillOnce(Invoke(
-          [&r1](grpc::ClientContext *, btproto::MutateRowsRequest const &) {
+          [&r1](grpc::ClientContext*, btproto::MutateRowsRequest const&) {
             return r1.release();
           }))
       .WillOnce(Invoke(
-          [&r2](grpc::ClientContext *, btproto::MutateRowsRequest const &) {
+          [&r2](grpc::ClientContext*, btproto::MutateRowsRequest const&) {
             return r2.release();
           }));
 
@@ -223,9 +223,9 @@ TEST_F(TableBulkApplyTest, TooManyFailures) {
   // Setup the mocks to fail more than 3 times.
   auto r1 = bigtable::internal::make_unique<MockReader>();
   EXPECT_CALL(*r1, Read(_))
-      .WillOnce(Invoke([](btproto::MutateRowsResponse *r) {
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
-          auto &e = *r->add_entries();
+          auto& e = *r->add_entries();
           e.set_index(0);
           e.mutable_status()->set_code(grpc::OK);
         }
@@ -235,8 +235,8 @@ TEST_F(TableBulkApplyTest, TooManyFailures) {
   EXPECT_CALL(*r1, Finish())
       .WillOnce(Return(grpc::Status(grpc::StatusCode::ABORTED, "")));
 
-  auto create_cancelled_stream = [&](grpc::ClientContext *,
-                                     btproto::MutateRowsRequest const &) {
+  auto create_cancelled_stream = [&](grpc::ClientContext*,
+                                     btproto::MutateRowsRequest const&) {
     auto stream = bigtable::internal::make_unique<MockReader>();
     EXPECT_CALL(*stream, Read(_)).WillOnce(Return(false));
     EXPECT_CALL(*stream, Finish())
@@ -246,7 +246,7 @@ TEST_F(TableBulkApplyTest, TooManyFailures) {
 
   EXPECT_CALL(*bigtable_stub_, MutateRowsRaw(_, _))
       .WillOnce(Invoke(
-          [&r1](grpc::ClientContext *, btproto::MutateRowsRequest const &) {
+          [&r1](grpc::ClientContext*, btproto::MutateRowsRequest const&) {
             return r1.release();
           }))
       .WillOnce(Invoke(create_cancelled_stream))
@@ -271,9 +271,9 @@ TEST_F(TableBulkApplyTest, RetryOnlyIdempotent) {
 
   auto r2 = bigtable::internal::make_unique<MockReader>();
   EXPECT_CALL(*r2, Read(_))
-      .WillOnce(Invoke([](btproto::MutateRowsResponse *r) {
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
-          auto &e = *r->add_entries();
+          auto& e = *r->add_entries();
           e.set_index(0);
           e.mutable_status()->set_code(grpc::OK);
         }
@@ -284,11 +284,11 @@ TEST_F(TableBulkApplyTest, RetryOnlyIdempotent) {
 
   EXPECT_CALL(*bigtable_stub_, MutateRowsRaw(_, _))
       .WillOnce(Invoke(
-          [&r1](grpc::ClientContext *, btproto::MutateRowsRequest const &) {
+          [&r1](grpc::ClientContext*, btproto::MutateRowsRequest const&) {
             return r1.release();
           }))
       .WillOnce(Invoke(
-          [&r2](grpc::ClientContext *, btproto::MutateRowsRequest const &) {
+          [&r2](grpc::ClientContext*, btproto::MutateRowsRequest const&) {
             return r2.release();
           }));
 
@@ -298,11 +298,11 @@ TEST_F(TableBulkApplyTest, RetryOnlyIdempotent) {
                               {bt::SetCell("fam", "col", 0_ms, "qux")}),
         bt::SingleRowMutation("not-idempotent",
                               {bt::SetCell("fam", "col", "baz")})));
-  } catch (bt::PermanentMutationFailure const &ex) {
+  } catch (bt::PermanentMutationFailure const& ex) {
     ASSERT_EQ(1UL, ex.failures().size());
     EXPECT_EQ(1, ex.failures()[0].original_index());
     EXPECT_EQ("not-idempotent", ex.failures()[0].mutation().row_key());
-  } catch (std::exception const &ex) {
+  } catch (std::exception const& ex) {
     FAIL() << "unexpected std::exception raised: " << ex.what();
   } catch (...) {
     FAIL() << "unexpected exception of unknown type raised";
@@ -319,7 +319,7 @@ TEST_F(TableBulkApplyTest, FailedRPC) {
 
   EXPECT_CALL(*bigtable_stub_, MutateRowsRaw(_, _))
       .WillOnce(Invoke(
-          [&reader](grpc::ClientContext *, btproto::MutateRowsRequest const &) {
+          [&reader](grpc::ClientContext*, btproto::MutateRowsRequest const&) {
             return reader.release();
           }));
 
@@ -328,11 +328,11 @@ TEST_F(TableBulkApplyTest, FailedRPC) {
         bt::SingleRowMutation("foo", {bt::SetCell("fam", "col", 0_ms, "baz")}),
         bt::SingleRowMutation("bar",
                               {bt::SetCell("fam", "col", 0_ms, "qux")})));
-  } catch (bt::PermanentMutationFailure const &ex) {
+  } catch (bt::PermanentMutationFailure const& ex) {
     EXPECT_EQ(2UL, ex.failures().size());
     EXPECT_EQ(grpc::StatusCode::FAILED_PRECONDITION, ex.status().error_code());
     EXPECT_EQ("no such table", ex.status().error_message());
-  } catch (std::exception const &ex) {
+  } catch (std::exception const& ex) {
     FAIL() << "unexpected std::exception raised: " << ex.what();
   } catch (...) {
     FAIL() << "unexpected exception of unknown type raised";

--- a/bigtable/client/table_readrow_test.cc
+++ b/bigtable/client/table_readrow_test.cc
@@ -39,7 +39,7 @@ TEST_F(TableReadRowTest, ReadRowSimple) {
   auto stream =
       bigtable::internal::make_unique<bigtable::testing::MockResponseStream>();
   EXPECT_CALL(*stream, Read(_))
-      .WillOnce(Invoke([&response](btproto::ReadRowsResponse *r) {
+      .WillOnce(Invoke([&response](btproto::ReadRowsResponse* r) {
         *r = response;
         return true;
       }))
@@ -47,8 +47,8 @@ TEST_F(TableReadRowTest, ReadRowSimple) {
   EXPECT_CALL(*stream, Finish()).WillOnce(Return(grpc::Status::OK));
 
   EXPECT_CALL(*bigtable_stub_, ReadRowsRaw(_, _))
-      .WillOnce(Invoke([&stream, this](grpc::ClientContext *,
-                                       btproto::ReadRowsRequest const &req) {
+      .WillOnce(Invoke([&stream, this](grpc::ClientContext*,
+                                       btproto::ReadRowsRequest const& req) {
         EXPECT_EQ(1, req.rows().row_keys_size());
         EXPECT_EQ("r1", req.rows().row_keys(0));
         EXPECT_EQ(1, req.rows_limit());
@@ -72,8 +72,8 @@ TEST_F(TableReadRowTest, ReadRowMissing) {
   EXPECT_CALL(*stream, Finish()).WillOnce(Return(grpc::Status::OK));
 
   EXPECT_CALL(*bigtable_stub_, ReadRowsRaw(_, _))
-      .WillOnce(Invoke([&stream, this](grpc::ClientContext *,
-                                       btproto::ReadRowsRequest const &req) {
+      .WillOnce(Invoke([&stream, this](grpc::ClientContext*,
+                                       btproto::ReadRowsRequest const& req) {
         EXPECT_EQ(1, req.rows().row_keys_size());
         EXPECT_EQ("r1", req.rows().row_keys(0));
         EXPECT_EQ(1, req.rows_limit());

--- a/bigtable/client/testing/mock_response_stream.h
+++ b/bigtable/client/testing/mock_response_stream.h
@@ -25,8 +25,8 @@ class MockResponseStream : public grpc::ClientReaderInterface<
  public:
   MOCK_METHOD0(WaitForInitialMetadata, void());
   MOCK_METHOD0(Finish, grpc::Status());
-  MOCK_METHOD1(NextMessageSize, bool(std::uint32_t *));
-  MOCK_METHOD1(Read, bool(::google::bigtable::v2::ReadRowsResponse *));
+  MOCK_METHOD1(NextMessageSize, bool(std::uint32_t*));
+  MOCK_METHOD1(Read, bool(::google::bigtable::v2::ReadRowsResponse*));
 };
 
 }  // namespace testing

--- a/tests/grpc-crash/client.cc
+++ b/tests/grpc-crash/client.cc
@@ -16,7 +16,7 @@
 #include <grpc++/grpc++.h>
 #include <future>
 
-void MakeStreamPing(Echo::Stub &echo, std::int32_t count) {
+void MakeStreamPing(Echo::Stub& echo, std::int32_t count) {
   for (int i = 0; i != 100; ++i) {
     grpc::ClientContext context;
     Request request;
@@ -35,7 +35,7 @@ void MakeStreamPing(Echo::Stub &echo, std::int32_t count) {
   std::cerr << "Error making StreamPing request" << std::endl;
 }
 
-void MakePing(Echo::Stub &echo, std::int32_t count) {
+void MakePing(Echo::Stub& echo, std::int32_t count) {
   for (int i = 0; i != 100; ++i) {
     grpc::ClientContext context;
     Request request;
@@ -50,7 +50,7 @@ void MakePing(Echo::Stub &echo, std::int32_t count) {
   std::cerr << "Error making Ping request" << std::endl;
 }
 
-void RunClient(std::string const &server_address, std::chrono::minutes duration,
+void RunClient(std::string const& server_address, std::chrono::minutes duration,
                int id) {
   grpc::ChannelArguments arguments;
   arguments.SetInt("foo-bar-baz", id);
@@ -71,7 +71,7 @@ void RunClient(std::string const &server_address, std::chrono::minutes duration,
   }
 }
 
-int main(int argc, char *argv[]) try {
+int main(int argc, char* argv[]) try {
   if (argc < 4) {
     std::cerr << "Usage: client <address> <thread-count>"
               << " <test-duration-in-minutes>" << std::endl;
@@ -89,13 +89,13 @@ int main(int argc, char *argv[]) try {
                                   test_duration, i));
   }
 
-  for (auto &t : tasks) {
+  for (auto& t : tasks) {
     t.get();
   }
   std::cout << " DONE." << std::endl;
 
   return 0;
-} catch (std::exception const &ex) {
+} catch (std::exception const& ex) {
   std::cerr << "Standard C++ exception raised: " << ex.what() << std::endl;
   return 1;
 }

--- a/tests/grpc-crash/server.cc
+++ b/tests/grpc-crash/server.cc
@@ -21,22 +21,22 @@ class EchoImpl : public Echo::Service {
  public:
   EchoImpl() {}
 
-  grpc::Status Ping(grpc::ServerContext *context, Request const *request,
-                    Response *response) override {
+  grpc::Status Ping(grpc::ServerContext* context, Request const* request,
+                    Response* response) override {
     response->set_value(request->value());
     return grpc::Status::OK;
   }
 
   virtual grpc::Status StreamPing(
-      grpc::ServerContext *context, Request const *request,
-      grpc::ServerWriter<Response> *writer) override {
+      grpc::ServerContext* context, Request const* request,
+      grpc::ServerWriter<Response>* writer) override {
     Response response;
     writer->WriteLast(response, grpc::WriteOptions());
     return grpc::Status::OK;
   }
 };
 
-int main(int argc, char *argv[]) try {
+int main(int argc, char* argv[]) try {
   if (argc < 3) {
     std::cerr << "Usage: server <port> <thread-count>" << std::endl;
     return 1;
@@ -60,14 +60,14 @@ int main(int argc, char *argv[]) try {
     }
     std::this_thread::sleep_for(std::chrono::seconds(20));
     server->Shutdown();
-    for (auto &t : tasks) {
+    for (auto& t : tasks) {
       t.get();
     }
     std::cout << "Shutdown completed." << std::endl;
   }
 
   return 0;
-} catch (std::exception const &ex) {
+} catch (std::exception const& ex) {
   std::cerr << "Standard C++ exception raised: " << ex.what() << std::endl;
   return 1;
 }

--- a/tests/grpc-round-robin-freeze/client.cc
+++ b/tests/grpc-round-robin-freeze/client.cc
@@ -16,7 +16,7 @@
 #include <grpc++/grpc++.h>
 #include <future>
 
-void MakeStreamPing(Echo::Stub &echo, std::int32_t count) {
+void MakeStreamPing(Echo::Stub& echo, std::int32_t count) {
   for (int i = 0; i != 100; ++i) {
     grpc::ClientContext context;
     Request request;
@@ -35,7 +35,7 @@ void MakeStreamPing(Echo::Stub &echo, std::int32_t count) {
   std::cerr << "Error making StreamPing request." << std::endl;
 }
 
-void MakePing(Echo::Stub &echo, std::int32_t count) {
+void MakePing(Echo::Stub& echo, std::int32_t count) {
   for (int i = 0; i != 100; ++i) {
     grpc::ClientContext context;
     Request request;
@@ -50,7 +50,7 @@ void MakePing(Echo::Stub &echo, std::int32_t count) {
   std::cerr << "Error making Ping request." << std::endl;
 }
 
-void RunClient(std::string const &server_address, std::chrono::minutes duration,
+void RunClient(std::string const& server_address, std::chrono::minutes duration,
                int id) {
   grpc::ChannelArguments arguments;
   arguments.SetLoadBalancingPolicyName("round_robin");
@@ -71,7 +71,7 @@ void RunClient(std::string const &server_address, std::chrono::minutes duration,
   }
 }
 
-int main(int argc, char *argv[]) try {
+int main(int argc, char* argv[]) try {
   if (argc < 4) {
     std::cerr << "Usage: client <address> <thread-count>"
               << " <test-duration-in-minutes>" << std::endl;
@@ -89,13 +89,13 @@ int main(int argc, char *argv[]) try {
                                   test_duration, i));
   }
 
-  for (auto &t : tasks) {
+  for (auto& t : tasks) {
     t.get();
   }
   std::cout << " DONE." << std::endl;
 
   return 0;
-} catch (std::exception const &ex) {
+} catch (std::exception const& ex) {
   std::cerr << "Standard C++ exception raised: " << ex.what() << std::endl;
   return 1;
 }

--- a/tests/grpc-round-robin-freeze/server.cc
+++ b/tests/grpc-round-robin-freeze/server.cc
@@ -21,15 +21,15 @@ class EchoImpl : public Echo::Service {
  public:
   EchoImpl() {}
 
-  grpc::Status Ping(grpc::ServerContext *context, Request const *request,
-                    Response *response) override {
+  grpc::Status Ping(grpc::ServerContext* context, Request const* request,
+                    Response* response) override {
     response->set_value(request->value());
     return grpc::Status::OK;
   }
 
   virtual grpc::Status StreamPing(
-      grpc::ServerContext *context, Request const *request,
-      grpc::ServerWriter<Response> *writer) override {
+      grpc::ServerContext* context, Request const* request,
+      grpc::ServerWriter<Response>* writer) override {
     Response response;
     writer->WriteLast(response, grpc::WriteOptions());
     return grpc::Status::OK;
@@ -42,7 +42,7 @@ struct Replica {
   std::future<void> task;
 };
 
-Replica CreateReplica(EchoImpl *echo_impl, std::string address) {
+Replica CreateReplica(EchoImpl* echo_impl, std::string address) {
   grpc::ServerBuilder builder;
   builder.AddListeningPort(address, grpc::InsecureServerCredentials());
   builder.RegisterService(echo_impl);
@@ -53,7 +53,7 @@ Replica CreateReplica(EchoImpl *echo_impl, std::string address) {
   return Replica{std::move(address), std::move(server), std::move(task)};
 }
 
-int main(int argc, char *argv[]) try {
+int main(int argc, char* argv[]) try {
   if (argc < 3) {
     std::cerr << "Usage: server <port> [port ...]" << std::endl;
     return 1;
@@ -70,18 +70,18 @@ int main(int argc, char *argv[]) try {
   // Continuously restart each server, to force reconnects from the client.
   while (true) {
     std::this_thread::sleep_for(std::chrono::seconds(20));
-    for (auto &replica : servers) {
+    for (auto& replica : servers) {
       replica.server->Shutdown();
       replica.task.get();
     }
     std::cout << "Shutdown completed." << std::endl;
-    for (auto &replica : servers) {
+    for (auto& replica : servers) {
       replica = CreateReplica(&echo_impl, std::move(replica.address));
     }
   }
 
   return 0;
-} catch (std::exception const &ex) {
+} catch (std::exception const& ex) {
   std::cerr << "Standard C++ exception raised: " << ex.what() << std::endl;
   return 1;
 }


### PR DESCRIPTION
Turns out you need to set `DerivePointerAlignment` to `false` to
stop `clang-format` from guessing, even if you also set
`PointerAlignment` to an specific value.  So now the references
and pointer sygils are properly aligned.  Fixed the code for
consistency.
