### PR TITLE
Add nlohmann json library

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -58,6 +58,14 @@ def google_cloud_cpp_deps():
                     sha256 = "39a73de6fa2a03bdb9c43c89a4283e09880833b3c1976ef3ce3edf45c8cacf72"
         )
 
+    # We need the nlohmann_json library
+    if "com_github_nlohmann_json_single_header" not in native.existing_rules():
+        native.http_file(
+            name = "com_github_nlohmann_json_single_header",
+            url = "https://github.com/nlohmann/json/releases/download/v3.1.2/json.hpp",
+            sha256 = "fbdfec4b4cf63b3b565d09f87e6c3c183bdd45c5be1864d3fcb338f6f02c1733",
+        )
+
     # We use the cc_proto_library() rule from @com_google_protobuf, which
     # assumes that grpc_cpp_plugin and grpc_lib are in the //external: module
     native.bind(

--- a/cmake/DownloadNlohmannJson.cmake
+++ b/cmake/DownloadNlohmannJson.cmake
@@ -1,0 +1,25 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A helper file for IncludeNlohmannJson.
+# We need to download the json.hpp file.  With old versions of cmake there
+# is no way to disable the untar step from all downloads, and we get
+# failures.  This is a custom cmake script to download that file.
+set(JSON_URL "https://github.com/nlohmann/json/releases/download/v3.1.2/json.hpp")
+set(JSON_SHA256 fbdfec4b4cf63b3b565d09f87e6c3c183bdd45c5be1864d3fcb338f6f02c1733)
+message("JSON_URL = ${JSON_URL}")
+message("JSON_SHA256 = ${JSON_SHA256}")
+message("DEST = ${DEST}")
+file(DOWNLOAD "${JSON_URL}" "${DEST}/json.hpp"
+        EXPECTED_HASH SHA256=${JSON_SHA256})

--- a/cmake/IncludeNlohmannJson.cmake
+++ b/cmake/IncludeNlohmannJson.cmake
@@ -24,8 +24,10 @@ ExternalProject_Add(nlohmann_json_project
         INSTALL_COMMAND ${CMAKE_COMMAND} -E copy <INSTALL_DIR>/src/json.hpp <INSTALL_DIR>/include/nlohmann/json.hpp
         LOG_DOWNLOAD ON
         LOG_INSTALL ON)
+
 add_library(nlohmann_json INTERFACE)
 add_dependencies(nlohmann_json nlohmann_json_project)
-target_include_directories(nlohmann_json INTERFACE
+target_include_directories(nlohmann_json
+    INTERFACE
         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/external/nlohmann_json/include>
         $<INSTALL_INTERFACE:include>)

--- a/cmake/IncludeNlohmannJson.cmake
+++ b/cmake/IncludeNlohmannJson.cmake
@@ -14,13 +14,15 @@
 
 include(ExternalProject)
 ExternalProject_Add(nlohmann_json_project
-        URL https://github.com/nlohmann/json/archive/v3.1.2.tar.gz
-        URL_HASH SHA256=e8fffa6cbdb3c15ecdff32eebf958b6c686bc188da8ad5c6489462d16f83ae54
+        URL https://github.com/nlohmann/json/releases/download/v3.1.2/json.hpp
+        URL_HASH SHA256=fbdfec4b4cf63b3b565d09f87e6c3c183bdd45c5be1864d3fcb338f6f02c1733
+        DOWNLOAD_NO_EXTRACT 1
         PREFIX "${CMAKE_BINARY_DIR}/external/nlohmann_json"
-        CONFIGURE_COMMAND ${CMAKE_COMMAND} -DJSON_BuildTests=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> -H<SOURCE_DIR> -B.build
-        BUILD_COMMAND ${CMAKE_COMMAND} --build .build --target all
-        INSTALL_COMMAND ${CMAKE_COMMAND} --build .build --target install
-        USES_TERMINAL_DOWNLOAD 1
+        CONFIGURE_COMMAND ""
+        # This is not great, we abuse the `build` step to create the target directory.
+        # Unfortunately there is no way to specify two commands in the install step.
+        BUILD_COMMAND ${CMAKE_COMMAND} -E make_directory <INSTALL_DIR>/include/nlohmann
+        INSTALL_COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/../json.hpp <INSTALL_DIR>/include/nlohmann/json.hpp
         LOG_DOWNLOAD ON
         LOG_INSTALL ON)
 add_library(nlohmann_json INTERFACE)

--- a/cmake/IncludeNlohmannJson.cmake
+++ b/cmake/IncludeNlohmannJson.cmake
@@ -1,0 +1,30 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(ExternalProject)
+ExternalProject_Add(nlohmann_json_project
+        URL https://github.com/nlohmann/json/archive/v3.1.2.tar.gz
+        URL_HASH SHA256=e8fffa6cbdb3c15ecdff32eebf958b6c686bc188da8ad5c6489462d16f83ae54
+        PREFIX "${CMAKE_BINARY_DIR}/external/nlohmann_json"
+        CONFIGURE_COMMAND ${CMAKE_COMMAND} -DJSON_BuildTests=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> -H<SOURCE_DIR> -B.build
+        BUILD_COMMAND ${CMAKE_COMMAND} --build .build --target all
+        INSTALL_COMMAND ${CMAKE_COMMAND} --build .build --target install
+        USES_TERMINAL_DOWNLOAD 1
+        LOG_DOWNLOAD ON
+        LOG_INSTALL ON)
+add_library(nlohmann_json INTERFACE)
+add_dependencies(nlohmann_json nlohmann_json_project)
+target_include_directories(nlohmann_json INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/external/nlohmann_json/include>
+        $<INSTALL_INTERFACE:include>)

--- a/cmake/IncludeNlohmannJson.cmake
+++ b/cmake/IncludeNlohmannJson.cmake
@@ -14,15 +14,14 @@
 
 include(ExternalProject)
 ExternalProject_Add(nlohmann_json_project
-        URL https://github.com/nlohmann/json/releases/download/v3.1.2/json.hpp
-        URL_HASH SHA256=fbdfec4b4cf63b3b565d09f87e6c3c183bdd45c5be1864d3fcb338f6f02c1733
-        DOWNLOAD_NO_EXTRACT 1
         PREFIX "${CMAKE_BINARY_DIR}/external/nlohmann_json"
+        DOWNLOAD_COMMAND
+            ${CMAKE_COMMAND} -DDEST=<INSTALL_DIR>/src -P ${PROJECT_SOURCE_DIR}/cmake/DownloadNlohmannJson.cmake
         CONFIGURE_COMMAND ""
         # This is not great, we abuse the `build` step to create the target directory.
         # Unfortunately there is no way to specify two commands in the install step.
         BUILD_COMMAND ${CMAKE_COMMAND} -E make_directory <INSTALL_DIR>/include/nlohmann
-        INSTALL_COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/../json.hpp <INSTALL_DIR>/include/nlohmann/json.hpp
+        INSTALL_COMMAND ${CMAKE_COMMAND} -E copy <INSTALL_DIR>/src/json.hpp <INSTALL_DIR>/include/nlohmann/json.hpp
         LOG_DOWNLOAD ON
         LOG_INSTALL ON)
 add_library(nlohmann_json INTERFACE)

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -41,6 +41,7 @@ set(DOXYGEN_PREDEFINED "STORAGE_CLIENT_NS=v${STORAGE_CLIENT_VERSION_MAJOR}")
 set(DOXYGEN_EXCLUDE_PATTERNS "*/client/internal/*")
 
 include(GoogleCloudCppCommon)
+include(IncludeNlohmannJson)
 
 # Define an interface library, i.e., a library that really has no sources, and
 # add public target options to it.  The targets then use the library via
@@ -68,7 +69,7 @@ add_subdirectory(client)
 
 # Install the libraries and headers in the locations determined by
 # GNUInstallDirs
-install(TARGETS storage_common_options
+install(TARGETS storage_common_options nlohmann_json
     EXPORT storage-targets
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/storage/client/BUILD
+++ b/storage/client/BUILD
@@ -36,12 +36,27 @@ cc_library(
     ],
 )
 
+genrule(
+    name = "nlohmann_json_include_hierarchy",
+    srcs = [ "@com_github_nlohmann_json_single_header//file" ],
+    outs = [ "nlohmann/json.hpp", ],
+    cmd = "cp $< $@ && echo GENDIR=$(GENDIR) @=$(@) S=$<",
+)
+
+cc_library(
+    name = "nlohmann_json",
+    hdrs = [ ":nlohmann_json_include_hierarchy" ],
+    includes = [ "." ],
+    deps = [],
+)
+
 load(":storage_client_unit_tests.bzl", "storage_client_unit_tests")
 [cc_test(
     name = "storage_client_" + test.replace('/', '_').replace('.cc', ''),
     srcs = [test],
     deps = [
       ":storage_client",
+      ":nlohmann_json",
       "//google/cloud:google_cloud_cpp_common",
       "@com_google_googletest//:gtest",
       "@com_google_googletest//:gtest_main",

--- a/storage/client/CMakeLists.txt
+++ b/storage/client/CMakeLists.txt
@@ -21,8 +21,13 @@ add_library(storage_client
     internal/nljson.h
     version.h
     version.cc)
-target_link_libraries(storage_client PUBLIC google_cloud_cpp_common CURL::CURL Threads::Threads
-    PRIVATE storage_common_options)
+target_link_libraries(storage_client
+    PUBLIC
+        google_cloud_cpp_common
+        CURL::CURL
+        Threads::Threads
+    PRIVATE
+        storage_common_options)
 target_include_directories(storage_client PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
@@ -53,8 +58,13 @@ foreach (fname ${storage_client_unit_tests})
     string(REPLACE ".cc" "" target ${target})
     set(target "storage_client_${target}")
     add_executable(${target} ${fname})
-    target_link_libraries(${target} PRIVATE
-        storage_client gmock CURL::CURL storage_common_options nlohmann_json)
+    target_link_libraries(${target}
+        PRIVATE
+            storage_client
+            gmock
+            CURL::CURL
+            storage_common_options
+            nlohmann_json)
     add_test(NAME ${target} COMMAND ${target})
 endforeach ()
 

--- a/storage/client/CMakeLists.txt
+++ b/storage/client/CMakeLists.txt
@@ -18,6 +18,7 @@ configure_file(version_info.h.in version_info.h)
 # the client library
 add_library(storage_client
     ${CMAKE_CURRENT_BINARY_DIR}/version_info.h
+    internal/nljson.h
     version.h
     version.cc)
 target_link_libraries(storage_client PUBLIC google_cloud_cpp_common CURL::CURL Threads::Threads

--- a/storage/client/CMakeLists.txt
+++ b/storage/client/CMakeLists.txt
@@ -44,6 +44,7 @@ endif ()
 
 # List the unit tests, then setup the targets and dependencies.
 set(storage_client_unit_tests
+    internal/nljson_test.cc
     link_test.cc)
 
 foreach (fname ${storage_client_unit_tests})
@@ -52,7 +53,7 @@ foreach (fname ${storage_client_unit_tests})
     set(target "storage_client_${target}")
     add_executable(${target} ${fname})
     target_link_libraries(${target} PRIVATE
-        storage_client gmock CURL::CURL storage_common_options)
+        storage_client gmock CURL::CURL storage_common_options nlohmann_json)
     add_test(NAME ${target} COMMAND ${target})
 endforeach ()
 

--- a/storage/client/internal/nljson.h
+++ b/storage/client/internal/nljson.h
@@ -1,0 +1,47 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_STORAGE_CLIENT_INTERNAL_NLJSON_H_
+#define GOOGLE_CLOUD_CPP_STORAGE_CLIENT_INTERNAL_NLJSON_H_
+
+#include "storage/client/version.h"
+
+/**
+ * @file
+ *
+ * Include the nlohmann/json headers but renaming the namespace.
+ *
+ * We use the excellent nlohmann/json library to parse JSON in this client.
+ * However, we do not want to create dependency conflicts where our version of
+ * the code clashes with a different version that the user may have included.
+ * We always include the library through this header, and rename its top-level
+ * namespace to avoid conflicts. Because nlohmann/json is a header-only library
+ * no further action is needed.
+ *
+ * @see https://github.com/nlohmann/json.git
+ */
+
+#define nlohmann google_cloud_storage_internal_nlohmann_3_1_2
+#include <nlohmann/json.hpp>
+#undef nlohmann
+
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace nl = ::google_cloud_storage_internal_nlohmann_3_1_2;
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_CLIENT_INTERNAL_NLJSON_H_

--- a/storage/client/internal/nljson_test.cc
+++ b/storage/client/internal/nljson_test.cc
@@ -1,0 +1,35 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/client/internal/nljson.h"
+#include <gtest/gtest.h>
+
+/// @test Verify that we can compile agains the nlohmann::json library.
+TEST(NlJsonTest, Simple) {
+  storage::internal::nl::json json2 = {
+      {"pi", 3.141},
+      {"happy", true},
+      {"name", "Niels"},
+      {"nothing", nullptr},
+      {"answer", {
+          {"everything", 42}
+      }},
+      {"list", {1, 0, 2}},
+      {"object", {
+          {"currency", "USD"},
+          {"value", 42.99}
+      }}
+  };
+  EXPECT_NEAR(3.141, json2["pi"], 0.001);
+}

--- a/storage/client/internal/nljson_test.cc
+++ b/storage/client/internal/nljson_test.cc
@@ -17,19 +17,14 @@
 
 /// @test Verify that we can compile agains the nlohmann::json library.
 TEST(NlJsonTest, Simple) {
-  storage::internal::nl::json json2 = {
+  storage::internal::nl::json json = {
       {"pi", 3.141},
       {"happy", true},
-      {"name", "Niels"},
       {"nothing", nullptr},
-      {"answer", {
-          {"everything", 42}
-      }},
+      {"answer", {{"everything", 42}}},
       {"list", {1, 0, 2}},
-      {"object", {
-          {"currency", "USD"},
-          {"value", 42.99}
-      }}
-  };
-  EXPECT_NEAR(3.141, json2["pi"], 0.001);
+      {"object", {{"currency", "USD"}, {"value", 42.99}}}};
+  EXPECT_NEAR(3.141, json["pi"], 0.001);
+  EXPECT_EQ("USD", json["object"]["currency"]);
+  EXPECT_EQ(1, json["list"][0]);
 }

--- a/storage/client/storage_client.bzl
+++ b/storage/client/storage_client.bzl
@@ -1,5 +1,6 @@
 # DO NOT EDIT -- GENERATED CODE
 storage_client_HDRS = [
+    "internal/nljson.h",
     "version.h",
 ]
 

--- a/storage/client/storage_client_unit_tests.bzl
+++ b/storage/client/storage_client_unit_tests.bzl
@@ -1,5 +1,6 @@
 # DO NOT EDIT -- GENERATED CODE
 storage_client_unit_tests = [
+    "internal/nljson_test.cc",
     "link_test.cc",
 ]
 


### PR DESCRIPTION
Check go/gcs-cpp:implementation-dd for details as to why this library.  I used `ExternalProject_Add` instead of submodules because (a) it is faster (download a lot less), and (b) I would like to move all dependencies to that model so both the Bazel and CMake builds use the same sources and magic numbers.
