### PR TITLE
unit tests in MetadataUpdatePolicy for parent, name and table_name x_goog_Request_params

### DIFF
--- a/bigtable/client/CMakeLists.txt
+++ b/bigtable/client/CMakeLists.txt
@@ -98,6 +98,8 @@ add_library(bigtable::client ALIAS bigtable_client)
 
 add_library(bigtable_client_testing
         testing/chrono_literals.h
+        testing/embedded_server_test_fixture.h
+        testing/embedded_server_test_fixture.cc
         testing/internal_table_test_fixture.h
         testing/internal_table_test_fixture.cc
         testing/mock_data_client.h
@@ -107,9 +109,7 @@ add_library(bigtable_client_testing
         testing/table_integration_test.h
         testing/table_integration_test.cc
         testing/table_test_fixture.h
-        testing/table_test_fixture.cc
-        testing/embedded_server_test_fixture.h
-        testing/embedded_server_test_fixture.cc)
+        testing/table_test_fixture.cc)
 target_link_libraries(bigtable_client_testing PUBLIC
         bigtable_client bigtable_protos
         gmock gRPC::grpc++ gRPC::grpc protobuf::libprotobuf

--- a/bigtable/client/CMakeLists.txt
+++ b/bigtable/client/CMakeLists.txt
@@ -101,11 +101,15 @@ add_library(bigtable_client_testing
         testing/internal_table_test_fixture.h
         testing/internal_table_test_fixture.cc
         testing/mock_data_client.h
+        testing/inprocess_data_client.h
+        testing/inprocess_admin_client.h
         testing/mock_response_stream.h
         testing/table_integration_test.h
         testing/table_integration_test.cc
         testing/table_test_fixture.h
-        testing/table_test_fixture.cc)
+        testing/table_test_fixture.cc
+        testing/embedded_server_test_fixture.h
+        testing/embedded_server_test_fixture.cc)
 target_link_libraries(bigtable_client_testing PUBLIC
         bigtable_client bigtable_protos
         gmock gRPC::grpc++ gRPC::grpc protobuf::libprotobuf

--- a/bigtable/client/metadata_update_policy_test.cc
+++ b/bigtable/client/metadata_update_policy_test.cc
@@ -39,7 +39,6 @@ TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServer) {
   auto client_metadata = admin_service_.client_metadata();
   auto range = client_metadata.equal_range("x-goog-request-params");
   ASSERT_EQ(1, std::distance(range.first, range.second));
-  std::string actual = range.first->second;
   EXPECT_EQ(expected, range.first->second);
 }
 
@@ -51,7 +50,6 @@ TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServerLazyMetadata) {
   auto client_metadata = admin_service_.client_metadata();
   auto range = client_metadata.equal_range("x-goog-request-params");
   ASSERT_EQ(1, std::distance(range.first, range.second));
-  std::string actual = range.first->second;
   EXPECT_EQ(expected, range.first->second);
 }
 
@@ -66,7 +64,6 @@ TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServerParamTableName) {
   auto client_metadata = bigtable_service_.client_metadata();
   auto range = client_metadata.equal_range("x-goog-request-params");
   ASSERT_EQ(1, std::distance(range.first, range.second));
-  std::string actual = range.first->second;
   EXPECT_EQ(expected, range.first->second);
 }
 

--- a/bigtable/client/metadata_update_policy_test.cc
+++ b/bigtable/client/metadata_update_policy_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 #include "bigtable/client/table_admin.h"
 #include "bigtable/client/testing/embedded_server_test_fixture.h"
 #include <gtest/gtest.h>
+#include <map>
 #include <thread>
 
 namespace btproto = google::bigtable::v2;
@@ -37,12 +38,9 @@ TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServer) {
   // Get metadata from embedded server
   auto client_metadata = admin_service_.client_metadata();
   auto range = client_metadata.equal_range("x-goog-request-params");
-  // first check to see if client_metadata has only one occurance of parameter.
-  EXPECT_EQ(1, std::distance(range.first, range.second));
-  for (auto it = range.first; it != range.second; ++it) {
-    std::string actual = it->second;
-    EXPECT_EQ(expected, actual);
-  }
+  ASSERT_EQ(1, std::distance(range.first, range.second));
+  std::string actual = range.first->second;
+  EXPECT_EQ(expected, range.first->second);
 }
 
 /// @test A test for setting metadata when table is not known.
@@ -52,12 +50,9 @@ TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServerLazyMetadata) {
   // Get metadata from embedded server
   auto client_metadata = admin_service_.client_metadata();
   auto range = client_metadata.equal_range("x-goog-request-params");
-  // first check to see if client_metadata has only one occurance of parameter.
-  EXPECT_EQ(1, std::distance(range.first, range.second));
-  for (auto it = range.first; it != range.second; ++it) {
-    std::string actual = it->second;
-    EXPECT_EQ(expected, actual);
-  }
+  ASSERT_EQ(1, std::distance(range.first, range.second));
+  std::string actual = range.first->second;
+  EXPECT_EQ(expected, range.first->second);
 }
 
 /// @test A test for setting metadata when table is known.
@@ -70,12 +65,9 @@ TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServerParamTableName) {
   // Get metadata from embedded server
   auto client_metadata = bigtable_service_.client_metadata();
   auto range = client_metadata.equal_range("x-goog-request-params");
-  // first check to see if client_metadata has only one occurance of parameter.
-  EXPECT_EQ(1, std::distance(range.first, range.second));
-  for (auto it = range.first; it != range.second; ++it) {
-    std::string actual = it->second;
-    EXPECT_EQ(expected, actual);
-  }
+  ASSERT_EQ(1, std::distance(range.first, range.second));
+  std::string actual = range.first->second;
+  EXPECT_EQ(expected, range.first->second);
 }
 
 /// @test A cloning test for normal construction of metadata .

--- a/bigtable/client/metadata_update_policy_test.cc
+++ b/bigtable/client/metadata_update_policy_test.cc
@@ -13,12 +13,277 @@
 // limitations under the License.
 
 #include "bigtable/client/metadata_update_policy.h"
+#include "bigtable/client/admin_client.h"
+#include "bigtable/client/internal/make_unique.h"
+#include "bigtable/client/table.h"
+#include "bigtable/client/table_admin.h"
+#include "google/bigtable/v2/bigtable.grpc.pb.h"
+#include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
 #include <gtest/gtest.h>
+#include <thread>
 
 std::string const kInstanceName = "projects/foo-project/instances/bar-instance";
 std::string const kTableId = "baz-table";
 std::string const kTableName =
     "projects/foo-project/instances/bar-instance/tables/baz-table";
+
+namespace btproto = google::bigtable::v2;
+namespace adminproto = google::bigtable::admin::v2;
+
+/**
+ * Implement the portions of the `google.bigtable.v2.Bigtable` interface
+ * necessary for the embedded server tests.
+ *
+ * This is not a Mock (use `google::bigtable::v2::MockBigtableStub` for that,
+ * nor is this a Fake implementation (use the Cloud Bigtable Emulator for that),
+ * this is an implementation of the interface that returns hardcoded values.
+ * It is suitable for the embedded server tests, but for nothing else.
+ */
+class BigtableImpl final : public btproto::Bigtable::Service {
+ public:
+  BigtableImpl() {}
+  grpc::Status ReadRows(
+      grpc::ServerContext* context,
+      google::bigtable::v2::ReadRowsRequest const* request,
+      grpc::ServerWriter<google::bigtable::v2::ReadRowsResponse>* writer)
+      override {
+    for (std::multimap<grpc::string_ref, grpc::string_ref>::const_iterator it =
+             context->client_metadata().begin();
+         it != context->client_metadata().end(); ++it) {
+      auto ele = std::make_pair((*it).first, (*it).second);
+      client_metadata_.emplace(ele);
+    }
+    return grpc::Status::OK;
+  }
+
+  const std::multimap<grpc::string_ref, grpc::string_ref>& client_metadata()
+      const {
+    return client_metadata_;
+  }
+
+ private:
+  std::multimap<grpc::string_ref, grpc::string_ref> client_metadata_;
+};
+
+/**
+ * Implement the `google.bigtable.admin.v2.BigtableTableAdmin` interface for the
+ * embedded server tests.
+ */
+class TableAdminImpl final : public adminproto::BigtableTableAdmin::Service {
+ public:
+  TableAdminImpl() {}
+
+  grpc::Status CreateTable(
+      grpc::ServerContext* context,
+      google::bigtable::admin::v2::CreateTableRequest const* request,
+      google::bigtable::admin::v2::Table* response) override {
+    for (std::multimap<grpc::string_ref, grpc::string_ref>::const_iterator it =
+             context->client_metadata().begin();
+         it != context->client_metadata().end(); ++it) {
+      auto ele = std::make_pair((*it).first, (*it).second);
+      client_metadata_.emplace(ele);
+    }
+    return grpc::Status::OK;
+  }
+
+  grpc::Status DeleteTable(
+      grpc::ServerContext* context,
+      google::bigtable::admin::v2::DeleteTableRequest const* request,
+      ::google::protobuf::Empty* response) override {
+    for (std::multimap<grpc::string_ref, grpc::string_ref>::const_iterator it =
+             context->client_metadata().begin();
+         it != context->client_metadata().end(); ++it) {
+      auto ele = std::make_pair((*it).first, (*it).second);
+      client_metadata_.emplace(ele);
+    }
+    return grpc::Status::OK;
+  }
+
+  grpc::Status GetTable(
+      grpc::ServerContext* context,
+      google::bigtable::admin::v2::GetTableRequest const* request,
+      google::bigtable::admin::v2::Table* response) override {
+    for (std::multimap<grpc::string_ref, grpc::string_ref>::const_iterator it =
+             context->client_metadata().begin();
+         it != context->client_metadata().end(); ++it) {
+      auto ele = std::make_pair((*it).first, (*it).second);
+      client_metadata_.emplace(ele);
+    }
+    return grpc::Status::OK;
+  }
+
+  const std::multimap<grpc::string_ref, grpc::string_ref>& client_metadata()
+      const {
+    return client_metadata_;
+  }
+
+ private:
+  std::multimap<grpc::string_ref, grpc::string_ref> client_metadata_;
+};
+
+/// The implementation of EmbeddedServer.
+class DefaultEmbeddedServer {
+ public:
+  explicit DefaultEmbeddedServer() {
+    int port;
+    std::string server_address("[::]:0");
+    builder_.AddListeningPort(server_address, grpc::InsecureServerCredentials(),
+                              &port);
+    builder_.RegisterService(&bigtable_service_);
+    builder_.RegisterService(&admin_service_);
+    server_ = builder_.BuildAndStart();
+    address_ = "localhost:" + std::to_string(port);
+  }
+
+  std::string address() const { return address_; }
+  void Shutdown() { server_->Shutdown(); }
+  void Wait() { server_->Wait(); }
+  const std::multimap<grpc::string_ref, grpc::string_ref>&
+  admin_service_client_metadata() const {
+    return admin_service_.client_metadata();
+  }
+  const std::multimap<grpc::string_ref, grpc::string_ref>&
+  bigtable_service_client_metadata() const {
+    return bigtable_service_.client_metadata();
+  }
+
+ private:
+  BigtableImpl bigtable_service_;
+  TableAdminImpl admin_service_;
+  grpc::ServerBuilder builder_;
+  std::unique_ptr<grpc::Server> server_;
+  std::string address_;
+};
+
+/// @test A test for setting metadata when table is not known.
+TEST(MetadataUpdatePolicy, RunWithEmbeddedServer) {
+  std::unique_ptr<DefaultEmbeddedServer> server =
+      bigtable::internal::make_unique<DefaultEmbeddedServer>();
+  std::string address = server->address();
+  EXPECT_FALSE(server->address().empty());
+  bigtable::ClientOptions options;
+  options.set_admin_endpoint(address);
+  options.set_data_endpoint(address);
+  options.SetCredentials(grpc::InsecureChannelCredentials());
+  std::thread wait_thread([&server]() { server->Wait(); });
+  EXPECT_TRUE(wait_thread.joinable());
+
+  // Create the table against embedded server.
+  bigtable::TableAdmin admin(
+      bigtable::CreateDefaultAdminClient("fake-project", options),
+      "fake-instance");
+  grpc::string_ref expected_x_goog_request_param =
+      "parent=projects/fake-project/instances/fake-instance";
+
+  auto gc = bigtable::GcRule::MaxNumVersions(42);
+  admin.CreateTable("fake-table-01", bigtable::TableConfig({{"fam", gc}}, {}));
+
+  // Get the metadata from embedded server
+  auto client_metadata = server->admin_service_client_metadata();
+  std::pair<std::multimap<grpc::string_ref, grpc::string_ref>::iterator,
+            std::multimap<grpc::string_ref, grpc::string_ref>::iterator>
+      result;
+  result = client_metadata.equal_range("x-goog-request-params");
+  // first check to see if client_metadata has only one occurance of parameter.
+  EXPECT_EQ(1, std::distance(result.first, result.second));
+
+  for (std::multimap<grpc::string_ref, grpc::string_ref>::iterator it =
+           result.first;
+       it != result.second; ++it) {
+    grpc::string_ref actual_x_goog_request_param = it->second;
+    EXPECT_EQ(expected_x_goog_request_param, actual_x_goog_request_param);
+  }
+  EXPECT_TRUE(wait_thread.joinable());
+  server->Shutdown();
+  wait_thread.join();
+}
+/// @test A test for setting metadata when table_id is known during the call.
+TEST(MetadataUpdatePolicy, RunWithEmbeddedServerLazyMetadata) {
+  std::unique_ptr<DefaultEmbeddedServer> server =
+      bigtable::internal::make_unique<DefaultEmbeddedServer>();
+  std::string address = server->address();
+  EXPECT_FALSE(server->address().empty());
+  bigtable::ClientOptions options;
+  options.set_admin_endpoint(address);
+  options.set_data_endpoint(address);
+  options.SetCredentials(grpc::InsecureChannelCredentials());
+  std::thread wait_thread([&server]() { server->Wait(); });
+  EXPECT_TRUE(wait_thread.joinable());
+
+  // Create the table against embedded server.
+  bigtable::TableAdmin admin(
+      bigtable::CreateDefaultAdminClient("fake-project", options),
+      "fake-instance");
+
+  admin.GetTable("fake-table-01");
+
+  grpc::string_ref expected_x_goog_request_param =
+      "name=projects/fake-project/instances/fake-instance/tables/fake-table-01";
+  // Get the metadata from embedded server
+  auto client_metadata = server->admin_service_client_metadata();
+  std::pair<std::multimap<grpc::string_ref, grpc::string_ref>::iterator,
+            std::multimap<grpc::string_ref, grpc::string_ref>::iterator>
+      result;
+  result = client_metadata.equal_range("x-goog-request-params");
+  // first check to see if client_metadata has only one occurance of parameter.
+  EXPECT_EQ(1, std::distance(result.first, result.second));
+
+  for (std::multimap<grpc::string_ref, grpc::string_ref>::iterator it =
+           result.first;
+       it != result.second; ++it) {
+    grpc::string_ref actual_x_goog_request_param = it->second;
+    EXPECT_EQ(expected_x_goog_request_param, actual_x_goog_request_param);
+  }
+  EXPECT_TRUE(wait_thread.joinable());
+  server->Shutdown();
+  wait_thread.join();
+}
+
+/// @test A test for setting metadata when table_id is known during the call.
+TEST(MetadataUpdatePolicy, RunWithEmbeddedServerParamTableName) {
+  std::unique_ptr<DefaultEmbeddedServer> server =
+      bigtable::internal::make_unique<DefaultEmbeddedServer>();
+  std::string address = server->address();
+  EXPECT_FALSE(server->address().empty());
+  bigtable::ClientOptions options;
+  options.set_admin_endpoint(address);
+  options.set_data_endpoint(address);
+  options.SetCredentials(grpc::InsecureChannelCredentials());
+  std::thread wait_thread([&server]() { server->Wait(); });
+  EXPECT_TRUE(wait_thread.joinable());
+
+  bigtable::Table table(bigtable::CreateDefaultDataClient(
+                            "fake-project", "fake-instance", options),
+                        "fake-table-01");
+
+  grpc::string_ref expected_x_goog_request_param =
+      "table_name=projects/fake-project/instances/fake-instance/tables/"
+      "fake-table-01";
+
+  auto reader = table.ReadRows(bigtable::RowSet("row1"), 1,
+                               bigtable::Filter::PassAllFilter());
+  // lets make the RPC call to send metadata
+  reader.begin();
+
+  // Get metadata from embedded server
+  auto client_metadata = server->bigtable_service_client_metadata();
+  std::pair<std::multimap<grpc::string_ref, grpc::string_ref>::iterator,
+            std::multimap<grpc::string_ref, grpc::string_ref>::iterator>
+      result;
+  result = client_metadata.equal_range("x-goog-request-params");
+  // first check to see if client_metadata has only one occurance of parameter.
+  EXPECT_EQ(1, std::distance(result.first, result.second));
+
+  for (std::multimap<grpc::string_ref, grpc::string_ref>::iterator it =
+           result.first;
+       it != result.second; ++it) {
+    grpc::string_ref actual_x_goog_request_param = it->second;
+    EXPECT_EQ(expected_x_goog_request_param, actual_x_goog_request_param);
+  }
+  EXPECT_TRUE(wait_thread.joinable());
+  server->Shutdown();
+  wait_thread.join();
+}
 
 /// @test A cloning test for normal construction of metadata .
 TEST(MetadataUpdatePolicy, SimpleDefault) {

--- a/bigtable/client/metadata_update_policy_test.cc
+++ b/bigtable/client/metadata_update_policy_test.cc
@@ -17,276 +17,69 @@
 #include "bigtable/client/internal/make_unique.h"
 #include "bigtable/client/table.h"
 #include "bigtable/client/table_admin.h"
-#include "google/bigtable/v2/bigtable.grpc.pb.h"
-#include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
+#include "bigtable/client/testing/embedded_server_test_fixture.h"
 #include <gtest/gtest.h>
 #include <thread>
-
-std::string const kInstanceName = "projects/foo-project/instances/bar-instance";
-std::string const kTableId = "baz-table";
-std::string const kTableName =
-    "projects/foo-project/instances/bar-instance/tables/baz-table";
 
 namespace btproto = google::bigtable::v2;
 namespace adminproto = google::bigtable::admin::v2;
 
-/**
- * Implement the portions of the `google.bigtable.v2.Bigtable` interface
- * necessary for the embedded server tests.
- *
- * This is not a Mock (use `google::bigtable::v2::MockBigtableStub` for that,
- * nor is this a Fake implementation (use the Cloud Bigtable Emulator for that),
- * this is an implementation of the interface that returns hardcoded values.
- * It is suitable for the embedded server tests, but for nothing else.
- */
-class BigtableImpl final : public btproto::Bigtable::Service {
- public:
-  BigtableImpl() {}
-  grpc::Status ReadRows(
-      grpc::ServerContext* context,
-      google::bigtable::v2::ReadRowsRequest const* request,
-      grpc::ServerWriter<google::bigtable::v2::ReadRowsResponse>* writer)
-      override {
-    for (std::multimap<grpc::string_ref, grpc::string_ref>::const_iterator it =
-             context->client_metadata().begin();
-         it != context->client_metadata().end(); ++it) {
-      auto ele = std::make_pair((*it).first, (*it).second);
-      client_metadata_.emplace(ele);
-    }
-    return grpc::Status::OK;
+namespace {
+class MetadataUpdatePolicyTest
+    : public bigtable::testing::EmbeddedServerTestFixture {};
+}  // anonymous namespace
+
+/// @test A test for setting metadata for admin operations.
+TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServer) {
+  grpc::string expected = "parent=" + kInstanceName;
+  auto gc = bigtable::GcRule::MaxNumVersions(42);
+  admin_->CreateTable(kTableName, bigtable::TableConfig({{"fam", gc}}, {}));
+  // Get metadata from embedded server
+  auto client_metadata = admin_service_.client_metadata();
+  auto range = client_metadata.equal_range("x-goog-request-params");
+  // first check to see if client_metadata has only one occurance of parameter.
+  EXPECT_EQ(1, std::distance(range.first, range.second));
+  for (auto it = range.first; it != range.second; ++it) {
+    std::string actual = it->second;
+    EXPECT_EQ(expected, actual);
   }
-
-  const std::multimap<grpc::string_ref, grpc::string_ref>& client_metadata()
-      const {
-    return client_metadata_;
-  }
-
- private:
-  std::multimap<grpc::string_ref, grpc::string_ref> client_metadata_;
-};
-
-/**
- * Implement the `google.bigtable.admin.v2.BigtableTableAdmin` interface for the
- * embedded server tests.
- */
-class TableAdminImpl final : public adminproto::BigtableTableAdmin::Service {
- public:
-  TableAdminImpl() {}
-
-  grpc::Status CreateTable(
-      grpc::ServerContext* context,
-      google::bigtable::admin::v2::CreateTableRequest const* request,
-      google::bigtable::admin::v2::Table* response) override {
-    for (std::multimap<grpc::string_ref, grpc::string_ref>::const_iterator it =
-             context->client_metadata().begin();
-         it != context->client_metadata().end(); ++it) {
-      auto ele = std::make_pair((*it).first, (*it).second);
-      client_metadata_.emplace(ele);
-    }
-    return grpc::Status::OK;
-  }
-
-  grpc::Status DeleteTable(
-      grpc::ServerContext* context,
-      google::bigtable::admin::v2::DeleteTableRequest const* request,
-      ::google::protobuf::Empty* response) override {
-    for (std::multimap<grpc::string_ref, grpc::string_ref>::const_iterator it =
-             context->client_metadata().begin();
-         it != context->client_metadata().end(); ++it) {
-      auto ele = std::make_pair((*it).first, (*it).second);
-      client_metadata_.emplace(ele);
-    }
-    return grpc::Status::OK;
-  }
-
-  grpc::Status GetTable(
-      grpc::ServerContext* context,
-      google::bigtable::admin::v2::GetTableRequest const* request,
-      google::bigtable::admin::v2::Table* response) override {
-    for (std::multimap<grpc::string_ref, grpc::string_ref>::const_iterator it =
-             context->client_metadata().begin();
-         it != context->client_metadata().end(); ++it) {
-      auto ele = std::make_pair((*it).first, (*it).second);
-      client_metadata_.emplace(ele);
-    }
-    return grpc::Status::OK;
-  }
-
-  const std::multimap<grpc::string_ref, grpc::string_ref>& client_metadata()
-      const {
-    return client_metadata_;
-  }
-
- private:
-  std::multimap<grpc::string_ref, grpc::string_ref> client_metadata_;
-};
-
-/// The implementation of EmbeddedServer.
-class DefaultEmbeddedServer {
- public:
-  explicit DefaultEmbeddedServer() {
-    int port;
-    std::string server_address("[::]:0");
-    builder_.AddListeningPort(server_address, grpc::InsecureServerCredentials(),
-                              &port);
-    builder_.RegisterService(&bigtable_service_);
-    builder_.RegisterService(&admin_service_);
-    server_ = builder_.BuildAndStart();
-    address_ = "localhost:" + std::to_string(port);
-  }
-
-  std::string address() const { return address_; }
-  void Shutdown() { server_->Shutdown(); }
-  void Wait() { server_->Wait(); }
-  const std::multimap<grpc::string_ref, grpc::string_ref>&
-  admin_service_client_metadata() const {
-    return admin_service_.client_metadata();
-  }
-  const std::multimap<grpc::string_ref, grpc::string_ref>&
-  bigtable_service_client_metadata() const {
-    return bigtable_service_.client_metadata();
-  }
-
- private:
-  BigtableImpl bigtable_service_;
-  TableAdminImpl admin_service_;
-  grpc::ServerBuilder builder_;
-  std::unique_ptr<grpc::Server> server_;
-  std::string address_;
-};
+}
 
 /// @test A test for setting metadata when table is not known.
-TEST(MetadataUpdatePolicy, RunWithEmbeddedServer) {
-  std::unique_ptr<DefaultEmbeddedServer> server =
-      bigtable::internal::make_unique<DefaultEmbeddedServer>();
-  std::string address = server->address();
-  EXPECT_FALSE(server->address().empty());
-  bigtable::ClientOptions options;
-  options.set_admin_endpoint(address);
-  options.set_data_endpoint(address);
-  options.SetCredentials(grpc::InsecureChannelCredentials());
-  std::thread wait_thread([&server]() { server->Wait(); });
-  EXPECT_TRUE(wait_thread.joinable());
-
-  // Create the table against embedded server.
-  bigtable::TableAdmin admin(
-      bigtable::CreateDefaultAdminClient("fake-project", options),
-      "fake-instance");
-  grpc::string_ref expected_x_goog_request_param =
-      "parent=projects/fake-project/instances/fake-instance";
-
-  auto gc = bigtable::GcRule::MaxNumVersions(42);
-  admin.CreateTable("fake-table-01", bigtable::TableConfig({{"fam", gc}}, {}));
-
-  // Get the metadata from embedded server
-  auto client_metadata = server->admin_service_client_metadata();
-  std::pair<std::multimap<grpc::string_ref, grpc::string_ref>::iterator,
-            std::multimap<grpc::string_ref, grpc::string_ref>::iterator>
-      result;
-  result = client_metadata.equal_range("x-goog-request-params");
+TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServerLazyMetadata) {
+  grpc::string expected = "name=" + kTableName;
+  admin_->GetTable(kTableId);
+  // Get metadata from embedded server
+  auto client_metadata = admin_service_.client_metadata();
+  auto range = client_metadata.equal_range("x-goog-request-params");
   // first check to see if client_metadata has only one occurance of parameter.
-  EXPECT_EQ(1, std::distance(result.first, result.second));
-
-  for (std::multimap<grpc::string_ref, grpc::string_ref>::iterator it =
-           result.first;
-       it != result.second; ++it) {
-    grpc::string_ref actual_x_goog_request_param = it->second;
-    EXPECT_EQ(expected_x_goog_request_param, actual_x_goog_request_param);
+  EXPECT_EQ(1, std::distance(range.first, range.second));
+  for (auto it = range.first; it != range.second; ++it) {
+    std::string actual = it->second;
+    EXPECT_EQ(expected, actual);
   }
-  EXPECT_TRUE(wait_thread.joinable());
-  server->Shutdown();
-  wait_thread.join();
-}
-/// @test A test for setting metadata when table_id is known during the call.
-TEST(MetadataUpdatePolicy, RunWithEmbeddedServerLazyMetadata) {
-  std::unique_ptr<DefaultEmbeddedServer> server =
-      bigtable::internal::make_unique<DefaultEmbeddedServer>();
-  std::string address = server->address();
-  EXPECT_FALSE(server->address().empty());
-  bigtable::ClientOptions options;
-  options.set_admin_endpoint(address);
-  options.set_data_endpoint(address);
-  options.SetCredentials(grpc::InsecureChannelCredentials());
-  std::thread wait_thread([&server]() { server->Wait(); });
-  EXPECT_TRUE(wait_thread.joinable());
-
-  // Create the table against embedded server.
-  bigtable::TableAdmin admin(
-      bigtable::CreateDefaultAdminClient("fake-project", options),
-      "fake-instance");
-
-  admin.GetTable("fake-table-01");
-
-  grpc::string_ref expected_x_goog_request_param =
-      "name=projects/fake-project/instances/fake-instance/tables/fake-table-01";
-  // Get the metadata from embedded server
-  auto client_metadata = server->admin_service_client_metadata();
-  std::pair<std::multimap<grpc::string_ref, grpc::string_ref>::iterator,
-            std::multimap<grpc::string_ref, grpc::string_ref>::iterator>
-      result;
-  result = client_metadata.equal_range("x-goog-request-params");
-  // first check to see if client_metadata has only one occurance of parameter.
-  EXPECT_EQ(1, std::distance(result.first, result.second));
-
-  for (std::multimap<grpc::string_ref, grpc::string_ref>::iterator it =
-           result.first;
-       it != result.second; ++it) {
-    grpc::string_ref actual_x_goog_request_param = it->second;
-    EXPECT_EQ(expected_x_goog_request_param, actual_x_goog_request_param);
-  }
-  EXPECT_TRUE(wait_thread.joinable());
-  server->Shutdown();
-  wait_thread.join();
 }
 
-/// @test A test for setting metadata when table_id is known during the call.
-TEST(MetadataUpdatePolicy, RunWithEmbeddedServerParamTableName) {
-  std::unique_ptr<DefaultEmbeddedServer> server =
-      bigtable::internal::make_unique<DefaultEmbeddedServer>();
-  std::string address = server->address();
-  EXPECT_FALSE(server->address().empty());
-  bigtable::ClientOptions options;
-  options.set_admin_endpoint(address);
-  options.set_data_endpoint(address);
-  options.SetCredentials(grpc::InsecureChannelCredentials());
-  std::thread wait_thread([&server]() { server->Wait(); });
-  EXPECT_TRUE(wait_thread.joinable());
-
-  bigtable::Table table(bigtable::CreateDefaultDataClient(
-                            "fake-project", "fake-instance", options),
-                        "fake-table-01");
-
-  grpc::string_ref expected_x_goog_request_param =
-      "table_name=projects/fake-project/instances/fake-instance/tables/"
-      "fake-table-01";
-
-  auto reader = table.ReadRows(bigtable::RowSet("row1"), 1,
-                               bigtable::Filter::PassAllFilter());
+/// @test A test for setting metadata when table is known.
+TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServerParamTableName) {
+  grpc::string expected = "table_name=" + kTableName;
+  auto reader = table_->ReadRows(bigtable::RowSet("row1"), 1,
+                                 bigtable::Filter::PassAllFilter());
   // lets make the RPC call to send metadata
   reader.begin();
-
   // Get metadata from embedded server
-  auto client_metadata = server->bigtable_service_client_metadata();
-  std::pair<std::multimap<grpc::string_ref, grpc::string_ref>::iterator,
-            std::multimap<grpc::string_ref, grpc::string_ref>::iterator>
-      result;
-  result = client_metadata.equal_range("x-goog-request-params");
+  auto client_metadata = bigtable_service_.client_metadata();
+  auto range = client_metadata.equal_range("x-goog-request-params");
   // first check to see if client_metadata has only one occurance of parameter.
-  EXPECT_EQ(1, std::distance(result.first, result.second));
-
-  for (std::multimap<grpc::string_ref, grpc::string_ref>::iterator it =
-           result.first;
-       it != result.second; ++it) {
-    grpc::string_ref actual_x_goog_request_param = it->second;
-    EXPECT_EQ(expected_x_goog_request_param, actual_x_goog_request_param);
+  EXPECT_EQ(1, std::distance(range.first, range.second));
+  for (auto it = range.first; it != range.second; ++it) {
+    std::string actual = it->second;
+    EXPECT_EQ(expected, actual);
   }
-  EXPECT_TRUE(wait_thread.joinable());
-  server->Shutdown();
-  wait_thread.join();
 }
 
 /// @test A cloning test for normal construction of metadata .
-TEST(MetadataUpdatePolicy, SimpleDefault) {
+TEST_F(MetadataUpdatePolicyTest, SimpleDefault) {
   auto const x_google_request_params = "parent=" + kInstanceName;
   bigtable::MetadataUpdatePolicy created(kInstanceName,
                                          bigtable::MetadataParamTypes::PARENT);
@@ -294,7 +87,7 @@ TEST(MetadataUpdatePolicy, SimpleDefault) {
 }
 
 /// @test A test for lazy behaviour of metadata .
-TEST(MetadataUpdatePolicy, SimpleLazy) {
+TEST_F(MetadataUpdatePolicyTest, SimpleLazy) {
   auto const x_google_request_params = "name=" + kTableName;
   bigtable::MetadataUpdatePolicy created(
       kInstanceName, bigtable::MetadataParamTypes::NAME, kTableId);

--- a/bigtable/client/testing/embedded_server_test_fixture.cc
+++ b/bigtable/client/testing/embedded_server_test_fixture.cc
@@ -27,7 +27,6 @@ void EmbeddedServerTestFixture::StartServer() {
   builder_.RegisterService(&bigtable_service_);
   builder_.RegisterService(&admin_service_);
   server_ = builder_.BuildAndStart();
-  address_ = "localhost:" + std::to_string(port);
   wait_thread_ = std::thread([this]() { server_->Wait(); });
 }
 

--- a/bigtable/client/testing/embedded_server_test_fixture.cc
+++ b/bigtable/client/testing/embedded_server_test_fixture.cc
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,43 +28,32 @@ void EmbeddedServerTestFixture::StartServer() {
   builder_.RegisterService(&admin_service_);
   server_ = builder_.BuildAndStart();
   address_ = "localhost:" + std::to_string(port);
-  is_server_started_ = true;
   wait_thread_ = std::thread([this]() { server_->Wait(); });
 }
 
 void EmbeddedServerTestFixture::SetUp() {
-  if (!is_server_started_) {
-    StartServer();
+  StartServer();
 
-    bigtable::ClientOptions options;
-    options.set_admin_endpoint(address_);
-    options.set_data_endpoint(address_);
-    options.SetCredentials(grpc::InsecureChannelCredentials());
+  grpc::ChannelArguments channel_arguments;
+  static std::string const prefix = "cbt-c++/" + version_string();
+  channel_arguments.SetUserAgentPrefix(prefix);
 
-    grpc::ChannelArguments channel_arguments;
-    static std::string const prefix = "cbt-c++/" + version_string();
-    channel_arguments.SetUserAgentPrefix(prefix);
+  std::shared_ptr<grpc::Channel> data_channel =
+      server_->InProcessChannel(channel_arguments);
+  data_client_ = std::make_shared<InProcessDataClient>(
+      std::move(kProjectId), std::move(kInstanceId), std::move(data_channel));
+  table_ = std::make_shared<bigtable::Table>(data_client_, kTableId);
 
-    std::shared_ptr<grpc::Channel> data_channel =
-        server_->InProcessChannel(channel_arguments);
-    data_client_ = std::make_shared<InProcessDtaClient>(
-        std::move(kProjectId), std::move(kInstanceId), std::move(options),
-        std::move(data_channel));
-    table_ = std::make_shared<bigtable::Table>(data_client_, kTableId);
-
-    std::shared_ptr<grpc::Channel> admin_channel =
-        server_->InProcessChannel(channel_arguments);
-    admin_client_ = std::make_shared<InProcessAdminClient>(
-        std::move(kProjectId), std::move(options), std::move(admin_channel));
-    admin_ = std::make_shared<bigtable::TableAdmin>(admin_client_, kInstanceId);
-  }
+  std::shared_ptr<grpc::Channel> admin_channel =
+      server_->InProcessChannel(channel_arguments);
+  admin_client_ = std::make_shared<InProcessAdminClient>(
+      std::move(kProjectId), std::move(admin_channel));
+  admin_ = std::make_shared<bigtable::TableAdmin>(admin_client_, kInstanceId);
 }
 
 void EmbeddedServerTestFixture::TearDown() {
-  if (is_server_started_) {
-    server_->Shutdown();
-    wait_thread_.join();
-  }
+  server_->Shutdown();
+  wait_thread_.join();
 }
 
 }  // namespace testing

--- a/bigtable/client/testing/embedded_server_test_fixture.cc
+++ b/bigtable/client/testing/embedded_server_test_fixture.cc
@@ -1,0 +1,71 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/client/testing/embedded_server_test_fixture.h"
+#include "bigtable/client/internal/throw_delegate.h"
+#include <thread>
+
+namespace bigtable {
+namespace testing {
+
+void EmbeddedServerTestFixture::StartServer() {
+  int port;
+  std::string server_address("[::]:0");
+  builder_.AddListeningPort(server_address, grpc::InsecureServerCredentials(),
+                            &port);
+  builder_.RegisterService(&bigtable_service_);
+  builder_.RegisterService(&admin_service_);
+  server_ = builder_.BuildAndStart();
+  address_ = "localhost:" + std::to_string(port);
+  is_server_started_ = true;
+  wait_thread_ = std::thread([this]() { server_->Wait(); });
+}
+
+void EmbeddedServerTestFixture::SetUp() {
+  if (!is_server_started_) {
+    StartServer();
+
+    bigtable::ClientOptions options;
+    options.set_admin_endpoint(address_);
+    options.set_data_endpoint(address_);
+    options.SetCredentials(grpc::InsecureChannelCredentials());
+
+    grpc::ChannelArguments channel_arguments;
+    static std::string const prefix = "cbt-c++/" + version_string();
+    channel_arguments.SetUserAgentPrefix(prefix);
+
+    std::shared_ptr<grpc::Channel> data_channel =
+        server_->InProcessChannel(channel_arguments);
+    data_client_ = std::make_shared<InProcessDtaClient>(
+        std::move(kProjectId), std::move(kInstanceId), std::move(options),
+        std::move(data_channel));
+    table_ = std::make_shared<bigtable::Table>(data_client_, kTableId);
+
+    std::shared_ptr<grpc::Channel> admin_channel =
+        server_->InProcessChannel(channel_arguments);
+    admin_client_ = std::make_shared<InProcessAdminClient>(
+        std::move(kProjectId), std::move(options), std::move(admin_channel));
+    admin_ = std::make_shared<bigtable::TableAdmin>(admin_client_, kInstanceId);
+  }
+}
+
+void EmbeddedServerTestFixture::TearDown() {
+  if (is_server_started_) {
+    server_->Shutdown();
+    wait_thread_.join();
+  }
+}
+
+}  // namespace testing
+}  // namespace bigtable

--- a/bigtable/client/testing/embedded_server_test_fixture.h
+++ b/bigtable/client/testing/embedded_server_test_fixture.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,12 +29,10 @@ using ReceivedMetadata = std::multimap<std::string, std::string>;
 
 inline void GetClientMetadata(grpc::ServerContext* context,
                               ReceivedMetadata& client_metadata) {
-  for (auto it = context->client_metadata().begin();
-       it != context->client_metadata().end(); ++it) {
-    auto ele =
-        std::make_pair(std::string(it->first.begin(), it->first.end()),
-                       std::string(it->second.begin(), it->second.end()));
-    client_metadata.emplace(ele);
+  for (auto const& kv : context->client_metadata()) {
+    auto ele = std::make_pair(std::string(kv.first.begin(), kv.first.end()),
+                              std::string(kv.second.begin(), kv.second.end()));
+    client_metadata.emplace(std::move(ele));
   }
 }
 
@@ -119,7 +117,7 @@ class EmbeddedServerTestFixture : public ::testing::Test {
   TableAdminImpl admin_service_;
   grpc::ServerBuilder builder_;
   std::unique_ptr<grpc::Server> server_;
-  bool is_server_started_ = false;
+  bool server_thread_active_ = false;
 };
 
 }  // namespace testing

--- a/bigtable/client/testing/embedded_server_test_fixture.h
+++ b/bigtable/client/testing/embedded_server_test_fixture.h
@@ -111,13 +111,11 @@ class EmbeddedServerTestFixture : public ::testing::Test {
   std::shared_ptr<AdminClient> admin_client_;
   std::shared_ptr<bigtable::Table> table_;
   std::shared_ptr<bigtable::TableAdmin> admin_;
-  std::string address_;
   std::thread wait_thread_;
   BigtableImpl bigtable_service_;
   TableAdminImpl admin_service_;
   grpc::ServerBuilder builder_;
   std::unique_ptr<grpc::Server> server_;
-  bool server_thread_active_ = false;
 };
 
 }  // namespace testing

--- a/bigtable/client/testing/embedded_server_test_fixture.h
+++ b/bigtable/client/testing/embedded_server_test_fixture.h
@@ -1,0 +1,128 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_EMBEDDED_SERVER_TEST_FIXTURE_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_EMBEDDED_SERVER_TEST_FIXTURE_H_
+
+#include "bigtable/client/table.h"
+#include "bigtable/client/table_admin.h"
+#include "bigtable/client/testing/inprocess_admin_client.h"
+#include "bigtable/client/testing/inprocess_data_client.h"
+#include "google/bigtable/v2/bigtable.grpc.pb.h"
+#include <gtest/gtest.h>
+
+namespace bigtable {
+namespace testing {
+
+using ReceivedMetadata = std::multimap<std::string, std::string>;
+
+inline void GetClientMetadata(grpc::ServerContext* context,
+                              ReceivedMetadata& client_metadata) {
+  for (auto it = context->client_metadata().begin();
+       it != context->client_metadata().end(); ++it) {
+    auto ele =
+        std::make_pair(std::string(it->first.begin(), it->first.end()),
+                       std::string(it->second.begin(), it->second.end()));
+    client_metadata.emplace(ele);
+  }
+}
+
+/**
+ * Implement the portions of the `google.bigtable.v2.Bigtable` interface
+ * necessary for the embedded server tests.
+ *
+ * This is not a Mock (use `google::bigtable::v2::MockBigtableStub` for that,
+ * nor is this a Fake implementation (use the Cloud Bigtable Emulator for that),
+ * this is an implementation of the interface that returns hardcoded values.
+ * It is suitable for the embedded server tests, but for nothing else.
+ */
+class BigtableImpl final : public google::bigtable::v2::Bigtable::Service {
+ public:
+  BigtableImpl() {}
+  grpc::Status ReadRows(
+      grpc::ServerContext* context,
+      google::bigtable::v2::ReadRowsRequest const* request,
+      grpc::ServerWriter<google::bigtable::v2::ReadRowsResponse>* writer) {
+    GetClientMetadata(context, client_metadata_);
+    return grpc::Status::OK;
+  }
+  const ReceivedMetadata& client_metadata() const { return client_metadata_; }
+
+ private:
+  ReceivedMetadata client_metadata_;
+};
+
+class TableAdminImpl final
+    : public google::bigtable::admin::v2::BigtableTableAdmin::Service {
+ public:
+  TableAdminImpl() {}
+
+  grpc::Status CreateTable(
+      grpc::ServerContext* context,
+      google::bigtable::admin::v2::CreateTableRequest const* request,
+      google::bigtable::admin::v2::Table* response) override {
+    GetClientMetadata(context, client_metadata_);
+    return grpc::Status::OK;
+  }
+  grpc::Status GetTable(
+      grpc::ServerContext* context,
+      google::bigtable::admin::v2::GetTableRequest const* request,
+      google::bigtable::admin::v2::Table* response) override {
+    GetClientMetadata(context, client_metadata_);
+    return grpc::Status::OK;
+  }
+  const ReceivedMetadata& client_metadata() const { return client_metadata_; }
+
+ private:
+  ReceivedMetadata client_metadata_;
+};
+
+/// Common fixture for integrating embedded server into tests.
+class EmbeddedServerTestFixture : public ::testing::Test {
+ protected:
+  void StartServer();
+  void SetUp();
+  void TearDown();
+  void ResetChannel();
+
+  std::string const kProjectId = "foo-project";
+  std::string const kInstanceId = "bar-instance";
+  std::string const kTableId = "baz-table";
+
+  // These are hardcoded, and not computed, because we want to test the
+  // computation.
+  std::string const kInstanceName =
+      "projects/foo-project/instances/bar-instance";
+  std::string const kTableName =
+      "projects/foo-project/instances/bar-instance/tables/baz-table";
+
+  std::string project_id_ = kProjectId;
+  std::string instance_id_ = kInstanceId;
+  std::shared_ptr<DataClient> data_client_;
+  std::shared_ptr<AdminClient> admin_client_;
+  std::shared_ptr<bigtable::Table> table_;
+  std::shared_ptr<bigtable::TableAdmin> admin_;
+  std::string address_;
+  std::thread wait_thread_;
+  BigtableImpl bigtable_service_;
+  TableAdminImpl admin_service_;
+  grpc::ServerBuilder builder_;
+  std::unique_ptr<grpc::Server> server_;
+  bool is_server_started_ = false;
+};
+
+}  // namespace testing
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_EMBEDDED_SERVER_TEST_FIXTURE_H_

--- a/bigtable/client/testing/inprocess_admin_client.h
+++ b/bigtable/client/testing/inprocess_admin_client.h
@@ -1,0 +1,61 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_INPROCESS_ADMIN_CLIENT_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_INPROCESS_ADMIN_CLIENT_H_
+
+#include "bigtable/client/admin_client.h"
+#include "bigtable/client/client_options.h"
+#include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
+
+namespace btadmin = ::google::bigtable::admin::v2;
+
+namespace bigtable {
+namespace testing {
+
+/**
+ * Connects to Cloud Bigtable's administration APIs.
+ *
+ * This class is mainly for testing purpose, it enable use of a single embedded
+ * server
+ * for multiple test cases. This adminlient uses a pre-defined channel.
+ */
+class InProcessAdminClient : public bigtable::AdminClient {
+ public:
+  InProcessAdminClient(std::string project, ClientOptions options,
+                       std::shared_ptr<grpc::Channel> channel)
+      : project_(std::move(project)),
+        options_(std::move(options)),
+        channel_(std::move(channel)) {}
+
+  using BigtableAdminStubPtr =
+      std::shared_ptr<btadmin::BigtableTableAdmin::StubInterface>;
+
+  std::string const& project() const override { return project_; }
+  BigtableAdminStubPtr Stub() override {
+    return btadmin::BigtableTableAdmin::NewStub(channel_);
+  }
+  void reset() override {}
+  void on_completion(grpc::Status const& status) override {}
+
+ private:
+  std::string project_;
+  ClientOptions options_;
+  std::shared_ptr<grpc::Channel> channel_;
+};
+
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_INPROCESS_ADMIN_CLIENT_H_

--- a/bigtable/client/testing/inprocess_admin_client.h
+++ b/bigtable/client/testing/inprocess_admin_client.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,11 +33,9 @@ namespace testing {
  */
 class InProcessAdminClient : public bigtable::AdminClient {
  public:
-  InProcessAdminClient(std::string project, ClientOptions options,
+  InProcessAdminClient(std::string project,
                        std::shared_ptr<grpc::Channel> channel)
-      : project_(std::move(project)),
-        options_(std::move(options)),
-        channel_(std::move(channel)) {}
+      : project_(std::move(project)), channel_(std::move(channel)) {}
 
   using BigtableAdminStubPtr =
       std::shared_ptr<btadmin::BigtableTableAdmin::StubInterface>;
@@ -51,7 +49,6 @@ class InProcessAdminClient : public bigtable::AdminClient {
 
  private:
   std::string project_;
-  ClientOptions options_;
   std::shared_ptr<grpc::Channel> channel_;
 };
 

--- a/bigtable/client/testing/inprocess_data_client.h
+++ b/bigtable/client/testing/inprocess_data_client.h
@@ -1,0 +1,65 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_INPROCESS_DATA_CLIENT_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_INPROCESS_DATA_CLIENT_H_
+
+#include "bigtable/client/client_options.h"
+#include "bigtable/client/data_client.h"
+#include <google/bigtable/v2/bigtable.grpc.pb.h>
+
+namespace btproto = ::google::bigtable::v2;
+
+namespace bigtable {
+namespace testing {
+
+/**
+ * Connects to Cloud Bigtable's data manipulation APIs.
+ *
+ * This class is mainly for testing purpose, it enable use of a single embedded
+ * server
+ * for multiple test cases. This dataclient uses a pre-defined channel.
+ */
+class InProcessDtaClient : public bigtable::DataClient {
+ public:
+  InProcessDtaClient(std::string project, std::string instance,
+                     ClientOptions options,
+                     std::shared_ptr<grpc::Channel> channel)
+      : project_(std::move(project)),
+        instance_(std::move(instance)),
+        options_(std::move(options)),
+        channel_(std::move(channel)) {}
+
+  using BigtableStubPtr =
+      std::shared_ptr<google::bigtable::v2::Bigtable::StubInterface>;
+
+  std::string const& project_id() const override { return project_; }
+  std::string const& instance_id() const override { return instance_; }
+  BigtableStubPtr Stub() override {
+    return btproto::Bigtable::NewStub(channel_);
+  }
+  void reset() override {}
+  void on_completion(grpc::Status const& status) override {}
+
+ private:
+  std::string project_;
+  std::string instance_;
+  ClientOptions options_;
+  std::shared_ptr<grpc::Channel> channel_;
+};
+
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_INPROCESS_DATA_CLIENT_H_

--- a/bigtable/client/testing/inprocess_data_client.h
+++ b/bigtable/client/testing/inprocess_data_client.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,20 +25,19 @@ namespace bigtable {
 namespace testing {
 
 /**
- * Connects to Cloud Bigtable's data manipulation APIs.
+ * Connect to an embedded Cloud Bigtable server implementing the data
+ * manipulation APIs.
  *
  * This class is mainly for testing purpose, it enable use of a single embedded
  * server
  * for multiple test cases. This dataclient uses a pre-defined channel.
  */
-class InProcessDtaClient : public bigtable::DataClient {
+class InProcessDataClient : public bigtable::DataClient {
  public:
-  InProcessDtaClient(std::string project, std::string instance,
-                     ClientOptions options,
-                     std::shared_ptr<grpc::Channel> channel)
+  InProcessDataClient(std::string project, std::string instance,
+                      std::shared_ptr<grpc::Channel> channel)
       : project_(std::move(project)),
         instance_(std::move(instance)),
-        options_(std::move(options)),
         channel_(std::move(channel)) {}
 
   using BigtableStubPtr =
@@ -55,7 +54,6 @@ class InProcessDtaClient : public bigtable::DataClient {
  private:
   std::string project_;
   std::string instance_;
-  ClientOptions options_;
   std::shared_ptr<grpc::Channel> channel_;
 };
 


### PR DESCRIPTION
added embedded server test cases for 3 different scenarios