### PR TITLE
Refactor throw delegate functions to google/cloud

### DIFF
--- a/bigtable/benchmarks/setup.cc
+++ b/bigtable/benchmarks/setup.cc
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 #include "bigtable/benchmarks/setup.h"
-#include "bigtable/client/internal/throw_delegate.h"
 #include "bigtable/client/testing/random.h"
+#include "bigtable/client/version.h"
 #include "google/cloud/internal/build_info.h"
+#include "google/cloud/internal/throw_delegate.h"
 #include <cctype>
 #include <iomanip>
+#include <iostream>
 #include <sstream>
 
 /// Supporting types and functions to implement `BenchmarkSetup`
@@ -69,7 +71,7 @@ BenchmarkSetup::BenchmarkSetup(std::string const& prefix, int& argc,
               << " [test-duration-seconds (" << kDefaultTestDuration << "min)]"
               << " [table-size (" << kDefaultTableSize << ")]"
               << " [use-embedded-server (false)]" << std::endl;
-    internal::RaiseRuntimeError(msg);
+    google::cloud::internal::RaiseRuntimeError(msg);
   };
 
   if (argc < 3) {

--- a/bigtable/client/client_options.h
+++ b/bigtable/client/client_options.h
@@ -16,10 +16,8 @@
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_CLIENT_OPTIONS_H_
 
 #include "bigtable/client/version.h"
-
+#include "google/cloud/internal/throw_delegate.h"
 #include <grpc++/grpc++.h>
-
-#include "bigtable/client/internal/throw_delegate.h"
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
@@ -95,7 +93,7 @@ class ClientOptions {
   /// Set the size of the connection pool.
   ClientOptions& set_connection_pool_size(std::size_t size) {
     if (size == 0) {
-      internal::RaiseRangeError(
+      google::cloud::internal::RaiseRangeError(
           "ClientOptions::set_connection_pool_size requires size > 0");
     }
     connection_pool_size_ = size;
@@ -182,7 +180,8 @@ class ClientOptions {
         std::chrono::duration_cast<std::chrono::milliseconds>(fallback_timeout);
 
     if (ft_ms.count() > std::numeric_limits<int>::max()) {
-      internal::RaiseRangeError("Duration Exceeds Range for int");
+      google::cloud::internal::RaiseRangeError(
+          "Duration Exceeds Range for int");
     }
     auto fallback_timeout_ms = static_cast<int>(ft_ms.count());
     channel_arguments_.SetGrpclbFallbackTimeout(fallback_timeout_ms);

--- a/bigtable/client/instance_admin.cc
+++ b/bigtable/client/instance_admin.cc
@@ -15,6 +15,7 @@
 #include "bigtable/client/instance_admin.h"
 #include "bigtable/client/internal/throw_delegate.h"
 #include "bigtable/client/internal/unary_client_utils.h"
+#include "google/cloud/internal/throw_delegate.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <google/protobuf/text_format.h>
 #include <type_traits>
@@ -89,7 +90,7 @@ google::bigtable::admin::v2::Instance InstanceAdmin::CreateInstanceImpl(
       if (response.has_response()) {
         auto const& any = response.response();
         if (not any.Is<google::bigtable::admin::v2::Instance>()) {
-          bigtable::internal::RaiseRuntimeError("invalid result type");
+          google::cloud::internal::RaiseRuntimeError("invalid result type");
         }
         any.UnpackTo(&result);
         return result;
@@ -111,7 +112,7 @@ btproto::Instance InstanceAdmin::GetInstance(std::string const& instance_id) {
   grpc::Status status;
   auto result = impl_.GetInstance(instance_id, status);
   if (not status.ok()) {
-    internal::RaiseRpcError(status, status.error_message());
+    bigtable::internal::RaiseRpcError(status, status.error_message());
   }
   return result;
 }
@@ -120,7 +121,7 @@ void InstanceAdmin::DeleteInstance(std::string const& instance_id) {
   grpc::Status status;
   impl_.DeleteInstance(instance_id, status);
   if (not status.ok()) {
-    internal::RaiseRpcError(status, status.error_message());
+    bigtable::internal::RaiseRpcError(status, status.error_message());
   }
 }
 
@@ -128,7 +129,7 @@ std::vector<btproto::Cluster> InstanceAdmin::ListClusters() {
   grpc::Status status;
   auto result = impl_.ListClusters(status);
   if (not status.ok()) {
-    internal::RaiseRpcError(status, status.error_message());
+    bigtable::internal::RaiseRpcError(status, status.error_message());
   }
   return result;
 }

--- a/bigtable/client/internal/endian.cc
+++ b/bigtable/client/internal/endian.cc
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #include "bigtable/client/internal/endian.h"
-#include "bigtable/client/internal/throw_delegate.h"
+#include "google/cloud/internal/throw_delegate.h"
+#include <cstring>
+#include <limits>
 
 #ifdef _MSC_VER
 #include <stdlib.h>
@@ -59,7 +61,8 @@ bigtable::bigendian64_t Encoder<bigtable::bigendian64_t>::Decode(
     std::string const& value) {
   // Check if value is BigEndian 64-bit integer
   if (value.size() != sizeof(bigtable::bigendian64_t)) {
-    internal::RaiseRangeError("Value is not convertible to uint64");
+    google::cloud::internal::RaiseRangeError(
+        "Value is not convertible to uint64");
   }
   bigtable::bigendian64_t big_endian_value(0);
   std::memcpy(&big_endian_value, value.c_str(),

--- a/bigtable/client/internal/readrowsparser_test.cc
+++ b/bigtable/client/internal/readrowsparser_test.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "bigtable/client/internal/readrowsparser.h"
-#include "bigtable/client/internal/throw_delegate.h"
 #include "bigtable/client/row.h"
+#include "google/cloud/internal/throw_delegate.h"
 #include <google/protobuf/text_format.h>
 #include <gtest/gtest.h>
 #include <numeric>
@@ -222,18 +222,18 @@ class AcceptanceTest : public ::testing::Test {
     for (auto const& chunk : chunks) {
       parser_.HandleChunk(chunk, status);
       if (not status.ok()) {
-        bigtable::internal::RaiseRuntimeError(status.error_message());
+        google::cloud::internal::RaiseRuntimeError(status.error_message());
       }
       if (parser_.HasNext()) {
         rows_.emplace_back(parser_.Next(status));
         if (not status.ok()) {
-          bigtable::internal::RaiseRuntimeError(status.error_message());
+          google::cloud::internal::RaiseRuntimeError(status.error_message());
         }
       }
     }
     parser_.HandleEndOfStream(status);
     if (not status.ok()) {
-      bigtable::internal::RaiseRuntimeError(status.error_message());
+      google::cloud::internal::RaiseRuntimeError(status.error_message());
     }
   }
 

--- a/bigtable/client/internal/rowreaderiterator.h
+++ b/bigtable/client/internal/rowreaderiterator.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_ROWREADERITERATOR_H_
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_ROWREADERITERATOR_H_
 
-#include "bigtable/client/internal/throw_delegate.h"
 #include "bigtable/client/row.h"
+#include "google/cloud/internal/throw_delegate.h"
 #include <iterator>
 
 namespace bigtable {
@@ -44,13 +44,13 @@ class OptionalRow {
 
   Row& value() {
     if (not has_row_) {
-      RaiseLogicError("access unset OptionalRow");
+      google::cloud::internal::RaiseLogicError("access unset OptionalRow");
     }
     return row_;
   }
   Row const& value() const {
     if (not has_row_) {
-      RaiseLogicError("access unset OptionalRow");
+      google::cloud::internal::RaiseLogicError("access unset OptionalRow");
     }
     return row_;
   }

--- a/bigtable/client/internal/throw_delegate.cc
+++ b/bigtable/client/internal/throw_delegate.cc
@@ -16,55 +16,9 @@
 #include "bigtable/client/grpc_error.h"
 #include <sstream>
 
-namespace {
-template <typename Exception>
-[[noreturn]] void RaiseException(char const* msg) {
-#ifdef GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  throw Exception(msg);
-#else
-  std::cerr << "Aborting because exceptions are disabled: " << msg << std::endl;
-  // TODO(#327) - make the call to std::abort() configurable.
-  std::abort();
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-}
-}
-
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
-
-[[noreturn]] void RaiseInvalidArgument(char const* msg) {
-  RaiseException<std::invalid_argument>(msg);
-}
-
-[[noreturn]] void RaiseInvalidArgument(std::string const& msg) {
-  RaiseException<std::invalid_argument>(msg.c_str());
-}
-
-[[noreturn]] void RaiseRangeError(char const* msg) {
-  RaiseException<std::range_error>(msg);
-}
-
-[[noreturn]] void RaiseRangeError(std::string const& msg) {
-  RaiseException<std::range_error>(msg.c_str());
-}
-
-[[noreturn]] void RaiseRuntimeError(char const* msg) {
-  RaiseException<std::runtime_error>(msg);
-}
-
-[[noreturn]] void RaiseRuntimeError(std::string const& msg) {
-  RaiseException<std::runtime_error>(msg.c_str());
-}
-
-[[noreturn]] void RaiseLogicError(char const* msg) {
-  RaiseException<std::logic_error>(msg);
-}
-
-[[noreturn]] void RaiseLogicError(std::string const& msg) {
-  RaiseException<std::logic_error>(msg.c_str());
-}
-
 [[noreturn]] void RaiseRpcError(grpc::Status const& status, char const* msg) {
 #ifdef GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   throw bigtable::GRpcError(msg, status);

--- a/bigtable/client/internal/throw_delegate_test.cc
+++ b/bigtable/client/internal/throw_delegate_test.cc
@@ -21,47 +21,7 @@ using namespace bigtable::internal;
 namespace {
 std::string const cmsg("testing with std::string const&");
 char const* msg = "testing with char const*";
-}
-
-TEST(ThrowDelegateTest, InvalidArgument) {
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(RaiseInvalidArgument(msg), std::invalid_argument);
-  EXPECT_THROW(RaiseInvalidArgument(cmsg), std::invalid_argument);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(RaiseInvalidArgument(msg), msg);
-  EXPECT_DEATH_IF_SUPPORTED(RaiseInvalidArgument(cmsg), cmsg);
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-}
-
-TEST(ThrowDelegateTest, RangeError) {
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(RaiseRangeError(msg), std::range_error);
-  EXPECT_THROW(RaiseRangeError(cmsg), std::range_error);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(RaiseRangeError(msg), msg);
-  EXPECT_DEATH_IF_SUPPORTED(RaiseRangeError(cmsg), cmsg);
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-}
-
-TEST(ThrowDelegateTest, RuntimeError) {
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(RaiseRuntimeError(msg), std::runtime_error);
-  EXPECT_THROW(RaiseRuntimeError(cmsg), std::runtime_error);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(RaiseRuntimeError(msg), msg);
-  EXPECT_DEATH_IF_SUPPORTED(RaiseRuntimeError(cmsg), cmsg);
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-}
-
-TEST(ThrowDelegateTest, LogicError) {
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(RaiseLogicError(msg), std::logic_error);
-  EXPECT_THROW(RaiseLogicError(cmsg), std::logic_error);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(RaiseLogicError(msg), msg);
-  EXPECT_DEATH_IF_SUPPORTED(RaiseLogicError(cmsg), cmsg);
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-}
+}  // anonymous namespace
 
 TEST(ThrowDelegateTest, RpcError) {
   grpc::Status status(grpc::StatusCode::UNAVAILABLE, "try-again");

--- a/bigtable/client/row_reader.cc
+++ b/bigtable/client/row_reader.cc
@@ -14,7 +14,7 @@
 
 #include "bigtable/client/row_reader.h"
 #include "bigtable/client/internal/make_unique.h"
-#include "bigtable/client/internal/throw_delegate.h"
+#include "google/cloud/internal/throw_delegate.h"
 #include <thread>
 
 namespace bigtable {
@@ -84,7 +84,8 @@ RowReader::RowReader(
 RowReader::iterator RowReader::begin() {
   if (operation_cancelled_) {
     if (raise_on_error_) {
-      internal::RaiseRuntimeError("Operation already cancelled.");
+      google::cloud::internal::RaiseRuntimeError(
+          "Operation already cancelled.");
     } else {
       status_ = grpc::Status::CANCELLED;
       return internal::RowReaderIterator(this, true);
@@ -170,9 +171,9 @@ void RowReader::Advance(internal::OptionalRow& row) {
 
     if (not status.ok() and not retry_policy_->on_failure(status)) {
       if (raise_on_error_) {
-        internal::RaiseRuntimeError("Unretriable error: " +
-                                    status.error_message());
-        /*NOTREACHED*/  // because internal::RaiseRuntimeError is [[noreturn]]
+        google::cloud::internal::RaiseRuntimeError("Unretriable error: " +
+                                                   status.error_message());
+        /*NOTREACHED*/
       }
       return;
     }
@@ -243,7 +244,7 @@ RowReader::~RowReader() {
   // Make sure we don't leave open streams.
   Cancel();
   if (not raise_on_error_ and not error_retrieved_ and not status_.ok()) {
-    internal::RaiseRuntimeError(
+    google::cloud::internal::RaiseRuntimeError(
         "Exception is disabled and error is not retrieved");
   }
 }

--- a/bigtable/client/row_reader_test.cc
+++ b/bigtable/client/row_reader_test.cc
@@ -17,6 +17,7 @@
 #include "bigtable/client/table.h"
 #include "bigtable/client/testing/mock_read_rows_reader.h"
 #include "bigtable/client/testing/table_test_fixture.h"
+#include "google/cloud/internal/throw_delegate.h"
 #include <gmock/gmock.h>
 #include <deque>
 #include <initializer_list>
@@ -100,7 +101,7 @@ class RetryPolicyMock : public bigtable::RPCRetryPolicy {
  public:
   RetryPolicyMock() {}
   std::unique_ptr<RPCRetryPolicy> clone() const override {
-    bigtable::internal::RaiseRuntimeError("Mocks cannot be copied.");
+    google::cloud::internal::RaiseRuntimeError("Mocks cannot be copied.");
   }
 
   MOCK_CONST_METHOD1(setup_impl, void(grpc::ClientContext&));
@@ -120,7 +121,7 @@ class BackoffPolicyMock : public bigtable::RPCBackoffPolicy {
  public:
   BackoffPolicyMock() {}
   std::unique_ptr<RPCBackoffPolicy> clone() const override {
-    bigtable::internal::RaiseRuntimeError("Mocks cannot be copied.");
+    google::cloud::internal::RaiseRuntimeError("Mocks cannot be copied.");
   }
   void setup(grpc::ClientContext& context) const override {}
   MOCK_METHOD1(on_completion_impl,

--- a/bigtable/client/table.cc
+++ b/bigtable/client/table.cc
@@ -79,7 +79,7 @@ std::pair<bool, Row> Table::ReadRow(std::string row_key, Filter filter) {
   grpc::Status status;
   auto result = impl_.ReadRow(std::move(row_key), std::move(filter), status);
   if (not status.ok()) {
-    bigtable::internal::RaiseRuntimeError(status.error_message());
+    google::cloud::internal::RaiseRuntimeError(status.error_message());
   }
   return result;
 }

--- a/bigtable/client/table.h
+++ b/bigtable/client/table.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TABLE_H_
 
 #include "bigtable/client/internal/table.h"
+#include "bigtable/client/internal/throw_delegate.h"
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
@@ -306,7 +307,7 @@ class Table {
     grpc::Status status;
     auto result = impl_.SampleRows<Collection>(status);
     if (not status.ok()) {
-      internal::RaiseRpcError(status, status.error_message());
+      bigtable::internal::RaiseRpcError(status, status.error_message());
     }
 
     return result;

--- a/bigtable/client/table_admin.h
+++ b/bigtable/client/table_admin.h
@@ -19,6 +19,7 @@
 #include "bigtable/client/bigtable_strong_types.h"
 #include "bigtable/client/column_family.h"
 #include "bigtable/client/internal/table_admin.h"
+#include "bigtable/client/internal/throw_delegate.h"
 #include "bigtable/client/table_config.h"
 #include <memory>
 
@@ -261,7 +262,7 @@ class TableAdmin {
     grpc::Status status;
     auto result = impl_.ListSnapshots<Collection>(status, cluster_id);
     if (not status.ok()) {
-      internal::RaiseRpcError(status, status.error_message());
+      bigtable::internal::RaiseRpcError(status, status.error_message());
     }
     return result;
   }

--- a/bigtable/client/testing/table_test_fixture.cc
+++ b/bigtable/client/testing/table_test_fixture.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "bigtable/client/testing/table_test_fixture.h"
-#include "bigtable/client/internal/throw_delegate.h"
+#include "google/cloud/internal/throw_delegate.h"
 #include <google/protobuf/text_format.h>
 
 namespace bigtable {
@@ -23,7 +23,7 @@ google::bigtable::v2::ReadRowsResponse ReadRowsResponseFromString(
     std::string repr) {
   google::bigtable::v2::ReadRowsResponse response;
   if (!google::protobuf::TextFormat::ParseFromString(repr, &response)) {
-    bigtable::internal::RaiseRuntimeError("Failed to parse " + repr);
+    google::cloud::internal::RaiseRuntimeError("Failed to parse " + repr);
   }
   return response;
 }

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -59,6 +59,8 @@ add_library(google_cloud_cpp_common
     internal/build_info.h
     ${CMAKE_CURRENT_BINARY_DIR}/internal/build_info.cc
     internal/port_platform.h
+    internal/throw_delegate.h
+    internal/throw_delegate.cc
     version.h)
 target_link_libraries(google_cloud_cpp_common PUBLIC Threads::Threads
     PRIVATE google_cloud_cpp_common_options)
@@ -72,7 +74,8 @@ target_compile_options(google_cloud_cpp_common PUBLIC
 include(CreateBazelConfig)
 create_bazel_config(google_cloud_cpp_common)
 
-set(google_cloud_cpp_common_unit_tests)
+set(google_cloud_cpp_common_unit_tests
+    internal/throw_delegate_test.cc)
 
 # Export the list of unit tests so the Bazel BUILD file can pick it up.
 export_list_to_bazel("google_cloud_cpp_common_unit_tests.bzl"

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -2,9 +2,11 @@
 google_cloud_cpp_common_HDRS = [
     "internal/build_info.h",
     "internal/port_platform.h",
+    "internal/throw_delegate.h",
     "version.h",
 ]
 
 google_cloud_cpp_common_SRCS = [
+    "internal/throw_delegate.cc",
 ]
 

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -1,4 +1,5 @@
 # DO NOT EDIT -- GENERATED CODE
 google_cloud_cpp_common_unit_tests = [
+    "internal/throw_delegate_test.cc",
 ]
 

--- a/google/cloud/internal/throw_delegate.cc
+++ b/google/cloud/internal/throw_delegate.cc
@@ -1,0 +1,72 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/throw_delegate.h"
+#include "google/cloud/internal/port_platform.h"
+#include <sstream>
+
+namespace {
+template <typename Exception>
+[[noreturn]] void RaiseException(char const* msg) {
+#ifdef GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  throw Exception(msg);
+#else
+  std::cerr << "Aborting because exceptions are disabled: " << msg << std::endl;
+  // TODO(#327) - make the call to std::abort() configurable.
+  std::abort();
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+}
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+[[noreturn]] void RaiseInvalidArgument(char const* msg) {
+  RaiseException<std::invalid_argument>(msg);
+}
+
+[[noreturn]] void RaiseInvalidArgument(std::string const& msg) {
+  RaiseException<std::invalid_argument>(msg.c_str());
+}
+
+[[noreturn]] void RaiseRangeError(char const* msg) {
+  RaiseException<std::range_error>(msg);
+}
+
+[[noreturn]] void RaiseRangeError(std::string const& msg) {
+  RaiseException<std::range_error>(msg.c_str());
+}
+
+[[noreturn]] void RaiseRuntimeError(char const* msg) {
+  RaiseException<std::runtime_error>(msg);
+}
+
+[[noreturn]] void RaiseRuntimeError(std::string const& msg) {
+  RaiseException<std::runtime_error>(msg.c_str());
+}
+
+[[noreturn]] void RaiseLogicError(char const* msg) {
+  RaiseException<std::logic_error>(msg);
+}
+
+[[noreturn]] void RaiseLogicError(std::string const& msg) {
+  RaiseException<std::logic_error>(msg.c_str());
+}
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/throw_delegate.cc
+++ b/google/cloud/internal/throw_delegate.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/internal/throw_delegate.h"
 #include "google/cloud/internal/port_platform.h"
+#include <iostream>
 #include <sstream>
 
 namespace {

--- a/google/cloud/internal/throw_delegate.h
+++ b/google/cloud/internal/throw_delegate.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_THROW_DELEGATE_H_
-#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_THROW_DELEGATE_H_
+#ifndef GOOGLE_CLOUD_CPP_COMMON_INTERNAL_THROW_DELEGATE_H_
+#define GOOGLE_CLOUD_CPP_COMMON_INTERNAL_THROW_DELEGATE_H_
 
-#include "bigtable/client/version.h"
-#include <grpc++/grpc++.h>
+#include "google/cloud/version.h"
 
-namespace bigtable {
-inline namespace BIGTABLE_CLIENT_NS {
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 
 //@{
@@ -33,13 +33,22 @@ namespace internal {
  * We copied this technique from Abseil.  Unfortunately we cannot use it
  * directly because it is not a public interface for Abseil.
  */
-[[noreturn]] void RaiseRpcError(grpc::Status const& status, char const* msg);
-[[noreturn]] void RaiseRpcError(grpc::Status const& status,
-                                std::string const& msg);
+[[noreturn]] void RaiseInvalidArgument(char const* msg);
+[[noreturn]] void RaiseInvalidArgument(std::string const& msg);
+
+[[noreturn]] void RaiseRangeError(char const* msg);
+[[noreturn]] void RaiseRangeError(std::string const& msg);
+
+[[noreturn]] void RaiseRuntimeError(char const* msg);
+[[noreturn]] void RaiseRuntimeError(std::string const& msg);
+
+[[noreturn]] void RaiseLogicError(char const* msg);
+[[noreturn]] void RaiseLogicError(std::string const& msg);
 //@}
 
 }  // namespace internal
-}  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_THROW_DELEGATE_H_
+#endif  // GOOGLE_CLOUD_CPP_COMMON_INTERNAL_THROW_DELEGATE_H_

--- a/google/cloud/internal/throw_delegate_test.cc
+++ b/google/cloud/internal/throw_delegate_test.cc
@@ -1,0 +1,63 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/throw_delegate.h"
+#include <gtest/gtest.h>
+
+using namespace google::cloud::internal;
+
+namespace {
+std::string const cmsg("testing with std::string const&");
+char const* msg = "testing with char const*";
+}
+
+TEST(ThrowDelegateTest, InvalidArgument) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(RaiseInvalidArgument(msg), std::invalid_argument);
+  EXPECT_THROW(RaiseInvalidArgument(cmsg), std::invalid_argument);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(RaiseInvalidArgument(msg), msg);
+  EXPECT_DEATH_IF_SUPPORTED(RaiseInvalidArgument(cmsg), cmsg);
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ThrowDelegateTest, RangeError) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(RaiseRangeError(msg), std::range_error);
+  EXPECT_THROW(RaiseRangeError(cmsg), std::range_error);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(RaiseRangeError(msg), msg);
+  EXPECT_DEATH_IF_SUPPORTED(RaiseRangeError(cmsg), cmsg);
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ThrowDelegateTest, RuntimeError) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(RaiseRuntimeError(msg), std::runtime_error);
+  EXPECT_THROW(RaiseRuntimeError(cmsg), std::runtime_error);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(RaiseRuntimeError(msg), msg);
+  EXPECT_DEATH_IF_SUPPORTED(RaiseRuntimeError(cmsg), cmsg);
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ThrowDelegateTest, LogicError) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(RaiseLogicError(msg), std::logic_error);
+  EXPECT_THROW(RaiseLogicError(cmsg), std::logic_error);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(RaiseLogicError(msg), msg);
+  EXPECT_DEATH_IF_SUPPORTED(RaiseLogicError(cmsg), cmsg);
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}

--- a/storage/client/version.h
+++ b/storage/client/version.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_VERSION_H_
-#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_VERSION_H_
+#ifndef GOOGLE_CLOUD_CPP_STORAGE_CLIENT_VERSION_H_
+#define GOOGLE_CLOUD_CPP_STORAGE_CLIENT_VERSION_H_
 
 #include "google/cloud/version.h"
 #include "storage/client/version_info.h"


### PR DESCRIPTION
With this change the storage/ and bigtable/ libraries share the functions to raise exceptions.
As a reminder, we use these functions (e.g. `google::cloud::RaiseRuntimeError`) to raise
an exception or call `std::abort()` depending on whether the code is compiled with
exceptions enabled or disabled, respectively.
