### PR TITLE
Do not use gcc-4.8 in CI builds.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,6 +14,9 @@ ignore:
   - "*.pb.h"
   # Ignore third party code and dependencies too.
   - "/third_party/**"
+  # The `tests` directory contains tests to reproduce bugs in gRPC, not
+  # interesting for code coverage analysis.
+  - "/tests/**"
   # Ignore the bigtable/client/testing directory, because these are components
   # to drive testing, their coverage is not interesting.
   - "/bigtable/client/testing/**"
@@ -23,5 +26,7 @@ ignore:
   # Ignore the benchmarks, they are not important for the experience for our
   # users.
   - "/bigtable/benchmarks/**"
+  # TODO(#492) - temporarily ignore the examples, they are not running yet.
+  - "/bigtable/examples/**"
   # Also ignore the unit tests.
   - "**/*_test.cc$"

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ matrix:
     - # Generate code coverage information and upload to codecov.io.
       os: linux
       compiler: gcc
-      env: DISTRO=ubuntu DISTRO_VERSION=14.04 BUILD_TYPE=Coverage
+      env: DISTRO=ubuntu DISTRO_VERSION=18  .04 BUILD_TYPE=Coverage
     - # Compile with exceptions disabled.
       os: linux
       compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ matrix:
     - # Generate code coverage information and upload to codecov.io.
       os: linux
       compiler: gcc
-      env: DISTRO=ubuntu DISTRO_VERSION=18  .04 BUILD_TYPE=Coverage
+      env: DISTRO=ubuntu DISTRO_VERSION=18.04 BUILD_TYPE=Coverage
     - # Compile with exceptions disabled.
       os: linux
       compiler: gcc

--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -18,13 +18,22 @@ set -eu
 
 sudo apt-get update
 sudo apt-get install -y \
-     g++ \
+     libcurl4-openssl-dev \
+     libssl-dev \
      pkg-config \
      python \
+     python-software-properties \
+     software-properties-common \
      unzip \
      wget \
      zip \
      zlib1g-dev
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+sudo apt-get update
+sudo apt-get install -y gcc-7 g++-7
+
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 100
 
 readonly BAZEL_VERSION=0.12.0
 readonly GITHUB_DL="https://github.com/bazelbuild/bazel/releases/download"

--- a/ci/upload-codecov.sh
+++ b/ci/upload-codecov.sh
@@ -33,8 +33,11 @@ fi
 
 # Upload the results using the script from codecov.io
 # Save the log to a file because it exceeds the 4MB limit in Travis.
-bash <(curl -s https://codecov.io/bash) >codecov.log 2>&1 \
-  || echo "codecov.io script failed."
+readonly CI_ENV=`bash <(curl -s https://codecov.io/env)`
+readonly IMAGE="cached-${DISTRO}-${DISTRO_VERSION}"
+sudo docker run $CI_ENV \
+    --volume $PWD:/v --workdir /v \
+    "${IMAGE}:tip" /bin/bash -c "/bin/bash <(curl -s https://codecov.io/bash)"
 
 echo "================================================================"
 head -1000 codecov.log


### PR DESCRIPTION
This version of gcc has poor C++11 support, and we are about to introduce changes that require better support.  With these changes we stop using gcc-4.8 on Ubuntu 14.04.  The CI builds document how to update the compiler on that distro.
