### PR TITLE
Issue#419 Implementation for InstanceAdmin::GetInstance with unit tests for no errors

### DIFF
--- a/bigtable/client/instance_admin.cc
+++ b/bigtable/client/instance_admin.cc
@@ -109,5 +109,14 @@ google::bigtable::admin::v2::Instance InstanceAdmin::CreateInstanceImpl(
   return result;
 }
 
+btproto::Instance InstanceAdmin::GetInstance(std::string const& instance_id) {
+  grpc::Status status;
+  auto result = impl_.GetInstance(instance_id, status);
+  if (not status.ok()) {
+    internal::RaiseRpcError(status, status.error_message());
+  }
+  return result;
+}
+
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/bigtable/client/instance_admin.h
+++ b/bigtable/client/instance_admin.h
@@ -80,12 +80,7 @@ class InstanceAdmin {
    */
   std::vector<google::bigtable::admin::v2::Instance> ListInstances();
 
-  /**
-   * Provide Instance based on Instance ID.
-   *
-   * Return the instance in the project.
-   * @return
-   */
+  /// Get the details of @p instance_id.
   google::bigtable::admin::v2::Instance GetInstance(
       std::string const& instance_id);
 

--- a/bigtable/client/instance_admin.h
+++ b/bigtable/client/instance_admin.h
@@ -80,6 +80,15 @@ class InstanceAdmin {
    */
   std::vector<google::bigtable::admin::v2::Instance> ListInstances();
 
+  /**
+   * @param Provide Instance based on Instance ID.
+   *
+   * Return the instance in the project.
+   * @return
+   */
+  google::bigtable::admin::v2::Instance GetInstance(
+      std::string const& instance_id);
+
  private:
   /// Implement CreateInstance() with a separate thread.
   google::bigtable::admin::v2::Instance CreateInstanceImpl(

--- a/bigtable/client/instance_admin.h
+++ b/bigtable/client/instance_admin.h
@@ -81,7 +81,7 @@ class InstanceAdmin {
   std::vector<google::bigtable::admin::v2::Instance> ListInstances();
 
   /**
-   * @param Provide Instance based on Instance ID.
+   * Provide Instance based on Instance ID.
    *
    * Return the instance in the project.
    * @return

--- a/bigtable/client/instance_admin_client.cc
+++ b/bigtable/client/instance_admin_client.cc
@@ -76,6 +76,13 @@ class DefaultInstanceAdminClient : public bigtable::InstanceAdminClient {
     return stub->GetOperation(context, request, response);
   }
 
+  grpc::Status GetInstance(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::GetInstanceRequest const& request,
+      google::bigtable::admin::v2::Instance* response) override {
+    return impl_.Stub()->GetInstance(context, request, response);
+  }
+
   DefaultInstanceAdminClient(DefaultInstanceAdminClient const&) = delete;
   DefaultInstanceAdminClient& operator=(DefaultInstanceAdminClient const&) =
       delete;

--- a/bigtable/client/instance_admin_client.h
+++ b/bigtable/client/instance_admin_client.h
@@ -74,6 +74,12 @@ class InstanceAdminClient {
       google::longrunning::GetOperationRequest const& request,
       google::longrunning::Operation* response) = 0;
   //@}
+
+virtual grpc::Status GetInstance(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::GetInstanceRequest const& request,
+      google::bigtable::admin::v2::Instance* response) = 0;
+};
 };
 
 /// Create a new admin client configured via @p options.

--- a/bigtable/client/instance_admin_client.h
+++ b/bigtable/client/instance_admin_client.h
@@ -75,11 +75,10 @@ class InstanceAdminClient {
       google::longrunning::Operation* response) = 0;
   //@}
 
-virtual grpc::Status GetInstance(
+  virtual grpc::Status GetInstance(
       grpc::ClientContext* context,
       google::bigtable::admin::v2::GetInstanceRequest const& request,
       google::bigtable::admin::v2::Instance* response) = 0;
-};
 };
 
 /// Create a new admin client configured via @p options.

--- a/bigtable/client/internal/instance_admin.cc
+++ b/bigtable/client/internal/instance_admin.cc
@@ -63,9 +63,8 @@ btproto::Instance InstanceAdmin::GetInstance(std::string const& instance_id,
   auto rpc_policy = rpc_retry_policy_->clone();
   auto backoff_policy = rpc_backoff_policy_->clone();
 
-  // Build the RPC request, try to minimize copying.
   btproto::GetInstanceRequest request;
-  // Set Instance ID
+  // Setting instance name.
   request.set_name(project_name_ + "/instances/" + instance_id);
 
   // Call RPC call to get response

--- a/bigtable/client/internal/instance_admin.cc
+++ b/bigtable/client/internal/instance_admin.cc
@@ -69,12 +69,10 @@ btproto::Instance InstanceAdmin::GetInstance(std::string const& instance_id,
   request.set_name(project_name_ + "/instances/" + instance_id);
 
   // Call RPC call to get response
-  auto response = ClientUtils::MakeCall(
-      *client_, *rpc_policy, *backoff_policy, metadata_update_policy_,
-      &InstanceAdminClient::GetInstance, request, "InstanceAdmin::GetInstance",
-      status, true);
-
-  return response;
+  return ClientUtils::MakeCall(*client_, *rpc_policy, *backoff_policy,
+                               metadata_update_policy_,
+                               &InstanceAdminClient::GetInstance, request,
+                               "InstanceAdmin::GetInstance", status, true);
 }
 
 }  // namespace noex

--- a/bigtable/client/internal/instance_admin.cc
+++ b/bigtable/client/internal/instance_admin.cc
@@ -65,28 +65,19 @@ btproto::Instance InstanceAdmin::GetInstance(std::string const& instance_id,
 
   // Build the RPC request, try to minimize copying.
   btproto::Instance result;
-  std::string page_token;
-  do {
-    btproto::ListInstancesRequest request;
-    request.set_page_token(std::move(page_token));
-    request.set_parent(project_name_);
+  btproto::GetInstanceRequest request;
+  // Set Instance ID
+  request.set_name(instance_id);
 
-    auto response = ClientUtils::MakeCall(
-        *client_, *rpc_policy, *backoff_policy, metadata_update_policy_,
-        &InstanceAdminClient::ListInstances, request,
-        "InstanceAdmin::ListInstances", status, true);
-    if (not status.ok()) {
-      return result;
-    }
+  // Call RPC call to get response
+  auto response = ClientUtils::MakeCall(
+      *client_, *rpc_policy, *backoff_policy, metadata_update_policy_,
+      &InstanceAdminClient::GetInstance, request, "InstanceAdmin::GetInstance",
+      status, true);
 
-    for (auto& x : *response.mutable_instances()) {
-      if (instance_id == x.name()) {
-        result = std::move(x);
-        return result;
-      }
-    }
-    page_token = std::move(*response.mutable_next_page_token());
-  } while (not page_token.empty());
+  if (status.ok()) {
+    result = response;
+  }
   return result;
 }
 

--- a/bigtable/client/internal/instance_admin.cc
+++ b/bigtable/client/internal/instance_admin.cc
@@ -64,10 +64,9 @@ btproto::Instance InstanceAdmin::GetInstance(std::string const& instance_id,
   auto backoff_policy = rpc_backoff_policy_->clone();
 
   // Build the RPC request, try to minimize copying.
-  btproto::Instance result;
   btproto::GetInstanceRequest request;
   // Set Instance ID
-  request.set_name(instance_id);
+  request.set_name(project_name_ + "/instances/" + instance_id);
 
   // Call RPC call to get response
   auto response = ClientUtils::MakeCall(
@@ -75,10 +74,7 @@ btproto::Instance InstanceAdmin::GetInstance(std::string const& instance_id,
       &InstanceAdminClient::GetInstance, request, "InstanceAdmin::GetInstance",
       status, true);
 
-  if (status.ok()) {
-    result = response;
-  }
-  return result;
+  return response;
 }
 
 }  // namespace noex

--- a/bigtable/client/internal/instance_admin.h
+++ b/bigtable/client/internal/instance_admin.h
@@ -75,30 +75,20 @@ class InstanceAdmin {
    */
   std::vector<::google::bigtable::admin::v2::Instance> ListInstances(
       grpc::Status& status);
-  //@}
 
-  //@{
   /**
-   * Provide Instance based on instance ID.
-   *
-   * @name No exception versions of InstanceAdmin::*
-   *
-   * These functions provide the same functionality as their counterparts in the
-   * `bigtable::InstanceAdmin` class, but do not raise exceptions on errors,
-   * instead they return the error on the status parameter.
-   *
-   * @code
-   * bigtable::nox::InstanceAdmin impl_;
-   * grpc::Status status;
-   * auto result = impl_.GetInstance(instance_id,status);
-   * @endcode
-   *
-   * @param Instance ID
-   * @return Instance
-   */
+  * Get the details of @p instance_id
+  *
+  * @code
+  * bigtable::nox::InstanceAdmin impl_;
+  * grpc::Status status;
+  * auto result = impl_.GetInstance(instance_id,status);
+  * @endcode
+  *
+  */
   ::google::bigtable::admin::v2::Instance GetInstance(
       std::string const& instance_id, grpc::Status& status);
-  //@{
+  //@}
 
  private:
   friend class bigtable::BIGTABLE_CLIENT_NS::InstanceAdmin;

--- a/bigtable/client/internal/instance_admin.h
+++ b/bigtable/client/internal/instance_admin.h
@@ -77,6 +77,29 @@ class InstanceAdmin {
       grpc::Status& status);
   //@}
 
+  //@{
+  /**
+   * Provide Instance based on instance ID.
+   *
+   * @name No exception versions of InstanceAdmin::*
+   *
+   * These functions provide the same functionality as their counterparts in the
+   * `bigtable::InstanceAdmin` class, but do not raise exceptions on errors,
+   * instead they return the error on the status parameter.
+   *
+   * @code
+   * bigtable::nox::InstanceAdmin impl_;
+   * grpc::Status status;
+   * auto result = impl_.GetInstance(instance_id,status);
+   * @endcode
+   *
+   * @param Instance ID
+   * @return Instance
+   */
+  ::google::bigtable::admin::v2::Instance GetInstance(
+      std::string const& instance_id, grpc::Status& status);
+  //@{
+
  private:
   friend class bigtable::BIGTABLE_CLIENT_NS::InstanceAdmin;
   std::shared_ptr<InstanceAdminClient> client_;

--- a/bigtable/client/internal/instance_admin.h
+++ b/bigtable/client/internal/instance_admin.h
@@ -76,16 +76,6 @@ class InstanceAdmin {
   std::vector<::google::bigtable::admin::v2::Instance> ListInstances(
       grpc::Status& status);
 
-  /**
-  * Get the details of @p instance_id
-  *
-  * @code
-  * bigtable::nox::InstanceAdmin impl_;
-  * grpc::Status status;
-  * auto result = impl_.GetInstance(instance_id,status);
-  * @endcode
-  *
-  */
   ::google::bigtable::admin::v2::Instance GetInstance(
       std::string const& instance_id, grpc::Status& status);
   //@}

--- a/bigtable/client/internal/instance_admin_test.cc
+++ b/bigtable/client/internal/instance_admin_test.cc
@@ -220,3 +220,21 @@ TEST_F(InstanceAdminTest, ListInstancesUnrecoverableFailures) {
   tested.ListInstances(status);
   EXPECT_FALSE(status.ok());
 }
+
+/// @test Verify that `bigtable::InstanceAdmin::GetInstance` works in the easy
+/// case.
+TEST_F(InstanceAdminTest, GetInstance) {
+  using namespace ::testing;
+
+  bigtable::noex::InstanceAdmin tested(client_);
+  auto mock_list_instances = create_list_instances_lambda("", "", {"t0", "t1"});
+  EXPECT_CALL(*client_, ListInstances(_, _, _))
+      .WillOnce(Invoke(mock_list_instances));
+
+  // After all the setup, make the actual call we want to test.
+  grpc::Status status;
+  std::string instance_id = "projects/the-project/instances/t1";
+  auto actual = tested.GetInstance(instance_id, status);
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ("projects/the-project/instances/t1", actual.name());
+}

--- a/bigtable/client/internal/instance_admin_test.cc
+++ b/bigtable/client/internal/instance_admin_test.cc
@@ -246,7 +246,7 @@ TEST_F(InstanceAdminTest, GetInstanceSimpleCase) {
 
   // After all the setup, make the actual call we want to test.
   grpc::Status status;
-  std::string instance_id = "projects/the-project/instances/t0";
+  std::string instance_id = "t0";
   auto actual = tested.GetInstance(instance_id, status);
   EXPECT_TRUE(status.ok());
   EXPECT_EQ("projects/the-project/instances/t0", actual.name());
@@ -263,7 +263,7 @@ TEST_F(InstanceAdminTest, GetInstanceFailCase) {
 
   // After all the setup, make the actual call we want to test.
   grpc::Status status;
-  std::string instance_id = "projects/the-project/instances/t1";
+  std::string instance_id = "t1";
   auto actual = tested.GetInstance(instance_id, status);
   EXPECT_TRUE(status.ok());
   EXPECT_NE("projects/the-project/instances/t0", actual.name());

--- a/bigtable/client/internal/instance_admin_test.cc
+++ b/bigtable/client/internal/instance_admin_test.cc
@@ -61,6 +61,20 @@ auto create_list_instances_lambda = [](std::string expected_token,
   };
 };
 
+// A lambda to create lambdas.  Basically we would be rewriting the same
+// lambda twice without this thing.
+auto create_instance = [](std::string expected_token,
+                          std::string returned_token, std::string instance_id) {
+  return [expected_token, returned_token, instance_id](
+      grpc::ClientContext* ctx, btproto::GetInstanceRequest const& request,
+      btproto::Instance* response) {
+    auto const project_name = "projects/" + kProjectId;
+    EXPECT_NE(nullptr, response);
+    response->set_name(request.name());
+    return grpc::Status::OK;
+  };
+};
+
 /**
  * Helper class to create the expectations for a simple RPC call.
  *
@@ -221,20 +235,36 @@ TEST_F(InstanceAdminTest, ListInstancesUnrecoverableFailures) {
   EXPECT_FALSE(status.ok());
 }
 
-/// @test Verify that `bigtable::InstanceAdmin::GetInstance` works in the easy
+/// @test Verify that `bigtable::InstanceAdmin::GetInstance` works in the simple
 /// case.
-TEST_F(InstanceAdminTest, GetInstance) {
+TEST_F(InstanceAdminTest, GetInstanceSimpleCase) {
   using namespace ::testing;
 
   bigtable::noex::InstanceAdmin tested(client_);
-  auto mock_list_instances = create_list_instances_lambda("", "", {"t0", "t1"});
-  EXPECT_CALL(*client_, ListInstances(_, _, _))
-      .WillOnce(Invoke(mock_list_instances));
+  auto mock_instances = create_instance("", "", {"t0"});
+  EXPECT_CALL(*client_, GetInstance(_, _, _)).WillOnce(Invoke(mock_instances));
+
+  // After all the setup, make the actual call we want to test.
+  grpc::Status status;
+  std::string instance_id = "projects/the-project/instances/t0";
+  auto actual = tested.GetInstance(instance_id, status);
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ("projects/the-project/instances/t0", actual.name());
+}
+
+/// @test Verify that `bigtable::InstanceAdmin::GetInstance` works in the fail
+/// case.
+TEST_F(InstanceAdminTest, GetInstanceFailCase) {
+  using namespace ::testing;
+
+  bigtable::noex::InstanceAdmin tested(client_);
+  auto mock_instances = create_instance("", "", {"t0"});
+  EXPECT_CALL(*client_, GetInstance(_, _, _)).WillOnce(Invoke(mock_instances));
 
   // After all the setup, make the actual call we want to test.
   grpc::Status status;
   std::string instance_id = "projects/the-project/instances/t1";
   auto actual = tested.GetInstance(instance_id, status);
   EXPECT_TRUE(status.ok());
-  EXPECT_EQ("projects/the-project/instances/t1", actual.name());
+  EXPECT_NE("projects/the-project/instances/t0", actual.name());
 }

--- a/bigtable/client/testing/mock_instance_admin_client.h
+++ b/bigtable/client/testing/mock_instance_admin_client.h
@@ -40,6 +40,11 @@ class MockInstanceAdminClient : public bigtable::InstanceAdminClient {
                grpc::Status(grpc::ClientContext*,
                             google::longrunning::GetOperationRequest const&,
                             google::longrunning::Operation*));
+MOCK_METHOD3(
+      GetInstance,
+      grpc::Status(grpc::ClientContext*,
+                   google::bigtable::admin::v2::GetInstanceRequest const&,
+                   google::bigtable::admin::v2::Instance*));
 };
 
 }  // namespace testing

--- a/bigtable/client/testing/mock_instance_admin_client.h
+++ b/bigtable/client/testing/mock_instance_admin_client.h
@@ -40,7 +40,8 @@ class MockInstanceAdminClient : public bigtable::InstanceAdminClient {
                grpc::Status(grpc::ClientContext*,
                             google::longrunning::GetOperationRequest const&,
                             google::longrunning::Operation*));
-MOCK_METHOD3(
+
+  MOCK_METHOD3(
       GetInstance,
       grpc::Status(grpc::ClientContext*,
                    google::bigtable::admin::v2::GetInstanceRequest const&,


### PR DESCRIPTION
PR Created for following:
- Implementing the function itself, Implementing the sample snippet and Implementing the unit tests for "no errors"
Following will be part of Next PR:
- Implementing the integration test, and Implementing the unit tests for "unrecoverable error", "retry with recoverable errors".

I have implemented GetInstance API with another way also as below, but in that I was facing problem, that how to get Instance based on instance ID.

btproto::GetInstanceRequest request;
 request.set_name(instance_id);
//Call RPC call to get response
auto response = ClientUtils::MakeCall(
	*client_, *rpc_policy, *backoff_policy, metadata_update_policy_,
	&InstanceAdminClient::GetInstance, request,
	"InstanceAdmin::GetInstance", status, true);
 if (status.ok()) {
	        result = response;
}