### PR TITLE
Make bigtable::InstanceAdmin CopyConstructible.

### DIFF
--- a/bigtable/client/instance_admin.cc
+++ b/bigtable/client/instance_admin.cc
@@ -14,11 +14,15 @@
 
 #include "bigtable/client/instance_admin.h"
 #include "bigtable/client/internal/throw_delegate.h"
+#include <type_traits>
 
 namespace btproto = ::google::bigtable::admin::v2;
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+static_assert(std::is_copy_assignable<bigtable::InstanceAdmin>::value,
+              "bigtable::InstanceAdmin must be CopyAssignable");
+
 std::vector<btproto::Instance> InstanceAdmin::ListInstances() {
   grpc::Status status;
   auto result = impl_.ListInstances(status);

--- a/bigtable/client/instance_admin.h
+++ b/bigtable/client/instance_admin.h
@@ -60,9 +60,6 @@ class InstanceAdmin {
    */
   std::vector<google::bigtable::admin::v2::Instance> ListInstances();
 
-  InstanceAdmin(InstanceAdmin const&) = delete;
-  InstanceAdmin operator=(InstanceAdmin const&) = delete;
-
  private:
   noex::InstanceAdmin impl_;
 };

--- a/bigtable/client/instance_admin_test.cc
+++ b/bigtable/client/instance_admin_test.cc
@@ -116,6 +116,50 @@ TEST_F(InstanceAdminTest, Default) {
   EXPECT_EQ("the-project", tested.project_id());
 }
 
+TEST_F(InstanceAdminTest, CopyConstructor) {
+  bigtable::InstanceAdmin source(client_);
+  std::string expected = source.project_id();
+  bigtable::InstanceAdmin copy(source);
+  EXPECT_EQ(expected, copy.project_id());
+}
+
+TEST_F(InstanceAdminTest, MoveConstructor) {
+  bigtable::InstanceAdmin source(client_);
+  std::string expected = source.project_id();
+  bigtable::InstanceAdmin copy(std::move(source));
+  EXPECT_EQ(expected, copy.project_id());
+}
+
+TEST_F(InstanceAdminTest, CopyAssignment) {
+  std::shared_ptr<MockAdminClient> other_client =
+      std::make_shared<MockAdminClient>();
+  std::string other_project = "other-project";
+  EXPECT_CALL(*other_client, project())
+      .WillRepeatedly(testing::ReturnRef(other_project));
+
+  bigtable::InstanceAdmin source(client_);
+  std::string expected = source.project_id();
+  bigtable::InstanceAdmin dest(other_client);
+  EXPECT_NE(expected, dest.project_id());
+  dest = source;
+  EXPECT_EQ(expected, dest.project_id());
+}
+
+TEST_F(InstanceAdminTest, MoveAssignment) {
+  std::shared_ptr<MockAdminClient> other_client =
+      std::make_shared<MockAdminClient>();
+  std::string other_project = "other-project";
+  EXPECT_CALL(*other_client, project())
+      .WillRepeatedly(testing::ReturnRef(other_project));
+
+  bigtable::InstanceAdmin source(client_);
+  std::string expected = source.project_id();
+  bigtable::InstanceAdmin dest(other_client);
+  EXPECT_NE(expected, dest.project_id());
+  dest = std::move(source);
+  EXPECT_EQ(expected, dest.project_id());
+}
+
 /// @test Verify that `bigtable::InstanceAdmin::ListInstances` works in the easy
 /// case.
 TEST_F(InstanceAdminTest, ListInstances) {

--- a/bigtable/client/internal/instance_admin.cc
+++ b/bigtable/client/internal/instance_admin.cc
@@ -13,12 +13,15 @@
 // limitations under the License.
 
 #include "bigtable/client/internal/instance_admin.h"
+#include <type_traits>
 
 namespace btproto = ::google::bigtable::admin::v2;
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace noex {
+static_assert(std::is_copy_assignable<bigtable::noex::InstanceAdmin>::value,
+              "bigtable::noex::InstanceAdmin must be CopyAssignable");
 
 std::vector<btproto::Instance> InstanceAdmin::ListInstances(
     grpc::Status& status) {

--- a/bigtable/client/internal/instance_admin.h
+++ b/bigtable/client/internal/instance_admin.h
@@ -75,9 +75,6 @@ class InstanceAdmin {
 
   //@}
 
-  InstanceAdmin(InstanceAdmin const&) = delete;
-  InstanceAdmin operator=(InstanceAdmin const&) = delete;
-
  private:
   /// Shortcuts to avoid typing long names over and over.
   using RpcUtils = bigtable::internal::noex::UnaryRpcUtils<InstanceAdminClient>;
@@ -86,8 +83,8 @@ class InstanceAdmin {
  private:
   std::shared_ptr<InstanceAdminClient> client_;
   std::string project_name_;
-  std::unique_ptr<RPCRetryPolicy> rpc_retry_policy_;
-  std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy_;
+  std::shared_ptr<RPCRetryPolicy> rpc_retry_policy_;
+  std::shared_ptr<RPCBackoffPolicy> rpc_backoff_policy_;
   MetadataUpdatePolicy metadata_update_policy_;
 };
 

--- a/bigtable/client/internal/instance_admin_test.cc
+++ b/bigtable/client/internal/instance_admin_test.cc
@@ -116,6 +116,50 @@ TEST_F(InstanceAdminTest, Default) {
   EXPECT_EQ("the-project", tested.project_id());
 }
 
+TEST_F(InstanceAdminTest, CopyConstructor) {
+  bigtable::noex::InstanceAdmin source(client_);
+  std::string expected = source.project_id();
+  bigtable::noex::InstanceAdmin copy(source);
+  EXPECT_EQ(expected, copy.project_id());
+}
+
+TEST_F(InstanceAdminTest, MoveConstructor) {
+  bigtable::noex::InstanceAdmin source(client_);
+  std::string expected = source.project_id();
+  bigtable::noex::InstanceAdmin copy(std::move(source));
+  EXPECT_EQ(expected, copy.project_id());
+}
+
+TEST_F(InstanceAdminTest, CopyAssignment) {
+  std::shared_ptr<MockAdminClient> other_client =
+      std::make_shared<MockAdminClient>();
+  std::string other_project = "other-project";
+  EXPECT_CALL(*other_client, project())
+      .WillRepeatedly(testing::ReturnRef(other_project));
+
+  bigtable::noex::InstanceAdmin source(client_);
+  std::string expected = source.project_id();
+  bigtable::noex::InstanceAdmin dest(other_client);
+  EXPECT_NE(expected, dest.project_id());
+  dest = source;
+  EXPECT_EQ(expected, dest.project_id());
+}
+
+TEST_F(InstanceAdminTest, MoveAssignment) {
+  std::shared_ptr<MockAdminClient> other_client =
+      std::make_shared<MockAdminClient>();
+  std::string other_project = "other-project";
+  EXPECT_CALL(*other_client, project())
+      .WillRepeatedly(testing::ReturnRef(other_project));
+
+  bigtable::noex::InstanceAdmin source(client_);
+  std::string expected = source.project_id();
+  bigtable::noex::InstanceAdmin dest(other_client);
+  EXPECT_NE(expected, dest.project_id());
+  dest = std::move(source);
+  EXPECT_EQ(expected, dest.project_id());
+}
+
 /// @test Verify that `bigtable::InstanceAdmin::ListInstances` works in the easy
 /// case.
 TEST_F(InstanceAdminTest, ListInstances) {


### PR DESCRIPTION
This fixes #437.