### PR TITLE
Run test-installs in the build-output subdirectory.

### DIFF
--- a/ci/build-docker.sh
+++ b/ci/build-docker.sh
@@ -93,13 +93,13 @@ if [ "${TEST_INSTALL}" = "yes" ]; then
   echo "${COLOR_YELLOW}Testing install rule.${COLOR_RESET}"
   cmake --build . --target install
   echo
-  echo "${COLOR_YELLOW}Test installed libraries using make(1).${COLOR_RESET}"
-  make -C /v/ci/test-install all
-  echo
   echo "${COLOR_YELLOW}Test installed libraries using cmake(1).${COLOR_RESET}"
   cd /v/ci/test-install
-  CMAKE_PREFIX_PATH=/usr/local/share cmake -H. -B.build
-  cmake --build .build
+  cmake -H/v/ci/test-install -B/v/build-output/test-install-cmake
+  cmake --build /v/build-output/test-install-cmake
+  echo
+  echo "${COLOR_YELLOW}Test installed libraries using make(1).${COLOR_RESET}"
+  make -C /v/build-output/test-install-make -f/v/ci/test-install/Makefile VPATH=/v/ci/test-install
 fi
 
 # If document generation is enabled, run it now.

--- a/ci/build-docker.sh
+++ b/ci/build-docker.sh
@@ -94,12 +94,15 @@ if [ "${TEST_INSTALL}" = "yes" ]; then
   cmake --build . --target install
   echo
   echo "${COLOR_YELLOW}Test installed libraries using cmake(1).${COLOR_RESET}"
-  cmake -H/v/ci/test-install -B/v/build-output/test-install-cmake
-  cmake --build /v/build-output/test-install-cmake
+  readonly TEST_INSTALL_DIR=/v/ci/test-install
+  readonly TEST_INSTALL_CMAKE_OUTPUT_DIR=/v/build-output/test-install-cmake
+  readonly TEST_INSTALL_MAKE_OUTPUT_DIR=/v/build-output/test-install-make
+  cmake -H"${TEST_INSTALL_DIR}" -B"${TEST_INSTALL_CMAKE_OUTPUT_DIR}"
+  cmake --build "${TEST_INSTALL_CMAKE_OUTPUT_DIR}"
   echo
   echo "${COLOR_YELLOW}Test installed libraries using make(1).${COLOR_RESET}"
-  mkdir -p /v/build-output/test-install-make
-  make -C /v/build-output/test-install-make -f/v/ci/test-install/Makefile VPATH=/v/ci/test-install
+  mkdir -p "${TEST_INSTALL_MAKE_OUTPUT_DIR}"
+  make -C "${TEST_INSTALL_CMAKE_OUTPUT_DIR}" -f"${TEST_INSTALL_DIR}/Makefile" VPATH="${TEST_INSTALL_DIR}"
 fi
 
 # If document generation is enabled, run it now.

--- a/ci/build-docker.sh
+++ b/ci/build-docker.sh
@@ -94,11 +94,11 @@ if [ "${TEST_INSTALL}" = "yes" ]; then
   cmake --build . --target install
   echo
   echo "${COLOR_YELLOW}Test installed libraries using cmake(1).${COLOR_RESET}"
-  cd /v/ci/test-install
   cmake -H/v/ci/test-install -B/v/build-output/test-install-cmake
   cmake --build /v/build-output/test-install-cmake
   echo
   echo "${COLOR_YELLOW}Test installed libraries using make(1).${COLOR_RESET}"
+  mkdir -p /v/build-output/test-install-make
   make -C /v/build-output/test-install-make -f/v/ci/test-install/Makefile VPATH=/v/ci/test-install
 fi
 


### PR DESCRIPTION
In the CI builds we install the code and then compile small examples against the installed code to verify it works correctly.  Before this change the build artifacts for those test-install targets were left in the git clone, which was inconvenient for developers wanting to test changes to the install target.

With this change the build artifacts for those "test install" builds go into the `build-output` subdirectory.
