### PR TITLE
Run integration tests in Ubuntu 14.04

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -23,3 +23,5 @@ ignore:
   # Ignore the benchmarks, they are not important for the experience for our
   # users.
   - "/bigtable/benchmarks/**"
+  # Also ignore the unit tests.
+  - "*_test.cc"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -24,4 +24,4 @@ ignore:
   # users.
   - "/bigtable/benchmarks/**"
   # Also ignore the unit tests.
-  - "*_test.cc"
+  - "**/*_test.cc$"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,3 +14,12 @@ ignore:
   - "*.pb.h"
   # Ignore third party code and dependencies too.
   - "/third_party/**"
+  # Ignore the bigtable/client/testing directory, because these are components
+  # to drive testing, their coverage is not interesting.
+  - "/bigtable/client/testing/**"
+  # Ignore the bigtable/tests/ directory, because these are integration tests,
+  # also used to drive testing and therefore their coverage is not interesting.
+  - "/bigtable/tests/**"
+  # Ignore the benchmarks, they are not important for the experience for our
+  # users.
+  - "/bigtable/benchmarks/**"

--- a/ci/build-docker.sh
+++ b/ci/build-docker.sh
@@ -74,12 +74,8 @@ echo "${COLOR_YELLOW}Finished build at: $(date)${COLOR_RESET}"
 # Run the tests and output any failures.
 CTEST_OUTPUT_ON_FAILURE=1 make -j ${NCPU} test
 
-# If possible, run the integration tests.
-if [ -r /etc/lsb-release ] && grep -q 14.04 /etc/lsb-release; then
-  echo "Skipping integration tests, Go version too old in Ubuntu 14.04."
-else
-  (cd bigtable/tests && /v/bigtable/tests/run_integration_tests_emulator.sh)
-fi
+# Run the integration tests.
+(cd bigtable/tests && /v/bigtable/tests/run_integration_tests_emulator.sh)
 
 # Some of the sanitizers only emit errors and do not change the error code
 # of the tests, find any such errors and report them as a build failure.


### PR DESCRIPTION
Enable the integration tests in Ubuntu 14.04.  They were previously disabled because
we could not compile the Cloud Bigtable Emulator from source on this platform, but
now we install the pre-compiled binaries.
Also cleaned up the code coverage to ignore test support code and tests.  That is a
more realistic measure of how good is the code that application developers will
actually use.  The new numbers are visible here:

https://codecov.io/gh/coryan/google-cloud-cpp/tree/run-integration-tests-in-ubuntu-14.04/bigtable/client

