### PR TITLE
Link code snippets from Doxygen docs.

### DIFF
--- a/bigtable/client/table.h
+++ b/bigtable/client/table.h
@@ -52,6 +52,7 @@ class Table {
    * The policies are passed by value, because this makes it easy for
    * applications to create them.  For example:
    *
+   * **Example**
    * @code
    * using namespace std::chrono_literals; // assuming C++14.
    * auto client = bigtable::CreateDefaultClient(...); // details ommitted
@@ -118,6 +119,7 @@ class Table {
    *     exception contains a copy of the original mutation, in case the
    *     application wants to retry, log, or otherwise handle the failure.
    *
+   * **Example**
    * @snippet bigtable_samples.cc apply
    */
   void Apply(SingleRowMutation&& mut);
@@ -250,7 +252,7 @@ class Table {
    * @param rules is the zero or more ReadModifyWriteRules to apply on a row.
    * @returns modified row
    *
-   * **Examples**
+   * **Example**
    * @snippet bigtable_samples.cc read modify write
    */
   template <typename... Args>

--- a/bigtable/client/table.h
+++ b/bigtable/client/table.h
@@ -117,6 +117,8 @@ class Table {
    *     successfully apply the mutation given the current policies. The
    *     exception contains a copy of the original mutation, in case the
    *     application wants to retry, log, or otherwise handle the failure.
+   *
+   * @snippet bigtable_samples.cc apply
    */
   void Apply(SingleRowMutation&& mut);
 
@@ -136,6 +138,9 @@ class Table {
    *     in the exception. The exception contains a copy of the original
    *     mutations, in case the application wants to retry, log, or otherwise
    *     handle the failed mutations.
+   *
+   * **Example**
+   * @snippet bigtable_samples.cc bulk apply
    */
   void BulkApply(BulkMutation&& mut);
 
@@ -144,6 +149,9 @@ class Table {
    *
    * @param row_set the rows to read from.
    * @param filter is applied on the server-side to data in the rows.
+   *
+   * **Example**
+   * @snippet bigtable_samples.cc read rows
    */
   RowReader ReadRows(RowSet row_set, Filter filter);
 
@@ -157,6 +165,9 @@ class Table {
    *
    * @throws std::runtime_error if rows_limit is < 0. rows_limit = 0(default)
    * will return all rows
+   *
+   * **Example**
+   * @snippet bigtable_samples.cc read rows with limit
    */
   RowReader ReadRows(RowSet row_set, std::int64_t rows_limit, Filter filter);
 
@@ -170,6 +181,9 @@ class Table {
    *     row does not exist.  If the first element is `true` the second element
    *     has the contents of the Row.  Note that the contents may be empty
    *     if the filter expression removes all column families and columns.
+   *
+   * **Example**
+   * @snippet bigtable_samples.cc read row
    */
   std::pair<bool, Row> ReadRow(std::string row_key, Filter filter);
 
@@ -186,6 +200,9 @@ class Table {
    * @param true_mutations the mutations for the "filter passed" case.
    * @param false_mutations the mutations for the "filter did not pass" case.
    * @returns true if the filter passed.
+   *
+   * **Example**
+   * @snippet bigtable_samples.cc check and mutate
    */
   bool CheckAndMutateRow(std::string row_key, Filter filter,
                          std::vector<Mutation> true_mutations,
@@ -194,12 +211,18 @@ class Table {
   /**
    * Sample of the row keys in the table, including approximate data sizes.
    *
-   * The application/user can specify the collection type(list and vector
-   * supported at this moment), for example:
-   * @code
-   * auto as_vector = table.SampleRows<std::vector>();
-   * auto as_list = table.SampleRows<std::list>();
-   * @endcode
+   * @tparam Collection the type of collection where the samples are returned.
+   * @returns Note that the sample may only include one element for small
+   *     tables.  In addition, the sample may include row keys that do not exist
+   *     on the table, and may include the empty row key to indicate
+   *     "end of table".
+   *
+   * **Examples**
+   * @snippet bigtable_samples.cc sample row keys
+   *
+   * In addition, application developers can specify other collection types, for
+   * example `std::list<>` or `std::deque<>`:
+   * @snippet bigtable_samples.cc sample row keys collections
    */
   template <template <typename...> class Collection = std::vector>
   Collection<bigtable::RowKeySample> SampleRows() {
@@ -226,6 +249,9 @@ class Table {
    *     Both rules accept the family and column identifier to modify.
    * @param rules is the zero or more ReadModifyWriteRules to apply on a row.
    * @returns modified row
+   *
+   * **Examples**
+   * @snippet bigtable_samples.cc read modify write
    */
   template <typename... Args>
   Row ReadModifyWriteRow(std::string row_key,

--- a/bigtable/client/table_admin.h
+++ b/bigtable/client/table_admin.h
@@ -64,15 +64,6 @@ class TableAdmin {
   /**
    * Create a new table in the instance.
    *
-   * This function creates a new table and sets its initial schema, for example:
-   *
-   * @code
-   * bigtable::TableAdmin admin = ...;
-   * admin.CreateTable(
-   *     "my-table", bigtable::TableConfig(
-   *         {{"family", bigtable::GcRule::MaxNumVersions(1)}}, {}));
-   * @endcode
-   *
    * @param table_id the name of the table relative to the instance managed by
    *     this object.  The full table name is
    *     `projects/<PROJECT_ID>/instances/<INSTANCE_ID>/tables/<table_id>`
@@ -82,6 +73,9 @@ class TableAdmin {
    * @return the attributes of the newly created table.  Notice that the server
    *     only populates the table_name() field at this time.
    * @throws std::exception if the operation cannot be completed.
+   *
+   * **Example**
+   * @snippet bigtable_samples.cc create table
    */
   ::google::bigtable::admin::v2::Table CreateTable(std::string table_id,
                                                    TableConfig config);
@@ -90,10 +84,13 @@ class TableAdmin {
    * Return all the tables in the instance.
    *
    * @param view define what information about the tables is retrieved.
-   *   - VIEW_UNSPECIFIED: equivalent to VIEW_SCHEMA.
-   *   - NAME: return only the name of the table.
-   *   - VIEW_SCHEMA: return the name and the schema.
-   *   - FULL: return all the information about the table.
+   *   - `VIEW_UNSPECIFIED`: equivalent to `VIEW_SCHEMA`.
+   *   - `NAME`: return only the name of the table.
+   *   - `VIEW_SCHEMA`: return the name and the schema.
+   *   - `FULL`: return all the information about the table.
+   *
+   * **Example**
+   * @snippet bigtable_samples.cc list tables
    */
   std::vector<::google::bigtable::admin::v2::Table> ListTables(
       ::google::bigtable::admin::v2::Table::View view);
@@ -112,6 +109,9 @@ class TableAdmin {
    * @return the information about the table.
    * @throws std::exception if the information could not be obtained before the
    *     RPC policies in effect gave up.
+   *
+   * **Example**
+   * @snippet bigtable_samples.cc get table
    */
   ::google::bigtable::admin::v2::Table GetTable(
       std::string table_id,
@@ -126,6 +126,9 @@ class TableAdmin {
    *     `this->instance_name() + "/tables/" + table_id`
    * @throws std::exception if the table could not be deleted before the RPC
    *     policies in effect gave up.
+   *
+   * **Example**
+   * @snippet bigtable_samples.cc delete table
    */
   void DeleteTable(std::string table_id);
 
@@ -138,6 +141,9 @@ class TableAdmin {
    * @param modifications the list of modifications to the schema.
    * @return the resulting table schema.
    * @throws std::exception if the operation cannot be completed.
+   *
+   * **Example**
+   * @snippet bigtable_samples.cc modify table
    */
   ::google::bigtable::admin::v2::Table ModifyColumnFamilies(
       std::string table_id,
@@ -151,6 +157,9 @@ class TableAdmin {
    *     `this->instance_name() + "/tables/" + table_id`
    * @param row_key_prefix drop any rows that start with this prefix.
    * @throws std::exception if the operation cannot be completed.
+   *
+   * **Example**
+   * @snippet bigtable_samples.cc drop rows by prefix
    */
   void DropRowsByPrefix(std::string table_id, std::string row_key_prefix);
 
@@ -161,6 +170,9 @@ class TableAdmin {
    *     this object. The full name of the table is
    *     `this->instance_name() + "/tables/" + table_id`
    * @throws std::exception if the operation cannot be completed.
+   *
+   * **Example**
+   * @snippet bigtable_samples.cc drop all rows
    */
   void DropAllRows(std::string table_id);
 


### PR DESCRIPTION
This changes the documentation for Cloud Bigtable to include the sample snippets in each API, for example:

https://coryan.github.io/google-cloud-cpp/classbigtable_1_1v0_1_1Table.html#abdb527ed7c658c736ccb973ff49f051a
https://coryan.github.io/google-cloud-cpp/classbigtable_1_1v0_1_1TableAdmin.html#a18be6d39746e6795fc82efb59cd6e34c
