### PR TITLE
Refactor integration test driver scripts.

### DIFF
--- a/bigtable/ci/run_integration_tests.sh
+++ b/bigtable/ci/run_integration_tests.sh
@@ -18,6 +18,6 @@ set -eu
 
 # This script should is called from the build directory, and it finds other
 # scripts in the source directory using its own path.
-readonly BINDIR=$(dirname $0)
+readonly BINDIR="$(dirname $0)"
 (cd bigtable/tests && "${BINDIR}/../tests/run_integration_tests_emulator.sh")
 (cd bigtable/tests && "${BINDIR}/../examples/run_examples_emulator.sh")

--- a/bigtable/ci/run_integration_tests.sh
+++ b/bigtable/ci/run_integration_tests.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# This script should is called from the build directory, and it finds other
+# scripts in the source directory using its own path.
+readonly BINDIR=$(dirname $0)
+(cd bigtable/tests && "${BINDIR}/../tests/run_integration_tests_emulator.sh")
+(cd bigtable/tests && "${BINDIR}/../examples/run_examples_emulator.sh")

--- a/ci/build-docker.sh
+++ b/ci/build-docker.sh
@@ -73,7 +73,7 @@ ctest --stop-on-failure
 # Run the integration tests.
 for subdir in bigtable storage; do
   echo
-  echo "${COLOR_RESET}Running integration tests for ${subdir}"
+  echo "Running integration tests for ${subdir}"
   /v/${subdir}/ci/run_integration_tests.sh
 done
 

--- a/ci/build-docker.sh
+++ b/ci/build-docker.sh
@@ -71,9 +71,11 @@ cd "${BUILD_DIR}"
 ctest --stop-on-failure
 
 # Run the integration tests.
-(cd bigtable/tests && /v/bigtable/tests/run_integration_tests_emulator.sh)
-(cd bigtable/tests && /v/bigtable/examples/run_examples_emulator.sh)
-(cd storage/tests && /v/storage/tests/run_integration_tests.sh)
+for subdir in bigtable storage; do
+  echo
+  echo "${COLOR_RESET}Running integration tests for ${subdir}"
+  /v/${subdir}/ci/run_integration_tests.sh
+done
 
 # Some of the sanitizers only emit errors and do not change the error code
 # of the tests, find any such errors and report them as a build failure.

--- a/storage/ci/run_integration_tests.sh
+++ b/storage/ci/run_integration_tests.sh
@@ -18,5 +18,5 @@ set -eu
 
 # This script should is called from the build directory, and it finds other
 # scripts in the source directory using its own path.
-readonly BINDIR=$(dirname $0)
+readonly BINDIR="$(dirname $0)"
 (cd storage/tests && "${BINDIR}/../tests/run_integration_tests.sh")

--- a/storage/ci/run_integration_tests.sh
+++ b/storage/ci/run_integration_tests.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# This script should is called from the build directory, and it finds other
+# scripts in the source directory using its own path.
+readonly BINDIR=$(dirname $0)
+(cd storage/tests && "${BINDIR}/../tests/run_integration_tests.sh")


### PR DESCRIPTION
We need to have a cleaner way to separate the integration tests
for each library.  This is a first attempt.