### PR TITLE
Capture full http response in storage::internal::CurlRequest

### DIFF
--- a/storage/client/internal/curl_request.cc
+++ b/storage/client/internal/curl_request.cc
@@ -81,8 +81,9 @@ void CurlRequest::PrepareRequest(nl::json data) {
   PrepareRequest(std::move(payload));
 }
 
-std::string CurlRequest::MakeRequest() {
+std::pair<long,std::string> CurlRequest::MakeRequest() {
   buffer_.CaptureOutputOf(curl_);
+  // TODO(#533) - capture the headers, even they are mostly unused.
 
   auto error = curl_easy_perform(curl_);
   if (error != CURLE_OK) {
@@ -93,7 +94,9 @@ std::string CurlRequest::MakeRequest() {
     google::cloud::internal::RaiseRuntimeError(os.str());
   }
 
-  return buffer_.contents();
+  long code;
+  curl_easy_getinfo(curl_, CURLINFO_RESPONSE_CODE, &code);
+  return std::make_pair(code, buffer_.contents());
 }
 
 }  // namespace internal

--- a/storage/client/internal/curl_request.h
+++ b/storage/client/internal/curl_request.h
@@ -18,6 +18,7 @@
 #include "storage/client/internal/curl_wrappers.h"
 #include "storage/client/internal/nljson.h"
 #include <curl/curl.h>
+#include <map>
 
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
@@ -25,6 +26,23 @@ namespace internal {
 /// Hold a character string created by CURL use correct deleter.
 using CurlString = std::unique_ptr<char, decltype(&curl_free)>;
 
+/**
+ * Contains the results of a HTTP request.
+ */
+struct HttpResponse {
+  long status_code;
+  std::string payload;
+  std::multimap<std::string, std::string> headers;
+};
+
+/**
+ * Automatically manage the resources associated with a libcurl HTTP request.
+ *
+ * The Google Cloud Storage Client library using libcurl to make http requests.
+ * However, libcurl is a fairly low-level C library, where the application is
+ * expected to manage all resources manually.  This is a wrapper to prepare and
+ * make synchronous HTTP requests.
+ */
 class CurlRequest {
  public:
   explicit CurlRequest(std::string base_url);
@@ -65,7 +83,7 @@ class CurlRequest {
    *
    * @throw std::runtime_error if the request cannot be made at all.
    */
-  std::pair<long, std::string> MakeRequest();
+  HttpResponse MakeRequest();
 
   CurlRequest(CurlRequest const&) = delete;
   CurlRequest& operator=(CurlRequest const&) = delete;
@@ -77,8 +95,10 @@ class CurlRequest {
   char const* query_parameter_separator_;
   CURL* curl_;
   curl_slist* headers_;
-  CurlBuffer buffer_;
   std::string payload_;
+
+  CurlBuffer response_payload_;
+  CurlHeaders response_headers_;
 };
 
 }  // namespace internal

--- a/storage/client/internal/curl_request.h
+++ b/storage/client/internal/curl_request.h
@@ -58,8 +58,14 @@ class CurlRequest {
    */
   void PrepareRequest(nl::json payload);
 
-  /// Make the prepared request and return the responsee.
-  std::string MakeRequest();
+  /**
+   * Make the prepared request.
+   *
+   * @return The response HTTP error code and the response payload.
+   *
+   * @throw std::runtime_error if the request cannot be made at all.
+   */
+  std::pair<long, std::string> MakeRequest();
 
   CurlRequest(CurlRequest const&) = delete;
   CurlRequest& operator=(CurlRequest const&) = delete;

--- a/storage/client/internal/curl_wrappers.cc
+++ b/storage/client/internal/curl_wrappers.cc
@@ -59,11 +59,20 @@ void CurlHeaders::Attach(CURL* curl) {
 }
 
 void CurlHeaders::Append(char* data, std::size_t size) {
+  if (size <= 2) {
+    // Empty header (including the \r\n, ignore.
+    return;
+  }
+  if (data[size - 1] != '\n' or data[size - 2] != '\r') {
+    // Invalid header (should end in \r\n, ignore.
+    return;
+  }
   auto separator = std::find(data, data + size, ':');
   std::string header_name = std::string(data, separator);
   std::string header_value{};
-  if (static_cast<std::size_t>(separator - data) < size) {
-    header_value = std::string(separator + 1, data + size);
+  // If there is a value, capture it, but ignore the final \r\n.
+  if (static_cast<std::size_t>(separator - data) < size - 2) {
+    header_value = std::string(separator + 2, data + size - 2);
   }
   contents_.emplace(std::move(header_name), std::move(header_value));
 }

--- a/storage/client/internal/curl_wrappers.cc
+++ b/storage/client/internal/curl_wrappers.cc
@@ -60,16 +60,16 @@ void CurlHeaders::Attach(CURL* curl) {
 
 void CurlHeaders::Append(char* data, std::size_t size) {
   if (size <= 2) {
-    // Empty header (including the \r\n, ignore.
+    // Empty header (including the \r\n), ignore.
     return;
   }
   if (data[size - 1] != '\n' or data[size - 2] != '\r') {
-    // Invalid header (should end in \r\n, ignore.
+    // Invalid header (should end in \r\n), ignore.
     return;
   }
   auto separator = std::find(data, data + size, ':');
   std::string header_name = std::string(data, separator);
-  std::string header_value{};
+  std::string header_value;
   // If there is a value, capture it, but ignore the final \r\n.
   if (static_cast<std::size_t>(separator - data) < size - 2) {
     header_value = std::string(separator + 2, data + size - 2);

--- a/storage/client/internal/curl_wrappers.cc
+++ b/storage/client/internal/curl_wrappers.cc
@@ -62,7 +62,7 @@ void CurlHeaders::Append(char* data, std::size_t size) {
   auto separator = std::find(data, data + size, ':');
   std::string header_name = std::string(data, separator);
   std::string header_value{};
-  if (separator - data < size) {
+  if (static_cast<std::size_t>(separator - data) < size) {
     header_value = std::string(separator + 1, data + size);
   }
   contents_.emplace(std::move(header_name), std::move(header_value));

--- a/storage/client/internal/curl_wrappers.cc
+++ b/storage/client/internal/curl_wrappers.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "storage/client/internal/curl_wrappers.h"
+#include <algorithm>
 #include <iostream>
 
 namespace {
@@ -31,18 +32,40 @@ extern "C" std::size_t WriteCallback(void* contents, std::size_t size,
   return size * nmemb;
 }
 
+extern "C" std::size_t HeaderCallback(char* contents, std::size_t size,
+                                      std::size_t nmemb, void* dest) {
+  auto* headers = reinterpret_cast<storage::internal::CurlHeaders*>(dest);
+  headers->Append(contents, size * nmemb);
+  return size * nmemb;
+}
+
 }  // anonymous namespace
 
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
-void CurlBuffer::CaptureOutputOf(CURL* curl) {
+void CurlBuffer::Attach(CURL* curl) {
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, this);
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
 }
 
 void CurlBuffer::Append(char* data, std::size_t size) {
   buffer_.append(data, size);
+}
+
+void CurlHeaders::Attach(CURL* curl) {
+  curl_easy_setopt(curl, CURLOPT_HEADERDATA, this);
+  curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, HeaderCallback);
+}
+
+void CurlHeaders::Append(char* data, std::size_t size) {
+  auto separator = std::find(data, data + size, ':');
+  std::string header_name = std::string(data, separator);
+  std::string header_value{};
+  if (separator - data < size) {
+    header_value = std::string(separator + 1, data + size);
+  }
+  contents_.emplace(std::move(header_name), std::move(header_value));
 }
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/storage/client/internal/curl_wrappers.cc
+++ b/storage/client/internal/curl_wrappers.cc
@@ -63,7 +63,7 @@ void CurlHeaders::Append(char* data, std::size_t size) {
     // Empty header (including the \r\n), ignore.
     return;
   }
-  if (data[size - 1] != '\n' or data[size - 2] != '\r') {
+  if ('\r' != data[size - 2] or '\n' != data[size - 1]) {
     // Invalid header (should end in \r\n), ignore.
     return;
   }

--- a/storage/client/internal/curl_wrappers.h
+++ b/storage/client/internal/curl_wrappers.h
@@ -17,29 +17,48 @@
 
 #include "storage/client/version.h"
 #include <curl/curl.h>
-#include <memory>
+#include <map>
 
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 /**
- *
+ * Receive the output from a libcurl request.
  */
 class CurlBuffer {
  public:
-  CurlBuffer() {}
+  CurlBuffer() = default;
 
-  /// Use this buffer to capture the response in the given handle.
-  void CaptureOutputOf(CURL* curl);
-
-  /// Add data to the buffer.
-  void Append(char* data, std::size_t size);
+  /// Use this object to capture the payload of the @p curl handle.
+  void Attach(CURL* curl);
 
   /// Return the contents and reset the contents.
   std::string contents() { return std::move(buffer_); }
 
+  /// Add data to the buffer.
+  void Append(char* data, std::size_t size);
+
  private:
   std::string buffer_;
+};
+
+class CurlHeaders {
+ public:
+  CurlHeaders() = default;
+
+  /// Use this object to capture the headers of the @p curl handle.
+  void Attach(CURL* curl);
+
+  /// Return the contents and reset them.
+  std::multimap<std::string, std::string> contents() {
+    return std::move(contents_);
+  }
+
+  /// Add a new header line to the contents.
+  void Append(char* header, std::size_t size);
+
+ private:
+  std::multimap<std::string, std::string> contents_;
 };
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/storage/client/internal/service_account_credentials.h
+++ b/storage/client/internal/service_account_credentials.h
@@ -99,10 +99,10 @@ class ServiceAccountCredentials : public storage::Credentials {
 
     // TODO(#516) - use retry policies to refresh the credentials.
     auto response = requestor_.MakeRequest();
-    if (response.first != 200) {
+    if (200 != response.status_code) {
       return false;
     }
-    nl::json access_token = nl::json::parse(response.second);
+    nl::json access_token = nl::json::parse(response.payload);
     std::string header = access_token["token_type"];
     header += ' ';
     header += access_token["access_token"].get_ref<std::string const&>();

--- a/storage/client/internal/service_account_credentials.h
+++ b/storage/client/internal/service_account_credentials.h
@@ -99,7 +99,10 @@ class ServiceAccountCredentials : public storage::Credentials {
 
     // TODO(#516) - use retry policies to refresh the credentials.
     auto response = requestor_.MakeRequest();
-    nl::json access_token = nl::json::parse(response);
+    if (response.first != 200) {
+      return false;
+    }
+    nl::json access_token = nl::json::parse(response.second);
     std::string header = access_token["token_type"];
     header += ' ';
     header += access_token["access_token"].get_ref<std::string const&>();

--- a/storage/client/internal/service_account_credentials_test.cc
+++ b/storage/client/internal/service_account_credentials_test.cc
@@ -29,7 +29,7 @@ class MockHttpRequestHandle {
   MOCK_METHOD1(MakeEscapedString, std::unique_ptr<char[]>(std::string const&));
   MOCK_METHOD1(PrepareRequest, void(std::string const&));
   MOCK_METHOD1(PrepareRequest, void(storage::internal::nl::json));
-  MOCK_METHOD0(MakeRequest, std::string());
+  MOCK_METHOD0(MakeRequest, std::pair<long, std::string>());
 };
 
 class MockHttpRequest {
@@ -67,7 +67,9 @@ class MockHttpRequest {
   void PrepareRequest(storage::internal::nl::json json) {
     handles_[url_]->PrepareRequest(std::move(json));
   }
-  std::string MakeRequest() { return handles_[url_]->MakeRequest(); }
+  std::pair<long, std::string> MakeRequest() {
+    return handles_[url_]->MakeRequest();
+  }
 
  private:
   std::string url_;
@@ -120,7 +122,8 @@ TEST_F(ServiceAccountCredentialsTest, Simple) {
     "id_token": "id-token-value",
     "expires_in": 1234
 })""";
-  EXPECT_CALL(*handle, MakeRequest()).WillOnce(Return(response));
+  EXPECT_CALL(*handle, MakeRequest())
+      .WillOnce(Return(std::make_pair(200, response)));
 
   ServiceAccountCredentials<MockHttpRequest> credentials(jwt);
   EXPECT_EQ("Type access-token-value", credentials.AuthorizationHeader());
@@ -161,7 +164,9 @@ TEST_F(ServiceAccountCredentialsTest, Refresh) {
     "id_token": "id-token-value",
     "expires_in": 1000
 })""";
-  EXPECT_CALL(*handle, MakeRequest()).WillOnce(Return(r1)).WillOnce(Return(r2));
+  EXPECT_CALL(*handle, MakeRequest())
+      .WillOnce(Return(std::make_pair(200, r1)))
+      .WillOnce(Return(std::make_pair(200, r2)));
 
   ServiceAccountCredentials<MockHttpRequest> credentials(jwt);
   EXPECT_EQ("Type access-token-r1", credentials.AuthorizationHeader());

--- a/storage/client/internal/service_account_credentials_test.cc
+++ b/storage/client/internal/service_account_credentials_test.cc
@@ -29,7 +29,7 @@ class MockHttpRequestHandle {
   MOCK_METHOD1(MakeEscapedString, std::unique_ptr<char[]>(std::string const&));
   MOCK_METHOD1(PrepareRequest, void(std::string const&));
   MOCK_METHOD1(PrepareRequest, void(storage::internal::nl::json));
-  MOCK_METHOD0(MakeRequest, std::pair<long, std::string>());
+  MOCK_METHOD0(MakeRequest, storage::internal::HttpResponse());
 };
 
 class MockHttpRequest {
@@ -67,7 +67,7 @@ class MockHttpRequest {
   void PrepareRequest(storage::internal::nl::json json) {
     handles_[url_]->PrepareRequest(std::move(json));
   }
-  std::pair<long, std::string> MakeRequest() {
+  storage::internal::HttpResponse MakeRequest() {
     return handles_[url_]->MakeRequest();
   }
 
@@ -123,7 +123,7 @@ TEST_F(ServiceAccountCredentialsTest, Simple) {
     "expires_in": 1234
 })""";
   EXPECT_CALL(*handle, MakeRequest())
-      .WillOnce(Return(std::make_pair(200, response)));
+      .WillOnce(Return(storage::internal::HttpResponse{200, response, {}}));
 
   ServiceAccountCredentials<MockHttpRequest> credentials(jwt);
   EXPECT_EQ("Type access-token-value", credentials.AuthorizationHeader());
@@ -165,8 +165,8 @@ TEST_F(ServiceAccountCredentialsTest, Refresh) {
     "expires_in": 1000
 })""";
   EXPECT_CALL(*handle, MakeRequest())
-      .WillOnce(Return(std::make_pair(200, r1)))
-      .WillOnce(Return(std::make_pair(200, r2)));
+      .WillOnce(Return(storage::internal::HttpResponse{200, r1, {}}))
+      .WillOnce(Return(storage::internal::HttpResponse{200, r2, {}}));
 
   ServiceAccountCredentials<MockHttpRequest> credentials(jwt);
   EXPECT_EQ("Type access-token-r1", credentials.AuthorizationHeader());

--- a/storage/tests/curl_request_integration_test.cc
+++ b/storage/tests/curl_request_integration_test.cc
@@ -27,8 +27,8 @@ TEST(CurlRequestTest, SimpleGET) {
 
   request.PrepareRequest(std::string{});
   auto response = request.MakeRequest();
-  EXPECT_EQ(200, response.first);
-  nl::json parsed = nl::json::parse(response.second);
+  EXPECT_EQ(200, response.status_code);
+  nl::json parsed = nl::json::parse(response.payload);
   nl::json args = parsed["args"];
   EXPECT_EQ("foo1&&&foo2", args["foo"].get<std::string>());
   EXPECT_EQ("bar1==bar2=", args["bar"].get<std::string>());
@@ -57,15 +57,15 @@ TEST(CurlRequestTest, RepeatedGET) {
   request.PrepareRequest(std::string{});
 
   auto response = request.MakeRequest();
-  EXPECT_EQ(200, response.first);
-  nl::json parsed = nl::json::parse(response.second);
+  EXPECT_EQ(200, response.status_code);
+  nl::json parsed = nl::json::parse(response.payload);
   nl::json args = parsed["args"];
   EXPECT_EQ("foo1&&&foo2", args["foo"].get<std::string>());
   EXPECT_EQ("bar1==bar2=", args["bar"].get<std::string>());
 
   response = request.MakeRequest();
-  EXPECT_EQ(200, response.first);
-  parsed = nl::json::parse(response.second);
+  EXPECT_EQ(200, response.status_code);
+  parsed = nl::json::parse(response.payload);
   args = parsed["args"];
   EXPECT_EQ("foo1&&&foo2", args["foo"].get<std::string>());
   EXPECT_EQ("bar1==bar2=", args["bar"].get<std::string>());
@@ -81,8 +81,8 @@ TEST(CurlRequestTest, SimpleJSON) {
 
   request.PrepareRequest(nl::json{{"int", 42}, {"string", "value"}});
   auto response = request.MakeRequest();
-  EXPECT_EQ(200, response.first);
-  nl::json parsed = nl::json::parse(response.second);
+  EXPECT_EQ(200, response.status_code);
+  nl::json parsed = nl::json::parse(response.payload);
   nl::json args = parsed["args"];
   EXPECT_EQ("bar&baz", args["foo"].get<std::string>());
   EXPECT_EQ("quux-123", args["qux"].get<std::string>());
@@ -96,9 +96,7 @@ TEST(CurlRequestTest, SimpleJSON) {
 TEST(CurlRequestTest, SimplePOST) {
   storage::internal::CurlRequest request("https://nghttp2.org/httpbin/post");
   std::vector<std::pair<std::string, std::string>> form_parameters = {
-      {"foo", "foo1&foo2 foo3"},
-      {"bar", "bar1-bar2"},
-      {"baz", "baz=baz2"},
+      {"foo", "foo1&foo2 foo3"}, {"bar", "bar1-bar2"}, {"baz", "baz=baz2"},
   };
   std::string data;
   char const* sep = "";
@@ -115,8 +113,8 @@ TEST(CurlRequestTest, SimplePOST) {
 
   request.PrepareRequest(data);
   auto response = request.MakeRequest();
-  EXPECT_EQ(200, response.first);
-  nl::json parsed = nl::json::parse(response.second);
+  EXPECT_EQ(200, response.status_code);
+  nl::json parsed = nl::json::parse(response.payload);
   nl::json form = parsed["form"];
   EXPECT_EQ("foo1&foo2 foo3", form["foo"].get<std::string>());
   EXPECT_EQ("bar1-bar2", form["bar"].get<std::string>());
@@ -131,7 +129,7 @@ TEST(CurlRequestTest, Handle404) {
 
   request.PrepareRequest(std::string{});
   auto response = request.MakeRequest();
-  EXPECT_EQ(404, response.first);
+  EXPECT_EQ(404, response.status_code);
 }
 
 /// @test Verify the payload for error status is included in the return value.
@@ -143,7 +141,7 @@ TEST(CurlRequestTest, HandleTeapot) {
 
   request.PrepareRequest(std::string{});
   auto response = request.MakeRequest();
-  EXPECT_EQ(418, response.first);
-  auto pos = response.second.find("[ teapot ]");
+  EXPECT_EQ(418, response.status_code);
+  auto pos = response.payload.find("[ teapot ]");
   EXPECT_NE(std::string::npos, pos);
 }

--- a/storage/tests/curl_request_integration_test.cc
+++ b/storage/tests/curl_request_integration_test.cc
@@ -96,7 +96,9 @@ TEST(CurlRequestTest, SimpleJSON) {
 TEST(CurlRequestTest, SimplePOST) {
   storage::internal::CurlRequest request("https://nghttp2.org/httpbin/post");
   std::vector<std::pair<std::string, std::string>> form_parameters = {
-      {"foo", "foo1&foo2 foo3"}, {"bar", "bar1-bar2"}, {"baz", "baz=baz2"},
+      {"foo", "foo1&foo2 foo3"},
+      {"bar", "bar1-bar2"},
+      {"baz", "baz=baz2"},
   };
   std::string data;
   char const* sep = "";
@@ -144,4 +146,23 @@ TEST(CurlRequestTest, HandleTeapot) {
   EXPECT_EQ(418, response.status_code);
   auto pos = response.payload.find("[ teapot ]");
   EXPECT_NE(std::string::npos, pos);
+}
+
+/// @test Verify the response includes the header values.
+TEST(CurlRequestTest, CheckResponseHeaders) {
+  storage::internal::CurlRequest request(
+      "https://nghttp2.org/httpbin/response-headers"
+      "?x-test-foo=bar"
+      "&x-test-foo=baz"
+      "&X-Test-Empty");
+  request.AddHeader("Accept: application/json");
+  request.AddHeader("charsets: utf-8");
+
+  request.PrepareRequest(std::string{});
+  auto response = request.MakeRequest();
+  EXPECT_EQ(200, response.status_code);
+  EXPECT_EQ(2U, response.headers.count("X-Test-Foo"));
+  EXPECT_EQ("bar", response.headers.find("X-Test-Foo")->second);
+  EXPECT_EQ(1U, response.headers.count("X-Test-Empty"));
+  EXPECT_EQ("", response.headers.find("X-Test-Empty")->second);
 }

--- a/storage/tests/curl_request_integration_test.cc
+++ b/storage/tests/curl_request_integration_test.cc
@@ -96,9 +96,7 @@ TEST(CurlRequestTest, SimpleJSON) {
 TEST(CurlRequestTest, SimplePOST) {
   storage::internal::CurlRequest request("https://nghttp2.org/httpbin/post");
   std::vector<std::pair<std::string, std::string>> form_parameters = {
-      {"foo", "foo1&foo2 foo3"},
-      {"bar", "bar1-bar2"},
-      {"baz", "baz=baz2"},
+      {"foo", "foo1&foo2 foo3"}, {"bar", "bar1-bar2"}, {"baz", "baz=baz2"},
   };
   std::string data;
   char const* sep = "";

--- a/storage/tests/curl_request_integration_test.cc
+++ b/storage/tests/curl_request_integration_test.cc
@@ -19,6 +19,7 @@
 namespace nl = storage::internal::nl;
 
 TEST(CurlRequestTest, SimpleGET) {
+  // TODO(#542) - use a local server to make tests more hermetic.
   storage::internal::CurlRequest request("https://nghttp2.org/httpbin/get");
   request.AddQueryParameter("foo", "foo1&&&foo2");
   request.AddQueryParameter("bar", "bar1==bar2=");
@@ -48,6 +49,7 @@ TEST(CurlRequestTest, FailedGET) {
 }
 
 TEST(CurlRequestTest, RepeatedGET) {
+  // TODO(#542) - use a local server to make tests more hermetic.
   storage::internal::CurlRequest request("https://nghttp2.org/httpbin/get");
   request.AddQueryParameter("foo", "foo1&&&foo2");
   request.AddQueryParameter("bar", "bar1==bar2=");
@@ -72,6 +74,7 @@ TEST(CurlRequestTest, RepeatedGET) {
 }
 
 TEST(CurlRequestTest, SimpleJSON) {
+  // TODO(#542) - use a local server to make tests more hermetic.
   storage::internal::CurlRequest request("https://nghttp2.org/httpbin/post");
   request.AddQueryParameter("foo", "bar&baz");
   request.AddQueryParameter("qux", "quux-123");
@@ -94,6 +97,7 @@ TEST(CurlRequestTest, SimpleJSON) {
 }
 
 TEST(CurlRequestTest, SimplePOST) {
+  // TODO(#542) - use a local server to make tests more hermetic.
   storage::internal::CurlRequest request("https://nghttp2.org/httpbin/post");
   std::vector<std::pair<std::string, std::string>> form_parameters = {
       {"foo", "foo1&foo2 foo3"}, {"bar", "bar1-bar2"}, {"baz", "baz=baz2"},
@@ -122,6 +126,7 @@ TEST(CurlRequestTest, SimplePOST) {
 }
 
 TEST(CurlRequestTest, Handle404) {
+  // TODO(#542) - use a local server to make tests more hermetic.
   storage::internal::CurlRequest request(
       "https://nghttp2.org/httpbin/status/404");
   request.AddHeader("Accept: application/json");
@@ -134,6 +139,7 @@ TEST(CurlRequestTest, Handle404) {
 
 /// @test Verify the payload for error status is included in the return value.
 TEST(CurlRequestTest, HandleTeapot) {
+  // TODO(#542) - use a local server to make tests more hermetic.
   storage::internal::CurlRequest request(
       "https://nghttp2.org/httpbin/status/418");
   request.AddHeader("Accept: application/json");
@@ -148,6 +154,7 @@ TEST(CurlRequestTest, HandleTeapot) {
 
 /// @test Verify the response includes the header values.
 TEST(CurlRequestTest, CheckResponseHeaders) {
+  // TODO(#542) - use a local server to make tests more hermetic.
   storage::internal::CurlRequest request(
       "https://nghttp2.org/httpbin/response-headers"
       "?x-test-foo=bar"


### PR DESCRIPTION
So far we had only captured the payload. With this change capture the payload, the response headers and the status code.  This fixes #533.