### PR TITLE
This time actually print output on test failures.

### DIFF
--- a/ci/build-docker.sh
+++ b/ci/build-docker.sh
@@ -59,7 +59,7 @@ echo "${COLOR_YELLOW}Finished build at: $(date)${COLOR_RESET}"
 
 # Run the tests and output any failures.
 cd "${BUILD_DIR}"
-ctest --stop-on-failure
+ctest --output-on-failure
 
 # Run the integration tests.
 for subdir in bigtable storage; do


### PR DESCRIPTION
Fixed a PBKAC (mine, coryan), where I used `--stop-on-failure`,
an option that does not exist, when I wanted `--output-on-failure`.
I guess `ctest` was trying to be helpful and run anyway.