### PR TITLE
Refactor AdminClient to support multiple services.

### DIFF
--- a/bigtable/client/CMakeLists.txt
+++ b/bigtable/client/CMakeLists.txt
@@ -123,10 +123,12 @@ add_library(bigtable_client_testing
         testing/embedded_server_test_fixture.cc
         testing/internal_table_test_fixture.h
         testing/internal_table_test_fixture.cc
+        testing/mock_admin_client.h
         testing/mock_data_client.h
         testing/mock_instance_admin_client.h
         testing/inprocess_data_client.h
         testing/inprocess_admin_client.h
+        testing/inprocess_admin_client.cc
         testing/mock_mutate_rows_reader.h
         testing/mock_read_rows_reader.h
         testing/mock_response_reader.h

--- a/bigtable/client/admin_client.cc
+++ b/bigtable/client/admin_client.cc
@@ -16,6 +16,8 @@
 #include "bigtable/client/internal/common_client.h"
 
 namespace {
+namespace btadmin = google::bigtable::admin::v2;
+
 /**
  * An AdminClient for single-threaded programs that refreshes credentials on all
  * gRPC errors.
@@ -39,8 +41,8 @@ class DefaultAdminClient : public bigtable::AdminClient {
     }
   };
 
-  using Impl = bigtable::internal::CommonClient<
-      AdminTraits, ::google::bigtable::admin::v2::BigtableTableAdmin>;
+  using Impl = bigtable::internal::CommonClient<AdminTraits,
+                                                btadmin::BigtableTableAdmin>;
 
  public:
   using AdminStubPtr = Impl::StubPtr;
@@ -49,9 +51,92 @@ class DefaultAdminClient : public bigtable::AdminClient {
       : project_(std::move(project)), impl_(std::move(options)) {}
 
   std::string const& project() const override { return project_; }
-  AdminStubPtr Stub() override { return impl_.Stub(); }
+  std::shared_ptr<grpc::Channel> Channel() override { return impl_.Channel(); }
   void reset() override { return impl_.reset(); }
-  void on_completion(grpc::Status const& status) override {}
+
+  grpc::Status CreateTable(grpc::ClientContext* context,
+                           btadmin::CreateTableRequest const& request,
+                           btadmin::Table* response) override {
+    return impl_.Stub()->CreateTable(context, request, response);
+  }
+
+  grpc::Status CreateTableFromSnapshot(
+      grpc::ClientContext* context,
+      btadmin::CreateTableFromSnapshotRequest const& request,
+      google::longrunning::Operation* response) override {
+    return impl_.Stub()->CreateTableFromSnapshot(context, request, response);
+  }
+
+  grpc::Status ListTables(grpc::ClientContext* context,
+                          btadmin::ListTablesRequest const& request,
+                          btadmin::ListTablesResponse* response) override {
+    return impl_.Stub()->ListTables(context, request, response);
+  }
+
+  grpc::Status GetTable(grpc::ClientContext* context,
+                        btadmin::GetTableRequest const& request,
+                        btadmin::Table* response) override {
+    return impl_.Stub()->GetTable(context, request, response);
+  }
+
+  grpc::Status DeleteTable(grpc::ClientContext* context,
+                           btadmin::DeleteTableRequest const& request,
+                           google::protobuf::Empty* response) override {
+    return impl_.Stub()->DeleteTable(context, request, response);
+  }
+
+  grpc::Status ModifyColumnFamilies(
+      grpc::ClientContext* context,
+      btadmin::ModifyColumnFamiliesRequest const& request,
+      btadmin::Table* response) override {
+    return impl_.Stub()->ModifyColumnFamilies(context, request, response);
+  }
+
+  grpc::Status DropRowRange(grpc::ClientContext* context,
+                            btadmin::DropRowRangeRequest const& request,
+                            google::protobuf::Empty* response) override {
+    return impl_.Stub()->DropRowRange(context, request, response);
+  }
+
+  grpc::Status GenerateConsistencyToken(
+      grpc::ClientContext* context,
+      btadmin::GenerateConsistencyTokenRequest const& request,
+      btadmin::GenerateConsistencyTokenResponse* response) override {
+    return impl_.Stub()->GenerateConsistencyToken(context, request, response);
+  }
+
+  grpc::Status CheckConsistency(
+      grpc::ClientContext* context,
+      btadmin::CheckConsistencyRequest const& request,
+      btadmin::CheckConsistencyResponse* response) override {
+    return impl_.Stub()->CheckConsistency(context, request, response);
+  }
+
+  grpc::Status SnapshotTable(
+      grpc::ClientContext* context,
+      btadmin::SnapshotTableRequest const& request,
+      google::longrunning::Operation* response) override {
+    return impl_.Stub()->SnapshotTable(context, request, response);
+  }
+
+  grpc::Status GetSnapshot(grpc::ClientContext* context,
+                           btadmin::GetSnapshotRequest const& request,
+                           btadmin::Snapshot* response) override {
+    return impl_.Stub()->GetSnapshot(context, request, response);
+  }
+
+  grpc::Status ListSnapshots(
+      grpc::ClientContext* context,
+      btadmin::ListSnapshotsRequest const& request,
+      btadmin::ListSnapshotsResponse* response) override {
+    return impl_.Stub()->ListSnapshots(context, request, response);
+  }
+
+  grpc::Status DeleteSnapshot(grpc::ClientContext* context,
+                              btadmin::DeleteSnapshotRequest const& request,
+                              google::protobuf::Empty* response) override {
+    return impl_.Stub()->DeleteSnapshot(context, request, response);
+  }
 
  private:
   std::string project_;

--- a/bigtable/client/admin_client.h
+++ b/bigtable/client/admin_client.h
@@ -42,13 +42,16 @@ class AdminClient {
   /// The project that this AdminClient works on.
   virtual std::string const& project() const = 0;
 
-  /// Return a new stub to handle admin operations.
-  virtual std::shared_ptr<
-      ::google::bigtable::admin::v2::BigtableTableAdmin::StubInterface>
-  Stub() = 0;
+  /**
+   * Return a new channel to handle admin operations.
+   *
+   * Intended to access rarely used services in the same endpoints as the
+   * Bigtable admin interfaces, for example, the google.longrunning.Operations.
+   */
+  virtual std::shared_ptr<grpc::Channel> Channel() = 0;
 
   /**
-   * Reset and create a new Stub().
+   * Reset and create new Channels.
    *
    * Currently this is only used in testing.  In the future, we expect this,
    * or a similar member function, will be needed to handle errors that require
@@ -56,13 +59,64 @@ class AdminClient {
    */
   virtual void reset() = 0;
 
-  /**
-   * A callback for completed RPCs.
-   *
-   * Currently this is only used in testing.  In the future, we expect that
-   * some errors may require the class to update its state.
-   */
-  virtual void on_completion(grpc::Status const&) = 0;
+  //@{
+  /// @name the google.bigtable.admin.v2.TableAdmin operations.
+  virtual grpc::Status CreateTable(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::CreateTableRequest const& request,
+      google::bigtable::admin::v2::Table* response) = 0;
+  virtual grpc::Status CreateTableFromSnapshot(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::CreateTableFromSnapshotRequest const&
+          request,
+      google::longrunning::Operation* response) = 0;
+  virtual grpc::Status ListTables(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::ListTablesRequest const& request,
+      google::bigtable::admin::v2::ListTablesResponse* response) = 0;
+  virtual grpc::Status GetTable(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::GetTableRequest const& request,
+      google::bigtable::admin::v2::Table* response) = 0;
+  virtual grpc::Status DeleteTable(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::DeleteTableRequest const& request,
+      google::protobuf::Empty* response) = 0;
+  virtual grpc::Status ModifyColumnFamilies(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::ModifyColumnFamiliesRequest const& request,
+      google::bigtable::admin::v2::Table* response) = 0;
+  virtual grpc::Status DropRowRange(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::DropRowRangeRequest const& request,
+      google::protobuf::Empty* response) = 0;
+  virtual grpc::Status GenerateConsistencyToken(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::GenerateConsistencyTokenRequest const&
+          request,
+      google::bigtable::admin::v2::GenerateConsistencyTokenResponse*
+          response) = 0;
+  virtual grpc::Status CheckConsistency(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::CheckConsistencyRequest const& request,
+      google::bigtable::admin::v2::CheckConsistencyResponse* response) = 0;
+  virtual grpc::Status SnapshotTable(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::SnapshotTableRequest const& request,
+      google::longrunning::Operation* response) = 0;
+  virtual grpc::Status GetSnapshot(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::GetSnapshotRequest const& request,
+      google::bigtable::admin::v2::Snapshot* response) = 0;
+  virtual grpc::Status ListSnapshots(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::ListSnapshotsRequest const& request,
+      google::bigtable::admin::v2::ListSnapshotsResponse* response) = 0;
+  virtual grpc::Status DeleteSnapshot(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::DeleteSnapshotRequest const& request,
+      google::protobuf::Empty* response) = 0;
+  //@}
 };
 
 /// Create a new admin client configured via @p options.

--- a/bigtable/client/admin_client_test.cc
+++ b/bigtable/client/admin_client_test.cc
@@ -21,14 +21,14 @@ TEST(AdminClientTest, Default) {
   ASSERT_TRUE(admin_client);
   EXPECT_EQ("test-project", admin_client->project());
 
-  auto stub0 = admin_client->Stub();
-  EXPECT_TRUE(stub0);
+  auto channel0 = admin_client->Channel();
+  EXPECT_TRUE(channel0);
 
-  auto stub1 = admin_client->Stub();
-  EXPECT_EQ(stub0.get(), stub1.get());
+  auto channel1 = admin_client->Channel();
+  EXPECT_EQ(channel0.get(), channel1.get());
 
   admin_client->reset();
-  stub1 = admin_client->Stub();
-  EXPECT_TRUE(stub1);
-  EXPECT_NE(stub0.get(), stub1.get());
+  channel1 = admin_client->Channel();
+  EXPECT_TRUE(channel1);
+  EXPECT_NE(channel0.get(), channel1.get());
 }

--- a/bigtable/client/instance_admin.h
+++ b/bigtable/client/instance_admin.h
@@ -17,7 +17,6 @@
 
 #include "bigtable/client/instance_admin_client.h"
 #include "bigtable/client/internal/instance_admin.h"
-#include "bigtable/client/internal/unary_rpc_utils.h"
 #include <memory>
 
 namespace bigtable {

--- a/bigtable/client/internal/table_admin.h
+++ b/bigtable/client/internal/table_admin.h
@@ -17,7 +17,9 @@
 
 #include "bigtable/client/admin_client.h"
 #include "bigtable/client/column_family.h"
-#include "bigtable/client/internal/unary_rpc_utils.h"
+#include "bigtable/client/metadata_update_policy.h"
+#include "bigtable/client/rpc_backoff_policy.h"
+#include "bigtable/client/rpc_retry_policy.h"
 #include "bigtable/client/table_admin_strong_types.h"
 #include "bigtable/client/table_config.h"
 #include <memory>
@@ -172,17 +174,13 @@ class TableAdmin {
       std::function<void(::google::bigtable::admin::v2::Snapshot)> inserter,
       std::function<void()> clearer, grpc::Status& status);
 
-  /// Shortcuts to avoid typing long names over and over.
-  using RpcUtils = bigtable::internal::noex::UnaryRpcUtils<AdminClient>;
-  using StubType = RpcUtils::StubType;
-
  private:
   std::shared_ptr<AdminClient> client_;
   std::string instance_id_;
   std::string instance_name_;
   std::shared_ptr<RPCRetryPolicy> rpc_retry_policy_;
   std::shared_ptr<RPCBackoffPolicy> rpc_backoff_policy_;
-  MetadataUpdatePolicy metadata_update_policy_;
+  bigtable::MetadataUpdatePolicy metadata_update_policy_;
 };
 
 }  // namespace noex

--- a/bigtable/client/table_admin.h
+++ b/bigtable/client/table_admin.h
@@ -18,7 +18,6 @@
 #include "bigtable/client/admin_client.h"
 #include "bigtable/client/column_family.h"
 #include "bigtable/client/internal/table_admin.h"
-#include "bigtable/client/internal/unary_rpc_utils.h"
 #include "bigtable/client/table_admin_strong_types.h"
 #include "bigtable/client/table_config.h"
 #include <memory>

--- a/bigtable/client/testing/inprocess_admin_client.cc
+++ b/bigtable/client/testing/inprocess_admin_client.cc
@@ -1,0 +1,105 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/client/testing/inprocess_admin_client.h"
+
+namespace bigtable {
+namespace testing {
+
+namespace btadmin = google::bigtable::admin::v2;
+
+grpc::Status InProcessAdminClient::CreateTable(
+    grpc::ClientContext* context, btadmin::CreateTableRequest const& request,
+    btadmin::Table* response) {
+  return Stub()->CreateTable(context, request, response);
+}
+
+grpc::Status InProcessAdminClient::CreateTableFromSnapshot(
+    grpc::ClientContext* context,
+    btadmin::CreateTableFromSnapshotRequest const& request,
+    google::longrunning::Operation* response) {
+  return Stub()->CreateTableFromSnapshot(context, request, response);
+}
+
+grpc::Status InProcessAdminClient::ListTables(
+    grpc::ClientContext* context, btadmin::ListTablesRequest const& request,
+    btadmin::ListTablesResponse* response) {
+  return Stub()->ListTables(context, request, response);
+}
+
+grpc::Status InProcessAdminClient::GetTable(
+    grpc::ClientContext* context, btadmin::GetTableRequest const& request,
+    btadmin::Table* response) {
+  return Stub()->GetTable(context, request, response);
+}
+
+grpc::Status InProcessAdminClient::DeleteTable(
+    grpc::ClientContext* context, btadmin::DeleteTableRequest const& request,
+    google::protobuf::Empty* response) {
+  return Stub()->DeleteTable(context, request, response);
+}
+
+grpc::Status InProcessAdminClient::ModifyColumnFamilies(
+    grpc::ClientContext* context,
+    btadmin::ModifyColumnFamiliesRequest const& request,
+    btadmin::Table* response) {
+  return Stub()->ModifyColumnFamilies(context, request, response);
+}
+
+grpc::Status InProcessAdminClient::DropRowRange(
+    grpc::ClientContext* context, btadmin::DropRowRangeRequest const& request,
+    google::protobuf::Empty* response) {
+  return Stub()->DropRowRange(context, request, response);
+}
+
+grpc::Status InProcessAdminClient::GenerateConsistencyToken(
+    grpc::ClientContext* context,
+    btadmin::GenerateConsistencyTokenRequest const& request,
+    btadmin::GenerateConsistencyTokenResponse* response) {
+  return Stub()->GenerateConsistencyToken(context, request, response);
+}
+
+grpc::Status InProcessAdminClient::CheckConsistency(
+    grpc::ClientContext* context,
+    btadmin::CheckConsistencyRequest const& request,
+    btadmin::CheckConsistencyResponse* response) {
+  return Stub()->CheckConsistency(context, request, response);
+}
+
+grpc::Status InProcessAdminClient::SnapshotTable(
+    grpc::ClientContext* context, btadmin::SnapshotTableRequest const& request,
+    google::longrunning::Operation* response) {
+  return Stub()->SnapshotTable(context, request, response);
+}
+
+grpc::Status InProcessAdminClient::GetSnapshot(
+    grpc::ClientContext* context, btadmin::GetSnapshotRequest const& request,
+    btadmin::Snapshot* response) {
+  return Stub()->GetSnapshot(context, request, response);
+}
+
+grpc::Status InProcessAdminClient::ListSnapshots(
+    grpc::ClientContext* context, btadmin::ListSnapshotsRequest const& request,
+    btadmin::ListSnapshotsResponse* response) {
+  return Stub()->ListSnapshots(context, request, response);
+}
+
+grpc::Status InProcessAdminClient::DeleteSnapshot(
+    grpc::ClientContext* context, btadmin::DeleteSnapshotRequest const& request,
+    google::protobuf::Empty* response) {
+  return Stub()->DeleteSnapshot(context, request, response);
+}
+
+}  // namespace testing
+}  // namespace bigtable

--- a/bigtable/client/testing/inprocess_admin_client.h
+++ b/bigtable/client/testing/inprocess_admin_client.h
@@ -19,8 +19,6 @@
 #include "bigtable/client/client_options.h"
 #include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
 
-namespace btadmin = ::google::bigtable::admin::v2;
-
 namespace bigtable {
 namespace testing {
 
@@ -37,22 +35,81 @@ class InProcessAdminClient : public bigtable::AdminClient {
                        std::shared_ptr<grpc::Channel> channel)
       : project_(std::move(project)), channel_(std::move(channel)) {}
 
-  using BigtableAdminStubPtr =
-      std::shared_ptr<btadmin::BigtableTableAdmin::StubInterface>;
+  std::unique_ptr<
+      google::bigtable::admin::v2::BigtableTableAdmin::StubInterface>
+  Stub() {
+    return google::bigtable::admin::v2::BigtableTableAdmin::NewStub(channel_);
+  }
 
   std::string const& project() const override { return project_; }
-  BigtableAdminStubPtr Stub() override {
-    return btadmin::BigtableTableAdmin::NewStub(channel_);
-  }
+  std::shared_ptr<grpc::Channel> Channel() override { return channel_; }
   void reset() override {}
-  void on_completion(grpc::Status const& status) override {}
+
+  //@{
+  /// @name the google.bigtable.admin.v2.TableAdmin operations.
+  virtual grpc::Status CreateTable(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::CreateTableRequest const& request,
+      google::bigtable::admin::v2::Table* response) override;
+  virtual grpc::Status CreateTableFromSnapshot(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::CreateTableFromSnapshotRequest const&
+          request,
+      google::longrunning::Operation* response) override;
+  virtual grpc::Status ListTables(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::ListTablesRequest const& request,
+      google::bigtable::admin::v2::ListTablesResponse* response) override;
+  virtual grpc::Status GetTable(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::GetTableRequest const& request,
+      google::bigtable::admin::v2::Table* response) override;
+  virtual grpc::Status DeleteTable(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::DeleteTableRequest const& request,
+      google::protobuf::Empty* response) override;
+  virtual grpc::Status ModifyColumnFamilies(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::ModifyColumnFamiliesRequest const& request,
+      google::bigtable::admin::v2::Table* response) override;
+  virtual grpc::Status DropRowRange(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::DropRowRangeRequest const& request,
+      google::protobuf::Empty* response) override;
+  virtual grpc::Status GenerateConsistencyToken(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::GenerateConsistencyTokenRequest const&
+          request,
+      google::bigtable::admin::v2::GenerateConsistencyTokenResponse* response)
+      override;
+  virtual grpc::Status CheckConsistency(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::CheckConsistencyRequest const& request,
+      google::bigtable::admin::v2::CheckConsistencyResponse* response) override;
+  virtual grpc::Status SnapshotTable(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::SnapshotTableRequest const& request,
+      google::longrunning::Operation* response) override;
+  virtual grpc::Status GetSnapshot(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::GetSnapshotRequest const& request,
+      google::bigtable::admin::v2::Snapshot* response) override;
+  virtual grpc::Status ListSnapshots(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::ListSnapshotsRequest const& request,
+      google::bigtable::admin::v2::ListSnapshotsResponse* response) override;
+  virtual grpc::Status DeleteSnapshot(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::DeleteSnapshotRequest const& request,
+      google::protobuf::Empty* response) override;
+  //@}
 
  private:
   std::string project_;
   std::shared_ptr<grpc::Channel> channel_;
 };
 
-}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace testing
 }  // namespace bigtable
 
 #endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_INPROCESS_ADMIN_CLIENT_H_

--- a/bigtable/client/testing/mock_admin_client.h
+++ b/bigtable/client/testing/mock_admin_client.h
@@ -1,0 +1,112 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_ADMIN_CLIENT_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_ADMIN_CLIENT_H_
+
+#include "bigtable/client/admin_client.h"
+#include <gmock/gmock.h>
+
+namespace bigtable {
+namespace testing {
+
+class MockAdminClient : public bigtable::AdminClient {
+ public:
+  MOCK_CONST_METHOD0(project, std::string const&());
+  MOCK_METHOD0(Channel, std::shared_ptr<grpc::Channel>());
+  MOCK_METHOD0(reset, void());
+
+  MOCK_METHOD3(
+      CreateTable,
+      grpc::Status(
+          grpc::ClientContext* context,
+          google::bigtable::admin::v2::CreateTableRequest const& request,
+          google::bigtable::admin::v2::Table* response));
+  MOCK_METHOD3(CreateTableFromSnapshot,
+               grpc::Status(grpc::ClientContext* context,
+                            google::bigtable::admin::v2::
+                                CreateTableFromSnapshotRequest const& request,
+                            google::longrunning::Operation* response));
+  MOCK_METHOD3(
+      ListTables,
+      grpc::Status(
+          grpc::ClientContext* context,
+          google::bigtable::admin::v2::ListTablesRequest const& request,
+          google::bigtable::admin::v2::ListTablesResponse* response));
+  MOCK_METHOD3(
+      GetTable,
+      grpc::Status(grpc::ClientContext* context,
+                   google::bigtable::admin::v2::GetTableRequest const& request,
+                   google::bigtable::admin::v2::Table* response));
+  MOCK_METHOD3(
+      DeleteTable,
+      grpc::Status(
+          grpc::ClientContext* context,
+          google::bigtable::admin::v2::DeleteTableRequest const& request,
+          google::protobuf::Empty* response));
+  MOCK_METHOD3(ModifyColumnFamilies,
+               grpc::Status(grpc::ClientContext* context,
+                            google::bigtable::admin::v2::
+                                ModifyColumnFamiliesRequest const& request,
+                            google::bigtable::admin::v2::Table* response));
+  MOCK_METHOD3(
+      DropRowRange,
+      grpc::Status(
+          grpc::ClientContext* context,
+          google::bigtable::admin::v2::DropRowRangeRequest const& request,
+          google::protobuf::Empty* response));
+  MOCK_METHOD3(
+      GenerateConsistencyToken,
+      grpc::Status(
+          grpc::ClientContext* context,
+          google::bigtable::admin::v2::GenerateConsistencyTokenRequest const&
+              request,
+          google::bigtable::admin::v2::GenerateConsistencyTokenResponse*
+              response));
+  MOCK_METHOD3(
+      CheckConsistency,
+      grpc::Status(
+          grpc::ClientContext* context,
+          google::bigtable::admin::v2::CheckConsistencyRequest const& request,
+          google::bigtable::admin::v2::CheckConsistencyResponse* response));
+  MOCK_METHOD3(
+      SnapshotTable,
+      grpc::Status(
+          grpc::ClientContext* context,
+          google::bigtable::admin::v2::SnapshotTableRequest const& request,
+          google::longrunning::Operation* response));
+  MOCK_METHOD3(
+      GetSnapshot,
+      grpc::Status(
+          grpc::ClientContext* context,
+          google::bigtable::admin::v2::GetSnapshotRequest const& request,
+          google::bigtable::admin::v2::Snapshot* response));
+  MOCK_METHOD3(
+      ListSnapshots,
+      grpc::Status(
+          grpc::ClientContext* context,
+          google::bigtable::admin::v2::ListSnapshotsRequest const& request,
+          google::bigtable::admin::v2::ListSnapshotsResponse* response));
+  MOCK_METHOD3(
+      DeleteSnapshot,
+      grpc::Status(
+          grpc::ClientContext* context,
+          google::bigtable::admin::v2::DeleteSnapshotRequest const& request,
+          google::protobuf::Empty* response));
+};
+
+}  // namespace testing
+}  // namespace bigtable
+
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_ADMIN_CLIENT_H_


### PR DESCRIPTION
This is a large change. It is part of the fixes for #433 and
for #418. The current implementation of bigtable::*Client makes
it really hard to write tests that use multiple services, and
when using long running operations you need to access at least
two services.

The good news is that the tests and some of the helpers get
easier to write, and this does not affect any of the APIs exposed
to the user.