### PR TITLE
Add a build to test Bazel as a dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,14 @@ matrix:
         packages:
       install: ci/install-bazel.sh
       script: ci/build-bazel.sh
+    - # Compile on Travis' native environment with Bazel
+      os: linux
+      compiler: gcc
+      env: TEST_BAZEL_AS_DEPENDENCY=yes
+      git:
+        submodules: false
+      install: ci/install-bazel.sh
+      script: ci/build-bazel.sh
     - # Compile against an installed version of gRPC.
       os: linux
       compiler: clang

--- a/ci/build-bazel.sh
+++ b/ci/build-bazel.sh
@@ -20,3 +20,9 @@ export PATH=$PATH:$HOME/bin
 
 bazel --batch build //...:all
 bazel --batch test  //...:all
+
+if [ "${TEST_BAZEL_AS_DEPENDENCY:-}" = "yes" ]; then
+  echo
+  echo "${COLOR_YELLOW}Testing Bazel files as dependency"
+  (cd /v/ci/test-install && bazel --batch build //...:all)
+fi

--- a/ci/build-bazel.sh
+++ b/ci/build-bazel.sh
@@ -30,8 +30,8 @@ fi
 
 export PATH=$PATH:$HOME/bin
 
-bazel --batch build //...:all
-bazel --batch test  //...:all
+bazel --batch build //bigtable/...:all //storage/...:all //google/...:all
+bazel --batch test  //bigtable/...:all //storage/...:all //google/...:all
 
 if [ "${TEST_BAZEL_AS_DEPENDENCY:-}" = "yes" ]; then
   echo

--- a/ci/build-bazel.sh
+++ b/ci/build-bazel.sh
@@ -36,5 +36,5 @@ bazel --batch test  //...:all
 if [ "${TEST_BAZEL_AS_DEPENDENCY:-}" = "yes" ]; then
   echo
   echo "${COLOR_YELLOW}Testing Bazel files as dependency${COLOR_RESET}"
-  (cd /v/ci/test-install && bazel --batch build //...:all)
+  (cd ci/test-install && bazel --batch build //...:all)
 fi

--- a/ci/build-bazel.sh
+++ b/ci/build-bazel.sh
@@ -16,6 +16,18 @@
 
 set -eu
 
+if [ "${TERM:-}" = "dumb" ]; then
+  readonly COLOR_RED=""
+  readonly COLOR_GREEN=""
+  readonly COLOR_YELLOW=""
+  readonly COLOR_RESET=""
+else
+  readonly COLOR_RED=$(tput setaf 1)
+  readonly COLOR_GREEN=$(tput setaf 2)
+  readonly COLOR_YELLOW=$(tput setaf 3)
+  readonly COLOR_RESET=$(tput sgr0)
+fi
+
 export PATH=$PATH:$HOME/bin
 
 bazel --batch build //...:all
@@ -23,6 +35,6 @@ bazel --batch test  //...:all
 
 if [ "${TEST_BAZEL_AS_DEPENDENCY:-}" = "yes" ]; then
   echo
-  echo "${COLOR_YELLOW}Testing Bazel files as dependency"
+  echo "${COLOR_YELLOW}Testing Bazel files as dependency${COLOR_RESET}"
   (cd /v/ci/test-install && bazel --batch build //...:all)
 fi


### PR DESCRIPTION
This is part of the fixes for #19.  It introduces one build where we use `google-cloud-cpp` as a dependency of a (test) Bazel project.
