### PR TITLE
implementation of InstanceAdmin::DeleteCluster

### DIFF
--- a/bigtable/client/CMakeLists.txt
+++ b/bigtable/client/CMakeLists.txt
@@ -19,6 +19,7 @@ configure_file(version_info.h.in version_info.h)
 add_library(bigtable_client
         admin_client.h
         admin_client.cc
+        bigtable_strong_types.h
         ${CMAKE_CURRENT_BINARY_DIR}/version_info.h
         cell.h
         client_options.h
@@ -86,7 +87,6 @@ add_library(bigtable_client
         table.cc
         table_admin.h
         table_admin.cc
-        table_admin_strong_types.h
         table_config.h
         table_config.cc
         version.h

--- a/bigtable/client/bigtable_client.bzl
+++ b/bigtable/client/bigtable_client.bzl
@@ -1,6 +1,7 @@
 # DO NOT EDIT -- GENERATED CODE
 bigtable_client_HDRS = [
     "admin_client.h",
+    "bigtable_strong_types.h",
     "cell.h",
     "client_options.h",
     "cluster_config.h",
@@ -38,7 +39,6 @@ bigtable_client_HDRS = [
     "metadata_update_policy.h",
     "table.h",
     "table_admin.h",
-    "table_admin_strong_types.h",
     "table_config.h",
     "version.h",
 ]

--- a/bigtable/client/bigtable_strong_types.h
+++ b/bigtable/client/bigtable_strong_types.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TABLE_ADMIN_STRONG_TYPES_H_
-#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TABLE_ADMIN_STRONG_TYPES_H_
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_BIGTABLE_STRONG_TYPES_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_BIGTABLE_STRONG_TYPES_H_
 
 #include "bigtable/client/internal/strong_type.h"
 
@@ -22,10 +22,11 @@ inline namespace BIGTABLE_CLIENT_NS {
 using ConsistencyToken =
     internal::StrongType<std::string, struct ConsistencyTokenParam>;
 using ClusterId = internal::StrongType<std::string, struct ClusterTag>;
+using InstanceId = internal::StrongType<std::string, struct InstanceTag>;
 using SnapshotId = internal::StrongType<std::string, struct SnapshotTag>;
 using TableId = internal::StrongType<std::string, struct TableParam>;
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
 
-#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TABLE_ADMIN_STRONG_TYPES_H_
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_BIGTABLE_STRONG_TYPES_H_

--- a/bigtable/client/instance_admin.cc
+++ b/bigtable/client/instance_admin.cc
@@ -133,8 +133,8 @@ std::vector<btproto::Cluster> InstanceAdmin::ListClusters() {
   return result;
 }
 
-void InstanceAdmin::DeleteCluster(std::string const& instance_id,
-                                  std::string const& cluster_id) {
+void InstanceAdmin::DeleteCluster(bigtable::InstanceId const& instance_id,
+                                  bigtable::ClusterId const& cluster_id) {
   grpc::Status status;
   impl_.DeleteCluster(instance_id, cluster_id, status);
   if (not status.ok()) {

--- a/bigtable/client/instance_admin.cc
+++ b/bigtable/client/instance_admin.cc
@@ -133,5 +133,14 @@ std::vector<btproto::Cluster> InstanceAdmin::ListClusters() {
   return result;
 }
 
+void InstanceAdmin::DeleteCluster(std::string const& instance_id,
+                                  std::string const& cluster_id) {
+  grpc::Status status;
+  impl_.DeleteCluster(instance_id, cluster_id, status);
+  if (not status.ok()) {
+    internal::RaiseRpcError(status, status.error_message());
+  }
+}
+
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/bigtable/client/instance_admin.h
+++ b/bigtable/client/instance_admin.h
@@ -115,6 +115,7 @@ class InstanceAdmin {
 
   /**
    * Deletes the specified cluster of an instance in the project.
+   *
    * @param instance_id the id of the instance in the project
    * @param cluster_id the id of the cluster in the project that needs to be
    *   deleted

--- a/bigtable/client/instance_admin.h
+++ b/bigtable/client/instance_admin.h
@@ -112,6 +112,18 @@ class InstanceAdmin {
    */
   std::vector<google::bigtable::admin::v2::Cluster> ListClusters();
 
+  /**
+   * Deletes the specified cluster of an instance in the project.
+   * @param instance_id the id of the instance in the project
+   * @param cluster_id the id of the cluster in the project that needs to be
+   *   deleted
+   *
+   *  **Example**
+   *  @snippet bigtable_samples_instance_admin.cc delete cluster
+   */
+  void DeleteCluster(std::string const& instance_id,
+                     std::string const& cluster_id);
+
  private:
   /// Implement CreateInstance() with a separate thread.
   google::bigtable::admin::v2::Instance CreateInstanceImpl(

--- a/bigtable/client/instance_admin.h
+++ b/bigtable/client/instance_admin.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INSTANCE_ADMIN_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INSTANCE_ADMIN_H_
 
+#include "bigtable/client/bigtable_strong_types.h"
 #include "bigtable/client/instance_admin_client.h"
 #include "bigtable/client/instance_config.h"
 #include "bigtable/client/internal/instance_admin.h"
@@ -118,11 +119,11 @@ class InstanceAdmin {
    * @param cluster_id the id of the cluster in the project that needs to be
    *   deleted
    *
-   *  **Example**
+   *  @par Example
    *  @snippet bigtable_samples_instance_admin.cc delete cluster
    */
-  void DeleteCluster(std::string const& instance_id,
-                     std::string const& cluster_id);
+  void DeleteCluster(bigtable::InstanceId const& instance_id,
+                     bigtable::ClusterId const& cluster_id);
 
  private:
   /// Implement CreateInstance() with a separate thread.

--- a/bigtable/client/instance_admin_client.cc
+++ b/bigtable/client/instance_admin_client.cc
@@ -97,6 +97,13 @@ class DefaultInstanceAdminClient : public bigtable::InstanceAdminClient {
     return impl_.Stub()->ListClusters(context, request, response);
   }
 
+  grpc::Status DeleteCluster(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::DeleteClusterRequest const& request,
+      google::protobuf::Empty* response) override {
+    return impl_.Stub()->DeleteCluster(context, request, response);
+  }
+
   DefaultInstanceAdminClient(DefaultInstanceAdminClient const&) = delete;
   DefaultInstanceAdminClient& operator=(DefaultInstanceAdminClient const&) =
       delete;

--- a/bigtable/client/instance_admin_client.h
+++ b/bigtable/client/instance_admin_client.h
@@ -89,6 +89,11 @@ class InstanceAdminClient {
       grpc::ClientContext* context,
       google::bigtable::admin::v2::ListClustersRequest const& request,
       google::bigtable::admin::v2::ListClustersResponse* response) = 0;
+
+  virtual grpc::Status DeleteCluster(
+      grpc::ClientContext* context,
+      google::bigtable::admin::v2::DeleteClusterRequest const& request,
+      google::protobuf::Empty* response) = 0;
 };
 
 /// Create a new admin client configured via @p options.

--- a/bigtable/client/instance_admin_test.cc
+++ b/bigtable/client/instance_admin_test.cc
@@ -572,8 +572,10 @@ TEST_F(InstanceAdminTest, DeleteCluster) {
   auto mock = MockRpcFactory<btproto::DeleteClusterRequest, Empty>::Create(
       expected_text);
   EXPECT_CALL(*client_, DeleteCluster(_, _, _)).WillOnce(Invoke(mock));
+  bigtable::InstanceId instance_id("the-instance");
+  bigtable::ClusterId cluster_id("the-cluster");
   // After all the setup, make the actual call we want to test.
-  tested.DeleteCluster("the-instance", "the-cluster");
+  tested.DeleteCluster(instance_id, cluster_id);
 }
 
 /// @test Verify unrecoverable error for DeleteCluster
@@ -583,14 +585,14 @@ TEST_F(InstanceAdminTest, DeleteClusterUnrecoverableError) {
   EXPECT_CALL(*client_, DeleteCluster(_, _, _))
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
+  bigtable::InstanceId instance_id("other-instance");
+  bigtable::ClusterId cluster_id("other-cluster");
 // After all the setup, make the actual call we want to test.
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(tested.DeleteCluster("other-instance", "other-cluster"),
-               std::exception);
+  EXPECT_THROW(tested.DeleteCluster(instance_id, cluster_id), std::exception);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      tested.DeleteCluster("other-instance", "other-cluster"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(tested.DeleteCluster(instance_id, cluster_id),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -602,13 +604,13 @@ TEST_F(InstanceAdminTest, DeleteClusterRecoverableError) {
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
 
+  bigtable::InstanceId instance_id("other-instance");
+  bigtable::ClusterId cluster_id("other-cluster");
 // After all the setup, make the actual call we want to test.
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(tested.DeleteCluster("other-instance", "other-cluster"),
-               std::exception);
+  EXPECT_THROW(tested.DeleteCluster(instance_id, cluster_id), std::exception);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      tested.DeleteCluster("other-instance", "other-cluster"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(tested.DeleteCluster(instance_id, cluster_id),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }

--- a/bigtable/client/internal/instance_admin.cc
+++ b/bigtable/client/internal/instance_admin.cc
@@ -116,8 +116,8 @@ std::vector<btproto::Cluster> InstanceAdmin::ListClusters(
   return result;
 }
 
-void InstanceAdmin::DeleteCluster(std::string const& instance_id,
-                                  std::string const& cluster_id,
+void InstanceAdmin::DeleteCluster(bigtable::InstanceId const& instance_id,
+                                  bigtable::ClusterId const& cluster_id,
                                   grpc::Status& status) {
   btproto::DeleteClusterRequest request;
   request.set_name(ClusterName(instance_id, cluster_id));

--- a/bigtable/client/internal/instance_admin.cc
+++ b/bigtable/client/internal/instance_admin.cc
@@ -116,6 +116,22 @@ std::vector<btproto::Cluster> InstanceAdmin::ListClusters(
   return result;
 }
 
+void InstanceAdmin::DeleteCluster(std::string const& instance_id,
+                                  std::string const& cluster_id,
+                                  grpc::Status& status) {
+  btproto::DeleteClusterRequest request;
+  request.set_name(ClusterName(instance_id, cluster_id));
+
+  MetadataUpdatePolicy metadata_update_policy(
+      ClusterName(instance_id, cluster_id), MetadataParamTypes::NAME);
+
+  // This API is not idempotent, lets call it without retry
+  ClientUtils::MakeNonIdemponentCall(
+      *client_, rpc_retry_policy_->clone(), metadata_update_policy_,
+      &InstanceAdminClient::DeleteCluster, request,
+      "InstanceAdmin::DeleteCluster", status);
+}
+
 }  // namespace noex
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/bigtable/client/internal/instance_admin.h
+++ b/bigtable/client/internal/instance_admin.h
@@ -70,6 +70,14 @@ class InstanceAdmin {
     return project_name() + "/instances/" + instance_id;
   }
 
+  /// Return the fully qualified name of the given cluster_id in give
+  /// instance_id.
+  std::string ClusterName(std::string const& instance_id,
+                          std::string const& cluster_id) const {
+    return project_name() + "/instances/" + instance_id + "/clusters/" +
+           cluster_id;
+  }
+
   //@{
   /**
    * @name No exception versions of InstanceAdmin::*
@@ -88,6 +96,9 @@ class InstanceAdmin {
 
   std::vector<::google::bigtable::admin::v2::Cluster> ListClusters(
       grpc::Status& status);
+
+  void DeleteCluster(std::string const& instance_id,
+                     std::string const& cluster_id, grpc::Status& status);
 
   //@}
 

--- a/bigtable/client/internal/instance_admin.h
+++ b/bigtable/client/internal/instance_admin.h
@@ -72,10 +72,10 @@ class InstanceAdmin {
 
   /// Return the fully qualified name of the given cluster_id in give
   /// instance_id.
-  std::string ClusterName(std::string const& instance_id,
-                          std::string const& cluster_id) const {
-    return project_name() + "/instances/" + instance_id + "/clusters/" +
-           cluster_id;
+  std::string ClusterName(bigtable::InstanceId const& instance_id,
+                          bigtable::ClusterId const& cluster_id) const {
+    return project_name() + "/instances/" + instance_id.get() + "/clusters/" +
+           cluster_id.get();
   }
 
   //@{
@@ -97,8 +97,9 @@ class InstanceAdmin {
   std::vector<::google::bigtable::admin::v2::Cluster> ListClusters(
       grpc::Status& status);
 
-  void DeleteCluster(std::string const& instance_id,
-                     std::string const& cluster_id, grpc::Status& status);
+  void DeleteCluster(bigtable::InstanceId const& instance_id,
+                     bigtable::ClusterId const& cluster_id,
+                     grpc::Status& status);
 
   //@}
 

--- a/bigtable/client/internal/instance_admin_test.cc
+++ b/bigtable/client/internal/instance_admin_test.cc
@@ -437,8 +437,10 @@ TEST_F(InstanceAdminTest, DeleteCluster) {
       expected_text);
   EXPECT_CALL(*client_, DeleteCluster(_, _, _)).WillOnce(Invoke(mock));
   grpc::Status status;
+  bigtable::InstanceId instance_id("the-instance");
+  bigtable::ClusterId cluster_id("the-cluster");
   // After all the setup, make the actual call we want to test.
-  tested.DeleteCluster("the-instance", "the-cluster", status);
+  tested.DeleteCluster(instance_id, cluster_id, status);
   EXPECT_TRUE(status.ok());
 }
 
@@ -449,9 +451,11 @@ TEST_F(InstanceAdminTest, DeleteClusterUnrecoverableError) {
   EXPECT_CALL(*client_, DeleteCluster(_, _, _))
       .WillOnce(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
-  // After all the setup, make the actual call we want to test.
   grpc::Status status;
-  tested.DeleteCluster("other-instance", "other-cluster", status);
+  bigtable::InstanceId instance_id("other-instance");
+  bigtable::ClusterId cluster_id("other-cluster");
+  // After all the setup, make the actual call we want to test.
+  tested.DeleteCluster(instance_id, cluster_id, status);
   EXPECT_FALSE(status.ok());
 }
 
@@ -461,8 +465,10 @@ TEST_F(InstanceAdminTest, DeleteClusterRecoverableError) {
   bigtable::noex::InstanceAdmin tested(client_);
   EXPECT_CALL(*client_, DeleteCluster(_, _, _))
       .WillOnce(Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "uh oh")));
-  // After all the setup, make the actual call we want to test.
   grpc::Status status;
-  tested.DeleteCluster("other-instance", "other-cluster", status);
+  bigtable::InstanceId instance_id("other-instance");
+  bigtable::ClusterId cluster_id("other-cluster");
+  // After all the setup, make the actual call we want to test.
+  tested.DeleteCluster(instance_id, cluster_id, status);
   EXPECT_FALSE(status.ok());
 }

--- a/bigtable/client/internal/table_admin.h
+++ b/bigtable/client/internal/table_admin.h
@@ -16,11 +16,11 @@
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_TABLE_ADMIN_H_
 
 #include "bigtable/client/admin_client.h"
+#include "bigtable/client/bigtable_strong_types.h"
 #include "bigtable/client/column_family.h"
 #include "bigtable/client/metadata_update_policy.h"
 #include "bigtable/client/rpc_backoff_policy.h"
 #include "bigtable/client/rpc_retry_policy.h"
-#include "bigtable/client/table_admin_strong_types.h"
 #include "bigtable/client/table_config.h"
 #include <memory>
 

--- a/bigtable/client/metadata_update_policy.h
+++ b/bigtable/client/metadata_update_policy.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_METADATA_UPDATE_POLICY_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_METADATA_UPDATE_POLICY_H_
 
-#include "bigtable/client/table_admin_strong_types.h"
 #include "bigtable/client/version.h"
+#include "bigtable_strong_types.h"
 #include <grpc++/grpc++.h>
 #include <memory>
 

--- a/bigtable/client/metadata_update_policy.h
+++ b/bigtable/client/metadata_update_policy.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_METADATA_UPDATE_POLICY_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_METADATA_UPDATE_POLICY_H_
 
+#include "bigtable/client/bigtable_strong_types.h"
 #include "bigtable/client/version.h"
-#include "bigtable_strong_types.h"
 #include <grpc++/grpc++.h>
 #include <memory>
 

--- a/bigtable/client/table_admin.h
+++ b/bigtable/client/table_admin.h
@@ -16,9 +16,9 @@
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TABLE_ADMIN_H_
 
 #include "bigtable/client/admin_client.h"
+#include "bigtable/client/bigtable_strong_types.h"
 #include "bigtable/client/column_family.h"
 #include "bigtable/client/internal/table_admin.h"
-#include "bigtable/client/table_admin_strong_types.h"
 #include "bigtable/client/table_config.h"
 #include <memory>
 

--- a/bigtable/client/testing/mock_instance_admin_client.h
+++ b/bigtable/client/testing/mock_instance_admin_client.h
@@ -59,6 +59,12 @@ class MockInstanceAdminClient : public bigtable::InstanceAdminClient {
       grpc::Status(grpc::ClientContext*,
                    google::bigtable::admin::v2::ListClustersRequest const&,
                    google::bigtable::admin::v2::ListClustersResponse*));
+
+  MOCK_METHOD3(
+      DeleteCluster,
+      grpc::Status(grpc::ClientContext*,
+                   google::bigtable::admin::v2::DeleteClusterRequest const&,
+                   google::protobuf::Empty*));
 };
 
 }  // namespace testing

--- a/bigtable/examples/bigtable_samples_instance_admin.cc
+++ b/bigtable/examples/bigtable_samples_instance_admin.cc
@@ -125,6 +125,18 @@ void ListClusters(bigtable::InstanceAdmin instance_admin, int argc,
 }
 //! [list clusters]
 
+//! [delete cluster]
+void DeleteCluster(bigtable::InstanceAdmin instance_admin, int argc,
+                   char* argv[]) {
+  if (argc != 3) {
+    throw Usage{"delete-cluster: <project-id> <instance-id> <cluster-id>"};
+  }
+  std::string instance_id = ConsumeArg(argc, argv);
+  std::string cluster_id = ConsumeArg(argc, argv);
+  instance_admin.DeleteCluster(instance_id, cluster_id);
+}
+//! [delete cluster]
+
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) try {
@@ -158,6 +170,8 @@ int main(int argc, char* argv[]) try {
     DeleteInstance(instance_admin, argc, argv);
   } else if (command == "list-clusters") {
     ListClusters(instance_admin, argc, argv);
+  } else if (command == "delete-cluster") {
+    DeleteCluster(instance_admin, argc, argv);
   } else {
     std::string msg("Unknown_command: " + command);
     PrintUsage(argc, argv, msg);

--- a/bigtable/examples/bigtable_samples_instance_admin.cc
+++ b/bigtable/examples/bigtable_samples_instance_admin.cc
@@ -131,8 +131,8 @@ void DeleteCluster(bigtable::InstanceAdmin instance_admin, int argc,
   if (argc != 3) {
     throw Usage{"delete-cluster: <project-id> <instance-id> <cluster-id>"};
   }
-  std::string instance_id = ConsumeArg(argc, argv);
-  std::string cluster_id = ConsumeArg(argc, argv);
+  bigtable::InstanceId instance_id(ConsumeArg(argc, argv));
+  bigtable::ClusterId cluster_id(ConsumeArg(argc, argv));
   instance_admin.DeleteCluster(instance_id, cluster_id);
 }
 //! [delete cluster]


### PR DESCRIPTION
This request includes implementation of DeleteCluster function, its unit tests and sample implementation. 
This request does not include integration test as it has a dependency on CreateCluster.