### PR TITLE
ReadRows integration test

### DIFF
--- a/bigtable/client/internal/table.cc
+++ b/bigtable/client/internal/table.cc
@@ -124,7 +124,7 @@ RowReader Table::ReadRows(RowSet row_set, Filter filter, bool raise_on_error) {
                    metadata_update_policy_,
                    bigtable::internal::make_unique<
                        bigtable::internal::ReadRowsParserFactory>(),
-                   false);
+                   raise_on_error);
 }
 
 RowReader Table::ReadRows(RowSet row_set, std::int64_t rows_limit,
@@ -134,7 +134,7 @@ RowReader Table::ReadRows(RowSet row_set, std::int64_t rows_limit,
                    rpc_backoff_policy_->clone(), metadata_update_policy_,
                    bigtable::internal::make_unique<
                        bigtable::internal::ReadRowsParserFactory>(),
-                   false);
+                   raise_on_error);
 }
 
 std::pair<bool, Row> Table::ReadRow(std::string row_key, Filter filter,

--- a/bigtable/client/internal/table.cc
+++ b/bigtable/client/internal/table.cc
@@ -124,7 +124,7 @@ RowReader Table::ReadRows(RowSet row_set, Filter filter, bool raise_on_error) {
                    metadata_update_policy_,
                    bigtable::internal::make_unique<
                        bigtable::internal::ReadRowsParserFactory>(),
-                   raise_on_error);
+                   false);
 }
 
 RowReader Table::ReadRows(RowSet row_set, std::int64_t rows_limit,
@@ -134,7 +134,7 @@ RowReader Table::ReadRows(RowSet row_set, std::int64_t rows_limit,
                    rpc_backoff_policy_->clone(), metadata_update_policy_,
                    bigtable::internal::make_unique<
                        bigtable::internal::ReadRowsParserFactory>(),
-                   raise_on_error);
+                   false);
 }
 
 std::pair<bool, Row> Table::ReadRow(std::string row_key, Filter filter,

--- a/bigtable/client/testing/inprocess_admin_client.h
+++ b/bigtable/client/testing/inprocess_admin_client.h
@@ -52,7 +52,7 @@ class InProcessAdminClient : public bigtable::AdminClient {
   std::shared_ptr<grpc::Channel> channel_;
 };
 
-}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace testing
 }  // namespace bigtable
 
 #endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_INPROCESS_ADMIN_CLIENT_H_

--- a/bigtable/client/testing/inprocess_data_client.h
+++ b/bigtable/client/testing/inprocess_data_client.h
@@ -57,7 +57,7 @@ class InProcessDataClient : public bigtable::DataClient {
   std::shared_ptr<grpc::Channel> channel_;
 };
 
-}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace testing
 }  // namespace bigtable
 
 #endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_INPROCESS_DATA_CLIENT_H_

--- a/bigtable/client/testing/table_integration_test.cc
+++ b/bigtable/client/testing/table_integration_test.cc
@@ -15,6 +15,7 @@
 #include "bigtable/client/testing/table_integration_test.h"
 #include "bigtable/client/internal/make_unique.h"
 #include <google/protobuf/text_format.h>
+#include <algorithm>
 #include <cctype>
 
 namespace bigtable {
@@ -75,7 +76,7 @@ std::vector<bigtable::Cell> TableIntegrationTest::MoveCellsFromReader(
     bigtable::RowReader& reader) {
   std::vector<bigtable::Cell> result;
   for (auto const& row : reader) {
-    std::copy(row.cells().begin(), row.cells().end(),
+    std::move(row.cells().begin(), row.cells().end(),
               std::back_inserter(result));
   }
   return result;

--- a/bigtable/client/testing/table_integration_test.cc
+++ b/bigtable/client/testing/table_integration_test.cc
@@ -71,6 +71,16 @@ std::vector<bigtable::Cell> TableIntegrationTest::ReadRows(
   return result;
 }
 
+std::vector<bigtable::Cell> TableIntegrationTest::MoveCellsFromReader(
+    bigtable::RowReader& reader) {
+  std::vector<bigtable::Cell> result;
+  for (auto const& row : reader) {
+    std::copy(row.cells().begin(), row.cells().end(),
+              std::back_inserter(result));
+  }
+  return result;
+}
+
 /// A helper function to create a list of cells.
 void TableIntegrationTest::CreateCells(
     bigtable::Table& table, std::vector<bigtable::Cell> const& cells) {

--- a/bigtable/client/testing/table_integration_test.h
+++ b/bigtable/client/testing/table_integration_test.h
@@ -65,6 +65,8 @@ class TableIntegrationTest : public ::testing::Test {
                                        std::int64_t rows_limit,
                                        bigtable::Filter filter);
 
+  std::vector<bigtable::Cell> MoveCellsFromReader(bigtable::RowReader& reader);
+
   /// Return all the cells in @p table that pass @p filter.
   void CreateCells(bigtable::Table& table,
                    std::vector<bigtable::Cell> const& cells);

--- a/bigtable/tests/data_integration_test.cc
+++ b/bigtable/tests/data_integration_test.cc
@@ -332,11 +332,17 @@ TEST_F(DataIntegrationTest, TableReadRowsNoRows) {
 
 TEST_F(DataIntegrationTest, TableReadRowsWrongTable) {
   std::string const table_name = "table-read-rows-wrong-table";
+
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   bigtable::Table table(data_client_, table_name);
+#else
+  bigtable::noex::Table table(data_client_, table_name);
+#endif
 
   auto read1 =
       table.ReadRows(bigtable::RowSet(bigtable::RowRange::InfiniteRange()),
                      bigtable::Filter::PassAllFilter());
+
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_THROW(read1.begin(), std::runtime_error);
 #else

--- a/bigtable/tests/data_integration_test.cc
+++ b/bigtable/tests/data_integration_test.cc
@@ -340,6 +340,10 @@ TEST_F(DataIntegrationTest, TableReadRowsWrongTable) {
                      bigtable::Filter::PassAllFilter());
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_THROW(read1.begin(), std::runtime_error);
+#else
+  EXPECT_EQ(read1.begin(), read1.end());
+  grpc::Status status1 = read1.Finish();
+  EXPECT_FALSE(status1.ok());
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 

--- a/bigtable/tests/data_integration_test.cc
+++ b/bigtable/tests/data_integration_test.cc
@@ -336,8 +336,6 @@ TEST_F(DataIntegrationTest, TableReadRowsWrongTable) {
                      bigtable::Filter::PassAllFilter());
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_THROW(read1.begin(), std::runtime_error);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(read1.begin(), "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 

--- a/bigtable/tests/data_integration_test.cc
+++ b/bigtable/tests/data_integration_test.cc
@@ -323,9 +323,8 @@ TEST_F(DataIntegrationTest, TableReadRowsNoRows) {
                       bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(expected, MoveCellsFromReader(read2));
 
-  auto read3 =
-      table->ReadRows(bigtable::RowSet(bigtable::RowRange::Empty()),
-                      bigtable::Filter::PassAllFilter());
+  auto read3 = table->ReadRows(bigtable::RowSet(bigtable::RowRange::Empty()),
+                               bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(expected, MoveCellsFromReader(read3));
 
   DeleteTable(table_name);

--- a/bigtable/tests/data_integration_test.cc
+++ b/bigtable/tests/data_integration_test.cc
@@ -323,7 +323,10 @@ TEST_F(DataIntegrationTest, TableReadRowsNoRows) {
                       bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(expected, MoveCellsFromReader(read2));
 
-  // TODO(#404): also call with bigtable::RowSet(bigtable::RowRange::Empty())
+  auto read3 =
+      table->ReadRows(bigtable::RowSet(bigtable::RowRange::Empty()),
+                      bigtable::Filter::PassAllFilter());
+  CheckEqualUnordered(expected, MoveCellsFromReader(read3));
 
   DeleteTable(table_name);
 }

--- a/bigtable/tests/data_integration_test.cc
+++ b/bigtable/tests/data_integration_test.cc
@@ -211,6 +211,120 @@ TEST_F(DataIntegrationTest, TableReadRowNotExistTest) {
   EXPECT_FALSE(row_cell.first);
 }
 
+TEST_F(DataIntegrationTest, TableReadRowsAllRows) {
+  std::string const table_name = "table-read-rows-all-rows";
+  auto table = CreateTable(table_name, table_config);
+  std::string const row_key1 = "row-key-1";
+  std::string const row_key2 = "row-key-2";
+  std::string const row_key3(1024, '3');    // a long key
+  std::string const long_value(1024, 'v');  // a long value
+
+  std::vector<bigtable::Cell> created{
+      {row_key1, family, "c1", 1000, "data1", {}},
+      {row_key1, family, "c2", 1000, "data2", {}},
+      {row_key2, family, "c1", 1000, "", {}},
+      {row_key3, family, "c1", 1000, long_value, {}}};
+
+  CreateCells(*table, created);
+
+  // Some equivalent ways to read the three rows
+  auto read1 =
+      table->ReadRows(bigtable::RowSet(bigtable::RowRange::InfiniteRange()),
+                      bigtable::Filter::PassAllFilter());
+  CheckEqualUnordered(created, MoveCellsFromReader(read1));
+
+  auto read2 =
+      table->ReadRows(bigtable::RowSet(bigtable::RowRange::InfiniteRange()), 3,
+                      bigtable::Filter::PassAllFilter());
+  CheckEqualUnordered(created, MoveCellsFromReader(read2));
+
+  auto read3 = table->ReadRows(
+      bigtable::RowSet(bigtable::RowRange::InfiniteRange()),
+      bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter());
+  CheckEqualUnordered(created, MoveCellsFromReader(read3));
+
+  DeleteTable(table_name);
+}
+
+TEST_F(DataIntegrationTest, TableReadRowsPartialRows) {
+  std::string const table_name = "table-read-rows-partial-rows";
+  auto table = CreateTable(table_name, table_config);
+  std::string const row_key1 = "row-key-1";
+  std::string const row_key2 = "row-key-2";
+  std::string const row_key3 = "row-key-3";
+
+  std::vector<bigtable::Cell> created{
+      {row_key1, family, "c1", 1000, "data1", {}},
+      {row_key1, family, "c2", 1000, "data2", {}},
+      {row_key2, family, "c1", 1000, "data3", {}},
+      {row_key3, family, "c1", 1000, "data4", {}}};
+
+  CreateCells(*table, created);
+
+  std::vector<bigtable::Cell> expected{
+      {row_key1, family, "c1", 1000, "data1", {}},
+      {row_key1, family, "c2", 1000, "data2", {}},
+      {row_key2, family, "c1", 1000, "data3", {}}};
+
+  // Some equivalent ways of reading just the first two rows
+  auto read1 =
+      table->ReadRows(bigtable::RowSet(bigtable::RowRange::InfiniteRange()), 2,
+                      bigtable::Filter::PassAllFilter());
+  CheckEqualUnordered(expected, MoveCellsFromReader(read1));
+
+  bigtable::RowSet rs2;
+  rs2.Append(row_key1);
+  rs2.Append(row_key2);
+  auto read2 =
+      table->ReadRows(std::move(rs2), bigtable::Filter::PassAllFilter());
+  CheckEqualUnordered(expected, MoveCellsFromReader(read2));
+
+  bigtable::RowSet rs3(bigtable::RowRange::Closed(row_key1, row_key2));
+  auto read3 =
+      table->ReadRows(std::move(rs3), bigtable::Filter::PassAllFilter());
+  CheckEqualUnordered(expected, MoveCellsFromReader(read3));
+
+  DeleteTable(table_name);
+}
+
+TEST_F(DataIntegrationTest, TableReadRowsNoRows) {
+  std::string const table_name = "table-read-rows-no-rows";
+  auto table = CreateTable(table_name, table_config);
+  std::string const row_key1 = "row-key-1";
+  std::string const row_key2 = "row-key-2";
+  std::string const row_key3 = "row-key-3";
+
+  std::vector<bigtable::Cell> created{
+      {row_key1, family, "c1", 1000, "data1", {}},
+      {row_key3, family, "c1", 1000, "data2", {}}};
+
+  CreateCells(*table, created);
+
+  std::vector<bigtable::Cell> expected;  // empty
+
+  // read nonexistent rows
+  auto read1 = table->ReadRows(bigtable::RowSet(row_key2),
+                               bigtable::Filter::PassAllFilter());
+  CheckEqualUnordered(expected, MoveCellsFromReader(read1));
+
+  auto read2 =
+      table->ReadRows(bigtable::RowSet(bigtable::RowRange::Prefix(row_key2)),
+                      bigtable::Filter::PassAllFilter());
+  CheckEqualUnordered(expected, MoveCellsFromReader(read2));
+
+  DeleteTable(table_name);
+}
+
+TEST_F(DataIntegrationTest, TableReadRowsWrongTable) {
+  std::string const table_name = "table-read-rows-wrong-table";
+  bigtable::Table table(data_client_, table_name);
+
+  auto read1 =
+      table.ReadRows(bigtable::RowSet(bigtable::RowRange::InfiniteRange()),
+                     bigtable::Filter::PassAllFilter());
+  EXPECT_THROW(read1.begin(), std::exception);
+}
+
 TEST_F(DataIntegrationTest, TableCheckAndMutateRowPass) {
   std::string const table_name = "table-check-and-mutate-row-pass";
   auto table = CreateTable(table_name, table_config);


### PR DESCRIPTION
This fixes #77.

I tried to cover the basic cases in a style similar to the other tests
- all rows, including a large key and large value
- a subset of rows
- no rows
- error - inexistent table.
