### PR TITLE
Minimal implementation of InstanceAdmin::CreateInstance

### DIFF
--- a/bigtable/client/instance_admin.cc
+++ b/bigtable/client/instance_admin.cc
@@ -67,7 +67,7 @@ google::bigtable::admin::v2::Instance InstanceAdmin::CreateInstanceImpl(
       request, error.c_str(), status, false);
   if (not status.ok()) {
     bigtable::internal::RaiseRpcError(
-        status, "unrecoverable error calling InstanceAdmin::CreateInstance()");
+        status, "unrecoverable error in MakeCall()");
   }
 
   google::bigtable::admin::v2::Instance result;

--- a/bigtable/client/instance_admin.cc
+++ b/bigtable/client/instance_admin.cc
@@ -66,8 +66,8 @@ google::bigtable::admin::v2::Instance InstanceAdmin::CreateInstanceImpl(
       impl_.metadata_update_policy_, &InstanceAdminClient::CreateInstance,
       request, error.c_str(), status, false);
   if (not status.ok()) {
-    bigtable::internal::RaiseRpcError(
-        status, "unrecoverable error in MakeCall()");
+    bigtable::internal::RaiseRpcError(status,
+                                      "unrecoverable error in MakeCall()");
   }
 
   google::bigtable::admin::v2::Instance result;

--- a/bigtable/client/instance_admin.h
+++ b/bigtable/client/instance_admin.h
@@ -16,7 +16,9 @@
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INSTANCE_ADMIN_H_
 
 #include "bigtable/client/instance_admin_client.h"
+#include "bigtable/client/instance_config.h"
 #include "bigtable/client/internal/instance_admin.h"
+#include <future>
 #include <memory>
 
 namespace bigtable {
@@ -54,10 +56,34 @@ class InstanceAdmin {
   std::string const& project_id() const { return impl_.project_id(); }
 
   /**
+   * Create a new instance of Cloud Bigtable.
+   *
+   * @warning Note that this is operation can take seconds or minutes to
+   * complete. The application may prefer to perform other work while waiting
+   * for this operation.
+   *
+   * @param instance_config a description of the new instance to be created.
+   * @return a future that becomes satisfied when (a) the operation has
+   *   completed successfully, in which case it returns a proto with the
+   *   Instance details, (b) the operation has failed, in which case the future
+   *   contains an exception (typically `bigtable::GrpcError`) with the details
+   *   of the failure, or (c) the state of the operation is unknown after the
+   *   time allocated by the retry policies has expired, in which case the
+   *   future contains an exception of type `bigtable::PollTimeout`.
+   */
+  std::future<google::bigtable::admin::v2::Instance> CreateInstance(
+      InstanceConfig instance_config);
+
+  /**
    * Return the list of instances in the project.
    * @return
    */
   std::vector<google::bigtable::admin::v2::Instance> ListInstances();
+
+ private:
+  /// Implement CreateInstance() with a separate thread.
+  google::bigtable::admin::v2::Instance CreateInstanceImpl(
+      InstanceConfig instance_config);
 
  private:
   noex::InstanceAdmin impl_;

--- a/bigtable/client/instance_admin_client.cc
+++ b/bigtable/client/instance_admin_client.cc
@@ -14,6 +14,7 @@
 
 #include "bigtable/client/instance_admin_client.h"
 #include "bigtable/client/internal/common_client.h"
+#include <google/longrunning/operations.grpc.pb.h>
 
 namespace {
 /**
@@ -58,6 +59,21 @@ class DefaultInstanceAdminClient : public bigtable::InstanceAdminClient {
       google::bigtable::admin::v2::ListInstancesRequest const& request,
       google::bigtable::admin::v2::ListInstancesResponse* response) override {
     return impl_.Stub()->ListInstances(context, request, response);
+  }
+
+  grpc::Status CreateInstance(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::CreateInstanceRequest const& request,
+      google::longrunning::Operation* response) override {
+    return impl_.Stub()->CreateInstance(context, request, response);
+  }
+
+  grpc::Status GetOperation(
+      grpc::ClientContext* context,
+      google::longrunning::GetOperationRequest const& request,
+      google::longrunning::Operation* response) override {
+    auto stub = google::longrunning::Operations::NewStub(Channel());
+    return stub->GetOperation(context, request, response);
   }
 
   DefaultInstanceAdminClient(DefaultInstanceAdminClient const&) = delete;

--- a/bigtable/client/instance_admin_client.h
+++ b/bigtable/client/instance_admin_client.h
@@ -61,6 +61,19 @@ class InstanceAdminClient {
       grpc::ClientContext* context,
       google::bigtable::admin::v2::ListInstancesRequest const& request,
       google::bigtable::admin::v2::ListInstancesResponse* response) = 0;
+
+  virtual grpc::Status CreateInstance(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::CreateInstanceRequest const& request,
+      google::longrunning::Operation* response) = 0;
+
+  //@{
+  /// @name Implement the google.longrunning.Operations wrappers.
+  virtual grpc::Status GetOperation(
+      grpc::ClientContext* context,
+      google::longrunning::GetOperationRequest const& request,
+      google::longrunning::Operation* response) = 0;
+  //@}
 };
 
 /// Create a new admin client configured via @p options.

--- a/bigtable/client/instance_admin_test.cc
+++ b/bigtable/client/instance_admin_test.cc
@@ -294,7 +294,7 @@ TEST_F(InstanceAdminTest, CreateInstanceRequestFailure) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_THROW(future.get(), bigtable::GRpcError);
 #else
-  EXPECT_DEATH_IF_SUPPORTEDTHROW(future.get(), "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(future.get(), "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -379,7 +379,7 @@ TEST_F(InstanceAdminTest, CreateInstancePollUnrecoverableFailure) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_THROW(future.get(), bigtable::GRpcError);
 #else
-  EXPECT_DEATH_IF_SUPPORTEDTHROW(future.get(), "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(future.get(), "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -429,6 +429,6 @@ TEST_F(InstanceAdminTest, CreateInstancePollReturnsFailure) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_THROW(future.get(), bigtable::GRpcError);
 #else
-  EXPECT_DEATH_IF_SUPPORTEDTHROW(future.get(), "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(future.get(), "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }

--- a/bigtable/client/instance_admin_test.cc
+++ b/bigtable/client/instance_admin_test.cc
@@ -15,6 +15,7 @@
 #include "bigtable/client/instance_admin.h"
 #include "bigtable/client/internal/make_unique.h"
 #include "bigtable/client/testing/mock_instance_admin_client.h"
+#include "grpc_error.h"
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
 #include <gmock/gmock.h>
@@ -218,7 +219,7 @@ TEST_F(InstanceAdminTest, ListInstancesUnrecoverableFailures) {
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
-/// @test Verify that `bigtable::InstanceAdmin::CreateInstance works.
+/// @test Verify that `bigtable::InstanceAdmin::CreateInstance` works.
 TEST_F(InstanceAdminTest, CreateInstance) {
   using ::testing::_;
   using ::testing::Invoke;
@@ -243,6 +244,18 @@ type: PRODUCTION
   ASSERT_TRUE(
       google::protobuf::TextFormat::ParseFromString(expected_text, &expected));
   EXPECT_CALL(*client_, GetOperation(_, _, _))
+      .WillOnce(Invoke([](grpc::ClientContext*,
+                          google::longrunning::GetOperationRequest const&,
+                          google::longrunning::Operation* operation) {
+        operation->set_done(false);
+        return grpc::Status::OK;
+      }))
+      .WillOnce(Invoke([](grpc::ClientContext*,
+                          google::longrunning::GetOperationRequest const&,
+                          google::longrunning::Operation* operation) {
+        operation->set_done(false);
+        return grpc::Status::OK;
+      }))
       .WillOnce(Invoke(
           [&expected](grpc::ClientContext*,
                       google::longrunning::GetOperationRequest const& request,
@@ -263,4 +276,159 @@ type: PRODUCTION
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
   EXPECT_TRUE(differencer.Compare(expected, actual)) << delta;
+}
+
+/// @test Failures in `bigtable::InstanceAdmin::CreateInstance`.
+TEST_F(InstanceAdminTest, CreateInstanceRequestFailure) {
+  using namespace ::testing;
+
+  bigtable::InstanceAdmin tested(client_);
+  EXPECT_CALL(*client_, CreateInstance(_, _, _))
+      .WillRepeatedly(
+          Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
+
+  auto future = tested.CreateInstance(bigtable::InstanceConfig(
+      bigtable::InstanceId("test-instance"), bigtable::DisplayName("foo bar"),
+      {{"c1", {"a-zone", 3, bigtable::ClusterConfig::SSD}}}));
+
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(future.get(), bigtable::GRpcError);
+#else
+  EXPECT_DEATH_IF_SUPPORTEDTHROW(future.get(), "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+/// @test Failures while polling in `bigtable::InstanceAdmin::CreateInstance`.
+TEST_F(InstanceAdminTest, CreateInstancePollRecoverableFailures) {
+  using ::testing::_;
+  using ::testing::Invoke;
+
+  bigtable::InstanceAdmin tested(client_);
+  EXPECT_CALL(*client_, CreateInstance(_, _, _))
+      .WillOnce(Invoke([](grpc::ClientContext*,
+                          btproto::CreateInstanceRequest const& request,
+                          google::longrunning::Operation* response) {
+        auto const project_name = "projects/" + kProjectId;
+        EXPECT_EQ(project_name, request.parent());
+        return grpc::Status::OK;
+      }));
+
+  std::string expected_text = R"(
+name: 'projects/my-project/instances/test-instance'
+display_name: 'foo bar'
+state: READY
+type: PRODUCTION
+)";
+  btproto::Instance expected;
+  ASSERT_TRUE(
+      google::protobuf::TextFormat::ParseFromString(expected_text, &expected));
+  EXPECT_CALL(*client_, GetOperation(_, _, _))
+      .WillOnce(Invoke([](grpc::ClientContext*,
+                          google::longrunning::GetOperationRequest const&,
+                          google::longrunning::Operation*) {
+        return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
+      }))
+      .WillOnce(Invoke([](grpc::ClientContext*,
+                          google::longrunning::GetOperationRequest const&,
+                          google::longrunning::Operation*) {
+        return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
+      }))
+      .WillOnce(Invoke(
+          [&expected](grpc::ClientContext*,
+                      google::longrunning::GetOperationRequest const& request,
+                      google::longrunning::Operation* operation) {
+            operation->set_done(true);
+            auto any = bigtable::internal::make_unique<google::protobuf::Any>();
+            any->PackFrom(expected);
+            operation->set_allocated_response(any.release());
+            return grpc::Status::OK;
+          }));
+
+  auto future = tested.CreateInstance(bigtable::InstanceConfig(
+      bigtable::InstanceId("test-instance"), bigtable::DisplayName("foo bar"),
+      {{"c1", {"a-zone", 3, bigtable::ClusterConfig::SSD}}}));
+  auto actual = future.get();
+
+  std::string delta;
+  google::protobuf::util::MessageDifferencer differencer;
+  differencer.ReportDifferencesToString(&delta);
+  EXPECT_TRUE(differencer.Compare(expected, actual)) << delta;
+}
+
+/// @test Failures while polling in `bigtable::InstanceAdmin::CreateInstance`.
+TEST_F(InstanceAdminTest, CreateInstancePollUnrecoverableFailure) {
+  using namespace ::testing;
+
+  bigtable::InstanceAdmin tested(client_);
+  EXPECT_CALL(*client_, CreateInstance(_, _, _))
+      .WillOnce(Invoke([](grpc::ClientContext*,
+                          btproto::CreateInstanceRequest const& request,
+                          google::longrunning::Operation* response) {
+        auto const project_name = "projects/" + kProjectId;
+        EXPECT_EQ(project_name, request.parent());
+        return grpc::Status::OK;
+      }));
+
+  EXPECT_CALL(*client_, GetOperation(_, _, _))
+      .WillRepeatedly(
+          Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
+
+  auto future = tested.CreateInstance(bigtable::InstanceConfig(
+      bigtable::InstanceId("test-instance"), bigtable::DisplayName("foo bar"),
+      {{"c1", {"a-zone", 3, bigtable::ClusterConfig::SSD}}}));
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(future.get(), bigtable::GRpcError);
+#else
+  EXPECT_DEATH_IF_SUPPORTEDTHROW(future.get(), "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+/// @test Polling in `bigtable::InstanceAdmin::CreateInstance` returns failure.
+TEST_F(InstanceAdminTest, CreateInstancePollReturnsFailure) {
+  using ::testing::_;
+  using ::testing::Invoke;
+
+  bigtable::InstanceAdmin tested(client_);
+  EXPECT_CALL(*client_, CreateInstance(_, _, _))
+      .WillOnce(Invoke([](grpc::ClientContext*,
+                          btproto::CreateInstanceRequest const& request,
+                          google::longrunning::Operation* response) {
+        auto const project_name = "projects/" + kProjectId;
+        EXPECT_EQ(project_name, request.parent());
+        return grpc::Status::OK;
+      }));
+
+  EXPECT_CALL(*client_, GetOperation(_, _, _))
+      .WillOnce(Invoke([](grpc::ClientContext*,
+                          google::longrunning::GetOperationRequest const&,
+                          google::longrunning::Operation* operation) {
+        operation->set_done(false);
+        return grpc::Status::OK;
+      }))
+      .WillOnce(Invoke([](grpc::ClientContext*,
+                          google::longrunning::GetOperationRequest const&,
+                          google::longrunning::Operation* operation) {
+        operation->set_done(false);
+        return grpc::Status::OK;
+      }))
+      .WillOnce(
+          Invoke([](grpc::ClientContext*,
+                    google::longrunning::GetOperationRequest const& request,
+                    google::longrunning::Operation* operation) {
+            operation->set_done(true);
+            auto error = bigtable::internal::make_unique<google::rpc::Status>();
+            error->set_code(grpc::StatusCode::FAILED_PRECONDITION);
+            error->set_message("something is broken");
+            operation->set_allocated_error(error.release());
+            return grpc::Status::OK;
+          }));
+
+  auto future = tested.CreateInstance(bigtable::InstanceConfig(
+      bigtable::InstanceId("test-instance"), bigtable::DisplayName("foo bar"),
+      {{"c1", {"a-zone", 3, bigtable::ClusterConfig::SSD}}}));
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(future.get(), bigtable::GRpcError);
+#else
+  EXPECT_DEATH_IF_SUPPORTEDTHROW(future.get(), "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }

--- a/bigtable/client/instance_admin_test.cc
+++ b/bigtable/client/instance_admin_test.cc
@@ -278,26 +278,6 @@ type: PRODUCTION
   EXPECT_TRUE(differencer.Compare(expected, actual)) << delta;
 }
 
-/// @test Failures in `bigtable::InstanceAdmin::CreateInstance`.
-TEST_F(InstanceAdminTest, CreateInstanceRequestFailure) {
-  using namespace ::testing;
-
-  bigtable::InstanceAdmin tested(client_);
-  EXPECT_CALL(*client_, CreateInstance(_, _, _))
-      .WillRepeatedly(
-          Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
-
-  auto future = tested.CreateInstance(bigtable::InstanceConfig(
-      bigtable::InstanceId("test-instance"), bigtable::DisplayName("foo bar"),
-      {{"c1", {"a-zone", 3, bigtable::ClusterConfig::SSD}}}));
-
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(future.get(), bigtable::GRpcError);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(future.get(), "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-}
-
 /// @test Failures while polling in `bigtable::InstanceAdmin::CreateInstance`.
 TEST_F(InstanceAdminTest, CreateInstancePollRecoverableFailures) {
   using ::testing::_;
@@ -355,6 +335,23 @@ type: PRODUCTION
   EXPECT_TRUE(differencer.Compare(expected, actual)) << delta;
 }
 
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+/// @test Failures in `bigtable::InstanceAdmin::CreateInstance`.
+TEST_F(InstanceAdminTest, CreateInstanceRequestFailure) {
+  using namespace ::testing;
+
+  bigtable::InstanceAdmin tested(client_);
+  EXPECT_CALL(*client_, CreateInstance(_, _, _))
+      .WillRepeatedly(
+          Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
+
+  auto future = tested.CreateInstance(bigtable::InstanceConfig(
+      bigtable::InstanceId("test-instance"), bigtable::DisplayName("foo bar"),
+      {{"c1", {"a-zone", 3, bigtable::ClusterConfig::SSD}}}));
+
+  EXPECT_THROW(future.get(), bigtable::GRpcError);
+}
+
 /// @test Failures while polling in `bigtable::InstanceAdmin::CreateInstance`.
 TEST_F(InstanceAdminTest, CreateInstancePollUnrecoverableFailure) {
   using namespace ::testing;
@@ -376,11 +373,7 @@ TEST_F(InstanceAdminTest, CreateInstancePollUnrecoverableFailure) {
   auto future = tested.CreateInstance(bigtable::InstanceConfig(
       bigtable::InstanceId("test-instance"), bigtable::DisplayName("foo bar"),
       {{"c1", {"a-zone", 3, bigtable::ClusterConfig::SSD}}}));
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_THROW(future.get(), bigtable::GRpcError);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(future.get(), "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 /// @test Polling in `bigtable::InstanceAdmin::CreateInstance` returns failure.
@@ -426,9 +419,6 @@ TEST_F(InstanceAdminTest, CreateInstancePollReturnsFailure) {
   auto future = tested.CreateInstance(bigtable::InstanceConfig(
       bigtable::InstanceId("test-instance"), bigtable::DisplayName("foo bar"),
       {{"c1", {"a-zone", 3, bigtable::ClusterConfig::SSD}}}));
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_THROW(future.get(), bigtable::GRpcError);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(future.get(), "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS

--- a/bigtable/client/internal/instance_admin.h
+++ b/bigtable/client/internal/instance_admin.h
@@ -23,6 +23,7 @@
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+class InstanceAdmin;
 namespace noex {
 
 /**
@@ -77,6 +78,7 @@ class InstanceAdmin {
   //@}
 
  private:
+  friend class bigtable::BIGTABLE_CLIENT_NS::InstanceAdmin;
   std::shared_ptr<InstanceAdminClient> client_;
   std::string project_name_;
   std::shared_ptr<RPCRetryPolicy> rpc_retry_policy_;

--- a/bigtable/client/testing/mock_instance_admin_client.h
+++ b/bigtable/client/testing/mock_instance_admin_client.h
@@ -31,6 +31,15 @@ class MockInstanceAdminClient : public bigtable::InstanceAdminClient {
       grpc::Status(grpc::ClientContext*,
                    google::bigtable::admin::v2::ListInstancesRequest const&,
                    google::bigtable::admin::v2::ListInstancesResponse*));
+  MOCK_METHOD3(
+      CreateInstance,
+      grpc::Status(grpc::ClientContext*,
+                   google::bigtable::admin::v2::CreateInstanceRequest const&,
+                   google::longrunning::Operation*));
+  MOCK_METHOD3(GetOperation,
+               grpc::Status(grpc::ClientContext*,
+                            google::longrunning::GetOperationRequest const&,
+                            google::longrunning::Operation*));
 };
 
 }  // namespace testing


### PR DESCRIPTION
This is part of the fixes for #418.  It still needs examples and the polling strategy is mixed with the RPC retriies, but it is good enough to discuss and improve upon.
