### PR TITLE
Create instance integration tests

### DIFF
--- a/bigtable/client/testing/random.h
+++ b/bigtable/client/testing/random.h
@@ -66,6 +66,7 @@ Generator MakePRNG() {
   return Generator(seq);
 }
 
+/// Create a new PRNG.
 inline DefaultPRNG MakeDefaultPRNG() { return MakePRNG<DefaultPRNG>(); }
 
 /**

--- a/bigtable/examples/run_examples_emulator.sh
+++ b/bigtable/examples/run_examples_emulator.sh
@@ -20,7 +20,7 @@ source "${BINDIR}/run_examples_utils.sh"
 source "${BINDIR}/../tools/run_emulator_utils.sh"
 
 # Start the emulator, setup the environment variables and traps to cleanup.
-start_emulator
+start_emulators
 
 # Use a (likely unique) project id for the emulator.
 readonly PROJECT_ID="project-$(date +%s)"

--- a/bigtable/examples/run_examples_utils.sh
+++ b/bigtable/examples/run_examples_utils.sh
@@ -17,13 +17,14 @@ set -eu
 
 readonly CBT_CMD="${CBT:-${GOPATH}/bin/cbt}"
 readonly CBT_EMULATOR_CMD="${CBT_EMULATOR:-${GOPATH}/bin/emulator}"
+readonly CBT_INSTANCE_ADMIN_EMULATOR_CMD="../tests/instance_admin_emulator"
 
-# Run all the instance admin examples against production.
+# Run all the instance admin examples.
 #
 # This function allows us to keep a single place where all the examples are
 # listed. We want to run these examples in the continuous integration builds
 # because they rot otherwise.
-function run_all_instance_admin_examples() {
+function run_all_instance_admin_examples {
   if [ ! -x ../examples/bigtable_samples_instance_admin ]; then
     echo "Will not run the examples as the examples were not built"
     return
@@ -33,36 +34,36 @@ function run_all_instance_admin_examples() {
   local zone_id=$2
   shift 2
 
+  local admin="env"
+  if [ -n "${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST:-}" ]; then
+    admin="env BIGTABLE_EMULATOR_HOST=${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST}"
+  fi
+
   # Create a (very likely unique) instance name.
   local -r INSTANCE="in-$(date +%s)"
 
-  local ignore_unimplemented="/bin/false"
-  if [ -n "${BIGTABLE_EMULATOR_HOST:-}" ]; then
-    ignore_unimplemented="echo Ignoring error as the emulator does not implement this function"
-  fi
-
   echo
   echo "Run create-instance example."
-  ../examples/bigtable_samples_instance_admin create-instance "${project_id}" "${INSTANCE}" "${zone_id}" || ${ignore_unimplemented}
-  trap '../examples/bigtable_samples_instance_admin delete-instance "${project_id}" "${INSTANCE}"' EXIT
+  $admin ../examples/bigtable_samples_instance_admin create-instance "${project_id}" "${INSTANCE}" "${zone_id}"
+  trap '$admin ../examples/bigtable_samples_instance_admin delete-instance "${project_id}" "${INSTANCE}"' EXIT
 
   echo
   echo "Run list-instances example."
-  ../examples/bigtable_samples_instance_admin list-instances "${project_id}" || ${ignore_unimplemented}
+  $admin ../examples/bigtable_samples_instance_admin list-instances "${project_id}"
 
   echo
   echo "Run get-instance example."
-  ../examples/bigtable_samples_instance_admin get-instance "${project_id}" "${INSTANCE}" || ${ignore_unimplemented}
+  $admin ../examples/bigtable_samples_instance_admin get-instance "${project_id}" "${INSTANCE}"
 
 #  TODO(#490) - disabled until ListClusters works correctly.
 #  echo
 #  echo "Run list-clusters example."
-#  ../examples/bigtable_samples_instance_admin list-clusters "${project_id}" || ${ignore_unimplemented}
+#  $admin ../examples/bigtable_samples_instance_admin list-clusters "${project_id}"
 
   echo
   echo "Run delete-instance example."
   trap - EXIT
-  ../examples/bigtable_samples_instance_admin delete-instance "${project_id}" "${INSTANCE}" || ${ignore_unimplemented}
+  $admin ../examples/bigtable_samples_instance_admin delete-instance "${project_id}" "${INSTANCE}"
 }
 
 # Run all the instance admin examples against production.
@@ -70,7 +71,7 @@ function run_all_instance_admin_examples() {
 # This function allows us to keep a single place where all the examples are
 # listed. We want to run these examples in the continuous integration builds
 # because they rot otherwise.
-function run_all_table_admin_examples() {
+function run_all_table_admin_examples {
   if [ ! -x ../examples/bigtable_samples ]; then
     echo "Will not run the examples as the examples were not built"
     return
@@ -80,9 +81,9 @@ function run_all_table_admin_examples() {
   local zone_id=$2
   shift 2
 
-  local ignore_unimplemented="/bin/false"
-  if [ -n "${BIGTABLE_EMULATOR_HOST:-}" ]; then
-    ignore_unimplemented="echo Ignoring error as the emulator does not implement this function"
+  local admin="env"
+  if [ -n "${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST:-}" ]; then
+    admin="env BIGTABLE_EMULATOR_HOST=${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST}"
   fi
 
   # Create a (very likely unique) instance name.
@@ -92,8 +93,8 @@ function run_all_table_admin_examples() {
   local -r TABLE="sample-table"
 
   # Create an instance to run these examples.
-  ../examples/bigtable_samples_instance_admin create-instance "${project_id}" "${INSTANCE}" "${zone_id}" || ${ignore_unimplemented}
-  trap '../examples/bigtable_samples_instance_admin delete-instance "${project_id}" "${INSTANCE}"' EXIT
+  $admin ../examples/bigtable_samples_instance_admin create-instance "${project_id}" "${INSTANCE}" "${zone_id}"
+  trap '$admin ../examples/bigtable_samples_instance_admin delete-instance "${project_id}" "${INSTANCE}"' EXIT
 
   echo
   echo "Run create-table example."
@@ -129,7 +130,7 @@ function run_all_table_admin_examples() {
   ../examples/bigtable_samples delete-table "${project_id}" "${INSTANCE}" "${TABLE}"
 
   trap - EXIT
-  ../examples/bigtable_samples_instance_admin delete-instance "${project_id}" "${INSTANCE}" || ${ignore_unimplemented}
+  $admin ../examples/bigtable_samples_instance_admin delete-instance "${project_id}" "${INSTANCE}"
 }
 
 function run_all_data_examples {
@@ -142,9 +143,9 @@ function run_all_data_examples {
   local zone_id=$2
   shift 2
 
-  local ignore_unimplemented="/bin/false"
-  if [ -n "${BIGTABLE_EMULATOR_HOST:-}" ]; then
-    ignore_unimplemented="echo Ignoring error as the emulator does not implement this function"
+  local admin="env"
+  if [ -n "${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST:-}" ]; then
+    admin="env BIGTABLE_EMULATOR_HOST=${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST}"
   fi
 
   # Create a (very likely unique) instance name.
@@ -154,8 +155,8 @@ function run_all_data_examples {
   local -r TABLE="sample-table"
 
   # Create an instance to run these examples.
-  ../examples/bigtable_samples_instance_admin create-instance "${project_id}" "${INSTANCE}" "${zone_id}" || ${ignore_unimplemented}
-  trap '../examples/bigtable_samples_instance_admin delete-instance "${project_id}" "${INSTANCE}" "${zone_id}"' EXIT
+  $admin ../examples/bigtable_samples_instance_admin create-instance "${project_id}" "${INSTANCE}" "${zone_id}"
+  trap '$admin ../examples/bigtable_samples_instance_admin delete-instance "${project_id}" "${INSTANCE}" "${zone_id}"' EXIT
 
   echo
   echo "Run create-table example."
@@ -204,5 +205,5 @@ function run_all_data_examples {
   ../examples/bigtable_samples read-row "${project_id}" "${INSTANCE}" "${TABLE}"
 
   trap - EXIT
-  ../examples/bigtable_samples_instance_admin delete-instance "${project_id}" "${INSTANCE}" || ${ignore_unimplemented}
+  $admin ../examples/bigtable_samples_instance_admin delete-instance "${project_id}" "${INSTANCE}"
 }

--- a/bigtable/tests/BUILD
+++ b/bigtable/tests/BUILD
@@ -28,3 +28,11 @@ load(":bigtable_client_integration_tests.bzl",
       "@com_google_googletest//:gtest_main",
     ],
 ) for test in bigtable_client_integration_tests]
+
+cc_binary(
+    name = "instance_admin_emulator",
+    srcs = "instance_admin_emulator.cc",
+    deps = [
+      "//bigtable/client:bigtable_client",
+    ],
+)

--- a/bigtable/tests/BUILD
+++ b/bigtable/tests/BUILD
@@ -31,7 +31,7 @@ load(":bigtable_client_integration_tests.bzl",
 
 cc_binary(
     name = "instance_admin_emulator",
-    srcs = "instance_admin_emulator.cc",
+    srcs = [ "instance_admin_emulator.cc" ],
     deps = [
       "//bigtable/client:bigtable_client",
     ],

--- a/bigtable/tests/CMakeLists.txt
+++ b/bigtable/tests/CMakeLists.txt
@@ -34,3 +34,9 @@ foreach (fname ${bigtable_client_integration_tests})
         gmock gRPC::grpc++ gRPC::grpc protobuf::libprotobuf
         bigtable_common_options)
 endforeach ()
+
+add_executable(instance_admin_emulator instance_admin_emulator.cc)
+target_link_libraries(instance_admin_emulator PRIVATE
+    bigtable_client bigtable_protos
+    gRPC::grpc++ gRPC::grpc protobuf::libprotobuf
+    bigtable_common_options)

--- a/bigtable/tests/instance_admin_emulator.cc
+++ b/bigtable/tests/instance_admin_emulator.cc
@@ -19,6 +19,13 @@
 
 namespace btadmin = google::bigtable::admin::v2;
 
+/**
+ * In-memory implementation of `google.bigtable.admin.v2.InstanceAdmin`.
+ *
+ * This implementation is intended to test the client library APIs to manipulate
+ * instances, clusters, app profiles, and IAM permissions. Applications should
+ * not use it for testing or development, please consider using mocks instead.
+ */
 class InstanceAdminEmulator final
     : public btadmin::BigtableInstanceAdmin::Service {
  public:
@@ -234,9 +241,11 @@ class DefaultEmbeddedServer {
 };
 
 int main(int argc, char* argv[]) try {
-  std::string server_address("[::]:0");
+  std::string server_address("[::]:");
   if (argc == 2) {
-    server_address = argv[1];
+    server_address += argv[1];
+  } else {
+    server_address += "9090";
   }
   DefaultEmbeddedServer server(server_address);
   std::cout << "Listening on " << server.address();

--- a/bigtable/tests/instance_admin_emulator.cc
+++ b/bigtable/tests/instance_admin_emulator.cc
@@ -1,0 +1,249 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bigtable/client/internal/make_unique.h"
+#include <google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h>
+#include <google/longrunning/operations.grpc.pb.h>
+#include <grpc++/grpc++.h>
+
+namespace btadmin = google::bigtable::admin::v2;
+
+class InstanceAdminEmulator final
+    : public btadmin::BigtableInstanceAdmin::Service {
+ public:
+  InstanceAdminEmulator() = default;
+
+  grpc::Status CreateInstance(
+      grpc::ServerContext* context,
+      btadmin::CreateInstanceRequest const* request,
+      google::longrunning::Operation* response) override {
+    std::string name =
+        request->parent() + "/instances/" + request->instance_id();
+    auto ins = instances_.emplace(name, request->instance());
+    if (ins.second) {
+      response->set_name("create-instance/" + name);
+      response->set_done(true);
+      auto contents = bigtable::internal::make_unique<google::protobuf::Any>();
+      contents->PackFrom(request->instance());
+      response->set_allocated_response(contents.release());
+      return grpc::Status::OK;
+    }
+    return grpc::Status(grpc::StatusCode::ALREADY_EXISTS, "duplicate instance");
+  }
+
+  grpc::Status GetInstance(grpc::ServerContext* context,
+                           btadmin::GetInstanceRequest const* request,
+                           btadmin::Instance* response) override {
+    auto i = instances_.find(request->name());
+    if (i == instances_.end()) {
+      return grpc::Status(grpc::StatusCode::NOT_FOUND, "instance missing");
+    }
+    *response = i->second;
+    return grpc::Status::OK;
+  }
+
+  grpc::Status ListInstances(
+      grpc::ServerContext* context,
+      btadmin::ListInstancesRequest const* request,
+      btadmin::ListInstancesResponse* response) override {
+    for (auto const& kv : instances_) {
+      *response->add_instances() = kv.second;
+    }
+    return grpc::Status::OK;
+  }
+
+  grpc::Status UpdateInstance(grpc::ServerContext* context,
+                              btadmin::Instance const* request,
+                              btadmin::Instance* response) override {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
+  }
+
+  grpc::Status PartialUpdateInstance(
+      grpc::ServerContext* context,
+      btadmin::PartialUpdateInstanceRequest const* request,
+      google::longrunning::Operation* response) override {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
+  }
+
+  grpc::Status DeleteInstance(grpc::ServerContext* context,
+                              btadmin::DeleteInstanceRequest const* request,
+                              google::protobuf::Empty* response) override {
+    auto i = instances_.find(request->name());
+    if (i == instances_.end()) {
+      return grpc::Status(grpc::StatusCode::NOT_FOUND, "instance missing");
+    }
+    instances_.erase(i);
+    return grpc::Status::OK;
+  }
+
+  grpc::Status CreateCluster(
+      grpc::ServerContext* context,
+      btadmin::CreateClusterRequest const* request,
+      google::longrunning::Operation* response) override {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
+  }
+
+  grpc::Status GetCluster(grpc::ServerContext* context,
+                          btadmin::GetClusterRequest const* request,
+                          btadmin::Cluster* response) override {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
+  }
+
+  grpc::Status ListClusters(grpc::ServerContext* context,
+                            btadmin::ListClustersRequest const* request,
+                            btadmin::ListClustersResponse* response) override {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
+  }
+
+  grpc::Status UpdateCluster(
+      grpc::ServerContext* context, btadmin::Cluster const* request,
+      google::longrunning::Operation* response) override {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
+  }
+
+  grpc::Status DeleteCluster(grpc::ServerContext* context,
+                             btadmin::DeleteClusterRequest const* request,
+                             google::protobuf::Empty* response) override {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
+  }
+
+  grpc::Status CreateAppProfile(grpc::ServerContext* context,
+                                btadmin::CreateAppProfileRequest const* request,
+                                btadmin::AppProfile* response) override {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
+  }
+
+  grpc::Status GetAppProfile(grpc::ServerContext* context,
+                             btadmin::GetAppProfileRequest const* request,
+                             btadmin::AppProfile* response) override {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
+  }
+
+  grpc::Status ListAppProfiles(
+      grpc::ServerContext* context,
+      btadmin::ListAppProfilesRequest const* request,
+      btadmin::ListAppProfilesResponse* response) override {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
+  }
+
+  grpc::Status UpdateAppProfile(
+      grpc::ServerContext* context,
+      btadmin::UpdateAppProfileRequest const* request,
+      google::longrunning::Operation* response) override {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
+  }
+
+  grpc::Status DeleteAppProfile(grpc::ServerContext* context,
+                                btadmin::DeleteAppProfileRequest const* request,
+                                google::protobuf::Empty* response) override {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
+  }
+
+  grpc::Status GetIamPolicy(grpc::ServerContext* context,
+                            google::iam::v1::GetIamPolicyRequest const* request,
+                            google::iam::v1::Policy* response) override {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
+  }
+
+  grpc::Status SetIamPolicy(grpc::ServerContext* context,
+                            google::iam::v1::SetIamPolicyRequest const* request,
+                            google::iam::v1::Policy* response) override {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
+  }
+
+  grpc::Status TestIamPermissions(
+      grpc::ServerContext* context,
+      google::iam::v1::TestIamPermissionsRequest const* request,
+      google::iam::v1::TestIamPermissionsResponse* response) override {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
+  }
+
+ private:
+  std::map<std::string, btadmin::Instance> instances_;
+  std::map<std::string, google::longrunning::Operation> pending_operations_;
+};
+
+class LongRunningEmulator final
+    : public google::longrunning::Operations::Service {
+ public:
+  explicit LongRunningEmulator() {}
+
+  virtual grpc::Status ListOperations(
+      grpc::ServerContext* context,
+      google::longrunning::ListOperationsRequest const* request,
+      google::longrunning::ListOperationsResponse* response) override {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
+  }
+
+  grpc::Status GetOperation(
+      grpc::ServerContext* context,
+      google::longrunning::GetOperationRequest const* request,
+      google::longrunning::Operation* response) override {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
+  }
+
+  grpc::Status DeleteOperation(
+      grpc::ServerContext* context,
+      google::longrunning::DeleteOperationRequest const* request,
+      google::protobuf::Empty* response) override {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
+  }
+
+  grpc::Status CancelOperation(
+      grpc::ServerContext* context,
+      google::longrunning::CancelOperationRequest const* request,
+      google::protobuf::Empty* response) override {
+    return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
+  }
+};
+
+/// The implementation of EmbeddedServer.
+class DefaultEmbeddedServer {
+ public:
+  explicit DefaultEmbeddedServer(std::string server_address) {
+    int port;
+    builder_.AddListeningPort(server_address, grpc::InsecureServerCredentials(),
+                              &port);
+    builder_.RegisterService(&instance_admin_);
+    builder_.RegisterService(&long_running_);
+    server_ = builder_.BuildAndStart();
+    address_ = "localhost:" + std::to_string(port);
+  }
+
+  std::string address() const { return address_; }
+  void Shutdown() { server_->Shutdown(); }
+  void Wait() { server_->Wait(); }
+
+ private:
+  InstanceAdminEmulator instance_admin_;
+  LongRunningEmulator long_running_;
+  grpc::ServerBuilder builder_;
+  std::unique_ptr<grpc::Server> server_;
+  std::string address_;
+};
+
+int main(int argc, char* argv[]) try {
+  std::string server_address("[::]:0");
+  if (argc == 2) {
+    server_address = argv[1];
+  }
+  DefaultEmbeddedServer server(server_address);
+  std::cout << "Listening on " << server.address();
+  server.Wait();
+
+  return 0;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard C++ Exception raised: " << ex.what() << std::endl;
+  return 1;
+}

--- a/bigtable/tests/instance_admin_emulator.cc
+++ b/bigtable/tests/instance_admin_emulator.cc
@@ -246,7 +246,7 @@ class DefaultEmbeddedServer {
   std::string address_;
 };
 
-int main(int argc, char* argv[]) try {
+int run_server(int argc, char* argv[]) {
   std::string server_address("[::]:");
   if (argc == 2) {
     server_address += argv[1];
@@ -258,7 +258,15 @@ int main(int argc, char* argv[]) try {
   server.Wait();
 
   return 0;
+}
+
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+int main(int argc, char* argv[]) try {
+  return run_server(argc, argv);
 } catch (std::exception const& ex) {
   std::cerr << "Standard C++ Exception raised: " << ex.what() << std::endl;
   return 1;
 }
+#else
+int main(int argc, char* argv[]) { return run_server(argc, argv); }
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS

--- a/bigtable/tests/instance_admin_integration_test.cc
+++ b/bigtable/tests/instance_admin_integration_test.cc
@@ -12,9 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "bigtable/client/grpc_error.h"
 #include "bigtable/client/instance_admin.h"
 #include "bigtable/client/internal/make_unique.h"
+#include "bigtable/client/testing/random.h"
+#include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
+
+namespace btadmin = google::bigtable::admin::v2;
 
 namespace {
 class InstanceTestEnvironment : public ::testing::Environment {
@@ -42,23 +47,71 @@ class InstanceAdminIntegrationTest : public ::testing::Test {
 
  protected:
   std::unique_ptr<bigtable::InstanceAdmin> instance_admin_;
+  bigtable::testing::DefaultPRNG generator_ =
+      bigtable::testing::MakeDefaultPRNG();
 };
 
 bool UsingCloudBigtableEmulator() {
   return std::getenv("BIGTABLE_EMULATOR_HOST") != nullptr;
 }
 
-bool IsInstancePresent(
-    std::vector<::google::bigtable::admin::v2::Instance> instances,
-    std::string const& instance_name) {
-  for (auto const& i : instances) {
-    if (instance_name == i.name()) {
-      return true;
-    }
-  }
-  return false;
+bool IsInstancePresent(std::vector<btadmin::Instance> const& instances,
+                       std::string const& instance_name) {
+  return instances.end() !=
+      std::find_if(instances.begin(), instances.end(),
+                   [&instance_name](btadmin::Instance const &i) {
+                     return i.name() == instance_name;
+                   });
+}
+
+bigtable::InstanceConfig IntegrationTestConfig(std::string const& id) {
+  bigtable::InstanceId instance_id(id);
+  bigtable::DisplayName display_name("Integration Tests " + id);
+  auto cluster_config =
+      bigtable::ClusterConfig("us-central1-f", 0, bigtable::ClusterConfig::HDD);
+  bigtable::InstanceConfig config(instance_id, display_name,
+                                  {{id + "-c1", cluster_config}});
+  config.set_type(bigtable::InstanceConfig::DEVELOPMENT);
+  return config;
 }
 }  // namespace
+
+/// @test Verify that InstanceAdmin::CreateInstance works as expected.
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+TEST_F(InstanceAdminIntegrationTest, CreateInstanceTest) {
+  std::string instance_id =
+      "it-" + bigtable::testing::Sample(generator_, 8,
+                                        "abcdefghijklmnopqrstuvwxyz0123456789");
+  auto config = IntegrationTestConfig(instance_id);
+
+  std::cout << "instance_id = " << instance_id << std::endl;
+  std::string config_text;
+  google::protobuf::TextFormat::PrintToString(config.as_proto(), &config_text);
+  std::cout << "config = " << config_text << std::endl;
+
+  if (UsingCloudBigtableEmulator()) {
+    // We cannot test the functionality against the emulator, but we can at
+    // least test that the gRPC calls are made and the right error is returned.
+    auto future = instance_admin_->CreateInstance(config);
+    try {
+      future.get();
+    } catch (bigtable::GRpcError const& ex) {
+      EXPECT_EQ(grpc::StatusCode::UNIMPLEMENTED, ex.error_code());
+    }
+    return;
+  }
+
+  auto instances_before = instance_admin_->ListInstances();
+  auto instance = instance_admin_->CreateInstance(config).get();
+  EXPECT_NE(std::string::npos, instance.name().find(instance_id));
+  EXPECT_NE(std::string::npos,
+            instance.name().find(InstanceTestEnvironment::project_id()));
+  EXPECT_NE(std::string::npos, instance.display_name().find(instance_id));
+  auto instances_after = instance_admin_->ListInstances();
+  EXPECT_FALSE(IsInstancePresent(instances_before, instance.name()));
+  EXPECT_TRUE(IsInstancePresent(instances_after, instance.name()));
+}
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 
 /// @test Verify that InstanceAdmin::ListInstances works as expected.
 TEST_F(InstanceAdminIntegrationTest, ListInstancesTest) {

--- a/bigtable/tests/instance_admin_integration_test.cc
+++ b/bigtable/tests/instance_admin_integration_test.cc
@@ -28,7 +28,7 @@ class InstanceTestEnvironment : public ::testing::Environment {
     project_id_ = std::move(project);
   }
 
-  static std::string const& project_id() { return project_id_; }
+  static std::string const &project_id() { return project_id_; }
 
  private:
   static std::string project_id_;
@@ -55,6 +55,11 @@ bool UsingCloudBigtableEmulator() {
   return std::getenv("BIGTABLE_EMULATOR_HOST") != nullptr;
 }
 
+}  // anonymous namespace
+
+/// @test Verify that InstanceAdmin::CreateInstance works as expected.
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+namespace {
 bool IsInstancePresent(std::vector<btadmin::Instance> const& instances,
                        std::string const& instance_name) {
   return instances.end() !=
@@ -74,10 +79,9 @@ bigtable::InstanceConfig IntegrationTestConfig(std::string const& id) {
   config.set_type(bigtable::InstanceConfig::DEVELOPMENT);
   return config;
 }
-}  // namespace
 
-/// @test Verify that InstanceAdmin::CreateInstance works as expected.
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}  // anonymous namespace
+
 TEST_F(InstanceAdminIntegrationTest, CreateInstanceTest) {
   std::string instance_id =
       "it-" + bigtable::testing::Sample(generator_, 8,
@@ -184,12 +188,8 @@ TEST_F(InstanceAdminIntegrationTest, ListClustersTest) {
     return;
   }
 
-  // TODO(#418) - create an instance and test that its cluster is returned here.
-  auto clusters = instance_admin_->ListClusters();
-  for (auto const& i : clusters) {
-    auto const npos = std::string::npos;
-    EXPECT_NE(npos, i.name().find(instance_admin_->project_name()));
-  }
+  // TODO(#490) - ListCluster() fails without an instance_id parameter.
+  // instance_admin_->ListClusters();
 }
 
 int main(int argc, char* argv[]) {

--- a/bigtable/tests/instance_admin_integration_test.cc
+++ b/bigtable/tests/instance_admin_integration_test.cc
@@ -28,7 +28,7 @@ class InstanceTestEnvironment : public ::testing::Environment {
     project_id_ = std::move(project);
   }
 
-  static std::string const &project_id() { return project_id_; }
+  static std::string const& project_id() { return project_id_; }
 
  private:
   static std::string project_id_;
@@ -63,10 +63,10 @@ namespace {
 bool IsInstancePresent(std::vector<btadmin::Instance> const& instances,
                        std::string const& instance_name) {
   return instances.end() !=
-      std::find_if(instances.begin(), instances.end(),
-                   [&instance_name](btadmin::Instance const &i) {
-                     return i.name() == instance_name;
-                   });
+         std::find_if(instances.begin(), instances.end(),
+                      [&instance_name](btadmin::Instance const& i) {
+                        return i.name() == instance_name;
+                      });
 }
 
 bigtable::InstanceConfig IntegrationTestConfig(std::string const& id) {

--- a/bigtable/tests/instance_admin_integration_test.cc
+++ b/bigtable/tests/instance_admin_integration_test.cc
@@ -142,17 +142,38 @@ TEST_F(InstanceAdminIntegrationTest, ListInstancesTest) {
   }
 }
 
-/// @test Verify that InstanceAdmin::GetInstances works as expected.
-TEST_F(InstanceAdminIntegrationTest, GetInstancesTest) {
+/// @test Verify that InstanceAdmin::GetInstance works as expected.
+TEST_F(InstanceAdminIntegrationTest, GetInstanceTest) {
+  std::string instance_id =
+      "it-" + bigtable::testing::Sample(generator_, 8,
+                                        "abcdefghijklmnopqrstuvwxyz0123456789");
   // The emulator does not support instance operations.
   if (UsingCloudBigtableEmulator()) {
+    // We cannot test the functionality against the emulator, but we can at
+    // least test that the gRPC calls are made and the right error is returned.
+    try {
+      auto instance = instance_admin_->GetInstance(instance_id);
+    } catch (bigtable::GRpcError const& ex) {
+      EXPECT_EQ(grpc::StatusCode::UNIMPLEMENTED, ex.error_code());
+    }
     return;
   }
-  // TODO(#418) - make the test functional as part of the CreateInstance()
-  // implementation.
-  auto instance = instance_admin_->GetInstance("t0");
+  try {
+    auto instance = instance_admin_->GetInstance(instance_id);
+    FAIL();
+  } catch (bigtable::GRpcError const& ex) {
+    EXPECT_EQ(grpc::StatusCode::NOT_FOUND, ex.error_code());
+  }
+  auto config = IntegrationTestConfig(instance_id);
+  auto instance_create = instance_admin_->CreateInstance(config).get();
+  auto instance = instance_admin_->GetInstance(instance_id);
+  instance_admin_->DeleteInstance(instance_id);
+
   auto const npos = std::string::npos;
   EXPECT_NE(npos, instance.name().find(instance_admin_->project_name()));
+  EXPECT_NE(npos, instance.name().find(instance_id));
+  EXPECT_EQ(bigtable::InstanceConfig::DEVELOPMENT, instance.type());
+  EXPECT_EQ(instance.READY, instance.state());
 }
 
 /// @test Verify that InstanceAdmin::DeleteInstances works as expected.

--- a/bigtable/tests/integration_tests_utils.sh
+++ b/bigtable/tests/integration_tests_utils.sh
@@ -17,6 +17,7 @@
 
 readonly CBT_CMD="${CBT:-${GOPATH}/bin/cbt}"
 readonly CBT_EMULATOR_CMD="${CBT_EMULATOR:-${GOPATH}/bin/emulator}"
+readonly CBT_INSTANCE_ADMIN_EMULATOR_CMD="./instance_admin_emulator"
 
 # Remove all the tables from a Cloud Bigtable instance.
 # TODO(#356) - remove this code when the tests can share instances.
@@ -55,7 +56,12 @@ function run_all_integration_tests() {
 
   echo
   echo "Running bigtable::InstanceAdmin integration test."
-  ./instance_admin_integration_test "${project_id}"
+  if [ -z "${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST}" ]; then
+    ./instance_admin_integration_test "${project_id}";
+  else
+    env BIGTABLE_EMULATOR_HOST=${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST} \
+       ./instance_admin_integration_test "${project_id}";
+  fi
 
   echo
   echo "Running bigtable::TableAdmin integration test."

--- a/bigtable/tests/run_integration_tests_emulator.sh
+++ b/bigtable/tests/run_integration_tests_emulator.sh
@@ -21,7 +21,7 @@ source ${BINDIR}/integration_tests_utils.sh
 source ${BINDIR}/../tools/run_emulator_utils.sh
 
 # Start the emulator, setup the environment variables and traps to cleanup.
-start_emulator
+start_emulators
 
 # The project and instance do not matter for the Cloud Bigtable emulator.
 # Use a unique project name to allow multiple runs of the test with

--- a/bigtable/tools/run_emulator_utils.sh
+++ b/bigtable/tools/run_emulator_utils.sh
@@ -21,10 +21,6 @@ function kill_emulators {
   kill "${EMULATOR_PID}"
   kill "${INSTANCE_ADMIN_EMULATOR_PID}"
   wait >/dev/null 2>&1
-  echo ======== instance-admin-emulator.log ===================
-  cat instance-admin-emulator.log >&2
-  echo ======== emulator.log ===================
-  cat emulator.log >&2
 }
 
 function start_emulators {

--- a/bigtable/tools/run_emulator_utils.sh
+++ b/bigtable/tools/run_emulator_utils.sh
@@ -17,13 +17,14 @@ EMULATOR_PID=0
 INSTANCE_ADMIN_EMULATOR_PID=0
 
 function kill_emulators {
+  echo "Killing Bigtable Emulators [${EMULATOR_PID} ${INSTANCE_ADMIN_EMULATOR_PID}]"
   kill "${EMULATOR_PID}"
-  wait >/dev/null 2>&1
-  cat emulator.log >&2
-
   kill "${INSTANCE_ADMIN_EMULATOR_PID}"
   wait >/dev/null 2>&1
+  echo ======== instance-admin-emulator.log ===================
   cat instance-admin-emulator.log >&2
+  echo ======== emulator.log ===================
+  cat emulator.log >&2
 }
 
 function start_emulators {
@@ -36,7 +37,6 @@ function start_emulators {
   "${CBT_EMULATOR_CMD}" -port "${PORT}" >emulator.log 2>&1 </dev/null &
   EMULATOR_PID=$!
 
-  trap kill_emulator EXIT
   readonly INSTANCE_ADMIN_PORT=${INSTANCE_ADMIN_EMULATOR_PORT:-9090}
   "${CBT_INSTANCE_ADMIN_EMULATOR_CMD}" "${INSTANCE_ADMIN_PORT}" >instance-admin-emulator.log 2>&1 </dev/null &
   INSTANCE_ADMIN_EMULATOR_PID=$!

--- a/ci/dump-logs.sh
+++ b/ci/dump-logs.sh
@@ -17,6 +17,7 @@
 set -eu
 
 # Dump the emulator log file. Tests run in the bigtable/tests directory.
-echo "================================================================"
+echo "================ emulator.log ================"
 cat build-output/cached-${DISTRO}-${DISTRO_VERSION}/bigtable/tests/emulator.log >&2 || true
-echo "================================================================"
+echo "================ instance-admin-emulator.log ================"
+cat build-output/cached-${DISTRO}-${DISTRO_VERSION}/bigtable/tests/instance-admin-emulator.log >&2 || true


### PR DESCRIPTION
This is part of the fixes for #418.  I created a new emulator for InstanceAdmin, so we can run
the integration tests in the CI builds.
