### PR TITLE
Implement a parser for RFC 3339 dates.

### DIFF
--- a/storage/client/CMakeLists.txt
+++ b/storage/client/CMakeLists.txt
@@ -24,9 +24,11 @@ add_library(storage_client
     internal/curl_request.cc
     internal/curl_wrappers.h
     internal/curl_wrappers.cc
+    internal/nljson.h
+    internal/parse_rfc3339.h
+    internal/parse_rfc3339.cc
     internal/service_account_credentials.h
     internal/service_account_credentials.cc
-    internal/nljson.h
     version.h
     version.cc)
 target_link_libraries(storage_client
@@ -67,8 +69,9 @@ endif ()
 
 # List the unit tests, then setup the targets and dependencies.
 set(storage_client_unit_tests
-    internal/service_account_credentials_test.cc
     internal/nljson_test.cc
+    internal/parse_rfc3339_test.cc
+    internal/service_account_credentials_test.cc
     link_test.cc)
 
 foreach (fname ${storage_client_unit_tests})

--- a/storage/client/internal/parse_rfc3339.cc
+++ b/storage/client/internal/parse_rfc3339.cc
@@ -75,10 +75,10 @@ std::chrono::system_clock::time_point ParseDateTime(
       31,  // December
   };
   if (day <= 0 or day > MAX_DAYS_IN_MONTH[month - 1]) {
-    ReportError(timestamp, "Out of range month day.");
+    ReportError(timestamp, "Out of range day for given month.");
   }
   if (2 == month and day > 28 and not IsLeapYear(year)) {
-    ReportError(timestamp, "Out of range month day.");
+    ReportError(timestamp, "Out of range day for given month.");
   }
   if (hours < 0 or hours > 23) {
     ReportError(timestamp, "Out of range hour.");

--- a/storage/client/internal/parse_rfc3339.cc
+++ b/storage/client/internal/parse_rfc3339.cc
@@ -14,6 +14,7 @@
 
 #include "storage/client/internal/parse_rfc3339.h"
 #include "google/cloud/internal/throw_delegate.h"
+#include <cctype>
 #include <cstdio>
 #include <iomanip>
 #include <iostream>

--- a/storage/client/internal/parse_rfc3339.cc
+++ b/storage/client/internal/parse_rfc3339.cc
@@ -104,7 +104,7 @@ std::chrono::system_clock::time_point ParseDateTime(
 std::chrono::system_clock::duration ParseFractionalSeconds(
     char const*& buffer, std::string const& timestamp) {
   if (buffer[0] != '.') {
-    return std::chrono::nanoseconds(0);
+    return std::chrono::system_clock::duration(0);
   }
   ++buffer;
 

--- a/storage/client/internal/parse_rfc3339.cc
+++ b/storage/client/internal/parse_rfc3339.cc
@@ -24,7 +24,7 @@ namespace {
 [[noreturn]] void ReportError(std::string const& timestamp, char const* msg) {
   std::ostringstream os;
   os << "Error parsing RFC 3339 timestamp: " << msg
-     << " Valid format is YYYY-MM-DD[Tt]HH:MM:SS[.s+](Z|+HH:MM), got="
+     << " Valid format is YYYY-MM-DD[Tt]HH:MM:SS[.s+](Z|[+-]HH:MM), got="
      << timestamp;
   google::cloud::internal::RaiseInvalidArgument(os.str());
 }
@@ -139,7 +139,7 @@ std::chrono::seconds ParseOffset(char const*& buffer,
     constexpr int EXPECTED_OFFSET_WIDTH = 5;
     constexpr int EXPECTED_OFFSET_FIELDS = 2;
     if (count != EXPECTED_OFFSET_FIELDS or pos != EXPECTED_OFFSET_WIDTH) {
-      ReportError(timestamp, "Invalid timezone offset, expected [+/-]HH:SS.");
+      ReportError(timestamp, "Invalid timezone offset, expected [+-]HH:MM.");
     }
     if (hours < 0 or hours > 23) {
       ReportError(timestamp, "Out of range offset hour.");

--- a/storage/client/internal/parse_rfc3339.cc
+++ b/storage/client/internal/parse_rfc3339.cc
@@ -180,7 +180,7 @@ std::chrono::system_clock::time_point ParseRfc3339(
 // The standard C++ function to convert time_t to a struct tm is not thread
 // safe (it holds global storage), use some OS specific stuff here:
 #if WIN32
-    gmtime_s(&now, &lcl);
+    gmtime_s(&lcl, &now);
 #else
     gmtime_r(&now, &lcl);
 #endif  // WIN32

--- a/storage/client/internal/parse_rfc3339.cc
+++ b/storage/client/internal/parse_rfc3339.cc
@@ -1,0 +1,181 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/client/internal/parse_rfc3339.h"
+#include "google/cloud/internal/throw_delegate.h"
+#include <cstdio>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+namespace {
+[[noreturn]] void ReportError(std::string const& timestamp, char const* msg) {
+  std::ostringstream os;
+  os << "Error parsing RFC 3339 timestamp: " << msg
+     << " Valid format is YYYY-MM-DD[Tt]HH:MM:SS[.s+](Z|+HH:MM), got="
+     << timestamp;
+  google::cloud::internal::RaiseInvalidArgument(os.str());
+}
+
+std::chrono::system_clock::time_point ParseDateTime(
+    char const*& buffer, std::string const& timestamp) {
+  // Use std::mktime to compute the number of seconds because RFC 3339 requires
+  // working with civil time, including the annoying leap seconds, and mktime
+  // does.
+  int year, mon, mday;
+  char date_time_separator;
+  int hh, mm, ss;
+
+  int pos;
+  auto count = std::sscanf(buffer, "%4d-%2d-%2d%c%2d:%2d:%2d%n", &year, &mon,
+                           &mday, &date_time_separator, &hh, &mm, &ss, &pos);
+  // All the fields up to this point have fixed width, so total width must be:
+  constexpr int EXPECTED_WIDTH = 19;
+  constexpr int EXPECTED_FIELDS = 7;
+  if (count != EXPECTED_FIELDS or pos != EXPECTED_WIDTH) {
+    ReportError(timestamp,
+                "Invalid format for RFC 3339 timestamp detected while parsing"
+                " the base date and time portion.");
+  }
+  if (date_time_separator != 'T' and date_time_separator != 't') {
+    ReportError(timestamp, "Invalid date-time separator, expected 'T' or 't'.");
+  }
+  if (mon <= 0 or mon > 12) {
+    ReportError(timestamp, "Out of range month.");
+  }
+  if (mday <= 0 or mday > 31) {
+    ReportError(timestamp, "Out of range month day.");
+  }
+  if (hh < 0 or hh > 23) {
+    ReportError(timestamp, "Out of range hour.");
+  }
+  if (mm < 0 or mm > 59) {
+    ReportError(timestamp, "Out of range minute.");
+  }
+  if (ss < 0 or ss > 60) {
+    ReportError(timestamp, "Out of range second.");
+  }
+  // Advance the pointer for all the characters read.
+  buffer += pos;
+
+  std::tm tm{0};
+  tm.tm_year = year - 1900;
+  tm.tm_mon = mon - 1;
+  tm.tm_mday = mday;
+  tm.tm_hour = hh;
+  tm.tm_min = mm;
+  tm.tm_sec = ss;
+  return std::chrono::system_clock::from_time_t(std::mktime(&tm));
+}
+
+std::chrono::nanoseconds ParseFractionalSeconds(char const*& buffer,
+                                                std::string const& timestamp) {
+  if (buffer[0] != '.') {
+    return std::chrono::nanoseconds(0);
+  }
+  ++buffer;
+
+  long fractional_seconds;
+  int pos;
+  auto count = std::sscanf(buffer, "%9ld%n", &fractional_seconds, &pos);
+  if (count != 1) {
+    ReportError(timestamp, "Invalid fractional seconds component.");
+  }
+  // Normalize the fractional seconds to nanoseconds.
+  for (int digits = pos; digits < 9; ++digits) {
+    fractional_seconds *= 10;
+  }
+  // Now skip any other digits ...
+  buffer += pos;
+  while (std::isdigit(buffer[0])) {
+    ++buffer;
+  }
+  return std::chrono::nanoseconds(fractional_seconds);
+}
+
+std::chrono::seconds ParseOffset(char const*& buffer,
+                                 std::string const& timestamp) {
+  if (buffer[0] == '+' or buffer[0] == '-') {
+    bool positive = buffer[0] == '+';
+    ++buffer;
+    // Parse the HH:MM offset.
+    int hh, mm, pos;
+    auto count = std::sscanf(buffer, "%2d:%2d%n", &hh, &mm, &pos);
+    constexpr int EXPECTED_OFFSET_WIDTH = 5;
+    constexpr int EXPECTED_OFFSET_FIELDS = 2;
+    if (count != EXPECTED_OFFSET_FIELDS or pos != EXPECTED_OFFSET_WIDTH) {
+      ReportError(timestamp, "Invalid timezone offset, expected [+/-]HH:SS.");
+    }
+    if (hh < 0 or hh > 23) {
+      ReportError(timestamp, "Out of range offset hour.");
+    }
+    if (mm < 0 or mm > 59) {
+      ReportError(timestamp, "Out of range offset minute.");
+    }
+    buffer += pos;
+    using namespace std::chrono;
+    if (positive) {
+      return duration_cast<seconds>(hours(hh) + minutes(mm));
+    }
+    return duration_cast<seconds>(-hours(hh) - minutes(mm));
+  }
+  if (buffer[0] != 'Z' and buffer[0] != 'z') {
+    ReportError(timestamp, "Invalid timezone offset, expected 'Z' or 'z'.");
+  }
+  ++buffer;
+  return std::chrono::seconds(0);
+}
+}  // anonymous namespace
+
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+std::chrono::system_clock::time_point ParseRfc3339(
+    std::string const& timestamp) {
+  // TODO(#530) - dynamically change the timezone offset.
+  // Because this computation is a bit expensive, assume the timezone offset
+  // does not change during the lifetime of the program.  This function takes
+  // the current time, converts to UTC and then convert back to a time_t.  The
+  // difference is the offset.
+  static std::chrono::seconds const LOCALTIME_OFFSET = []() {
+    auto now = std::time(nullptr);
+    std::tm lcl;
+// The standard C++ function to convert time_t to a struct tm is not thread
+// safe (it holds global storage), use some OS specific stuff here:
+#if WIN32
+    gmtime_s(&now, &lcl);
+#else
+    gmtime_r(&now, &lcl);
+#endif  // WIN32
+    return std::chrono::seconds(mktime(&lcl) - now);
+  }();
+
+  char const* buffer = timestamp.c_str();
+  auto time_point = ParseDateTime(buffer, timestamp);
+  std::chrono::nanoseconds nsec = ParseFractionalSeconds(buffer, timestamp);
+  std::chrono::seconds offset = ParseOffset(buffer, timestamp);
+
+  if (buffer[0] != '\0') {
+    ReportError(timestamp, "Additional text after RFC 3339 date.");
+  }
+
+  time_point += nsec;
+  time_point -= offset;
+  time_point -= LOCALTIME_OFFSET;
+  return time_point;
+}
+
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage

--- a/storage/client/internal/parse_rfc3339.cc
+++ b/storage/client/internal/parse_rfc3339.cc
@@ -87,7 +87,7 @@ std::chrono::system_clock::time_point ParseDateTime(
     ReportError(timestamp, "Out of range minute.");
   }
   // RFC-3339 points out that the seconds field can only assume value '60' for
-  // leap seconds, so theoretically we should validate that (furthermore we
+  // leap seconds, so theoretically, we should validate that (furthermore, we
   // should valid that `seconds` is smaller than 59 for negative leap seconds).
   // This would require loading a table, and adds too much complexity for little
   // value.
@@ -125,7 +125,7 @@ std::chrono::system_clock::duration ParseFractionalSeconds(
     fractional_seconds *= 10;
   }
   // Skip any other digits. This loses precision for sub-nanosecond timestamps,
-  // we do not consider this a problem for Internet timestamps.
+  // but we do not consider this a problem for Internet timestamps.
   buffer += pos;
   while (std::isdigit(buffer[0])) {
     ++buffer;

--- a/storage/client/internal/parse_rfc3339.h
+++ b/storage/client/internal/parse_rfc3339.h
@@ -1,0 +1,43 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_STORAGE_CLIENT_INTERNAL_PARSE_RFC3339_H_
+#define GOOGLE_CLOUD_CPP_STORAGE_CLIENT_INTERNAL_PARSE_RFC3339_H_
+
+#include "storage/client/version.h"
+#include <chrono>
+#include <string>
+
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+/**
+ * Parse @p timestamp as RFC-3339 format.
+ *
+ * Google Cloud Storage uses RFC-3339 for timestamps, this function is used to
+ * parse them and convert to `std::chrono::system_clock::time_point`, the C++
+ * class used to represent timestamps.  Depending on the underlying C++
+ * implementation the timestamp may lose precision, C++ only requires the
+ * system_clock to have
+ *
+ * @see https://tools.ietf.org/html/rfc3339
+ */
+std::chrono::system_clock::time_point ParseRfc3339(
+    std::string const& timestamp);
+
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_CLIENT_INTERNAL_CURL_WRAPPERS_H_

--- a/storage/client/internal/parse_rfc3339.h
+++ b/storage/client/internal/parse_rfc3339.h
@@ -28,8 +28,11 @@ namespace internal {
  * Google Cloud Storage uses RFC-3339 for timestamps, this function is used to
  * parse them and convert to `std::chrono::system_clock::time_point`, the C++
  * class used to represent timestamps.  Depending on the underlying C++
- * implementation the timestamp may lose precision, C++ only requires the
- * system_clock to have
+ * implementation the timestamp may lose precision. C++ does not specify the
+ * precision of the system clock, though most implementations have sub-second
+ * precision, and nanoseconds is common.  The RFC-3339 spec allows for arbitrary
+ * precision in fractional seconds, though it would be surprising to see
+ * femtosecond timestamp for Internet events.
  *
  * @see https://tools.ietf.org/html/rfc3339
  */

--- a/storage/client/internal/parse_rfc3339_test.cc
+++ b/storage/client/internal/parse_rfc3339_test.cc
@@ -1,0 +1,348 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/client/internal/parse_rfc3339.h"
+#include <gtest/gtest.h>
+#include <ctime>
+
+TEST(ParseRfc3339Test, ParseEpoch) {
+  auto timestamp = storage::internal::ParseRfc3339("1970-01-01T00:00:00Z");
+  // The C++ 11, 14 and 17 standards do not guarantee that the system clock's
+  // epoch is actually the same as the Unix Epoch. Luckily, the platforms we
+  // support actually have that property, and C++ 20 fixes things. If this test
+  // breaks because somebody is unlucky enough to have a C++ compiler + library
+  // with a different Epoch then at least we know what the problem is.
+  EXPECT_EQ(0, timestamp.time_since_epoch().count());
+}
+
+TEST(ParseRfc3339Test, ParseSimpleZulu) {
+  auto timestamp = storage::internal::ParseRfc3339("2018-05-18T14:42:03Z");
+  // Use `date -u +%s --date='2018-05-18T14:42:03'` to get the magic value:
+  using namespace std::chrono;
+  EXPECT_EQ(1526654523L,
+            duration_cast<seconds>(timestamp.time_since_epoch()).count());
+}
+
+TEST(ParseRfc3339Test, ParseAlternativeSeparators) {
+  auto timestamp = storage::internal::ParseRfc3339("2018-05-18t14:42:03z");
+  // Use `date -u +%s --date='2018-05-18T14:42:03'` to get the magic value:
+  using namespace std::chrono;
+  EXPECT_EQ(1526654523L,
+            duration_cast<seconds>(timestamp.time_since_epoch()).count());
+}
+
+TEST(ParseRfc3339Test, ParseFractional) {
+  auto timestamp =
+      storage::internal::ParseRfc3339("2018-05-18T14:42:03.123456789Z");
+  // Use `date -u +%s --date='2018-05-18T14:42:03'` to get the magic value:
+  using namespace std::chrono;
+  auto actual_seconds = duration_cast<seconds>(timestamp.time_since_epoch());
+  EXPECT_EQ(1526654523L, actual_seconds.count());
+  auto actual_nanoseconds =
+      duration_cast<nanoseconds>(timestamp.time_since_epoch() - actual_seconds);
+  EXPECT_EQ(123456789L, actual_nanoseconds.count());
+}
+
+TEST(ParseRfc3339Test, ParseFractionalMoreThanNanos) {
+  auto timestamp =
+      storage::internal::ParseRfc3339("2018-05-18T14:42:03.1234567890123Z");
+  // Use `date -u +%s --date='2018-05-18T14:42:03'` to get the magic value:
+  using namespace std::chrono;
+  auto actual_seconds = duration_cast<seconds>(timestamp.time_since_epoch());
+  EXPECT_EQ(1526654523L, actual_seconds.count());
+  auto actual_nanoseconds =
+      duration_cast<nanoseconds>(timestamp.time_since_epoch() - actual_seconds);
+  EXPECT_EQ(123456789L, actual_nanoseconds.count());
+}
+
+TEST(ParseRfc3339Test, ParseFractionalLessThanNanos) {
+  auto timestamp =
+      storage::internal::ParseRfc3339("2018-05-18T14:42:03.123456Z");
+  // Use `date -u +%s --date='2018-05-18T14:42:03'` to get the magic value:
+  using namespace std::chrono;
+  auto actual_seconds = duration_cast<seconds>(timestamp.time_since_epoch());
+  EXPECT_EQ(1526654523L, actual_seconds.count());
+  auto actual_nanoseconds =
+      duration_cast<nanoseconds>(timestamp.time_since_epoch() - actual_seconds);
+  EXPECT_EQ(123456000L, actual_nanoseconds.count());
+}
+
+TEST(ParseRfc3339Test, ParseWithOffset) {
+  auto timestamp = storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:00");
+  // Use `date -u +%s --date='2018-05-18T14:42:03+08:00'` to get the magic
+  // value.
+  using namespace std::chrono;
+  auto actual_seconds = duration_cast<seconds>(timestamp.time_since_epoch());
+  EXPECT_EQ(1526625723L, actual_seconds.count());
+}
+
+TEST(ParseRfc3339Test, ParseFull) {
+  auto timestamp =
+      storage::internal::ParseRfc3339("2018-05-18T14:42:03.5-01:05");
+  // Use `date -u +%s --date='2018-05-18T14:42:03.5-01:05'` to get the magic
+  // value.
+  using namespace std::chrono;
+  auto actual_seconds = duration_cast<seconds>(timestamp.time_since_epoch());
+  EXPECT_EQ(1526658423L, actual_seconds.count());
+  auto actual_milliseconds = duration_cast<milliseconds>(
+      timestamp.time_since_epoch() - actual_seconds);
+  EXPECT_EQ(500, actual_milliseconds.count());
+}
+
+TEST(ParseRfc3339Test, DetectInvalidSeparator) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18x14:42:03Z"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18x14:42:03Z"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03x"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03x"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectLongYear) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("52018-05-18T14:42:03Z"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("52018-05-18T14:42:03Z"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectShortYear) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("218-05-18T14:42:03Z"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("218-05-18T14:42:03Z"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectLongMonth) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-123-18T14:42:03Z"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-123-18T14:42:03Z"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectShortMonth) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-1-18T14:42:03Z"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-1-18T14:42:03Z"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectOutOfRangeMonth) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-33-18T14:42:03Z"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-33-18T14:42:03Z"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectLongMDay) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-181T14:42:03Z"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-181T14:42:03Z"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectShortMDay) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-1T14:42:03Z"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-1T14:42:03Z"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectOutOfRangeMDay) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-55T14:42:03Z"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-55T14:42:03Z"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectLongHour) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T144:42:03Z"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T144:42:03Z"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectShortHour) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T1:42:03Z"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T1:42:03Z"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectOutOfRangeHour) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T24:42:03Z"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T24:42:03Z"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectLongMinute) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:442:03Z"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:442:03Z"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectShortMinute) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:2:03Z"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:2:03Z"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectOutOfRangeMinute) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T22:60:03Z"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T22:60:03Z"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectLongSecond) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:003Z"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:003Z"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectShortSecond) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:3Z"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:3Z"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectOutOfRangeSecond) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T22:42:61Z"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T22:42:61Z"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectLongOffsetHour) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+008:00"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+008:00"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectShortOffsetHour) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+8:00"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+8:00"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectOutOfRangeOffsetHour) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+24:00"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+24:00"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectLongOffsetMinute) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:001"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:001"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectShortOffsetMinute) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:1"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:1"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(ParseRfc3339Test, DetectOutOfRangeOffsetMinute) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:60"),
+               std::invalid_argument);
+#else
+  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:60"),
+               "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}

--- a/storage/client/internal/parse_rfc3339_test.cc
+++ b/storage/client/internal/parse_rfc3339_test.cc
@@ -124,15 +124,17 @@ TEST(ParseRfc3339Test, DetectInvalidSeparator) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18x14:42:03Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18x14:42:03Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-05-18x14:42:03Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03x"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03x"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-05-18T14:42:03x"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -141,8 +143,9 @@ TEST(ParseRfc3339Test, DetectLongYear) {
   EXPECT_THROW(storage::internal::ParseRfc3339("52018-05-18T14:42:03Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("52018-05-18T14:42:03Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("52018-05-18T14:42:03Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -151,8 +154,9 @@ TEST(ParseRfc3339Test, DetectShortYear) {
   EXPECT_THROW(storage::internal::ParseRfc3339("218-05-18T14:42:03Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("218-05-18T14:42:03Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("218-05-18T14:42:03Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -161,8 +165,9 @@ TEST(ParseRfc3339Test, DetectLongMonth) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-123-18T14:42:03Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-123-18T14:42:03Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-123-18T14:42:03Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -171,8 +176,9 @@ TEST(ParseRfc3339Test, DetectShortMonth) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-1-18T14:42:03Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-1-18T14:42:03Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-1-18T14:42:03Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -181,8 +187,9 @@ TEST(ParseRfc3339Test, DetectOutOfRangeMonth) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-33-18T14:42:03Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-33-18T14:42:03Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-33-18T14:42:03Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -191,8 +198,9 @@ TEST(ParseRfc3339Test, DetectLongMDay) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-181T14:42:03Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-181T14:42:03Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-05-181T14:42:03Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -201,8 +209,9 @@ TEST(ParseRfc3339Test, DetectShortMDay) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-1T14:42:03Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-1T14:42:03Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-05-1T14:42:03Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -211,8 +220,9 @@ TEST(ParseRfc3339Test, DetectOutOfRangeMDay) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-55T14:42:03Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-55T14:42:03Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-05-55T14:42:03Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -221,8 +231,9 @@ TEST(ParseRfc3339Test, DetectOutOfRangeMDay30) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-06-31T14:42:03Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-06-31T14:42:03Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-06-31T14:42:03Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -231,8 +242,9 @@ TEST(ParseRfc3339Test, DetectOutOfRangeMDayFebLeap) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2016-02-30T14:42:03Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2016-02-30T14:42:03Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2016-02-30T14:42:03Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -241,8 +253,9 @@ TEST(ParseRfc3339Test, DetectOutOfRangeMDayFebNonLeap) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2017-02-29T14:42:03Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2017-02-29T14:42:03Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2017-02-29T14:42:03Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -251,8 +264,9 @@ TEST(ParseRfc3339Test, DetectLongHour) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T144:42:03Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T144:42:03Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-05-18T144:42:03Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -261,8 +275,9 @@ TEST(ParseRfc3339Test, DetectShortHour) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T1:42:03Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T1:42:03Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-05-18T1:42:03Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -271,8 +286,9 @@ TEST(ParseRfc3339Test, DetectOutOfRangeHour) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T24:42:03Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T24:42:03Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-05-18T24:42:03Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -281,8 +297,9 @@ TEST(ParseRfc3339Test, DetectLongMinute) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:442:03Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:442:03Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-05-18T14:442:03Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -291,8 +308,9 @@ TEST(ParseRfc3339Test, DetectShortMinute) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:2:03Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:2:03Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-05-18T14:2:03Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -301,8 +319,9 @@ TEST(ParseRfc3339Test, DetectOutOfRangeMinute) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T22:60:03Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T22:60:03Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-05-18T22:60:03Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -311,8 +330,9 @@ TEST(ParseRfc3339Test, DetectLongSecond) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:003Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:003Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-05-18T14:42:003Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -321,8 +341,9 @@ TEST(ParseRfc3339Test, DetectShortSecond) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:3Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:3Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-05-18T14:42:3Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -331,8 +352,9 @@ TEST(ParseRfc3339Test, DetectOutOfRangeSecond) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T22:42:61Z"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T22:42:61Z"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-05-18T22:42:61Z"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -341,8 +363,9 @@ TEST(ParseRfc3339Test, DetectLongOffsetHour) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+008:00"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+008:00"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-05-18T14:42:03+008:00"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -351,8 +374,9 @@ TEST(ParseRfc3339Test, DetectShortOffsetHour) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+8:00"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+8:00"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-05-18T14:42:03+8:00"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -361,8 +385,9 @@ TEST(ParseRfc3339Test, DetectOutOfRangeOffsetHour) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+24:00"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+24:00"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-05-18T14:42:03+24:00"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -371,8 +396,9 @@ TEST(ParseRfc3339Test, DetectLongOffsetMinute) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:001"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:001"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:001"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -381,8 +407,9 @@ TEST(ParseRfc3339Test, DetectShortOffsetMinute) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:1"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:1"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:1"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -391,7 +418,8 @@ TEST(ParseRfc3339Test, DetectOutOfRangeOffsetMinute) {
   EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:60"),
                std::invalid_argument);
 #else
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:60"),
-               "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:60"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }

--- a/storage/client/internal/parse_rfc3339_test.cc
+++ b/storage/client/internal/parse_rfc3339_test.cc
@@ -80,9 +80,20 @@ TEST(ParseRfc3339Test, ParseFractionalMoreThanNanos) {
   using namespace std::chrono;
   auto actual_seconds = duration_cast<seconds>(timestamp.time_since_epoch());
   EXPECT_EQ(1526654523L, actual_seconds.count());
-  auto actual_nanoseconds =
-      duration_cast<nanoseconds>(timestamp.time_since_epoch() - actual_seconds);
-  EXPECT_EQ(123456789L, actual_nanoseconds.count());
+  bool system_clock_has_nanos = std::ratio_greater_equal<
+      std::nano, std::chrono::system_clock::duration::period>::value;
+  if (system_clock_has_nanos) {
+    auto actual_nanoseconds = duration_cast<nanoseconds>(
+        timestamp.time_since_epoch() - actual_seconds);
+    EXPECT_EQ(123456789L, actual_nanoseconds.count());
+  } else {
+    // On platforms where the system clock has less than nanosecond precision
+    // just check for milliseconds, we could check at the highest possible
+    // precision but that is overkill.
+    auto actual_milliseconds = duration_cast<milliseconds>(
+        timestamp.time_since_epoch() - actual_seconds);
+    EXPECT_EQ(123L, actual_milliseconds.count());
+  }
 }
 
 TEST(ParseRfc3339Test, ParseFractionalLessThanNanos) {

--- a/storage/client/storage_client.bzl
+++ b/storage/client/storage_client.bzl
@@ -3,8 +3,9 @@ storage_client_HDRS = [
     "credentials.h",
     "internal/curl_request.h",
     "internal/curl_wrappers.h",
-    "internal/service_account_credentials.h",
     "internal/nljson.h",
+    "internal/parse_rfc3339.h",
+    "internal/service_account_credentials.h",
     "version.h",
 ]
 
@@ -12,6 +13,7 @@ storage_client_SRCS = [
     "credentials.cc",
     "internal/curl_request.cc",
     "internal/curl_wrappers.cc",
+    "internal/parse_rfc3339.cc",
     "internal/service_account_credentials.cc",
     "version.cc",
 ]

--- a/storage/client/storage_client_unit_tests.bzl
+++ b/storage/client/storage_client_unit_tests.bzl
@@ -1,7 +1,8 @@
 # DO NOT EDIT -- GENERATED CODE
 storage_client_unit_tests = [
-    "internal/service_account_credentials_test.cc",
     "internal/nljson_test.cc",
+    "internal/parse_rfc3339_test.cc",
+    "internal/service_account_credentials_test.cc",
     "link_test.cc",
 ]
 


### PR DESCRIPTION
Google Cloud Storage returns RFC 3339 dates in the JSON messages.
I could not find a parser for them, the nlophmann::json library
does not have own, curl has a parser that accepts too many other
formats. Protobuf has a parser, but that would introduce a strange
dependency, and (I believe, by code inspection), the parser does
not handle leap seconds correctly.