### PR TITLE
Refactor InstanceAdminClient to support multiple services

### DIFF
--- a/bigtable/client/CMakeLists.txt
+++ b/bigtable/client/CMakeLists.txt
@@ -123,6 +123,7 @@ add_library(bigtable_client_testing
         testing/internal_table_test_fixture.h
         testing/internal_table_test_fixture.cc
         testing/mock_data_client.h
+        testing/mock_instance_admin_client.h
         testing/inprocess_data_client.h
         testing/inprocess_admin_client.h
         testing/mock_response_stream.h

--- a/bigtable/client/CMakeLists.txt
+++ b/bigtable/client/CMakeLists.txt
@@ -65,6 +65,7 @@ add_library(bigtable_client
         internal/table_admin.cc
         internal/throw_delegate.h
         internal/throw_delegate.cc
+        internal/unary_client_utils.h
         internal/unary_rpc_utils.h
         idempotent_mutation_policy.h
         idempotent_mutation_policy.cc

--- a/bigtable/client/instance_admin_client.cc
+++ b/bigtable/client/instance_admin_client.cc
@@ -51,6 +51,7 @@ class DefaultInstanceAdminClient : public bigtable::InstanceAdminClient {
 
   std::string const& project() const override { return project_; }
   AdminStubPtr Stub() override { return impl_.Stub(); }
+  Impl::ChannelPtr Channel() override { return impl_.Channel(); }
   void reset() override { return impl_.reset(); }
   void on_completion(grpc::Status const& status) override {}
 

--- a/bigtable/client/instance_admin_client.cc
+++ b/bigtable/client/instance_admin_client.cc
@@ -50,10 +50,15 @@ class DefaultInstanceAdminClient : public bigtable::InstanceAdminClient {
       : project_(std::move(project)), impl_(std::move(options)) {}
 
   std::string const& project() const override { return project_; }
-  AdminStubPtr Stub() override { return impl_.Stub(); }
   Impl::ChannelPtr Channel() override { return impl_.Channel(); }
   void reset() override { return impl_.reset(); }
-  void on_completion(grpc::Status const& status) override {}
+
+  grpc::Status ListInstances(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::ListInstancesRequest const& request,
+      google::bigtable::admin::v2::ListInstancesResponse* response) override {
+    return impl_.Stub()->ListInstances(context, request, response);
+  }
 
   DefaultInstanceAdminClient(DefaultInstanceAdminClient const&) = delete;
   DefaultInstanceAdminClient& operator=(DefaultInstanceAdminClient const&) =

--- a/bigtable/client/instance_admin_client.h
+++ b/bigtable/client/instance_admin_client.h
@@ -46,6 +46,14 @@ class InstanceAdminClient {
   Stub() = 0;
 
   /**
+   * Return a new channel to handle admin operations.
+   *
+   * Intended to access rarely used services in the same endpoints as the
+   * Bigtable admin interfaces, for example, the google.longrunning.Operations.
+   */
+  virtual std::shared_ptr<grpc::Channel> Channel() = 0;
+
+  /**
    * Reset and create a new Stub().
    *
    * Currently this is only used in testing.  In the future, we expect this,

--- a/bigtable/client/instance_admin_client.h
+++ b/bigtable/client/instance_admin_client.h
@@ -40,11 +40,6 @@ class InstanceAdminClient {
   /// The project that this AdminClient works on.
   virtual std::string const& project() const = 0;
 
-  /// Return a new stub to handle admin operations.
-  virtual std::shared_ptr<
-      ::google::bigtable::admin::v2::BigtableInstanceAdmin::StubInterface>
-  Stub() = 0;
-
   /**
    * Return a new channel to handle admin operations.
    *
@@ -62,13 +57,10 @@ class InstanceAdminClient {
    */
   virtual void reset() = 0;
 
-  /**
-   * A callback for completed RPCs.
-   *
-   * Currently this is only used in testing.  In the future, we expect that
-   * some errors may require the class to update its state.
-   */
-  virtual void on_completion(grpc::Status const&) = 0;
+  virtual grpc::Status ListInstances(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::ListInstancesRequest const& request,
+      google::bigtable::admin::v2::ListInstancesResponse* response) = 0;
 };
 
 /// Create a new admin client configured via @p options.

--- a/bigtable/client/instance_admin_client_test.cc
+++ b/bigtable/client/instance_admin_client_test.cc
@@ -21,32 +21,14 @@ TEST(InstanceAdminClientTest, Default) {
   ASSERT_TRUE(admin_client);
   EXPECT_EQ("test-project", admin_client->project());
 
-  auto stub0 = admin_client->Stub();
+  auto stub0 = admin_client->Channel();
   EXPECT_TRUE(stub0);
 
-  auto stub1 = admin_client->Stub();
+  auto stub1 = admin_client->Channel();
   EXPECT_EQ(stub0.get(), stub1.get());
 
   admin_client->reset();
-  stub1 = admin_client->Stub();
+  stub1 = admin_client->Channel();
   EXPECT_TRUE(stub1);
   EXPECT_NE(stub0.get(), stub1.get());
-}
-
-TEST(InstanceAdminClientTest, Channel) {
-  auto admin_client = bigtable::CreateDefaultInstanceAdminClient(
-      "test-project", bigtable::ClientOptions().set_connection_pool_size(1));
-  ASSERT_TRUE(admin_client);
-  EXPECT_EQ("test-project", admin_client->project());
-
-  auto channel0 = admin_client->Channel();
-  EXPECT_TRUE(channel0);
-
-  auto channel1 = admin_client->Channel();
-  EXPECT_EQ(channel0.get(), channel1.get());
-
-  admin_client->reset();
-  channel1 = admin_client->Channel();
-  EXPECT_TRUE(channel1);
-  EXPECT_NE(channel0.get(), channel1.get());
 }

--- a/bigtable/client/instance_admin_client_test.cc
+++ b/bigtable/client/instance_admin_client_test.cc
@@ -32,3 +32,21 @@ TEST(InstanceAdminClientTest, Default) {
   EXPECT_TRUE(stub1);
   EXPECT_NE(stub0.get(), stub1.get());
 }
+
+TEST(InstanceAdminClientTest, Channel) {
+  auto admin_client = bigtable::CreateDefaultInstanceAdminClient(
+      "test-project", bigtable::ClientOptions().set_connection_pool_size(1));
+  ASSERT_TRUE(admin_client);
+  EXPECT_EQ("test-project", admin_client->project());
+
+  auto channel0 = admin_client->Channel();
+  EXPECT_TRUE(channel0);
+
+  auto channel1 = admin_client->Channel();
+  EXPECT_EQ(channel0.get(), channel1.get());
+
+  admin_client->reset();
+  channel1 = admin_client->Channel();
+  EXPECT_TRUE(channel1);
+  EXPECT_NE(channel0.get(), channel1.get());
+}

--- a/bigtable/client/instance_admin_test.cc
+++ b/bigtable/client/instance_admin_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "bigtable/client/instance_admin.h"
+#include "bigtable/client/testing/mock_instance_admin_client.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin_mock.grpc.pb.h>
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
@@ -21,14 +22,7 @@
 namespace {
 namespace btproto = ::google::bigtable::admin::v2;
 
-class MockAdminClient : public bigtable::InstanceAdminClient {
- public:
-  MOCK_CONST_METHOD0(project, std::string const&());
-  MOCK_METHOD0(
-      Stub, std::shared_ptr<btproto::BigtableInstanceAdmin::StubInterface>());
-  MOCK_METHOD1(on_completion, void(grpc::Status const& status));
-  MOCK_METHOD0(reset, void());
-};
+using MockAdminClient = bigtable::testing::MockInstanceAdminClient;
 
 std::string const kProjectId = "the-project";
 

--- a/bigtable/client/internal/instance_admin.cc
+++ b/bigtable/client/internal/instance_admin.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "bigtable/client/internal/instance_admin.h"
+#include "bigtable/client/internal/unary_client_utils.h"
 #include <type_traits>
 
 namespace btproto = ::google::bigtable::admin::v2;
@@ -23,13 +24,14 @@ namespace noex {
 static_assert(std::is_copy_assignable<bigtable::noex::InstanceAdmin>::value,
               "bigtable::noex::InstanceAdmin must be CopyAssignable");
 
+using ClientUtils =
+    bigtable::internal::noex::UnaryClientUtils<bigtable::InstanceAdminClient>;
+
 std::vector<btproto::Instance> InstanceAdmin::ListInstances(
     grpc::Status& status) {
   // Copy the policies in effect for the operation.
   auto rpc_policy = rpc_retry_policy_->clone();
   auto backoff_policy = rpc_backoff_policy_->clone();
-
-  std::string error = "InstanceAdmin::ListInstances(" + project_id() + ")";
 
   // Build the RPC request, try to minimize copying.
   std::vector<btproto::Instance> result;
@@ -39,9 +41,10 @@ std::vector<btproto::Instance> InstanceAdmin::ListInstances(
     request.set_page_token(std::move(page_token));
     request.set_parent(project_name_);
 
-    auto response = RpcUtils::CallWithRetryBorrow(
+    auto response = ClientUtils::MakeCall(
         *client_, *rpc_policy, *backoff_policy, metadata_update_policy_,
-        &StubType::ListInstances, request, error.c_str(), status);
+        &InstanceAdminClient::ListInstances, request,
+        "InstanceAdmin::ListInstances", status, true);
     if (not status.ok()) {
       return result;
     }

--- a/bigtable/client/internal/instance_admin.h
+++ b/bigtable/client/internal/instance_admin.h
@@ -16,7 +16,9 @@
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_INSTANCE_ADMIN_H_
 
 #include "bigtable/client/instance_admin_client.h"
-#include "bigtable/client/internal/unary_rpc_utils.h"
+#include "bigtable/client/metadata_update_policy.h"
+#include "bigtable/client/rpc_backoff_policy.h"
+#include "bigtable/client/rpc_retry_policy.h"
 #include <memory>
 
 namespace bigtable {
@@ -72,13 +74,7 @@ class InstanceAdmin {
    */
   std::vector<::google::bigtable::admin::v2::Instance> ListInstances(
       grpc::Status& status);
-
   //@}
-
- private:
-  /// Shortcuts to avoid typing long names over and over.
-  using RpcUtils = bigtable::internal::noex::UnaryRpcUtils<InstanceAdminClient>;
-  using StubType = RpcUtils::StubType;
 
  private:
   std::shared_ptr<InstanceAdminClient> client_;

--- a/bigtable/client/internal/instance_admin_test.cc
+++ b/bigtable/client/internal/instance_admin_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "bigtable/client/internal/instance_admin.h"
+#include "bigtable/client/testing/mock_instance_admin_client.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin_mock.grpc.pb.h>
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
@@ -21,14 +22,7 @@
 namespace {
 namespace btproto = ::google::bigtable::admin::v2;
 
-class MockAdminClient : public bigtable::InstanceAdminClient {
- public:
-  MOCK_CONST_METHOD0(project, std::string const&());
-  MOCK_METHOD0(
-      Stub, std::shared_ptr<btproto::BigtableInstanceAdmin::StubInterface>());
-  MOCK_METHOD1(on_completion, void(grpc::Status const& status));
-  MOCK_METHOD0(reset, void());
-};
+using MockAdminClient = bigtable::testing::MockInstanceAdminClient;
 
 std::string const kProjectId = "the-project";
 

--- a/bigtable/client/internal/unary_client_utils.h
+++ b/bigtable/client/internal/unary_client_utils.h
@@ -1,0 +1,246 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_UNARY_CLIENT_UTILS_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_UNARY_CLIENT_UTILS_H_
+
+#include "bigtable/client/internal/throw_delegate.h"
+#include "bigtable/client/metadata_update_policy.h"
+#include "bigtable/client/rpc_backoff_policy.h"
+#include "bigtable/client/rpc_retry_policy.h"
+#include <thread>
+
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
+namespace noex {
+/**
+ * Helper functions to make (unary) gRPC calls under the right policies.
+ *
+ * Many of the gRPC calls made the the Cloud Bigtable C++ client library are
+ * wrapped in essentially the same loop:
+ *
+ * @code
+ * clone the policies for the call
+ * do {
+ *   make rpc call
+ *   return if successful
+ *   update policies
+ * } while(policies allow retry);
+ * report failure
+ * @endcode
+ *
+ * The loop is not hard to write, but gets tedious, `CallWithRetry` provides a
+ * function that implements this loop.  The code is a bit difficult because the
+ * signature of the gRPC functions look like this:
+ *
+ * @code
+ * grpc::Status (StubType::*)(grpc::ClientContext*, Request const&, Response*);
+ * @endcode
+ *
+ * Where `Request` and `Response` are the protos in the gRPC call.
+ *
+ * @tparam ClientType the type of the client used for the gRPC call.
+ */
+template <typename ClientType>
+struct UnaryClientUtils {
+  /**
+   * Determine if @p T is a pointer to member function with the expected
+   * signature for `MakeCall()`.
+   *
+   * This is the generic case, where the type does not match the expected
+   * signature.  The class derives from `std::false_type`, so
+   * `CheckSignature<T>::%value` is `false`.
+   *
+   * @tparam T the type to check against the expected signature.
+   */
+  template <typename T>
+  struct CheckSignature : public std::false_type {
+    /// Must define ResponseType because it is used in std::enable_if<>.
+    using ResponseType = void;
+  };
+
+  /**
+   * Determine if a type is a pointer to member function with the correct
+   * signature for `MakeCall()`.
+   *
+   * This is the case where the type actually matches the expected signature.
+   * This class derives from `std::true_type`, so `CheckSignature<T>::%value` is
+   * `true`.  The class also extracts the request and response types used in the
+   * implementation of `CallWithRetry()`.
+   *
+   * @tparam Request the RPC request type.
+   * @tparam Response the RPC response type.
+   */
+  template <typename Request, typename Response>
+  struct CheckSignature<grpc::Status (ClientType::*)(grpc::ClientContext*,
+                                                     Request const&, Response*)>
+      : public std::true_type {
+    using RequestType = Request;
+    using ResponseType = Response;
+    using MemberFunctionType = grpc::Status (ClientType::*)(
+        grpc::ClientContext*, Request const&, Response*);
+  };
+
+  /**
+   * Call a simple unary RPC with retries.
+   *
+   * Given a pointer to member function in the grpc StubInterface class this
+   * generic function calls it with retries until success or until the RPC
+   * policies determine that this is an error.
+   *
+   * We use std::enable_if<> to stop signature errors at compile-time.  The
+   * `CheckSignature` meta function returns `false` if given a type that is not
+   * a pointer to member with the right signature, that disables this function
+   * altogether, and the developer gets a nice-ish error message.
+   *
+   * @tparam MemberFunction the signature of the member function.
+   * @param client the object that holds the gRPC stub.
+   * @param rpc_policy the policy controlling what failures are retryable.
+   * @param backoff_policy the policy controlling how long to wait before
+   *     retrying.
+   * @param metadata_update_policy to keep metadata like
+   *     x-goog-request-params.
+   * @param function the pointer to the member function to call.
+   * @param request an initialized request parameter for the RPC.
+   * @param error_message include this message in any exception or error log.
+   * @return the return parameter from the RPC.
+   * @throw std::exception with a description of the last RPC error.
+   */
+  template <typename MemberFunction>
+  static typename std::enable_if<
+      CheckSignature<MemberFunction>::value,
+      typename CheckSignature<MemberFunction>::ResponseType>::type
+  MakeCall(ClientType& client,
+           std::unique_ptr<bigtable::RPCRetryPolicy> rpc_policy,
+           std::unique_ptr<bigtable::RPCBackoffPolicy> backoff_policy,
+           bigtable::MetadataUpdatePolicy const& metadata_update_policy,
+           MemberFunction function,
+           typename CheckSignature<MemberFunction>::RequestType const& request,
+           char const* error_message, grpc::Status& status,
+           bool retry_on_failure) {
+    return MakeCall(client, *rpc_policy, *backoff_policy,
+                    metadata_update_policy, function, request, error_message,
+                    status, retry_on_failure);
+  }
+
+  /**
+   * Call a simple unary RPC with retries borrowing the RPC policies.
+   *
+   * This implements `MakeCall()`, but does not assume ownership of the RPC
+   * policies.  Some RPCs, notably those with pagination, can reuse most of the
+   * code in `MakeCall()` but must reuse the same policies across several
+   * calls.
+   *
+   * @tparam MemberFunction the signature of the member function.
+   * @param client the object that holds the gRPC stub.
+   * @param rpc_policy the policy controlling what failures are retryable.
+   * @param backoff_policy the policy controlling how long to wait before
+   *     retrying.
+   * @param metadata_update_policy to keep metadata like
+   *     x-goog-request-params.
+   * @param function the pointer to the member function to call.
+   * @param request an initialized request parameter for the RPC.
+   * @param error_message include this message in any exception or error log.
+   * @return the return parameter from the RPC.
+   * @throw std::exception with a description of the last RPC error.
+   */
+  template <typename MemberFunction>
+  static typename std::enable_if<
+      CheckSignature<MemberFunction>::value,
+      typename CheckSignature<MemberFunction>::ResponseType>::type
+  MakeCall(ClientType& client, bigtable::RPCRetryPolicy& rpc_policy,
+           bigtable::RPCBackoffPolicy& backoff_policy,
+           bigtable::MetadataUpdatePolicy const& metadata_update_policy,
+           MemberFunction function,
+           typename CheckSignature<MemberFunction>::RequestType const& request,
+           char const* error_message, grpc::Status& status,
+           bool retry_on_failure) {
+    typename CheckSignature<MemberFunction>::ResponseType response;
+    do {
+      grpc::ClientContext client_context;
+      rpc_policy.setup(client_context);
+      backoff_policy.setup(client_context);
+      metadata_update_policy.setup(client_context);
+      // Call the pointer to member function.
+      status = (client.*function)(&client_context, request, &response);
+      if (status.ok()) {
+        break;
+      }
+      if (not rpc_policy.on_failure(status)) {
+        std::string full_message = error_message;
+        full_message +=
+            "(" + metadata_update_policy.x_google_request_params().second + ")";
+        status = grpc::Status(status.error_code(), full_message);
+        break;
+      }
+      auto delay = backoff_policy.on_completion(status);
+      std::this_thread::sleep_for(delay);
+    } while (retry_on_failure);
+    return response;
+  }
+
+  /**
+   * Call a simple unary RPC with no retry.
+   *
+   * Given a pointer to member function in the grpc StubInterface class this
+   * generic function calls it with retries until success or until the RPC
+   * policies determine that this is an error.
+   *
+   * We use std::enable_if<> to stop signature errors at compile-time.  The
+   * `CheckSignature` meta function returns `false` if given a type that is not
+   * a pointer to member with the right signature, that disables this function
+   * altogether, and the developer gets a nice-ish error message.
+   *
+   * @tparam MemberFunction the signature of the member function.
+   * @param client the object that holds the gRPC stub.
+   * @param rpc_policy the policy to control timeouts.
+   * @param metadata_update_policy to keep metadata like
+   *     x-goog-request-params.
+   * @param function the pointer to the member function to call.
+   * @param request an initialized request parameter for the RPC.
+   * @param error_message include this message in any exception or error log.
+   * @return the return parameter from the RPC.
+   * @throw std::exception with a description of the last RPC error.
+   */
+  template <typename MemberFunction>
+  static typename std::enable_if<
+      CheckSignature<MemberFunction>::value,
+      typename CheckSignature<MemberFunction>::ResponseType>::type
+  MakeNonIdemponentCall(
+      ClientType& client, std::unique_ptr<bigtable::RPCRetryPolicy> rpc_policy,
+      bigtable::MetadataUpdatePolicy const& metadata_update_policy,
+      MemberFunction function,
+      typename CheckSignature<MemberFunction>::RequestType const& request,
+      char const* error_message, grpc::Status& status) {
+    typename CheckSignature<MemberFunction>::ResponseType response;
+
+    grpc::ClientContext client_context;
+
+    // Policies can set timeouts so allowing them to update context
+    rpc_policy->setup(client_context);
+    metadata_update_policy.setup(client_context);
+    // Call the pointer to member function.
+    status = (client.*function)(&client_context, request, &response);
+
+    return response;
+  }
+};
+
+}  // namespace noex
+}  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_UNARY_CLIENT_UTILS_H_

--- a/bigtable/client/testing/mock_instance_admin_client.h
+++ b/bigtable/client/testing/mock_instance_admin_client.h
@@ -24,13 +24,13 @@ namespace testing {
 class MockInstanceAdminClient : public bigtable::InstanceAdminClient {
  public:
   MOCK_CONST_METHOD0(project, std::string const&());
-  MOCK_METHOD0(
-      Stub,
-      std::shared_ptr<
-          google::bigtable::admin::v2::BigtableInstanceAdmin::StubInterface>());
   MOCK_METHOD0(Channel, std::shared_ptr<grpc::Channel>());
-  MOCK_METHOD1(on_completion, void(grpc::Status const& status));
   MOCK_METHOD0(reset, void());
+  MOCK_METHOD3(
+      ListInstances,
+      grpc::Status(grpc::ClientContext*,
+                   google::bigtable::admin::v2::ListInstancesRequest const&,
+                   google::bigtable::admin::v2::ListInstancesResponse*));
 };
 
 }  // namespace testing

--- a/bigtable/client/testing/mock_instance_admin_client.h
+++ b/bigtable/client/testing/mock_instance_admin_client.h
@@ -1,0 +1,39 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_DATA_CLIENT_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_DATA_CLIENT_H_
+
+#include "bigtable/client/instance_admin_client.h"
+#include <gmock/gmock.h>
+
+namespace bigtable {
+namespace testing {
+
+class MockInstanceAdminClient : public bigtable::InstanceAdminClient {
+ public:
+  MOCK_CONST_METHOD0(project, std::string const&());
+  MOCK_METHOD0(
+      Stub,
+      std::shared_ptr<
+          google::bigtable::admin::v2::BigtableInstanceAdmin::StubInterface>());
+  MOCK_METHOD0(Channel, std::shared_ptr<grpc::Channel>());
+  MOCK_METHOD1(on_completion, void(grpc::Status const& status));
+  MOCK_METHOD0(reset, void());
+};
+
+}  // namespace testing
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_DATA_CLIENT_H_


### PR DESCRIPTION
This is a large change.  It is part of the fixes for #433 and for #418.  The current implementation of `bigtable::*Client` makes it really hard to write tests that use multiple services, and when using long running operations you need to access at least two services.

The good news is that the tests and some of the helpers get easier to write, and this does not affect any of the APIs exposed to the user.
