### PR TITLE
Create ClientOptions constructor with Credentials argument.

### DIFF
--- a/bigtable/client/client_options.cc
+++ b/bigtable/client/client_options.cc
@@ -32,13 +32,11 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 ClientOptions::ClientOptions(std::shared_ptr<grpc::ChannelCredentials> creds)
     : credentials_(std::move(creds)),
-      channel_arguments_(),
-      connection_pool_name_(),
       connection_pool_size_(BIGTABLE_CLIENT_DEFAULT_CONNECTION_POOL_SIZE),
       data_endpoint_("bigtable.googleapis.com"),
       admin_endpoint_("bigtableadmin.googleapis.com") {
-  static std::string const USER_AGENT_PREFIX = "cbt-c++/" + version_string();
-  channel_arguments_.SetUserAgentPrefix(USER_AGENT_PREFIX);
+  static std::string const user_agent_prefix = "cbt-c++/" + version_string();
+  channel_arguments_.SetUserAgentPrefix(user_agent_prefix);
 }
 
 ClientOptions::ClientOptions() : ClientOptions(BigtableDefaultCredentials()) {

--- a/bigtable/client/client_options.cc
+++ b/bigtable/client/client_options.cc
@@ -26,28 +26,28 @@ std::shared_ptr<grpc::ChannelCredentials> BigtableDefaultCredentials() {
   }
   return grpc::GoogleDefaultCredentials();
 }
-}
+}  // anonymous namespace
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 ClientOptions::ClientOptions(std::shared_ptr<grpc::ChannelCredentials> creds)
-    : credentials_(creds)
-    , connection_pool_size_(BIGTABLE_CLIENT_DEFAULT_CONNECTION_POOL_SIZE) {
-  channel_arguments_ = grpc::ChannelArguments();
-  static std::string const prefix = "cbt-c++/" + version_string();
-  channel_arguments_.SetUserAgentPrefix(prefix);
+    : credentials_(std::move(creds)),
+      channel_arguments_(),
+      connection_pool_name_(),
+      connection_pool_size_(BIGTABLE_CLIENT_DEFAULT_CONNECTION_POOL_SIZE),
+      data_endpoint_("bigtable.googleapis.com"),
+      admin_endpoint_("bigtableadmin.googleapis.com") {
+  static std::string const USER_AGENT_PREFIX = "cbt-c++/" + version_string();
+  channel_arguments_.SetUserAgentPrefix(USER_AGENT_PREFIX);
+}
 
+ClientOptions::ClientOptions() : ClientOptions(BigtableDefaultCredentials()) {
   char const* emulator = std::getenv("BIGTABLE_EMULATOR_HOST");
   if (emulator != nullptr) {
     data_endpoint_ = emulator;
     admin_endpoint_ = emulator;
-  } else {
-    data_endpoint_ = "bigtable.googleapis.com";
-    admin_endpoint_ = "bigtableadmin.googleapis.com";
   }
 }
-
-ClientOptions::ClientOptions() : ClientOptions(BigtableDefaultCredentials()) {}
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/bigtable/client/client_options.h
+++ b/bigtable/client/client_options.h
@@ -34,8 +34,29 @@ inline namespace BIGTABLE_CLIENT_NS {
  */
 class ClientOptions {
  public:
-  ClientOptions(std::shared_ptr<grpc::ChannelCredentials> creds);
+  /**
+   * Initialize the client options with the default credentials.
+   *
+   * If the `BIGTABLE_EMULATOR_HOST` environment variable is set this
+   * constructor configures the object to connect to the host and port set in
+   * that environment variable. If the environment variable is not set, this
+   * constructor configures the object to connect to the production instance of
+   * Cloud Bigtable using the aplication default credentials.
+   *
+   * @see The Google Cloud Platform introduction to
+   * [application default
+   * credentials](https://cloud.google.com/docs/authentication/production)
+   */
   ClientOptions();
+
+  /**
+   * Connect to the production instance of Cloud Bigtable using @p creds.
+   *
+   * This constructor always connects to the production instance of Cloud
+   * Bigtable, and can be used when the application default credentials are
+   * not configured in the environment where the application is running.
+   */
+  explicit ClientOptions(std::shared_ptr<grpc::ChannelCredentials> creds);
 
   /// Return the current endpoint for data RPCs.
   std::string const& data_endpoint() const { return data_endpoint_; }
@@ -253,12 +274,12 @@ class ClientOptions {
   }
 
  private:
-  std::string data_endpoint_;
-  std::string admin_endpoint_;
   std::shared_ptr<grpc::ChannelCredentials> credentials_;
   grpc::ChannelArguments channel_arguments_;
   std::string connection_pool_name_;
   std::size_t connection_pool_size_;
+  std::string data_endpoint_;
+  std::string admin_endpoint_;
 };
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/bigtable/client/client_options.h
+++ b/bigtable/client/client_options.h
@@ -34,6 +34,7 @@ inline namespace BIGTABLE_CLIENT_NS {
  */
 class ClientOptions {
  public:
+  ClientOptions(std::shared_ptr<grpc::ChannelCredentials> creds);
   ClientOptions();
 
   /// Return the current endpoint for data RPCs.

--- a/bigtable/client/client_options_test.cc
+++ b/bigtable/client/client_options_test.cc
@@ -88,8 +88,22 @@ TEST_F(ClientOptionsEmulatorTest, Default) {
             client_options_object.data_endpoint());
   EXPECT_EQ("testendpoint.googleapis.com",
             client_options_object.admin_endpoint());
-  EXPECT_EQ(typeid(grpc::InsecureChannelCredentials()),
-            typeid(client_options_object.credentials()));
+}
+
+TEST_F(ClientOptionsEmulatorTest, WithCredentials) {
+  auto credentials = grpc::GoogleDefaultCredentials();
+  bigtable::ClientOptions tested(credentials);
+  EXPECT_EQ("bigtable.googleapis.com", tested.data_endpoint());
+  EXPECT_EQ("bigtableadmin.googleapis.com", tested.admin_endpoint());
+  EXPECT_EQ(credentials.get(), tested.credentials().get());
+}
+
+TEST_F(ClientOptionsEmulatorTest, DefaultNoEmulator) {
+  UnsetEnv("BIGTABLE_EMULATOR_HOST");  // TearDown() will restore
+  auto credentials = grpc::GoogleDefaultCredentials();
+  bigtable::ClientOptions tested(credentials);
+  EXPECT_EQ("bigtable.googleapis.com", tested.data_endpoint());
+  EXPECT_EQ("bigtableadmin.googleapis.com", tested.admin_endpoint());
 }
 
 TEST(ClientOptionsTest, EditDataEndpoint) {


### PR DESCRIPTION
This fixes #465.  Make it possible to initialize ClientOptions when there are no default
credentials configured.
