### PR TITLE
Enable one build with gcc-4.9.

### DIFF
--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -17,23 +17,21 @@
 set -eu
 
 sudo apt-get update
+sudo apt-get install -y software-properties-common
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+sudo apt-get update
 sudo apt-get install -y \
+     gcc-4.9 \
+     g++-4.9 \
      libcurl4-openssl-dev \
      libssl-dev \
-     pkg-config \
-     python \
-     python-software-properties \
-     software-properties-common \
      unzip \
      wget \
      zip \
      zlib1g-dev
-sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-sudo apt-get update
-sudo apt-get install -y gcc-7 g++-7
 
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100
-sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 100
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 100
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 100
 
 readonly BAZEL_VERSION=0.12.0
 readonly GITHUB_DL="https://github.com/bazelbuild/bazel/releases/download"


### PR DESCRIPTION
Since we say we support it, at least one build should use that
compiler.  Used the Bazel build because we already install
a specific version of the compiler for it, and I wanted to
remove unnecessary dependencies.