### PR TITLE
Protect client APIs from accidental use.

### DIFF
--- a/bigtable/client/admin_client.h
+++ b/bigtable/client/admin_client.h
@@ -24,6 +24,12 @@
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+// Forward declare some classes so we can be friends.
+class TableAdmin;
+namespace noex {
+class TableAdmin;
+}  // namespace noex
+
 /**
  * Connects to Cloud Bigtable's table administration APIs.
  *
@@ -59,8 +65,15 @@ class AdminClient {
    */
   virtual void reset() = 0;
 
+  // The member functions of this class are not intended for general use by
+  // application developers (they are simply a dependency injection point). Make
+  // them protected, so the mock classes can override them, and then make the
+  // classes that do use them friends.
+protected:
+  friend class TableAdmin;
+  friend class noex::TableAdmin;
   //@{
-  /// @name the google.bigtable.admin.v2.TableAdmin operations.
+  /// @name The `google.bigtable.admin.v2.TableAdmin` operations.
   virtual grpc::Status CreateTable(
       grpc::ClientContext* context,
       google::bigtable::admin::v2::CreateTableRequest const& request,

--- a/bigtable/client/admin_client.h
+++ b/bigtable/client/admin_client.h
@@ -69,7 +69,7 @@ class AdminClient {
   // application developers (they are simply a dependency injection point). Make
   // them protected, so the mock classes can override them, and then make the
   // classes that do use them friends.
-protected:
+ protected:
   friend class TableAdmin;
   friend class noex::TableAdmin;
   //@{

--- a/bigtable/client/data_client.h
+++ b/bigtable/client/data_client.h
@@ -20,6 +20,15 @@
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+// Forward declare some classes so we can be friends.
+class Table;
+namespace noex {
+class Table;
+}  // namespace noex
+namespace internal {
+class BulkMutator;
+}  // namespace internal
+
 /**
  * Connects to Cloud Bigtable's data manipulation APIs.
  *
@@ -54,8 +63,17 @@ class DataClient {
    */
   virtual void reset() = 0;
 
+  // The member functions of this class are not intended for general use by
+  // application developers (they are simply a dependency injection point). Make
+  // them protected, so the mock classes can override them, and then make the
+  // classes that do use them friends.
+ protected:
+  friend class Table;
+  friend class noex::Table;
+  friend class internal::BulkMutator;
+  friend class RowReader;
   //@{
-  /// @name the google.bigtable.v2.Bigtable operations.
+  /// @name the `google.bigtable.v2.Bigtable` wrappers.
   virtual grpc::Status MutateRow(
       grpc::ClientContext* context,
       google::bigtable::v2::MutateRowRequest const& request,

--- a/bigtable/client/instance_admin_client.h
+++ b/bigtable/client/instance_admin_client.h
@@ -22,6 +22,12 @@
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+// Forward declare some classes so we can be friends.
+class InstanceAdmin;
+namespace noex {
+class InstanceAdmin;
+}  // namespace noex
+
 /**
  * Connects to Cloud Bigtable's instance administration APIs.
  *
@@ -57,6 +63,15 @@ class InstanceAdminClient {
    */
   virtual void reset() = 0;
 
+  // The member functions of this class are not intended for general use by
+  // application developers (they are simply a dependency injection point). Make
+  // them protected, so the mock classes can override them, and then make the
+  // classes that do use them friends.
+ protected:
+  friend class InstanceAdmin;
+  friend class noex::InstanceAdmin;
+  //@{
+  /// @name The `google.bigtable.v2.InstanceAdmin` wrappers.
   virtual grpc::Status ListInstances(
       grpc::ClientContext* context,
       google::bigtable::admin::v2::ListInstancesRequest const& request,
@@ -66,14 +81,6 @@ class InstanceAdminClient {
       grpc::ClientContext* context,
       google::bigtable::admin::v2::CreateInstanceRequest const& request,
       google::longrunning::Operation* response) = 0;
-
-  //@{
-  /// @name Implement the google.longrunning.Operations wrappers.
-  virtual grpc::Status GetOperation(
-      grpc::ClientContext* context,
-      google::longrunning::GetOperationRequest const& request,
-      google::longrunning::Operation* response) = 0;
-  //@}
 
   virtual grpc::Status GetInstance(
       grpc::ClientContext* context,
@@ -94,6 +101,15 @@ class InstanceAdminClient {
       grpc::ClientContext* context,
       google::bigtable::admin::v2::DeleteClusterRequest const& request,
       google::protobuf::Empty* response) = 0;
+  //@}
+
+  //@{
+  /// @name The `google.longrunning.Operations` wrappers.
+  virtual grpc::Status GetOperation(
+      grpc::ClientContext* context,
+      google::longrunning::GetOperationRequest const& request,
+      google::longrunning::Operation* response) = 0;
+  //@}
 };
 
 /// Create a new admin client configured via @p options.


### PR DESCRIPTION
Most of the APIs in the `bigtable::*Client` classes are not for
public consumption.  Make them protected and then make only the
classes that need access friends.

Also, the `InstanceAdmin` APIs where not grouped well, fixed that.
