### PR TITLE
Use GOOGLE_APPLICATION_CREDENTIALS if set.

### DIFF
--- a/storage/client/internal/service_account_credentials.cc
+++ b/storage/client/internal/service_account_credentials.cc
@@ -43,6 +43,10 @@ char const* DefaultServiceAccountCredentialsHomeVariable() {
 }
 
 std::string DefaultServiceAccountCredentialsFile() {
+  auto override_value = std::getenv("GOOGLE_APPLICATION_CREDENTIALS");
+  if (override_value != nullptr) {
+    return override_value;
+  }
   // There are probably more efficient ways to do this, but meh, the strings
   // are typically short, and this does not happen that often.
   auto root = std::getenv(CREDENTIALS_HOME_VAR);

--- a/storage/client/internal/service_account_credentials_test.cc
+++ b/storage/client/internal/service_account_credentials_test.cc
@@ -190,7 +190,8 @@ class EnvironmentVariableRestore {
 class DefaultServiceAccountFileTest : public ::testing::Test {
  public:
   DefaultServiceAccountFileTest()
-      : home_(storage::internal::DefaultServiceAccountCredentialsHomeVariable()),
+      : home_(
+            storage::internal::DefaultServiceAccountCredentialsHomeVariable()),
         override_variable_("GOOGLE_APPLICATION_CREDENTIALS") {}
 
  protected:
@@ -204,7 +205,7 @@ class DefaultServiceAccountFileTest : public ::testing::Test {
   }
 
  protected:
-  EnvironmentVariableRestore home_ ;
+  EnvironmentVariableRestore home_;
   EnvironmentVariableRestore override_variable_;
 };
 

--- a/storage/client/internal/service_account_credentials_test.cc
+++ b/storage/client/internal/service_account_credentials_test.cc
@@ -169,21 +169,56 @@ TEST_F(ServiceAccountCredentialsTest, Refresh) {
   EXPECT_EQ("Type access-token-r2", credentials.AuthorizationHeader());
 }
 
+class EnvironmentVariableRestore {
+ public:
+  explicit EnvironmentVariableRestore(char const* variable_name)
+      : EnvironmentVariableRestore(std::string(variable_name)) {}
+
+  explicit EnvironmentVariableRestore(std::string variable_name)
+      : variable_name_(std::move(variable_name)) {}
+
+  void SetUp() { previous_ = std::getenv(variable_name_.c_str()); }
+  void TearDown() {
+    google::cloud::internal::SetEnv(variable_name_.c_str(), previous_);
+  }
+
+ private:
+  std::string variable_name_;
+  char const* previous_;
+};
+
 class DefaultServiceAccountFileTest : public ::testing::Test {
+ public:
+  DefaultServiceAccountFileTest()
+      : home_(storage::internal::DefaultServiceAccountCredentialsHomeVariable()),
+        override_variable_("GOOGLE_APPLICATION_CREDENTIALS") {}
+
  protected:
-  void SetUp() override { previous_ = std::getenv(variable_.c_str()); }
+  void SetUp() override {
+    home_.SetUp();
+    override_variable_.SetUp();
+  }
   void TearDown() override {
-    google::cloud::internal::SetEnv(variable_.c_str(), previous_);
+    override_variable_.TearDown();
+    home_.TearDown();
   }
 
  protected:
-  std::string variable_ =
-      storage::internal::DefaultServiceAccountCredentialsHomeVariable();
-  char const* previous_ = nullptr;
+  EnvironmentVariableRestore home_ ;
+  EnvironmentVariableRestore override_variable_;
 };
 
-/// @test Verify that the file path works as expected.
+/// @test Verify that the application can override the default credentials.
+TEST_F(DefaultServiceAccountFileTest, EnvironmentVariableSet) {
+  google::cloud::internal::SetEnv("GOOGLE_APPLICATION_CREDENTIALS",
+                                  "/foo/bar/baz");
+  auto actual = storage::internal::DefaultServiceAccountCredentialsFile();
+  EXPECT_EQ("/foo/bar/baz", actual);
+}
+
+/// @test Verify that the file path works as expected when using HOME.
 TEST_F(DefaultServiceAccountFileTest, HomeSet) {
+  google::cloud::internal::SetEnv("GOOGLE_APPLICATION_CREDENTIALS", nullptr);
   char const* home =
       storage::internal::DefaultServiceAccountCredentialsHomeVariable();
   google::cloud::internal::SetEnv(home, "/foo/bar/baz");
@@ -194,6 +229,7 @@ TEST_F(DefaultServiceAccountFileTest, HomeSet) {
 
 /// @test Verify that the service account file path fails when HOME is not set.
 TEST_F(DefaultServiceAccountFileTest, HomeNotSet) {
+  google::cloud::internal::SetEnv("GOOGLE_APPLICATION_CREDENTIALS", nullptr);
   char const* home =
       storage::internal::DefaultServiceAccountCredentialsHomeVariable();
   google::cloud::internal::UnsetEnv(home);


### PR DESCRIPTION
This fixes #522. Turns out we needed this functionality earlier
than I expected.