### PR TITLE
Enforce include header guard formatting.

### DIFF
--- a/bigtable/benchmarks/random_mutation.h
+++ b/bigtable/benchmarks/random_mutation.h
@@ -31,4 +31,4 @@ std::string MakeRandomValue(bigtable::testing::DefaultPRNG& gen);
 }  // namespace benchmarks
 }  // namespace bigtable
 
-#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_RANDOM_H_
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_RANDOM_MUTATION_H_

--- a/bigtable/benchmarks/setup.h
+++ b/bigtable/benchmarks/setup.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_BENCHMARK_SETUP_H_
-#define GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_BENCHMARK_SETUP_H_
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_SETUP_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_SETUP_H_
 
 #include "bigtable/benchmarks/constants.h"
 #include <chrono>
@@ -60,4 +60,4 @@ class BenchmarkSetup {
 }  // namespace benchmarks
 }  // namespace bigtable
 
-#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_BENCHMARK_SETUP_H_
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_BENCHMARKS_SETUP_H_

--- a/bigtable/client/cell.h
+++ b/bigtable/client/cell.h
@@ -108,4 +108,4 @@ class Cell {
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
 
-#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_ROW_H_
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_CELL_H_

--- a/bigtable/client/testing/mock_instance_admin_client.h
+++ b/bigtable/client/testing/mock_instance_admin_client.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_DATA_CLIENT_H_
-#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_DATA_CLIENT_H_
+#ifndef GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_INSTANCE_ADMIN_CLIENT_H_
+#define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_INSTANCE_ADMIN_CLIENT_H_
 
 #include "bigtable/client/instance_admin_client.h"
 #include <gmock/gmock.h>
@@ -77,4 +77,4 @@ class MockInstanceAdminClient : public bigtable::InstanceAdminClient {
 }  // namespace testing
 }  // namespace bigtable
 
-#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_DATA_CLIENT_H_
+#endif  // GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_TESTING_MOCK_INSTANCE_ADMIN_CLIENT_H_

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -25,6 +25,7 @@ RUN apt update && \
         cmake \
         curl \
         doxygen \
+        gawk \
         git \
         gcc \
         g++ \

--- a/firestore/client/field_path.h
+++ b/firestore/client/field_path.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_FIRESTORE_GOOGLE_CLIENT_FIELD_PATH_H_
-#define GOOGLE_CLOUD_CPP_FIRESTORE_GOOGLE_CLIENT_FIELD_PATH_H_
+#ifndef GOOGLE_CLOUD_CPP_FIRESTORE_CLIENT_FIELD_PATH_H_
+#define GOOGLE_CLOUD_CPP_FIRESTORE_CLIENT_FIELD_PATH_H_
 
 #include <iostream>
 #include <regex>
@@ -183,4 +183,4 @@ class FieldPath {
 };
 }  // namespace firestore
 
-#endif  // GOOGLE_CLOUD_CPP_FIRESTORE_GOOGLE_FIRESTORE_FIELD_PATH_H_
+#endif  // GOOGLE_CLOUD_CPP_FIRESTORE_CLIENT_FIELD_PATH_H_

--- a/google/cloud/internal/build_info.h
+++ b/google/cloud/internal/build_info.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_INTERNAL_BUILD_INFO_H_
-#define GOOGLE_CLOUD_CPP_INTERNAL_BUILD_INFO_H_
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_BUILD_INFO_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_BUILD_INFO_H_
 
 #include "google/cloud/version.h"
 
@@ -31,8 +31,8 @@ extern char const compiler[];
 extern char const compiler_flags[];
 
 }  // namespace internal
-}  // namespace GOOGLE_CLOUD_CPP_CLIENT_NS
+}  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_INTERNAL_BUILD_INFO_H_
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_BUILD_INFO_H_

--- a/google/cloud/internal/port_platform.h
+++ b/google/cloud/internal/port_platform.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_INTERNAL_PORT_PLATFORM_H_
-#define GOOGLE_CLOUD_CPP_INTERNAL_PORT_PLATFORM_H_
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_PORT_PLATFORM_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_PORT_PLATFORM_H_
 
 /**
  * @file
@@ -68,4 +68,4 @@
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 // clang-format on
 
-#endif  // GOOGLE_CLOUD_CPP_INTERNAL_PORT_PLATFORM_H_
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_PORT_PLATFORM_H_

--- a/google/cloud/internal/setenv.h
+++ b/google/cloud/internal/setenv.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_INTERNAL_SETENV_H_
-#define GOOGLE_CLOUD_CPP_INTERNAL_SETENV_H_
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_SETENV_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_SETENV_H_
 
 #include "google/cloud/version.h"
 
@@ -37,4 +37,4 @@ void SetEnv(char const* variable, char const* value);
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_INTERNAL_SETENV_H_
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_SETENV_H_

--- a/google/cloud/internal/throw_delegate.h
+++ b/google/cloud/internal/throw_delegate.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_COMMON_INTERNAL_THROW_DELEGATE_H_
-#define GOOGLE_CLOUD_CPP_COMMON_INTERNAL_THROW_DELEGATE_H_
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_THROW_DELEGATE_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_THROW_DELEGATE_H_
 
 #include "google/cloud/version.h"
 
@@ -51,4 +51,4 @@ namespace internal {
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_COMMON_INTERNAL_THROW_DELEGATE_H_
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_THROW_DELEGATE_H_

--- a/google/cloud/version.h
+++ b/google/cloud/version.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_VERSION_H_
-#define GOOGLE_CLOUD_CPP_VERSION_H_
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_VERSION_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_VERSION_H_
 
 #include "google/cloud/internal/port_platform.h"
 #include "google/cloud/internal/version_info.h"
@@ -76,4 +76,4 @@ std::string version_string();
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_VERSION_H_
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_VERSION_H_

--- a/storage/client/credentials.h
+++ b/storage/client/credentials.h
@@ -36,6 +36,6 @@ class Credentials {
 std::shared_ptr<Credentials> GoogleDefaultCredentials();
 
 }  // namespace STORAGE_CLIENT_NS
-}  // storage
+}  // namespace storage
 
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_CLIENT_CREDENTIALS_H_

--- a/storage/client/internal/parse_rfc3339.h
+++ b/storage/client/internal/parse_rfc3339.h
@@ -43,4 +43,4 @@ std::chrono::system_clock::time_point ParseRfc3339(
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 
-#endif  // GOOGLE_CLOUD_CPP_STORAGE_CLIENT_INTERNAL_CURL_WRAPPERS_H_
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_CLIENT_INTERNAL_PARSE_RFC3339_H_

--- a/storage/client/internal/service_account_credentials.h
+++ b/storage/client/internal/service_account_credentials.h
@@ -132,4 +132,4 @@ class ServiceAccountCredentials : public storage::Credentials {
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 
-#endif  // GOOGLE_CLOUD_CPP_STORAGE_CLIENT_SERVICE_ACCOUNT_CREDENTIALS_H_
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_CLIENT_INTERNAL_SERVICE_ACCOUNT_CREDENTIALS_H_


### PR DESCRIPTION
Enforce the formatting rules defined in the style guide.  Fix the
existing problems.  This fixes #136.