### PR TITLE
Run benchmarks in CI build

### DIFF
--- a/bigtable/benchmarks/benchmark.cc
+++ b/bigtable/benchmarks/benchmark.cc
@@ -26,7 +26,9 @@ double const kResultPercentiles[] = {0, 50, 90, 95, 99, 99.9, 100};
 namespace bigtable {
 namespace benchmarks {
 Benchmark::Benchmark(BenchmarkSetup const& setup)
-    : setup_(setup), key_width_(KeyWidth()) {
+    : setup_(setup),
+      key_width_(KeyWidth()),
+      client_options_(grpc::InsecureChannelCredentials()) {
   if (setup_.use_embedded_server()) {
     server_ = CreateEmbeddedServer();
     std::string address = server_->address();
@@ -36,7 +38,8 @@ Benchmark::Benchmark(BenchmarkSetup const& setup)
 
     client_options_.set_admin_endpoint(address);
     client_options_.set_data_endpoint(address);
-    client_options_.SetCredentials(grpc::InsecureChannelCredentials());
+  } else {
+    client_options_ = bigtable::ClientOptions();
   }
   client_options_.set_connection_pool_size(
       static_cast<std::size_t>(setup_.thread_count()));

--- a/bigtable/ci/run_integration_tests.sh
+++ b/bigtable/ci/run_integration_tests.sh
@@ -41,8 +41,8 @@ for benchmark in endurance apply_read_latency scan_throughput; do
   else
     echo   "${COLOR_RED}[    ERROR ]${COLOR_RESET} ${benchmark} benchmark"
     echo
-    echo "================ ${LOG} ================"
+    echo "================ [begin ${log}] ================"
     cat "${log}"
-    echo "================ ${LOG} ================"
+    echo "================ [end ${log}] ================"
   fi
 done

--- a/bigtable/ci/run_integration_tests.sh
+++ b/bigtable/ci/run_integration_tests.sh
@@ -29,20 +29,20 @@ source "${BINDIR}/../../ci/colors.sh"
 # consistent enough to use the results, but we want to detect crashes and ensure
 # the code at least is able to run as soon as possible.
 for benchmark in endurance apply_read_latency scan_throughput; do
-  LOG=$(mktemp --tmpdir "bigtable_benchmarks_${benchmark}_XXXXXXXXXX.log")
+  log="$(mktemp --tmpdir "bigtable_benchmarks_${benchmark}.XXXXXXXXXX.log")"
   if [ ! -x ./bigtable/benchmarks/${benchmark}_benchmark ]; then
     echo "${COLOR_YELLOW}[ SKIPPED  ]${COLOR_RESET} ${benchmark} benchmark"
     continue
   fi
   echo "${COLOR_GREEN}[ RUN      ]${COLOR_RESET} ${benchmark}"
-  ./bigtable/benchmarks/${benchmark}_benchmark unused unused 1 5 1000 true >${LOG} 2>&1 </dev/null
+  "./bigtable/benchmarks/${benchmark}_benchmark" unused unused 1 5 1000 true >"${log}" 2>&1 </dev/null
   if [ $? = 0 ]; then
     echo "${COLOR_GREEN}[       OK ]${COLOR_RESET} ${benchmark} benchmark"
   else
     echo   "${COLOR_RED}[    ERROR ]${COLOR_RESET} ${benchmark} benchmark"
     echo
     echo "================ ${LOG} ================"
-    cat ${LOG}
+    cat "${log}"
     echo "================ ${LOG} ================"
   fi
 done

--- a/bigtable/ci/run_integration_tests.sh
+++ b/bigtable/ci/run_integration_tests.sh
@@ -19,5 +19,26 @@ set -eu
 # This script should is called from the build directory, and it finds other
 # scripts in the source directory using its own path.
 readonly BINDIR="$(dirname $0)"
+source "${BINDIR}/../../ci/colors.sh"
+
 (cd bigtable/tests && "${BINDIR}/../tests/run_integration_tests_emulator.sh")
 (cd bigtable/tests && "${BINDIR}/../examples/run_examples_emulator.sh")
+
+# To improve coverage (and avoid bitrot), run the Bigtable benchmarks using the
+# embedded server.  The performance in the Travis and AppVeyor CI builds is not
+# consistent enough to use the results, but we want to detect crashes and ensure
+# the code at least is able to run as soon as possible.
+for benchmark in endurance apply_read_latency scan_throughput; do
+  LOG=$(mktemp --tmpdir "bigtable_benchmarks_${benchmark}_XXXXXXXXXX.log")
+  echo "${COLOR_GREEN}[ RUN      ]${COLOR_RESET} ${benchmark}"
+  ./bigtable/benchmarks/${benchmark}_benchmark unused unused 1 5 1000 true >${LOG} 2>&1 </dev/null
+  if [ $? = 0 ]; then
+    echo "${COLOR_GREEN}[       OK ]${COLOR_RESET} ${benchmark} benchmark"
+  else
+    echo   "${COLOR_RED}[    ERROR ]${COLOR_RESET} ${benchmark} benchmark"
+    echo
+    echo "================ ${LOG} ================"
+    cat ${LOG}
+    echo "================ ${LOG} ================"
+  fi
+done

--- a/bigtable/ci/run_integration_tests.sh
+++ b/bigtable/ci/run_integration_tests.sh
@@ -31,6 +31,10 @@ source "${BINDIR}/../../ci/colors.sh"
 for benchmark in endurance apply_read_latency scan_throughput; do
   LOG=$(mktemp --tmpdir "bigtable_benchmarks_${benchmark}_XXXXXXXXXX.log")
   echo "${COLOR_GREEN}[ RUN      ]${COLOR_RESET} ${benchmark}"
+  if [ ! -x ./bigtable/benchmarks/${benchmark}_benchmark ]; then
+    echo "${COLOR_YELLOW}[ SKIPPED  ]${COLOR_RESET} ${benchmark} benchmark"
+    continue
+  fi
   ./bigtable/benchmarks/${benchmark}_benchmark unused unused 1 5 1000 true >${LOG} 2>&1 </dev/null
   if [ $? = 0 ]; then
     echo "${COLOR_GREEN}[       OK ]${COLOR_RESET} ${benchmark} benchmark"

--- a/bigtable/ci/run_integration_tests.sh
+++ b/bigtable/ci/run_integration_tests.sh
@@ -30,11 +30,11 @@ source "${BINDIR}/../../ci/colors.sh"
 # the code at least is able to run as soon as possible.
 for benchmark in endurance apply_read_latency scan_throughput; do
   LOG=$(mktemp --tmpdir "bigtable_benchmarks_${benchmark}_XXXXXXXXXX.log")
-  echo "${COLOR_GREEN}[ RUN      ]${COLOR_RESET} ${benchmark}"
   if [ ! -x ./bigtable/benchmarks/${benchmark}_benchmark ]; then
     echo "${COLOR_YELLOW}[ SKIPPED  ]${COLOR_RESET} ${benchmark} benchmark"
     continue
   fi
+  echo "${COLOR_GREEN}[ RUN      ]${COLOR_RESET} ${benchmark}"
   ./bigtable/benchmarks/${benchmark}_benchmark unused unused 1 5 1000 true >${LOG} 2>&1 </dev/null
   if [ $? = 0 ]; then
     echo "${COLOR_GREEN}[       OK ]${COLOR_RESET} ${benchmark} benchmark"

--- a/ci/build-docker.sh
+++ b/ci/build-docker.sh
@@ -68,20 +68,6 @@ for subdir in bigtable storage; do
   /v/${subdir}/ci/run_integration_tests.sh
 done
 
-# Some of the sanitizers only emit errors and do not change the error code
-# of the tests, find any such errors and report them as a build failure.
-echo
-echo "Searching for sanitizer errors in the test log:"
-echo
-if grep -e '/v/.*\.cc:[0-9][0-9]*' \
-       Testing/Temporary/LastTest.log; then
-  echo
-  echo "some sanitizer errors found."
-  exit 1
-else
-  echo "no sanitizer errors found."
-fi
-
 # Test the install rule and that the installation works.
 if [ "${TEST_INSTALL}" = "yes" ]; then
   echo
@@ -103,6 +89,21 @@ fi
 # If document generation is enabled, run it now.
 if [ "${GENERATE_DOCS}" = "yes" ]; then
   make doxygen-docs
+fi
+
+# Some of the sanitizers only emit errors and do not change the error code
+# of the tests, find any such errors and report them as a build failure.
+echo
+echo -n "Searching for sanitizer errors in the test log: "
+if grep -qe '/v/.*\.cc:[0-9][0-9]*' \
+       Testing/Temporary/LastTest.log; then
+  echo "${COLOR_RED}some sanitizer errors found."
+  echo
+  grep -e '/v/.*\.cc:[0-9][0-9]*' Testing/Temporary/LastTest.log
+  echo "${COLOR_RESET}"
+  exit 1
+else
+  echo "${COLOR_GREEN}no sanitizer errors found.${COLOR_RESET}"
 fi
 
 # Collect the output from the Clang static analyzer and provide instructions to


### PR DESCRIPTION
To improve code coverage, run very short versions of the benchmarks in the CI build.
