### PR TITLE
Fix the integration tests against production.

### DIFF
--- a/bigtable/tests/instance_admin_emulator.cc
+++ b/bigtable/tests/instance_admin_emulator.cc
@@ -96,6 +96,11 @@ class InstanceAdminEmulator final
 
     for (int index = 0; index != request->update_mask().paths_size(); ++index) {
       if ("display_name" == request->update_mask().paths(index)) {
+        auto size = request->instance().display_name().size();
+        if (size < 4 or size > 30) {
+          return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                              "display name size must be in range [4,30]");
+        }
         stored_instance.set_display_name(request->instance().display_name());
       }
       if ("name" == request->update_mask().paths(index)) {

--- a/bigtable/tests/instance_admin_integration_test.cc
+++ b/bigtable/tests/instance_admin_integration_test.cc
@@ -108,7 +108,8 @@ TEST_F(InstanceAdminIntegrationTest, UpdateInstanceTest) {
   btadmin::Instance instance_copy;
   instance_copy.CopyFrom(instance);
   bigtable::InstanceUpdateConfig instance_update_config(std::move(instance));
-  instance_update_config.set_display_name("foo");
+  auto const updated_display_name = instance_id + " updated";
+  instance_update_config.set_display_name(updated_display_name);
 
   auto instance_after =
       instance_admin_->UpdateInstance(std::move(instance_update_config)).get();
@@ -120,7 +121,7 @@ TEST_F(InstanceAdminIntegrationTest, UpdateInstanceTest) {
   EXPECT_NE(std::string::npos, instance_copy.name().find(instance_id));
   EXPECT_NE(std::string::npos,
             instance_copy.name().find(InstanceTestEnvironment::project_id()));
-  EXPECT_EQ("foo", instance_after.display_name());
+  EXPECT_EQ(updated_display_name, instance_after.display_name());
   EXPECT_NE(std::string::npos, instance_copy.display_name().find(instance_id));
 }
 /// @test Verify that InstanceAdmin::ListInstances works as expected.


### PR DESCRIPTION
The integration test was setting the display name to something
too short. Fixed the test and change the emulator to have the
same check.

Why did this make it to the master branch you ask? Because the
PR that introduced this change was created before we had enabled
integration tests against production in Kokoro.
