### PR TITLE
Use compiler with full C++11 support for CentOS.

### DIFF
--- a/ci/Dockerfile.centos
+++ b/ci/Dockerfile.centos
@@ -20,24 +20,18 @@ MAINTAINER "Carlos O'Ryan <coryan@google.com>"
 RUN rpm -Uvh \
     https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
+RUN yum install -y centos-release-scl
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
+
 RUN yum makecache && yum install -y \
-    autoconf \
-    automake \
+    devtoolset-7 \
     c-ares-devel \
-    clang \
-    clang-tools-extra \
     cmake3 \
     curl \
     curl-devel \
-    dia \
-    doxygen \
-    gcc-c++ \
     git \
     golang \
     graphviz \
-    lcov \
-    libtool \
-    make \
     openssl-devel \
     pkgconfig \
     python \

--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -22,6 +22,12 @@ if [ "${TRAVIS_OS_NAME}" != "linux" ]; then
 fi
 
 readonly IMAGE="cached-${DISTRO}-${DISTRO_VERSION}"
+if [ "${IMAGE}" = "cached-centos-7" ]; then
+  build_script="scl enable devtoolset-7 /v/ci/build-docker.sh";
+else
+  build_script="/v/ci/build-docker.sh";
+fi
+
 sudo docker run --cap-add SYS_PTRACE -it \
      --env DISTRO="${DISTRO}" \
      --env DISTRO_VERSION="${DISTRO_VERSION}" \
@@ -37,4 +43,4 @@ sudo docker run --cap-add SYS_PTRACE -it \
      --env CBT=/usr/local/google-cloud-sdk/bin/cbt \
      --env CBT_EMULATOR=/usr/local/google-cloud-sdk/platform/bigtable-emulator/cbtemulator \
      --env TERM=${TERM:-dumb} \
-     --volume $PWD:/v --workdir /v "${IMAGE}:tip" /v/ci/build-docker.sh
+     --volume $PWD:/v --workdir /v "${IMAGE}:tip" ${build_script}


### PR DESCRIPTION
The stock compiler (gcc-4.8) has really broken C++11 support, upgrade
(to gcc-7.x) the continuous integration build before making changes that
will break with that compiler.

