### PR TITLE
Refactor common *Reader mocks.

### DIFF
--- a/bigtable/client/CMakeLists.txt
+++ b/bigtable/client/CMakeLists.txt
@@ -127,7 +127,10 @@ add_library(bigtable_client_testing
         testing/mock_instance_admin_client.h
         testing/inprocess_data_client.h
         testing/inprocess_admin_client.h
-        testing/mock_response_stream.h
+        testing/mock_mutate_rows_reader.h
+        testing/mock_read_rows_reader.h
+        testing/mock_response_reader.h
+        testing/mock_sample_row_keys_reader.h
         testing/table_integration_test.h
         testing/table_integration_test.cc
         testing/table_test_fixture.h

--- a/bigtable/client/internal/bulk_mutator_test.cc
+++ b/bigtable/client/internal/bulk_mutator_test.cc
@@ -15,18 +15,12 @@
 #include "bigtable/client/internal/bulk_mutator.h"
 #include "bigtable/client/internal/make_unique.h"
 #include "bigtable/client/testing/chrono_literals.h"
+#include "bigtable/client/testing/mock_mutate_rows_reader.h"
 #include <google/bigtable/v2/bigtable_mock.grpc.pb.h>
 
 /// Define types and functions used in the tests.
 namespace {
-class MockReader : public grpc::ClientReaderInterface<
-                       ::google::bigtable::v2::MutateRowsResponse> {
- public:
-  MOCK_METHOD0(WaitForInitialMetadata, void());
-  MOCK_METHOD0(Finish, grpc::Status());
-  MOCK_METHOD1(NextMessageSize, bool(std::uint32_t*));
-  MOCK_METHOD1(Read, bool(::google::bigtable::v2::MutateRowsResponse*));
-};
+using bigtable::testing::MockMutateRowsReader;
 }  // anonymous namespace
 
 /// @test Verify that MultipleRowsMutator handles easy cases.
@@ -45,7 +39,7 @@ TEST(MultipleRowsMutatorTest, Simple) {
   // Prepare the mocks.  The mutator should issue a RPC which must return a
   // stream of responses, we prepare the stream first because it is easier than
   // to create one of the fly.
-  auto reader = bigtable::internal::make_unique<MockReader>();
+  auto reader = bigtable::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*reader, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -98,7 +92,7 @@ TEST(MultipleRowsMutatorTest, RetryPartialFailure) {
 
   // Prepare the mocks for the request.  First create a stream response which
   // indicates a partial failure.
-  auto r1 = bigtable::internal::make_unique<MockReader>();
+  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         // Simulate a partial (and recoverable) failure.
@@ -115,7 +109,7 @@ TEST(MultipleRowsMutatorTest, RetryPartialFailure) {
 
   // Prepare a second stream response, because the client should retry after
   // the partial failure.
-  auto r2 = bigtable::internal::make_unique<MockReader>();
+  auto r2 = bigtable::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r2, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -172,7 +166,7 @@ TEST(MultipleRowsMutatorTest, PermanentFailure) {
       bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0_ms, "qux")}));
 
   // Make the first RPC return one recoverable and one unrecoverable failures.
-  auto r1 = bigtable::internal::make_unique<MockReader>();
+  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         // Simulate a partial failure, which is recoverable for this first
@@ -191,7 +185,7 @@ TEST(MultipleRowsMutatorTest, PermanentFailure) {
 
   // The BulkMutator should issue a second request, which will return success
   // for the remaining mutation.
-  auto r2 = bigtable::internal::make_unique<MockReader>();
+  auto r2 = bigtable::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r2, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -249,7 +243,7 @@ TEST(MultipleRowsMutatorTest, PartialStream) {
 
   // This will be the stream returned by the first request.  It is missing
   // information about one of the mutations.
-  auto r1 = bigtable::internal::make_unique<MockReader>();
+  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         auto& e0 = *r->add_entries();
@@ -263,7 +257,7 @@ TEST(MultipleRowsMutatorTest, PartialStream) {
   // The BulkMutation should issue a second request, this is the stream returned
   // by the second request, which indicates success for the missed mutation
   // on r1.
-  auto r2 = bigtable::internal::make_unique<MockReader>();
+  auto r2 = bigtable::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r2, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -318,7 +312,7 @@ TEST(MultipleRowsMutatorTest, RetryOnlyIdempotent) {
 
   // We will setup the mock to return recoverable failures for idempotent
   // mutations.
-  auto r1 = bigtable::internal::make_unique<MockReader>();
+  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         // Simulate recoverable failures for both elements.
@@ -335,7 +329,7 @@ TEST(MultipleRowsMutatorTest, RetryOnlyIdempotent) {
 
   // The BulkMutator should issue a second request, with only the idempotent
   // mutations, make the mocks return success for them.
-  auto r2 = bigtable::internal::make_unique<MockReader>();
+  auto r2 = bigtable::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r2, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {

--- a/bigtable/client/internal/table_test.cc
+++ b/bigtable/client/internal/table_test.cc
@@ -14,6 +14,9 @@
 
 #include "bigtable/client/testing/chrono_literals.h"
 #include "bigtable/client/testing/internal_table_test_fixture.h"
+#include "bigtable/client/testing/mock_mutate_rows_reader.h"
+#include "bigtable/client/testing/mock_read_rows_reader.h"
+#include "bigtable/client/testing/mock_sample_row_keys_reader.h"
 
 using testing::_;
 using testing::Return;
@@ -31,30 +34,16 @@ class TableApplyTest : public bigtable::testing::internal::TableTestFixture {};
 
 class TableSampleRowKeysTest
     : public bigtable::testing::internal::TableTestFixture {};
-class MockReader : public grpc::ClientReaderInterface<
-                       ::google::bigtable::v2::MutateRowsResponse> {
- public:
-  MOCK_METHOD0(WaitForInitialMetadata, void());
-  MOCK_METHOD0(Finish, grpc::Status());
-  MOCK_METHOD1(NextMessageSize, bool(std::uint32_t*));
-  MOCK_METHOD1(Read, bool(::google::bigtable::v2::MutateRowsResponse*));
-};
-
-class MockReaderSampleRowKeysResponse
-    : public grpc::ClientReaderInterface<
-          ::google::bigtable::v2::SampleRowKeysResponse> {
- public:
-  MOCK_METHOD0(WaitForInitialMetadata, void());
-  MOCK_METHOD0(Finish, grpc::Status());
-  MOCK_METHOD1(NextMessageSize, bool(std::uint32_t*));
-  MOCK_METHOD1(Read, bool(::google::bigtable::v2::SampleRowKeysResponse*));
-};
 
 class TableBulkApplyTest
     : public bigtable::testing::internal::TableTestFixture {};
 
 class TableCheckAndMutateRowTest
     : public bigtable::testing::internal::TableTestFixture {};
+
+using bigtable::testing::MockMutateRowsReader;
+using bigtable::testing::MockReadRowsReader;
+using bigtable::testing::MockSampleRowKeysReader;
 }  // anonymous namespace
 
 TEST_F(TableTest, ClientProjectId) {
@@ -135,8 +124,7 @@ TEST_F(TableReadRowTest, ReadRowSimple) {
                                                               status);
   EXPECT_TRUE(status.ok());
 
-  auto stream =
-      bigtable::internal::make_unique<bigtable::testing::MockResponseStream>();
+  auto stream = bigtable::internal::make_unique<MockReadRowsReader>();
   EXPECT_CALL(*stream, Read(_))
       .WillOnce(Invoke([&response](btproto::ReadRowsResponse* r) {
         *r = response;
@@ -166,8 +154,7 @@ TEST_F(TableReadRowTest, ReadRowMissing) {
   using namespace ::testing;
   namespace btproto = ::google::bigtable::v2;
 
-  auto stream =
-      bigtable::internal::make_unique<bigtable::testing::MockResponseStream>();
+  auto stream = bigtable::internal::make_unique<MockReadRowsReader>();
   EXPECT_CALL(*stream, Read(_)).WillOnce(Return(false));
   EXPECT_CALL(*stream, Finish()).WillOnce(Return(grpc::Status::OK));
 
@@ -190,8 +177,7 @@ TEST_F(TableReadRowTest, ReadRowError) {
   using namespace ::testing;
   namespace btproto = ::google::bigtable::v2;
 
-  auto stream =
-      bigtable::internal::make_unique<bigtable::testing::MockResponseStream>();
+  auto stream = bigtable::internal::make_unique<MockReadRowsReader>();
   EXPECT_CALL(*stream, Read(_)).WillOnce(Return(false));
   EXPECT_CALL(*stream, Finish())
       .WillOnce(
@@ -229,7 +215,7 @@ TEST_F(TableReadRowsTest, ReadRowsCanReadOneRow) {
   EXPECT_TRUE(status.ok());
 
   // must be a new pointer, it is wrapped in unique_ptr by ReadRows
-  auto stream = new bigtable::testing::MockResponseStream;
+  auto stream = new MockReadRowsReader;
   EXPECT_CALL(*bigtable_stub_, ReadRowsRaw(_, _)).WillOnce(Return(stream));
   EXPECT_CALL(*stream, Read(testing::_))
       .WillOnce(DoAll(SetArgPointee<0>(response), Return(true)))
@@ -278,8 +264,8 @@ TEST_F(TableReadRowsTest, ReadRowsCanReadWithRetries) {
   EXPECT_TRUE(status.ok());
 
   // must be a new pointer, it is wrapped in unique_ptr by ReadRows
-  auto stream = new bigtable::testing::MockResponseStream;
-  auto stream_retry = new bigtable::testing::MockResponseStream;
+  auto stream = new MockReadRowsReader;
+  auto stream_retry = new MockReadRowsReader;
 
   EXPECT_CALL(*bigtable_stub_, ReadRowsRaw(_, _))
       .WillOnce(Return(stream))
@@ -316,7 +302,7 @@ TEST_F(TableReadRowsTest, ReadRowsCanReadWithRetries) {
 TEST_F(TableReadRowsTest, ReadRowsThrowsWhenTooManyErrors) {
   EXPECT_CALL(*bigtable_stub_, ReadRowsRaw(_, _))
       .WillRepeatedly(testing::WithoutArgs(testing::Invoke([] {
-        auto stream = new bigtable::testing::MockResponseStream;
+        auto stream = new MockReadRowsReader;
         EXPECT_CALL(*stream, Read(_)).WillOnce(Return(false));
         EXPECT_CALL(*stream, Finish())
             .WillOnce(
@@ -401,7 +387,7 @@ TEST_F(TableBulkApplyTest, Simple) {
   namespace btproto = ::google::bigtable::v2;
   namespace bt = ::bigtable;
 
-  auto reader = bigtable::internal::make_unique<MockReader>();
+  auto reader = bigtable::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*reader, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -441,7 +427,7 @@ TEST_F(TableBulkApplyTest, RetryPartialFailure) {
   namespace btproto = ::google::bigtable::v2;
   namespace bt = ::bigtable;
 
-  auto r1 = bigtable::internal::make_unique<MockReader>();
+  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         // Simulate a partial (recoverable) failure.
@@ -456,7 +442,7 @@ TEST_F(TableBulkApplyTest, RetryPartialFailure) {
       .WillOnce(Return(false));
   EXPECT_CALL(*r1, Finish()).WillOnce(Return(grpc::Status::OK));
 
-  auto r2 = bigtable::internal::make_unique<MockReader>();
+  auto r2 = bigtable::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r2, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -497,7 +483,7 @@ TEST_F(TableBulkApplyTest, PermanentFailure) {
   namespace btproto = ::google::bigtable::v2;
   namespace bt = ::bigtable;
 
-  auto r1 = bigtable::internal::make_unique<MockReader>();
+  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -540,7 +526,7 @@ TEST_F(TableBulkApplyTest, CanceledStream) {
   // the BulkApply() operation to retry the request, because the mutation is in
   // an undetermined state.  Well, it should retry assuming it is idempotent,
   // which happens to be the case in this test.
-  auto r1 = bigtable::internal::make_unique<MockReader>();
+  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -554,7 +540,7 @@ TEST_F(TableBulkApplyTest, CanceledStream) {
   EXPECT_CALL(*r1, Finish()).WillOnce(Return(grpc::Status::OK));
 
   // Create a second stream returned by the mocks when the client retries.
-  auto r2 = bigtable::internal::make_unique<MockReader>();
+  auto r2 = bigtable::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r2, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -608,7 +594,7 @@ TEST_F(TableBulkApplyTest, TooManyFailures) {
       bt::SafeIdempotentMutationPolicy());
 
   // Setup the mocks to fail more than 3 times.
-  auto r1 = bigtable::internal::make_unique<MockReader>();
+  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -624,7 +610,7 @@ TEST_F(TableBulkApplyTest, TooManyFailures) {
 
   auto create_cancelled_stream = [&](grpc::ClientContext*,
                                      btproto::MutateRowsRequest const&) {
-    auto stream = bigtable::internal::make_unique<MockReader>();
+    auto stream = bigtable::internal::make_unique<MockMutateRowsReader>();
     EXPECT_CALL(*stream, Read(_)).WillOnce(Return(false));
     EXPECT_CALL(*stream, Finish())
         .WillOnce(Return(grpc::Status(grpc::StatusCode::ABORTED, "")));
@@ -657,11 +643,11 @@ TEST_F(TableBulkApplyTest, RetryOnlyIdempotent) {
   // We will send both idempotent and non-idempotent mutations.  We prepare the
   // mocks to return an empty stream in the first RPC request.  That will force
   // the client to only retry the idempotent mutations.
-  auto r1 = bigtable::internal::make_unique<MockReader>();
+  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_)).WillOnce(Return(false));
   EXPECT_CALL(*r1, Finish()).WillOnce(Return(grpc::Status::OK));
 
-  auto r2 = bigtable::internal::make_unique<MockReader>();
+  auto r2 = bigtable::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r2, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -704,7 +690,7 @@ TEST_F(TableBulkApplyTest, FailedRPC) {
   namespace btproto = ::google::bigtable::v2;
   namespace bt = ::bigtable;
 
-  auto reader = bigtable::internal::make_unique<MockReader>();
+  auto reader = bigtable::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*reader, Read(_)).WillOnce(Return(false));
   EXPECT_CALL(*reader, Finish())
       .WillOnce(Return(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
@@ -764,7 +750,7 @@ TEST_F(TableSampleRowKeysTest, DefaultParameterTest) {
   using namespace ::testing;
   namespace btproto = ::google::bigtable::v2;
 
-  auto reader = new MockReaderSampleRowKeysResponse;
+  auto reader = new MockSampleRowKeysReader;
   EXPECT_CALL(*bigtable_stub_, SampleRowKeysRaw(_, _)).WillOnce(Return(reader));
   EXPECT_CALL(*reader, Read(_))
       .WillOnce(Invoke([](btproto::SampleRowKeysResponse* r) {
@@ -791,7 +777,7 @@ TEST_F(TableSampleRowKeysTest, SimpleVectorTest) {
   using namespace ::testing;
   namespace btproto = ::google::bigtable::v2;
 
-  auto reader = new MockReaderSampleRowKeysResponse;
+  auto reader = new MockSampleRowKeysReader;
   EXPECT_CALL(*bigtable_stub_, SampleRowKeysRaw(_, _)).WillOnce(Return(reader));
   EXPECT_CALL(*reader, Read(_))
       .WillOnce(Invoke([](btproto::SampleRowKeysResponse* r) {
@@ -819,7 +805,7 @@ TEST_F(TableSampleRowKeysTest, SimpleListTest) {
   using namespace ::testing;
   namespace btproto = ::google::bigtable::v2;
 
-  auto reader = new MockReaderSampleRowKeysResponse;
+  auto reader = new MockSampleRowKeysReader;
   EXPECT_CALL(*bigtable_stub_, SampleRowKeysRaw(_, _)).WillOnce(Return(reader));
   EXPECT_CALL(*reader, Read(_))
       .WillOnce(Invoke([](btproto::SampleRowKeysResponse* r) {
@@ -846,8 +832,8 @@ TEST_F(TableSampleRowKeysTest, SampleRowKeysRetryTest) {
   using namespace ::testing;
   namespace btproto = ::google::bigtable::v2;
 
-  auto reader = new MockReaderSampleRowKeysResponse;
-  auto reader_retry = new MockReaderSampleRowKeysResponse;
+  auto reader = new MockSampleRowKeysReader;
+  auto reader_retry = new MockSampleRowKeysReader;
   EXPECT_CALL(*bigtable_stub_, SampleRowKeysRaw(_, _))
       .WillOnce(Return(reader))
       .WillOnce(Return(reader_retry));
@@ -915,7 +901,7 @@ TEST_F(TableSampleRowKeysTest, TooManyFailures) {
       ::bigtable::SafeIdempotentMutationPolicy());
 
   // Setup the mocks to fail more than 3 times.
-  auto r1 = new MockReaderSampleRowKeysResponse;
+  auto r1 = new MockSampleRowKeysReader;
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::SampleRowKeysResponse* r) {
         {
@@ -930,7 +916,7 @@ TEST_F(TableSampleRowKeysTest, TooManyFailures) {
 
   auto create_cancelled_stream = [&](grpc::ClientContext*,
                                      btproto::SampleRowKeysRequest const&) {
-    auto stream = new MockReaderSampleRowKeysResponse;
+    auto stream = new MockSampleRowKeysReader;
     EXPECT_CALL(*stream, Read(_)).WillOnce(Return(false));
     EXPECT_CALL(*stream, Finish())
         .WillOnce(Return(grpc::Status(grpc::StatusCode::ABORTED, "")));

--- a/bigtable/client/table_readrow_test.cc
+++ b/bigtable/client/table_readrow_test.cc
@@ -14,11 +14,13 @@
 
 #include "bigtable/client/internal/make_unique.h"
 #include "bigtable/client/table.h"
+#include "bigtable/client/testing/mock_read_rows_reader.h"
 #include "bigtable/client/testing/table_test_fixture.h"
 
 /// Define helper types and functions for this test.
 namespace {
 class TableReadRowTest : public bigtable::testing::TableTestFixture {};
+using bigtable::testing::MockReadRowsReader;
 }  // anonymous namespace
 
 TEST_F(TableReadRowTest, ReadRowSimple) {
@@ -36,8 +38,7 @@ TEST_F(TableReadRowTest, ReadRowSimple) {
       }
 )");
 
-  auto stream =
-      bigtable::internal::make_unique<bigtable::testing::MockResponseStream>();
+  auto stream = bigtable::internal::make_unique<MockReadRowsReader>();
   EXPECT_CALL(*stream, Read(_))
       .WillOnce(Invoke([&response](btproto::ReadRowsResponse* r) {
         *r = response;
@@ -66,8 +67,7 @@ TEST_F(TableReadRowTest, ReadRowMissing) {
   using namespace ::testing;
   namespace btproto = ::google::bigtable::v2;
 
-  auto stream =
-      bigtable::internal::make_unique<bigtable::testing::MockResponseStream>();
+  auto stream = bigtable::internal::make_unique<MockReadRowsReader>();
   EXPECT_CALL(*stream, Read(_)).WillOnce(Return(false));
   EXPECT_CALL(*stream, Finish()).WillOnce(Return(grpc::Status::OK));
 

--- a/bigtable/client/testing/internal_table_test_fixture.h
+++ b/bigtable/client/testing/internal_table_test_fixture.h
@@ -17,7 +17,6 @@
 
 #include "bigtable/client/internal/table.h"
 #include "bigtable/client/testing/mock_data_client.h"
-#include "bigtable/client/testing/mock_response_stream.h"
 
 namespace bigtable {
 namespace testing {

--- a/bigtable/client/testing/mock_mutate_rows_reader.h
+++ b/bigtable/client/testing/mock_mutate_rows_reader.h
@@ -1,0 +1,31 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_MUTATE_ROWS_READER_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_MUTATE_ROWS_READER_H_
+
+#include "mock_response_reader.h"
+#include <google/bigtable/v2/bigtable.pb.h>
+#include <gmock/gmock.h>
+
+namespace bigtable {
+namespace testing {
+using MockMutateRowsReader =
+    MockResponseReader<google::bigtable::v2::MutateRowsResponse,
+                       google::bigtable::v2::MutateRowsRequest>;
+
+}  // namespace testing
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_MUTATE_ROWS_READER_H_

--- a/bigtable/client/testing/mock_read_rows_reader.h
+++ b/bigtable/client/testing/mock_read_rows_reader.h
@@ -1,0 +1,31 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_READ_ROWS_READER_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_READ_ROWS_READER_H_
+
+#include "mock_response_reader.h"
+#include <google/bigtable/v2/bigtable.grpc.pb.h>
+#include <gmock/gmock.h>
+
+namespace bigtable {
+namespace testing {
+using MockReadRowsReader =
+    MockResponseReader<google::bigtable::v2::ReadRowsResponse,
+                       google::bigtable::v2::ReadRowsRequest>;
+
+}  // namespace testing
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_READ_ROWS_READER_H_

--- a/bigtable/client/testing/mock_response_reader.h
+++ b/bigtable/client/testing/mock_response_reader.h
@@ -1,0 +1,43 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_RESPONSE_READER_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_RESPONSE_READER_H_
+
+#include <gmock/gmock.h>
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/impl/codegen/sync_stream.h>
+
+namespace bigtable {
+namespace testing {
+/**
+ * Refactor code common to several mock objects.
+ *
+ * Mocking a grpc::ClientReaderInterface<> was getting tedious.
+ *
+ * @tparam Response the response type.
+ */
+template <typename Response, typename Request>
+class MockResponseReader : public grpc::ClientReaderInterface<Response> {
+ public:
+  MOCK_METHOD0(WaitForInitialMetadata, void());
+  MOCK_METHOD0(Finish, grpc::Status());
+  MOCK_METHOD1(NextMessageSize, bool(std::uint32_t*));
+  MOCK_METHOD1_T(Read, bool(Response*));
+};
+
+}  // namespace testing
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_RESPONSE_READER_H_

--- a/bigtable/client/testing/mock_sample_row_keys_reader.h
+++ b/bigtable/client/testing/mock_sample_row_keys_reader.h
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,24 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_RESPONSE_STREAM_H_
-#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_RESPONSE_STREAM_H_
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_SAMPLE_ROW_KEYS_READER_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_SAMPLE_ROW_KEYS_READER_H_
 
-#include <google/bigtable/v2/bigtable.pb.h>
+#include "mock_response_reader.h"
+#include <google/bigtable/v2/bigtable.grpc.pb.h>
 #include <gmock/gmock.h>
 
 namespace bigtable {
 namespace testing {
-class MockResponseStream : public grpc::ClientReaderInterface<
-                               ::google::bigtable::v2::ReadRowsResponse> {
- public:
-  MOCK_METHOD0(WaitForInitialMetadata, void());
-  MOCK_METHOD0(Finish, grpc::Status());
-  MOCK_METHOD1(NextMessageSize, bool(std::uint32_t*));
-  MOCK_METHOD1(Read, bool(::google::bigtable::v2::ReadRowsResponse*));
-};
+using MockSampleRowKeysReader =
+    MockResponseReader<google::bigtable::v2::SampleRowKeysResponse,
+                       google::bigtable::v2::SampleRowKeysRequest>;
 
 }  // namespace testing
 }  // namespace bigtable
 
-#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_RESPONSE_STREAM_H_
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_SAMPLE_ROW_KEYS_READER_H_

--- a/bigtable/client/testing/table_integration_test.h
+++ b/bigtable/client/testing/table_integration_test.h
@@ -20,8 +20,7 @@
 #include "bigtable/client/data_client.h"
 #include "bigtable/client/table.h"
 #include "bigtable/client/table_admin.h"
-#include "bigtable/client/testing/mock_data_client.h"
-#include "bigtable/client/testing/mock_response_stream.h"
+#include <gmock/gmock.h>
 
 namespace bigtable {
 namespace testing {

--- a/bigtable/client/testing/table_test_fixture.h
+++ b/bigtable/client/testing/table_test_fixture.h
@@ -17,7 +17,6 @@
 
 #include "bigtable/client/table.h"
 #include "bigtable/client/testing/mock_data_client.h"
-#include "bigtable/client/testing/mock_response_stream.h"
 
 namespace bigtable {
 namespace testing {


### PR DESCRIPTION
Several tests were re-implementing the same mocks. Refactored
them to the testing library.  This will be more handy for
future changes related to #433.