### PR TITLE
Use @par for examples in Doxygen docs.

### DIFF
--- a/bigtable/client/instance_admin.h
+++ b/bigtable/client/instance_admin.h
@@ -77,7 +77,7 @@ class InstanceAdmin {
   /**
    * Return the list of instances in the project.
    *
-   * **Example**
+   * @par Example
    * @snippet bigtable_samples_instance_admin.cc list instances
    */
   std::vector<google::bigtable::admin::v2::Instance> ListInstances();
@@ -91,7 +91,7 @@ class InstanceAdmin {
    * @param instance_id the id of the instance in the project that needs to be
    * deleted
    *
-   * **Example**
+   * @par Example
    * @snippet bigtable_samples_instance_admin.cc delete instance
    */
   void DeleteInstance(std::string const& instance_id);
@@ -99,7 +99,7 @@ class InstanceAdmin {
   /**
    * Return the list of clusters in the project.
    *
-   * **Example**
+   * @par Example
    * @snippet bigtable_samples_instance_admin.cc list clusters
    */
   std::vector<google::bigtable::admin::v2::Cluster> ListClusters();

--- a/bigtable/client/table.h
+++ b/bigtable/client/table.h
@@ -66,7 +66,7 @@ class Table {
    * The policies are passed by value, because this makes it easy for
    * applications to create them.  For example:
    *
-   * **Example**
+   * @par Example
    * @code
    * using namespace std::chrono_literals; // assuming C++14.
    * auto client = bigtable::CreateDefaultClient(...); // details ommitted
@@ -124,7 +124,7 @@ class Table {
    * The policies are passed by value, because this makes it easy for
    * applications to create them.  For example:
    *
-   * **Example**
+   * @par Example
    * @code
    * using namespace std::chrono_literals; // assuming C++14.
    * auto client = bigtable::CreateDefaultClient(...); // details ommitted
@@ -194,7 +194,7 @@ class Table {
    *     exception contains a copy of the original mutation, in case the
    *     application wants to retry, log, or otherwise handle the failure.
    *
-   * **Example**
+   * @par Example
    * @snippet bigtable_samples.cc apply
    */
   void Apply(SingleRowMutation&& mut);
@@ -216,7 +216,7 @@ class Table {
    *     mutations, in case the application wants to retry, log, or otherwise
    *     handle the failed mutations.
    *
-   * **Example**
+   * @par Example
    * @snippet bigtable_samples.cc bulk apply
    */
   void BulkApply(BulkMutation&& mut);
@@ -227,7 +227,7 @@ class Table {
    * @param row_set the rows to read from.
    * @param filter is applied on the server-side to data in the rows.
    *
-   * **Example**
+   * @par Example
    * @snippet bigtable_samples.cc read rows
    */
   RowReader ReadRows(RowSet row_set, Filter filter);
@@ -243,7 +243,7 @@ class Table {
    * @throws std::runtime_error if rows_limit is < 0. rows_limit = 0(default)
    * will return all rows
    *
-   * **Example**
+   * @par Example
    * @snippet bigtable_samples.cc read rows with limit
    */
   RowReader ReadRows(RowSet row_set, std::int64_t rows_limit, Filter filter);
@@ -259,7 +259,7 @@ class Table {
    *     has the contents of the Row.  Note that the contents may be empty
    *     if the filter expression removes all column families and columns.
    *
-   * **Example**
+   * @par Example
    * @snippet bigtable_samples.cc read row
    */
   std::pair<bool, Row> ReadRow(std::string row_key, Filter filter);
@@ -278,7 +278,7 @@ class Table {
    * @param false_mutations the mutations for the "filter did not pass" case.
    * @returns true if the filter passed.
    *
-   * **Example**
+   * @par Example
    * @snippet bigtable_samples.cc check and mutate
    */
   bool CheckAndMutateRow(std::string row_key, Filter filter,
@@ -294,7 +294,7 @@ class Table {
    *     on the table, and may include the empty row key to indicate
    *     "end of table".
    *
-   * **Examples**
+   * @par Examples
    * @snippet bigtable_samples.cc sample row keys
    *
    * In addition, application developers can specify other collection types, for
@@ -327,7 +327,7 @@ class Table {
    * @param rules is the zero or more ReadModifyWriteRules to apply on a row.
    * @returns modified row
    *
-   * **Example**
+   * @par Example
    * @snippet bigtable_samples.cc read modify write
    */
   template <typename... Args>

--- a/bigtable/client/table_admin.h
+++ b/bigtable/client/table_admin.h
@@ -77,7 +77,7 @@ class TableAdmin {
    *     only populates the table_name() field at this time.
    * @throws std::exception if the operation cannot be completed.
    *
-   * **Example**
+   * @par Example
    * @snippet bigtable_samples.cc create table
    */
   ::google::bigtable::admin::v2::Table CreateTable(std::string table_id,
@@ -92,7 +92,7 @@ class TableAdmin {
    *   - `VIEW_SCHEMA`: return the name and the schema.
    *   - `FULL`: return all the information about the table.
    *
-   * **Example**
+   * @par Example
    * @snippet bigtable_samples.cc list tables
    */
   std::vector<::google::bigtable::admin::v2::Table> ListTables(
@@ -113,7 +113,7 @@ class TableAdmin {
    * @throws std::exception if the information could not be obtained before the
    *     RPC policies in effect gave up.
    *
-   * **Example**
+   * @par Example
    * @snippet bigtable_samples.cc get table
    */
   ::google::bigtable::admin::v2::Table GetTable(
@@ -130,7 +130,7 @@ class TableAdmin {
    * @throws std::exception if the table could not be deleted before the RPC
    *     policies in effect gave up.
    *
-   * **Example**
+   * @par Example
    * @snippet bigtable_samples.cc delete table
    */
   void DeleteTable(std::string const& table_id);
@@ -145,7 +145,7 @@ class TableAdmin {
    * @return the resulting table schema.
    * @throws std::exception if the operation cannot be completed.
    *
-   * **Example**
+   * @par Example
    * @snippet bigtable_samples.cc modify table
    */
   ::google::bigtable::admin::v2::Table ModifyColumnFamilies(
@@ -161,7 +161,7 @@ class TableAdmin {
    * @param row_key_prefix drop any rows that start with this prefix.
    * @throws std::exception if the operation cannot be completed.
    *
-   * **Example**
+   * @par Example
    * @snippet bigtable_samples.cc drop rows by prefix
    */
   void DropRowsByPrefix(std::string const& table_id,
@@ -175,7 +175,7 @@ class TableAdmin {
    *     `this->instance_name() + "/tables/" + table_id`
    * @throws std::exception if the operation cannot be completed.
    *
-   * **Example**
+   * @par Example
    * @snippet bigtable_samples.cc drop all rows
    */
   void DropAllRows(std::string const& table_id);


### PR DESCRIPTION
Instead of using **Example** use `@par Example`, which produces
slightly more pleasing output (matches the other sections of the
documentation), and has the right semantics. This fixes #481.