### PR TITLE
Enable (and fix) clang-tidy performance warnings.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,19 +4,21 @@
 # Disabled:
 #  -google-readability-namespace-comments the BIGTABLE_CLIENT_NS is a macro, and
 #   clang-tidy fails to match it against the initial value.
-Checks: google-readability-*,modernize-*,readability-*,-google-readability-namespace-comments
+Checks: google-readability-*,modernize-*,readability-*,performance-*,-google-readability-namespace-comments
 
 # Enable most warnings as errors.
-WarningsAsErrors: clang-*,google-*,modernize-*,readability-*,-readability-identifier-naming
+WarningsAsErrors: clang-*,google-*,modernize-*,readability-*,performance-*,-readability-identifier-naming
 
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }
   - { key: readability-identifier-naming.ClassCase,              value: CamelCase  }
   - { key: readability-identifier-naming.StructCase,             value: CamelCase  }
+  - { key: readability-identifier-naming.TemplateParameterCase,  value: CamelCase  }
   - { key: readability-identifier-naming.FunctionCase,           value: CamelCase  }
   - { key: readability-identifier-naming.VariableCase,           value: lower_case }
   - { key: readability-identifier-naming.PrivateMemberSuffix,    value: _          }
   - { key: readability-identifier-naming.ProtectedMemberSuffix,  value: _          }
   - { key: readability-identifier-naming.MacroDefinitionCase,    value: UPPER_CASE }
   - { key: readability-identifier-naming.EnumConstantCase,       value: UPPER_CASE }
-  - { key: readability-identifier-naming.TemplateParameterCase,  value: CamelCase  }
+  - { key: readability-identifier-naming.ConstexprVariableCase,  value: UPPER_CASE }
+  - { key: readability-identifier-naming.ConstantCase,           value: UPPER_CASE }

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ matrix:
       # it has a version of cmake(1) that reports clang-tidy errors.
       os: linux
       compiler: clang
-      env: DISTRO=fedora DISTRO_VERSION=27 BUILD_TYPE=Debug
+      env: DISTRO=ubuntu DISTRO_VERSION=18.04 BUILD_TYPE=Debug
             CMAKE_FLAGS=-DBIGTABLE_CLIENT_CLANG_TIDY=yes
     - # Generate code coverage information and upload to codecov.io.
       os: linux

--- a/bigtable/client/internal/table.cc
+++ b/bigtable/client/internal/table.cc
@@ -183,7 +183,7 @@ bool Table::CheckAndMutateRow(std::string row_key, Filter filter,
 }
 
 Row Table::CallReadModifyWriteRowRequest(
-    btproto::ReadModifyWriteRowRequest request, grpc::Status& status) {
+    btproto::ReadModifyWriteRowRequest const& request, grpc::Status& status) {
   auto response = ClientUtils::MakeNonIdemponentCall(
       *client_, rpc_retry_policy_->clone(), metadata_update_policy_,
       &DataClient::ReadModifyWriteRow, request, "ReadModifyWriteRowRequest",
@@ -217,9 +217,9 @@ Row Table::CallReadModifyWriteRowRequest(
 // successful. When RPC is finished, this function returns the SampleRowKeys
 // as a Collection specified by the user. If the RPC fails, it will keep
 // retrying until the policies in effect tell us to stop.
-void Table::SampleRowsImpl(std::function<void(bigtable::RowKeySample)> inserter,
-                           std::function<void()> clearer,
-                           grpc::Status& status) {
+void Table::SampleRowsImpl(
+    std::function<void(bigtable::RowKeySample)> const& inserter,
+    std::function<void()> const& clearer, grpc::Status& status) {
   // Copy the policies in effect for this operation.
   auto backoff_policy = rpc_backoff_policy_->clone();
   auto retry_policy = rpc_retry_policy_->clone();

--- a/bigtable/client/internal/table.h
+++ b/bigtable/client/internal/table.h
@@ -183,7 +183,7 @@ class Table {
    * Send request ReadModifyWriteRowRequest to modify the row and get it back
    */
   Row CallReadModifyWriteRowRequest(
-      ::google::bigtable::v2::ReadModifyWriteRowRequest request,
+      ::google::bigtable::v2::ReadModifyWriteRowRequest const& request,
       grpc::Status& status);
 
   /**
@@ -195,8 +195,9 @@ class Table {
    * @param inserter Function to insert the object to result.
    * @param clearer Function to clear the result object if RPC fails.
    */
-  void SampleRowsImpl(std::function<void(bigtable::RowKeySample)> inserter,
-                      std::function<void()> clearer, grpc::Status& status);
+  void SampleRowsImpl(
+      std::function<void(bigtable::RowKeySample)> const& inserter,
+      std::function<void()> const& clearer, grpc::Status& status);
 
   std::shared_ptr<DataClient> client_;
   std::string app_profile_id_;

--- a/bigtable/client/internal/table_admin.cc
+++ b/bigtable/client/internal/table_admin.cc
@@ -73,7 +73,7 @@ std::vector<::google::bigtable::admin::v2::Table> TableAdmin::ListTables(
 }
 
 ::google::bigtable::admin::v2::Table TableAdmin::GetTable(
-    std::string table_id, grpc::Status& status,
+    std::string const& table_id, grpc::Status& status,
     ::google::bigtable::admin::v2::Table::View view) {
   btproto::GetTableRequest request;
   request.set_name(TableName(table_id));
@@ -87,7 +87,8 @@ std::vector<::google::bigtable::admin::v2::Table> TableAdmin::ListTables(
                                request, "GetTable", status, true);
 }
 
-void TableAdmin::DeleteTable(std::string table_id, grpc::Status& status) {
+void TableAdmin::DeleteTable(std::string const& table_id,
+                             grpc::Status& status) {
   btproto::DeleteTableRequest request;
   request.set_name(TableName(table_id));
   MetadataUpdatePolicy metadata_update_policy(
@@ -100,8 +101,8 @@ void TableAdmin::DeleteTable(std::string table_id, grpc::Status& status) {
 }
 
 ::google::bigtable::admin::v2::Table TableAdmin::ModifyColumnFamilies(
-    std::string table_id, std::vector<ColumnFamilyModification> modifications,
-    grpc::Status& status) {
+    std::string const& table_id,
+    std::vector<ColumnFamilyModification> modifications, grpc::Status& status) {
   btproto::ModifyColumnFamiliesRequest request;
   request.set_name(TableName(table_id));
   for (auto& m : modifications) {
@@ -115,7 +116,7 @@ void TableAdmin::DeleteTable(std::string table_id, grpc::Status& status) {
       status);
 }
 
-void TableAdmin::DropRowsByPrefix(std::string table_id,
+void TableAdmin::DropRowsByPrefix(std::string const& table_id,
                                   std::string row_key_prefix,
                                   grpc::Status& status) {
   btproto::DropRowRangeRequest request;
@@ -128,7 +129,8 @@ void TableAdmin::DropRowsByPrefix(std::string table_id,
       &AdminClient::DropRowRange, request, "DropRowByPrefix", status);
 }
 
-void TableAdmin::DropAllRows(std::string table_id, grpc::Status& status) {
+void TableAdmin::DropAllRows(std::string const& table_id,
+                             grpc::Status& status) {
   btproto::DropRowRangeRequest request;
   request.set_name(TableName(table_id));
   request.set_delete_all_data_from_table(true);
@@ -204,8 +206,8 @@ void TableAdmin::DeleteSnapshot(bigtable::ClusterId const& cluster_id,
 
 void TableAdmin::ListSnapshotsImpl(
     bigtable::ClusterId const& cluster_id,
-    std::function<void(::google::bigtable::admin::v2::Snapshot)> inserter,
-    std::function<void()> clearer, grpc::Status& status) {
+    std::function<void(google::bigtable::admin::v2::Snapshot)> const& inserter,
+    std::function<void()> const& clearer, grpc::Status& status) {
   // Copy the policies in effect for the operation.
   auto rpc_policy = rpc_retry_policy_->clone();
   auto backoff_policy = rpc_backoff_policy_->clone();

--- a/bigtable/client/internal/table_admin.h
+++ b/bigtable/client/internal/table_admin.h
@@ -90,20 +90,21 @@ class TableAdmin {
       ::google::bigtable::admin::v2::Table::View view, grpc::Status& status);
 
   ::google::bigtable::admin::v2::Table GetTable(
-      std::string table_id, grpc::Status& status,
+      std::string const& table_id, grpc::Status& status,
       ::google::bigtable::admin::v2::Table::View view =
           ::google::bigtable::admin::v2::Table::SCHEMA_VIEW);
 
-  void DeleteTable(std::string table_id, grpc::Status& status);
+  void DeleteTable(std::string const& table_id, grpc::Status& status);
 
   ::google::bigtable::admin::v2::Table ModifyColumnFamilies(
-      std::string table_id, std::vector<ColumnFamilyModification> modifications,
+      std::string const& table_id,
+      std::vector<ColumnFamilyModification> modifications,
       grpc::Status& status);
 
-  void DropRowsByPrefix(std::string table_id, std::string row_key_prefix,
+  void DropRowsByPrefix(std::string const& table_id, std::string row_key_prefix,
                         grpc::Status& status);
 
-  void DropAllRows(std::string table_id, grpc::Status& status);
+  void DropAllRows(std::string const& table_id, grpc::Status& status);
 
   ::google::bigtable::admin::v2::Snapshot GetSnapshot(
       bigtable::ClusterId const& cluster_id,
@@ -171,8 +172,9 @@ class TableAdmin {
    */
   void ListSnapshotsImpl(
       bigtable::ClusterId const& cluster_id,
-      std::function<void(::google::bigtable::admin::v2::Snapshot)> inserter,
-      std::function<void()> clearer, grpc::Status& status);
+      std::function<void(google::bigtable::admin::v2::Snapshot)> const&
+          inserter,
+      std::function<void()> const& clearer, grpc::Status& status);
 
  private:
   std::shared_ptr<AdminClient> client_;

--- a/bigtable/client/internal/unary_client_utils.h
+++ b/bigtable/client/internal/unary_client_utils.h
@@ -180,8 +180,7 @@ struct UnaryClientUtils {
       }
       if (not rpc_policy.on_failure(status)) {
         std::string full_message = error_message;
-        full_message +=
-            "(" + metadata_update_policy.x_google_request_params().second + ")";
+        full_message += "(" + metadata_update_policy.value() + ")";
         status = grpc::Status(status.error_code(), full_message);
         break;
       }

--- a/bigtable/client/metadata_update_policy.cc
+++ b/bigtable/client/metadata_update_policy.cc
@@ -24,27 +24,28 @@ MetadataParamTypes const MetadataParamTypes::NAME("name");
 MetadataParamTypes const MetadataParamTypes::TABLE_NAME("table_name");
 
 MetadataUpdatePolicy::MetadataUpdatePolicy(
-    std::string resource_name, MetadataParamTypes metadata_param_type) {
+    std::string const& resource_name,
+    MetadataParamTypes const& metadata_param_type) {
   std::string value = metadata_param_type.type();
   value += "=";
   value += resource_name;
-  x_google_request_params_ =
-      std::make_pair("x-goog-request-params", std::move(value));
+  value_ = std::move(value);
 }
 
 MetadataUpdatePolicy::MetadataUpdatePolicy(
-    std::string resource_name, MetadataParamTypes metadata_param_type,
-    std::string table_id) {
+    std::string const& resource_name,
+    MetadataParamTypes const& metadata_param_type,
+    std::string const& table_id) {
   std::string value = metadata_param_type.type();
   value += "=";
   value += resource_name;
   value += "/tables/" + table_id;
-  x_google_request_params_ =
-      std::make_pair("x-goog-request-params", std::move(value));
+  value_ = std::move(value);
 }
 
 MetadataUpdatePolicy::MetadataUpdatePolicy(
-    std::string const& resource_name, MetadataParamTypes metadata_param_type,
+    std::string const& resource_name,
+    MetadataParamTypes const& metadata_param_type,
     bigtable::ClusterId const& cluster_id,
     bigtable::SnapshotId const& snapshot_id) {
   std::string value = metadata_param_type.type();
@@ -52,28 +53,22 @@ MetadataUpdatePolicy::MetadataUpdatePolicy(
   value += resource_name;
   value += "/clusters/" + cluster_id.get();
   value += "/snapshots/" + snapshot_id.get();
-  x_google_request_params_ =
-      std::make_pair("x-goog-request-params", std::move(value));
+  value_ = std::move(value);
 }
 
 MetadataUpdatePolicy::MetadataUpdatePolicy(
-    std::string const& resource_name, MetadataParamTypes metadata_param_type,
+    std::string const& resource_name,
+    MetadataParamTypes const& metadata_param_type,
     bigtable::ClusterId const& cluster_id) {
   std::string value = metadata_param_type.type();
   value += "=";
   value += resource_name;
   value += "/clusters/" + cluster_id.get();
-  x_google_request_params_ =
-      std::make_pair("x-goog-request-params", std::move(value));
-}
-
-MetadataUpdatePolicy::MetadataUpdatePolicy(MetadataUpdatePolicy const& rhs) {
-  x_google_request_params_ = rhs.x_google_request_params_;
+  value_ = std::move(value);
 }
 
 void MetadataUpdatePolicy::setup(grpc::ClientContext& context) const {
-  context.AddMetadata(x_google_request_params_.first,
-                      x_google_request_params_.second);
+  context.AddMetadata(std::string("x-goog-request-params"), value());
 }
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/bigtable/client/metadata_update_policy.h
+++ b/bigtable/client/metadata_update_policy.h
@@ -60,8 +60,8 @@ class MetadataUpdatePolicy {
    * @param metadata_param_type type to decide prefix for the value of
    *     x-goog-request-params
    */
-  MetadataUpdatePolicy(std::string resource_name,
-                       MetadataParamTypes metadata_param_type);
+  MetadataUpdatePolicy(std::string const& resource_name,
+                       MetadataParamTypes const& metadata_param_type);
 
   /**
    * Constructor with default metadata pair.
@@ -72,9 +72,9 @@ class MetadataUpdatePolicy {
    *     x-goog-request-params.
    * @param table_id table_id used in RPC call.
    */
-  MetadataUpdatePolicy(std::string resource_name,
-                       MetadataParamTypes metadata_param_type,
-                       std::string table_id);
+  MetadataUpdatePolicy(std::string const& resource_name,
+                       MetadataParamTypes const& metadata_param_type,
+                       std::string const& table_id);
 
   /**
    * Constructor with default metadata pair.
@@ -87,7 +87,7 @@ class MetadataUpdatePolicy {
    * @param snapshot_id snapshot_id used in RPC call.
    */
   MetadataUpdatePolicy(std::string const& resource_name,
-                       MetadataParamTypes metadata_param_type,
+                       MetadataParamTypes const& metadata_param_type,
                        bigtable::ClusterId const& cluster_id,
                        bigtable::SnapshotId const& snapshot_id);
 
@@ -101,22 +101,20 @@ class MetadataUpdatePolicy {
    * @param cluster_id cluster_id of the cluster.
    */
   MetadataUpdatePolicy(std::string const& resource_name,
-                       MetadataParamTypes metadata_param_type,
+                       MetadataParamTypes const& metadata_param_type,
                        bigtable::ClusterId const& cluster_id);
 
   MetadataUpdatePolicy(MetadataUpdatePolicy&& rhs) noexcept = default;
-  MetadataUpdatePolicy(MetadataUpdatePolicy const& rhs);
+  MetadataUpdatePolicy(MetadataUpdatePolicy const& rhs) = default;
   MetadataUpdatePolicy& operator=(MetadataUpdatePolicy const& rhs) = default;
 
   // Update the ClientContext for the next call.
   void setup(grpc::ClientContext& context) const;
 
-  std::pair<std::string, std::string> x_google_request_params() const {
-    return x_google_request_params_;
-  }
+  std::string const& value() const { return value_; }
 
  private:
-  std::pair<std::string, std::string> x_google_request_params_;
+  std::string value_;
 };
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/bigtable/client/metadata_update_policy_test.cc
+++ b/bigtable/client/metadata_update_policy_test.cc
@@ -71,7 +71,7 @@ TEST_F(MetadataUpdatePolicyTest, SimpleDefault) {
   auto const x_google_request_params = "parent=" + kInstanceName;
   bigtable::MetadataUpdatePolicy created(kInstanceName,
                                          bigtable::MetadataParamTypes::PARENT);
-  EXPECT_EQ(x_google_request_params, created.x_google_request_params().second);
+  EXPECT_EQ(x_google_request_params, created.value());
 }
 
 /// @test A test for lazy behaviour of metadata .
@@ -79,7 +79,7 @@ TEST_F(MetadataUpdatePolicyTest, SimpleLazy) {
   auto const x_google_request_params = "name=" + kTableName;
   bigtable::MetadataUpdatePolicy created(
       kInstanceName, bigtable::MetadataParamTypes::NAME, kTableId);
-  EXPECT_EQ(x_google_request_params, created.x_google_request_params().second);
+  EXPECT_EQ(x_google_request_params, created.value());
 }
 
 /// @test Another test for lazy behaviour of metadata.
@@ -92,7 +92,7 @@ TEST_F(MetadataUpdatePolicyTest, SimpleLazy_Test) {
   bigtable::MetadataUpdatePolicy created(kInstanceName,
                                          bigtable::MetadataParamTypes::NAME,
                                          cluster_id, snapshot_id);
-  EXPECT_EQ(x_google_request_params, created.x_google_request_params().second);
+  EXPECT_EQ(x_google_request_params, created.value());
 }
 
 //@test Another test for lazy behaviour of metadata.
@@ -102,5 +102,5 @@ TEST_F(MetadataUpdatePolicyTest, SimpleClusterId_Test) {
   bigtable::ClusterId cluster_id(kClusterId);
   bigtable::MetadataUpdatePolicy created(
       kInstanceName, bigtable::MetadataParamTypes::PARENT, cluster_id);
-  EXPECT_EQ(x_google_request_params, created.x_google_request_params().second);
+  EXPECT_EQ(x_google_request_params, created.value());
 }

--- a/bigtable/client/mutations.cc
+++ b/bigtable/client/mutations.cc
@@ -66,7 +66,7 @@ grpc::Status FailedMutation::to_grpc_status(google::rpc::Status const& status) {
     details = "error [could not print details as string]";
   }
   return grpc::Status(static_cast<grpc::StatusCode>(status.code()),
-                      status.message(), std::move(details));
+                      status.message(), details);
 }
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/bigtable/client/table_admin.cc
+++ b/bigtable/client/table_admin.cc
@@ -39,7 +39,7 @@ static_assert(std::is_copy_assignable<bigtable::TableAdmin>::value,
 std::vector<::google::bigtable::admin::v2::Table> TableAdmin::ListTables(
     ::google::bigtable::admin::v2::Table::View view) {
   grpc::Status status;
-  auto result = impl_.ListTables(std::move(view), status);
+  auto result = impl_.ListTables(view, status);
   if (not status.ok()) {
     internal::RaiseRpcError(status, status.error_message());
   }
@@ -47,47 +47,48 @@ std::vector<::google::bigtable::admin::v2::Table> TableAdmin::ListTables(
 }
 
 ::google::bigtable::admin::v2::Table TableAdmin::GetTable(
-    std::string table_id, ::google::bigtable::admin::v2::Table::View view) {
+    std::string const& table_id,
+    ::google::bigtable::admin::v2::Table::View view) {
   grpc::Status status;
-  auto result = impl_.GetTable(std::move(table_id), status, std::move(view));
+  auto result = impl_.GetTable(table_id, status, view);
   if (not status.ok()) {
     internal::RaiseRpcError(status, status.error_message());
   }
   return result;
 }
 
-void TableAdmin::DeleteTable(std::string table_id) {
+void TableAdmin::DeleteTable(std::string const& table_id) {
   grpc::Status status;
-  impl_.DeleteTable(std::move(table_id), status);
+  impl_.DeleteTable(table_id, status);
   if (not status.ok()) {
     internal::RaiseRpcError(status, status.error_message());
   }
 }
 
 ::google::bigtable::admin::v2::Table TableAdmin::ModifyColumnFamilies(
-    std::string table_id, std::vector<ColumnFamilyModification> modifications) {
+    std::string const& table_id,
+    std::vector<ColumnFamilyModification> modifications) {
   grpc::Status status;
-  auto result = impl_.ModifyColumnFamilies(std::move(table_id),
-                                           std::move(modifications), status);
+  auto result =
+      impl_.ModifyColumnFamilies(table_id, std::move(modifications), status);
   if (not status.ok()) {
     internal::RaiseRpcError(status, status.error_message());
   }
   return result;
 }
 
-void TableAdmin::DropRowsByPrefix(std::string table_id,
+void TableAdmin::DropRowsByPrefix(std::string const& table_id,
                                   std::string row_key_prefix) {
   grpc::Status status;
-  impl_.DropRowsByPrefix(std::move(table_id), std::move(row_key_prefix),
-                         status);
+  impl_.DropRowsByPrefix(table_id, std::move(row_key_prefix), status);
   if (not status.ok()) {
     internal::RaiseRpcError(status, status.error_message());
   }
 }
 
-void TableAdmin::DropAllRows(std::string table_id) {
+void TableAdmin::DropAllRows(std::string const& table_id) {
   grpc::Status status;
-  impl_.DropAllRows(std::move(table_id), status);
+  impl_.DropAllRows(table_id, status);
   if (not status.ok()) {
     internal::RaiseRpcError(status, status.error_message());
   }
@@ -106,8 +107,7 @@ void TableAdmin::DropAllRows(std::string table_id) {
 
 std::string TableAdmin::GenerateConsistencyToken(std::string const& table_id) {
   grpc::Status status;
-  std::string token =
-      impl_.GenerateConsistencyToken(std::move(table_id), status);
+  std::string token = impl_.GenerateConsistencyToken(table_id, status);
   if (not status.ok()) {
     internal::RaiseRpcError(status, status.error_message());
   }

--- a/bigtable/client/table_admin.h
+++ b/bigtable/client/table_admin.h
@@ -117,7 +117,7 @@ class TableAdmin {
    * @snippet bigtable_samples.cc get table
    */
   ::google::bigtable::admin::v2::Table GetTable(
-      std::string table_id,
+      std::string const& table_id,
       ::google::bigtable::admin::v2::Table::View view =
           ::google::bigtable::admin::v2::Table::SCHEMA_VIEW);
 
@@ -133,7 +133,7 @@ class TableAdmin {
    * **Example**
    * @snippet bigtable_samples.cc delete table
    */
-  void DeleteTable(std::string table_id);
+  void DeleteTable(std::string const& table_id);
 
   /**
    * Modify the schema for an existing table.
@@ -149,7 +149,7 @@ class TableAdmin {
    * @snippet bigtable_samples.cc modify table
    */
   ::google::bigtable::admin::v2::Table ModifyColumnFamilies(
-      std::string table_id,
+      std::string const& table_id,
       std::vector<ColumnFamilyModification> modifications);
 
   /**
@@ -164,7 +164,8 @@ class TableAdmin {
    * **Example**
    * @snippet bigtable_samples.cc drop rows by prefix
    */
-  void DropRowsByPrefix(std::string table_id, std::string row_key_prefix);
+  void DropRowsByPrefix(std::string const& table_id,
+                        std::string row_key_prefix);
 
   /**
    * Delete all the rows in a table.
@@ -177,7 +178,7 @@ class TableAdmin {
    * **Example**
    * @snippet bigtable_samples.cc drop all rows
    */
-  void DropAllRows(std::string table_id);
+  void DropAllRows(std::string const& table_id);
 
   /**
    * Get information about a single snapshot.

--- a/bigtable/client/table_config.cc
+++ b/bigtable/client/table_config.cc
@@ -16,6 +16,7 @@
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+// NOLINTNEXTLINE(readability-identifier-naming)
 ::google::bigtable::admin::v2::CreateTableRequest TableConfig::as_proto_move() {
   // As a challenge, we implement the strong exception guarantee in this
   // function.

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -46,6 +46,12 @@ RUN if grep -q 14.04 /etc/lsb-release; then \
       apt-get install -y clang-format; \
     fi
 
+RUN if grep -q 18.04 /etc/lsb-release; then \
+      apt-get install -y clang-tidy; \
+      update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-6.0 100; \
+      update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-6.0 100; \
+    fi
+
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.
 WORKDIR /var/tmp/install/cbt-components


### PR DESCRIPTION
Enable the `performance-*` warnings in the `clang-tidy` build.  Fixed a number of problems caught by these warnings.
