### PR TITLE
C++ goes after .NET because '.' [skip ci].

### DIFF
--- a/doc/landing/index.html
+++ b/doc/landing/index.html
@@ -23,15 +23,15 @@
         <div class="nav-current">C++</div>
         <ul class="menu">
             <li>
-                <a href="#" title="google-cloud-cpp">
-                    <img src="img/icon-lang-cpp.svg" alt="google-cloud-cpp" class="menu-icon" />
-                    C++
-                </a>
-            </li>
-            <li>
                 <a href="//googlecloudplatform.github.io/google-cloud-dotnet/" title="google-cloud-dotnet">
                     <img src="img/icon-lang-dotnet.svg" alt="google-cloud-dotnet" class="menu-icon" />
                     .NET
+                </a>
+            </li>
+            <li>
+                <a href="#" title="google-cloud-cpp">
+                    <img src="img/icon-lang-cpp.svg" alt="google-cloud-cpp" class="menu-icon" />
+                    C++
                 </a>
             </li>
             <li>


### PR DESCRIPTION
I thought we were using 'd'.  Meh.
