### PR TITLE
Remote CurlRequest::PrepareRequest(nl::json) overload

### DIFF
--- a/storage/client/internal/curl_request.cc
+++ b/storage/client/internal/curl_request.cc
@@ -76,11 +76,6 @@ void CurlRequest::PrepareRequest(std::string payload) {
   }
 }
 
-void CurlRequest::PrepareRequest(nl::json data) {
-  std::string payload = data.dump();
-  PrepareRequest(std::move(payload));
-}
-
 HttpResponse CurlRequest::MakeRequest() {
   response_payload_.Attach(curl_);
   response_headers_.Attach(curl_);

--- a/storage/client/internal/curl_request.h
+++ b/storage/client/internal/curl_request.h
@@ -70,13 +70,6 @@ class CurlRequest {
   void PrepareRequest(std::string payload);
 
   /**
-   * Make a request with the given payload.
-   *
-   * @param payload The JSON object to send as part of the request.
-   */
-  void PrepareRequest(nl::json payload);
-
-  /**
    * Make the prepared request.
    *
    * @return The response HTTP error code and the response payload.

--- a/storage/client/internal/nljson_test.cc
+++ b/storage/client/internal/nljson_test.cc
@@ -15,7 +15,7 @@
 #include "storage/client/internal/nljson.h"
 #include <gtest/gtest.h>
 
-/// @test Verify that we can compile agains the nlohmann::json library.
+/// @test Verify that we can compile against the nlohmann::json library.
 TEST(NlJsonTest, Simple) {
   storage::internal::nl::json json = {
       {"pi", 3.141},

--- a/storage/client/testing/mock_http_request.cc
+++ b/storage/client/testing/mock_http_request.cc
@@ -59,9 +59,6 @@ std::unique_ptr<char[]> MockHttpRequest::MakeEscapedString(
 void MockHttpRequest::PrepareRequest(std::string const& payload) {
   handles_[url_]->PrepareRequest(payload);
 }
-void MockHttpRequest::PrepareRequest(storage::internal::nl::json json) {
-  handles_[url_]->PrepareRequest(std::move(json));
-}
 storage::internal::HttpResponse MockHttpRequest::MakeRequest() {
   return handles_[url_]->MakeRequest();
 }

--- a/storage/client/testing/mock_http_request.h
+++ b/storage/client/testing/mock_http_request.h
@@ -37,7 +37,6 @@ class MockHttpRequestHandle {
   MOCK_METHOD2(AddQueryParameter, void(std::string const&, std::string const&));
   MOCK_METHOD1(MakeEscapedString, std::unique_ptr<char[]>(std::string const&));
   MOCK_METHOD1(PrepareRequest, void(std::string const&));
-  MOCK_METHOD1(PrepareRequest, void(storage::internal::nl::json));
   MOCK_METHOD0(MakeRequest, storage::internal::HttpResponse());
 
   /**
@@ -68,7 +67,6 @@ class MockHttpRequest {
   void AddQueryParameter(std::string const& name, std::string const& value);
   std::unique_ptr<char[]> MakeEscapedString(std::string const& x);
   void PrepareRequest(std::string const& payload);
-  void PrepareRequest(storage::internal::nl::json json);
   storage::internal::HttpResponse MakeRequest();
 
  private:

--- a/storage/tests/curl_request_integration_test.cc
+++ b/storage/tests/curl_request_integration_test.cc
@@ -82,7 +82,8 @@ TEST(CurlRequestTest, SimpleJSON) {
   request.AddHeader("Content-Type: application/json");
   request.AddHeader("charsets: utf-8");
 
-  request.PrepareRequest(nl::json{{"int", 42}, {"string", "value"}});
+  std::string payload = nl::json{{"int", 42}, {"string", "value"}}.dump();
+  request.PrepareRequest(std::move(payload));
   auto response = request.MakeRequest();
   EXPECT_EQ(200, response.status_code);
   nl::json parsed = nl::json::parse(response.payload);


### PR DESCRIPTION
The overload is not used, and is a problem with newer compilers
when mocked.