### PR TITLE
Automatically find dependencies in CMake configuration files.

### DIFF
--- a/bigtable/client/config.cmake.in
+++ b/bigtable/client/config.cmake.in
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(CMakeFindDependencyMacro)
+find_dependency(grpc)
+find_dependency(protobuf)
+
 include("${CMAKE_CURRENT_LIST_DIR}/bigtable-targets.cmake")
 
 add_library(bigtable::protos IMPORTED INTERFACE)


### PR DESCRIPTION
This saves users the trouble of having to explicitly find the dependencies of `bigtable_client`.
Thanks to @ras0219-msft for the suggestion.
