### PR TITLE
Correctly cleanup when using the emulator.

### DIFF
--- a/bigtable/examples/run_examples_utils.sh
+++ b/bigtable/examples/run_examples_utils.sh
@@ -24,10 +24,6 @@ function cleanup_instance {
   local instance=$2
   shift 2
 
-  if [ -z "${project}" -o -z "${instance}" ]; then
-    return
-  fi
-
   echo
   echo "Cleaning up test instance projects/${project}/instances/${instance}"
   local setenv="env"
@@ -42,14 +38,18 @@ function exit_handler {
   local instance=$2
   shift 2
 
-  cleanup_instance "${project}" "${instance}"
   if [ -n "${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST:-}" ]; then
-    # If the test is running against the emulator there is no need to cleanup
-    # the instance, just kill the emulators.
     kill_emulators
+  else
+    cleanup_instance "${project}" "${instance}"
   fi
 }
 
+# When we finish running a series of examples we want to explicitly cleanup the
+# instance.  We cannot just let the exit handler do it because when running
+# on the emulator the exit handler would kill the emulator.  And when running
+# in production we create a different instance in each group of examples, and
+# there is only one trap at a time.
 function reset_trap {
   if [ -n "${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST:-}" ]; then
     # If the test is running against the emulator there is no need to cleanup
@@ -86,7 +86,7 @@ function run_all_instance_admin_examples {
   echo
   echo "Run create-instance example."
   ${setenv} ../examples/bigtable_samples_instance_admin create-instance "${project_id}" "${INSTANCE}" "${zone_id}"
-  trap 'exit_handler ${project_id} ${INSTANCE}' EXIT
+  trap 'exit_handler "${project_id}" "${INSTANCE}"' EXIT
 
   echo
   echo "Run list-instances example."
@@ -99,12 +99,12 @@ function run_all_instance_admin_examples {
 #  TODO(#490) - disabled until ListClusters works correctly.
 #  echo
 #  echo "Run list-clusters example."
-#  ${admin} ../examples/bigtable_samples_instance_admin list-clusters "${project_id}"
+#  ${setenv} ../examples/bigtable_samples_instance_admin list-clusters "${project_id}"
 
   reset_trap
   echo
   echo "Run delete-instance example."
-  cleanup_instance ${project_id} ${INSTANCE}
+  cleanup_instance "${project_id}" "${INSTANCE}"
 }
 
 # Run all the table admin examples.
@@ -134,8 +134,8 @@ function run_all_table_admin_examples {
   local -r TABLE="sample-table"
 
   # Create an instance to run these examples.
-  $setenv ../examples/bigtable_samples_instance_admin create-instance "${project_id}" "${INSTANCE}" "${zone_id}"
-  trap 'exit_handler ${project_id} ${INSTANCE}' EXIT
+  ${setenv} ../examples/bigtable_samples_instance_admin create-instance "${project_id}" "${INSTANCE}" "${zone_id}"
+  trap 'exit_handler "${project_id}" "${INSTANCE}"' EXIT
 
   echo
   echo "Run create-table example."
@@ -171,7 +171,7 @@ function run_all_table_admin_examples {
   ../examples/bigtable_samples delete-table "${project_id}" "${INSTANCE}" "${TABLE}"
 
   reset_trap
-  cleanup_instance ${project_id} ${INSTANCE}
+  cleanup_instance "${project_id}" "${INSTANCE}"
 }
 
 # Run the Bigtable data manipulation examples.
@@ -201,8 +201,8 @@ function run_all_data_examples {
   local -r TABLE="sample-table"
 
   # Create an instance to run these examples.
-  $setenv ../examples/bigtable_samples_instance_admin create-instance "${project_id}" "${INSTANCE}" "${zone_id}"
-  trap 'exit_handler ${project_id} ${INSTANCE}' EXIT
+  ${setenv} ../examples/bigtable_samples_instance_admin create-instance "${project_id}" "${INSTANCE}" "${zone_id}"
+  trap 'exit_handler "${project_id}" "${INSTANCE}"' EXIT
 
   echo
   echo "Run create-table example."
@@ -251,5 +251,5 @@ function run_all_data_examples {
   ../examples/bigtable_samples read-row "${project_id}" "${INSTANCE}" "${TABLE}"
 
   reset_trap
-  cleanup_instance ${project_id} ${INSTANCE}
+  cleanup_instance "${project_id}" "${INSTANCE}"
 }

--- a/bigtable/examples/run_examples_utils.sh
+++ b/bigtable/examples/run_examples_utils.sh
@@ -19,6 +19,47 @@ readonly CBT_CMD="${CBT:-${GOPATH}/bin/cbt}"
 readonly CBT_EMULATOR_CMD="${CBT_EMULATOR:-${GOPATH}/bin/emulator}"
 readonly CBT_INSTANCE_ADMIN_EMULATOR_CMD="../tests/instance_admin_emulator"
 
+function cleanup_instance {
+  local project=$1
+  local instance=$2
+  shift 2
+
+  if [ -z "${project}" -o -z "${instance}" ]; then
+    return
+  fi
+
+  echo
+  echo "Cleaning up test instance projects/${project}/instances/${instance}"
+  local setenv="env"
+  if [ -n "${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST:-}" ]; then
+    setenv="env BIGTABLE_EMULATOR_HOST=${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST}"
+  fi
+  ${setenv} ../examples/bigtable_samples_instance_admin delete-instance "${project}" "${instance}"
+}
+
+function exit_handler {
+  local project=$1
+  local instance=$2
+  shift 2
+
+  cleanup_instance "${project}" "${instance}"
+  if [ -n "${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST:-}" ]; then
+    # If the test is running against the emulator there is no need to cleanup
+    # the instance, just kill the emulators.
+    kill_emulators
+  fi
+}
+
+function reset_trap {
+  if [ -n "${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST:-}" ]; then
+    # If the test is running against the emulator there is no need to cleanup
+    # the instance, just kill the emulators.
+    trap kill_emulators EXIT
+  else
+    trap - EXIT
+  fi
+}
+
 # Run all the instance admin examples.
 #
 # This function allows us to keep a single place where all the examples are
@@ -34,9 +75,9 @@ function run_all_instance_admin_examples {
   local zone_id=$2
   shift 2
 
-  local admin="env"
+  local setenv="env"
   if [ -n "${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST:-}" ]; then
-    admin="env BIGTABLE_EMULATOR_HOST=${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST}"
+    setenv="env BIGTABLE_EMULATOR_HOST=${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST}"
   fi
 
   # Create a (very likely unique) instance name.
@@ -44,26 +85,26 @@ function run_all_instance_admin_examples {
 
   echo
   echo "Run create-instance example."
-  $admin ../examples/bigtable_samples_instance_admin create-instance "${project_id}" "${INSTANCE}" "${zone_id}"
-  trap '$admin ../examples/bigtable_samples_instance_admin delete-instance "${project_id}" "${INSTANCE}"' EXIT
+  ${setenv} ../examples/bigtable_samples_instance_admin create-instance "${project_id}" "${INSTANCE}" "${zone_id}"
+  trap 'exit_handler ${project_id} ${INSTANCE}' EXIT
 
   echo
   echo "Run list-instances example."
-  $admin ../examples/bigtable_samples_instance_admin list-instances "${project_id}"
+  ${setenv} ../examples/bigtable_samples_instance_admin list-instances "${project_id}"
 
   echo
   echo "Run get-instance example."
-  $admin ../examples/bigtable_samples_instance_admin get-instance "${project_id}" "${INSTANCE}"
+  ${setenv} ../examples/bigtable_samples_instance_admin get-instance "${project_id}" "${INSTANCE}"
 
 #  TODO(#490) - disabled until ListClusters works correctly.
 #  echo
 #  echo "Run list-clusters example."
-#  $admin ../examples/bigtable_samples_instance_admin list-clusters "${project_id}"
+#  ${admin} ../examples/bigtable_samples_instance_admin list-clusters "${project_id}"
 
+  reset_trap
   echo
   echo "Run delete-instance example."
-  trap - EXIT
-  $admin ../examples/bigtable_samples_instance_admin delete-instance "${project_id}" "${INSTANCE}"
+  cleanup_instance ${project_id} ${INSTANCE}
 }
 
 # Run all the table admin examples.
@@ -81,9 +122,9 @@ function run_all_table_admin_examples {
   local zone_id=$2
   shift 2
 
-  local admin="env"
+  local setenv="env"
   if [ -n "${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST:-}" ]; then
-    admin="env BIGTABLE_EMULATOR_HOST=${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST}"
+    setenv="env BIGTABLE_EMULATOR_HOST=${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST}"
   fi
 
   # Create a (very likely unique) instance name.
@@ -93,8 +134,8 @@ function run_all_table_admin_examples {
   local -r TABLE="sample-table"
 
   # Create an instance to run these examples.
-  $admin ../examples/bigtable_samples_instance_admin create-instance "${project_id}" "${INSTANCE}" "${zone_id}"
-  trap '$admin ../examples/bigtable_samples_instance_admin delete-instance "${project_id}" "${INSTANCE}"' EXIT
+  $setenv ../examples/bigtable_samples_instance_admin create-instance "${project_id}" "${INSTANCE}" "${zone_id}"
+  trap 'exit_handler ${project_id} ${INSTANCE}' EXIT
 
   echo
   echo "Run create-table example."
@@ -129,8 +170,8 @@ function run_all_table_admin_examples {
   echo "Run delete-table example."
   ../examples/bigtable_samples delete-table "${project_id}" "${INSTANCE}" "${TABLE}"
 
-  trap - EXIT
-  $admin ../examples/bigtable_samples_instance_admin delete-instance "${project_id}" "${INSTANCE}"
+  reset_trap
+  cleanup_instance ${project_id} ${INSTANCE}
 }
 
 # Run the Bigtable data manipulation examples.
@@ -148,9 +189,9 @@ function run_all_data_examples {
   local zone_id=$2
   shift 2
 
-  local admin="env"
+  local setenv="env"
   if [ -n "${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST:-}" ]; then
-    admin="env BIGTABLE_EMULATOR_HOST=${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST}"
+    setenv="env BIGTABLE_EMULATOR_HOST=${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST}"
   fi
 
   # Create a (very likely unique) instance name.
@@ -160,8 +201,8 @@ function run_all_data_examples {
   local -r TABLE="sample-table"
 
   # Create an instance to run these examples.
-  $admin ../examples/bigtable_samples_instance_admin create-instance "${project_id}" "${INSTANCE}" "${zone_id}"
-  trap '$admin ../examples/bigtable_samples_instance_admin delete-instance "${project_id}" "${INSTANCE}" "${zone_id}"' EXIT
+  $setenv ../examples/bigtable_samples_instance_admin create-instance "${project_id}" "${INSTANCE}" "${zone_id}"
+  trap 'exit_handler ${project_id} ${INSTANCE}' EXIT
 
   echo
   echo "Run create-table example."
@@ -209,6 +250,6 @@ function run_all_data_examples {
   ../examples/bigtable_samples read-modify-write "${project_id}" "${INSTANCE}" "${TABLE}"
   ../examples/bigtable_samples read-row "${project_id}" "${INSTANCE}" "${TABLE}"
 
-  trap - EXIT
-  $admin ../examples/bigtable_samples_instance_admin delete-instance "${project_id}" "${INSTANCE}"
+  reset_trap
+  cleanup_instance ${project_id} ${INSTANCE}
 }

--- a/bigtable/tools/run_emulator_utils.sh
+++ b/bigtable/tools/run_emulator_utils.sh
@@ -17,11 +17,11 @@ EMULATOR_PID=0
 INSTANCE_ADMIN_EMULATOR_PID=0
 
 function kill_emulators {
-  echo -n "Killing Bigtable Emulators [${EMULATOR_PID} ${INSTANCE_ADMIN_EMULATOR_PID}]"
+  echo -n "Killing Bigtable Emulators [${EMULATOR_PID} ${INSTANCE_ADMIN_EMULATOR_PID}] ... "
   kill "${EMULATOR_PID}"
   kill "${INSTANCE_ADMIN_EMULATOR_PID}"
   wait >/dev/null 2>&1
-  echo " DONE"
+  echo "done."
 }
 
 function start_emulators {

--- a/bigtable/tools/run_emulator_utils.sh
+++ b/bigtable/tools/run_emulator_utils.sh
@@ -17,10 +17,11 @@ EMULATOR_PID=0
 INSTANCE_ADMIN_EMULATOR_PID=0
 
 function kill_emulators {
-  echo "Killing Bigtable Emulators [${EMULATOR_PID} ${INSTANCE_ADMIN_EMULATOR_PID}]"
+  echo -n "Killing Bigtable Emulators [${EMULATOR_PID} ${INSTANCE_ADMIN_EMULATOR_PID}]"
   kill "${EMULATOR_PID}"
   kill "${INSTANCE_ADMIN_EMULATOR_PID}"
   wait >/dev/null 2>&1
+  echo " DONE"
 }
 
 function start_emulators {


### PR DESCRIPTION
I was using trap to cleanup instances and kill the emulators, but
only one trap can be in effect at a time. Stacking traps is a
pain in bash, but since we know what traps are in effect we can
simplify things.