### PR TITLE
Fixed for  issue #337 bigtable::Cell::timestamp() should return a std::chrono::microseconds.

### DIFF
--- a/bigtable/client/cell.h
+++ b/bigtable/client/cell.h
@@ -17,6 +17,7 @@
 
 #include "bigtable/client/version.h"
 
+#include <chrono>
 #include <vector>
 
 namespace bigtable {
@@ -58,7 +59,10 @@ class Cell {
   std::string const& column_qualifier() const { return column_qualifier_; }
 
   /// Return the timestamp of this cell.
-  int64_t timestamp() const { return timestamp_; }
+  std::chrono::microseconds timestamp() const {
+    std::chrono::microseconds timestamp(timestamp_);
+    return timestamp;
+  }
 
   /// Return the contents of this cell. The returned value is not valid after
   /// this object is deleted.

--- a/bigtable/client/cell_test.cc
+++ b/bigtable/client/cell_test.cc
@@ -32,7 +32,7 @@ TEST(CellTest, Simple) {
   EXPECT_EQ(row_key, cell.row_key());
   EXPECT_EQ(family_name, cell.family_name());
   EXPECT_EQ(column_qualifier, cell.column_qualifier());
-  EXPECT_EQ(timestamp, cell.timestamp());
+  EXPECT_EQ(timestamp, cell.timestamp().count());
   EXPECT_EQ(value, cell.value());
   EXPECT_EQ(0U, cell.labels().size());
 }

--- a/bigtable/client/internal/readrowsparser_test.cc
+++ b/bigtable/client/internal/readrowsparser_test.cc
@@ -87,7 +87,7 @@ TEST(ReadRowsParserTest, SingleChunkSucceeds) {
   EXPECT_EQ("F", cell_it->family_name());
   EXPECT_EQ("C", cell_it->column_qualifier());
   EXPECT_EQ("V", cell_it->value());
-  EXPECT_EQ(42, cell_it->timestamp());
+  EXPECT_EQ(42, cell_it->timestamp().count());
 
   parser.HandleEndOfStream(status);
   EXPECT_TRUE(status.ok());
@@ -170,7 +170,7 @@ void PrintTo(Cell const& c, std::ostream* os) {
   *os << "rk: " << std::string(c.row_key()) << "\n";
   *os << "fm: " << std::string(c.family_name()) << "\n";
   *os << "qual: " << std::string(c.column_qualifier()) << "\n";
-  *os << "ts: " << c.timestamp() << "\n";
+  *os << "ts: " << c.timestamp().count() << "\n";
   *os << "value: " << std::string(c.value()) << "\n";
   *os << "label: ";
   char const* del = "";

--- a/bigtable/client/testing/table_integration_test.cc
+++ b/bigtable/client/testing/table_integration_test.cc
@@ -166,7 +166,7 @@ bool operator<(Cell const& lhs, Cell const& rhs) {
 void PrintTo(bigtable::Cell const& cell, std::ostream* os) {
   *os << "  row_key=" << cell.row_key() << ", family=" << cell.family_name()
       << ", column=" << cell.column_qualifier()
-      << ", timestamp=" << cell.timestamp() << ", value=<";
+      << ", timestamp=" << cell.timestamp().count() << ", value=<";
   // Replace non-printable values with '.' to make the output more readable.
   bool has_non_printable = false;
   for (char c : cell.value()) {

--- a/bigtable/examples/bigtable_hello_world.cc
+++ b/bigtable/examples/bigtable_hello_world.cc
@@ -90,7 +90,7 @@ int main(int argc, char* argv[]) try {
   }
   auto const& cell = result.second.cells().front();
   std::cout << cell.family_name() << ":" << cell.column_qualifier() << "    @ "
-            << cell.timestamp() << "us\n"
+            << cell.timestamp().count() << "us\n"
             << '"' << cell.value() << '"' << std::endl;
   //! [read row]
 
@@ -101,7 +101,7 @@ int main(int argc, char* argv[]) try {
     std::cout << row.row_key() << ":\n";
     for (auto& cell : row.cells()) {
       std::cout << "\t" << cell.family_name() << ":" << cell.column_qualifier()
-                << "    @ " << cell.timestamp() << "us\n"
+                << "    @ " << cell.timestamp().count() << "us\n"
                 << "\t\"" << cell.value() << '"' << std::endl;
     }
   }


### PR DESCRIPTION
Fixed for  issue #337 bigtable::Cell::timestamp() should return a std::chrono::microseconds.