### PR TITLE
Handle special types of ranges

### DIFF
--- a/bigtable/client/row_range.cc
+++ b/bigtable/client/row_range.cc
@@ -52,6 +52,14 @@ bool RowRange::IsEmpty() const {
       return false;
   }
 
+  // Special case of an open interval of two consecutive strings.
+  // The only way for two strings to be consecutive is for the
+  // second to be equal to the first with an appended zero char.
+  if (start_open and end_open and (end->length() == start->length() + 1) and
+      (*(end->rbegin()) == '\0') and
+      (end->compare(0, start->length(), *start) == 0))
+    return true;
+
   // Compare the strings as byte vectors (careful with unsigned chars).
   int cmp = start->compare(*end);
   if (cmp == 0) {

--- a/bigtable/client/row_range.h
+++ b/bigtable/client/row_range.h
@@ -64,8 +64,10 @@ class RowRange {
   /// Return an empty range.
   static RowRange Empty() {
     RowRange result;
+    // Return an open interval that contains no key, using "\0" for the end key.
+    // We can't use "", because when appearing as the end it means 'infinity'.
     result.row_range_.set_start_key_open("");
-    result.row_range_.set_end_key_open("");
+    result.row_range_.set_end_key_open(std::string("\0", 1));
     return result;
   }
 
@@ -85,9 +87,7 @@ class RowRange {
   /// Return a range representing the interval [@p begin, @p end).
   static RowRange RightOpen(std::string begin, std::string end) {
     RowRange result;
-    if (not begin.empty()) {
-      result.row_range_.set_start_key_closed(std::move(begin));
-    }
+    result.row_range_.set_start_key_closed(std::move(begin));
     if (not end.empty()) {
       result.row_range_.set_end_key_open(std::move(end));
     }
@@ -97,9 +97,7 @@ class RowRange {
   /// Return a range representing the interval (@p begin, @p end].
   static RowRange LeftOpen(std::string begin, std::string end) {
     RowRange result;
-    if (not begin.empty()) {
-      result.row_range_.set_start_key_open(std::move(begin));
-    }
+    result.row_range_.set_start_key_open(std::move(begin));
     if (not end.empty()) {
       result.row_range_.set_end_key_closed(std::move(end));
     }
@@ -109,9 +107,7 @@ class RowRange {
   /// Return a range representing the interval (@p begin, @p end).
   static RowRange Open(std::string begin, std::string end) {
     RowRange result;
-    if (not begin.empty()) {
-      result.row_range_.set_start_key_open(std::move(begin));
-    }
+    result.row_range_.set_start_key_open(std::move(begin));
     if (not end.empty()) {
       result.row_range_.set_end_key_open(std::move(end));
     }
@@ -121,9 +117,7 @@ class RowRange {
   /// Return a range representing the interval [@p begin, @p end].
   static RowRange Closed(std::string begin, std::string end) {
     RowRange result;
-    if (not begin.empty()) {
-      result.row_range_.set_start_key_closed(std::move(begin));
-    }
+    result.row_range_.set_start_key_closed(std::move(begin));
     if (not end.empty()) {
       result.row_range_.set_end_key_closed(std::move(end));
     }

--- a/bigtable/client/row_range_test.cc
+++ b/bigtable/client/row_range_test.cc
@@ -94,8 +94,10 @@ TEST(RowRangeTest, IsEmpty) {
   EXPECT_TRUE(bigtable::RowRange::Range("foo", "foo").IsEmpty());
   EXPECT_TRUE(bigtable::RowRange::Range("foo", "bar").IsEmpty());
   EXPECT_FALSE(bigtable::RowRange::StartingAt("").IsEmpty());
-  EXPECT_FALSE(
-      bigtable::RowRange::RightOpen("", std::string("\0", 1)).IsEmpty());
+
+  std::string const only_00 = std::string("\0", 1);
+  EXPECT_FALSE(bigtable::RowRange::RightOpen("", only_00).IsEmpty());
+  EXPECT_TRUE(bigtable::RowRange::Open("", only_00).IsEmpty());
 }
 
 TEST(RowRangeTest, ContainsRightOpen) {

--- a/bigtable/client/row_range_test.cc
+++ b/bigtable/client/row_range_test.cc
@@ -291,7 +291,7 @@ TEST(RowRangeTest, EqualsStartingAt) {
 TEST(RowRangeTest, EqualsEndingAt) {
   using R = bigtable::RowRange;
   EXPECT_EQ(R::EndingAt("b"), R::EndingAt("b"));
-  EXPECT_EQ(R::EndingAt("b"), R::Closed("", "b"));
+  EXPECT_NE(R::EndingAt("b"), R::Closed("", "b"));
   EXPECT_NE(R::EndingAt("b"), R::EndingAt("a"));
   EXPECT_NE(R::EndingAt("b"), R::RightOpen("a", "b"));
   EXPECT_NE(R::EndingAt("b"), R::LeftOpen("a", "b"));

--- a/bigtable/client/row_set_test.cc
+++ b/bigtable/client/row_set_test.cc
@@ -73,6 +73,8 @@ TEST(RowSetTest, VariadicConstructor) {
   ASSERT_EQ(2, proto.row_keys_size());
   EXPECT_EQ("foo", proto.row_keys(0));
   EXPECT_EQ("bar", proto.row_keys(1));
+
+  EXPECT_TRUE(bigtable::RowSet(R::Empty()).IsEmpty());
 }
 
 TEST(RowSetTest, IntersectRightOpen) {


### PR DESCRIPTION
Fixes IsEmpty() for open ranges with consecutive ends.
Returns such a range, namely ("", "\0"), as the Empty() range.
The reason being that a range ending in open "" is considered
infinite by the server side logic.

A side effect of the change is that we explicitly set the
beginning of the ranges even if it is an empty string,
which makes things like
```cpp
EXPECT_TRUE(bigtable::RowRange::Open("", only_00).IsEmpty());
```
behave more predictably.

Fixes #404 