### PR TITLE
Turn clang-tidy warnings into errors.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,7 +7,7 @@
 Checks: google-readability-*,modernize-*,readability-*,performance-*,-google-readability-namespace-comments
 
 # Enable most warnings as errors.
-WarningsAsErrors: clang-*,google-*,modernize-*,readability-*,performance-*,-readability-identifier-naming
+WarningsAsErrors: clang-*,google-*,modernize-*,readability-*,performance-*
 
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }
@@ -21,4 +21,5 @@ CheckOptions:
   - { key: readability-identifier-naming.MacroDefinitionCase,    value: UPPER_CASE }
   - { key: readability-identifier-naming.EnumConstantCase,       value: UPPER_CASE }
   - { key: readability-identifier-naming.ConstexprVariableCase,  value: UPPER_CASE }
-  - { key: readability-identifier-naming.ConstantCase,           value: UPPER_CASE }
+  - { key: readability-identifier-naming.GlobalConstantCase,     value: UPPER_CASE }
+  - { key: readability-identifier-naming.MemberConstantCase,     value: UPPER_CASE }

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ matrix:
       os: linux
       compiler: clang
       env:
-        CMAKE_FLAGS=-DBIGTABLE_CLIENT_CLANG_TIDY=yes
+        CMAKE_FLAGS=-DGOOGLE_CLOUD_CPP_CLANG_TIDY=yes
         BUILD_TYPE=Debug
         DISTRO=ubuntu
         DISTRO_VERSION=18.04

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,7 +193,7 @@ which combinations are tested regularly.
      same options to avoid false positives.
    * All the sanitizers require Clang, remember to select the compiler as
      described above.
- * `-DBIGTABLE_CLIENT_CLANG_TIDY=yes`: configure the build to run `clang-tidy`
-   for the code in the `bigtable/` subdirectory.  Check the
+ * `-DGOOGLE_CLOUD_CPP_CLANG_TIDY=yes`: configure the build to run `clang-tidy`
+   for the Google Cloud C++ Libraries.  Check the
    [configuration file](.clang-tidy) for details on what `clang-tidy` options
    we use.

--- a/bigtable/benchmarks/benchmark_test.cc
+++ b/bigtable/benchmarks/benchmark_test.cc
@@ -178,9 +178,9 @@ TEST(BenchmarkTest, PrintCsv) {
 
   // The output includes the version and compiler info.
   EXPECT_NE(std::string::npos, output.find(bigtable::version_string()));
-  EXPECT_NE(std::string::npos, output.find(google::cloud::internal::compiler));
+  EXPECT_NE(std::string::npos, output.find(google::cloud::internal::COMPILER));
   EXPECT_NE(std::string::npos,
-            output.find(google::cloud::internal::compiler_flags));
+            output.find(google::cloud::internal::COMPILER_FLAGS));
 
   // The output includes the latency results.
   EXPECT_NE(std::string::npos, output.find(",100,"));    // p0

--- a/bigtable/benchmarks/setup.cc
+++ b/bigtable/benchmarks/setup.cc
@@ -36,8 +36,8 @@ std::string FormattedStartTime() {
 
 std::string FormattedAnnotations() {
   std::string notes = bigtable::version_string() + ";" +
-                      google::cloud::internal::compiler + ";" +
-                      google::cloud::internal::compiler_flags;
+                      google::cloud::internal::COMPILER + ";" +
+                      google::cloud::internal::COMPILER_FLAGS;
   std::transform(notes.begin(), notes.end(), notes.begin(),
                  [](char c) { return c == '\n' ? ';' : c; });
   return notes;

--- a/bigtable/client/CMakeLists.txt
+++ b/bigtable/client/CMakeLists.txt
@@ -109,17 +109,7 @@ add_library(bigtable::client ALIAS bigtable_client)
 
 include(CreateBazelConfig)
 create_bazel_config(bigtable_client)
-
-option(BIGTABLE_CLIENT_CLANG_TIDY
-    "If set compiles the Cloud Bigtable client with clang-tidy."
-    "")
-if (CLANG_TIDY_EXE AND BIGTABLE_CLIENT_CLANG_TIDY)
-    message(STATUS "clang-tidy build enabled.")
-    set_target_properties(
-        bigtable_client PROPERTIES
-        CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
-    )
-endif ()
+google_cloud_cpp_add_clang_tidy(bigtable_client)
 
 add_library(bigtable_client_testing
         testing/chrono_literals.h

--- a/bigtable/client/grpc_error.cc
+++ b/bigtable/client/grpc_error.cc
@@ -16,7 +16,7 @@
 #include <sstream>
 
 namespace {
-constexpr char const* kKnownCodes[] = {
+constexpr char const* KNOWN_STATUS_CODES[] = {
     "OK",
     "CANCELLED",
     "UNKNOWN",
@@ -35,7 +35,8 @@ constexpr char const* kKnownCodes[] = {
     "DATA_LOSS",
     "UNAUTHENTICATED",
 };
-constexpr int kKnownCodesSize = sizeof(kKnownCodes) / sizeof(kKnownCodes[0]);
+constexpr int KNOWN_STATUS_CODES_SIZE =
+    sizeof(KNOWN_STATUS_CODES) / sizeof(KNOWN_STATUS_CODES[0]);
 }  // anonymous namespace
 
 namespace bigtable {
@@ -52,8 +53,8 @@ std::string GRpcError::CreateWhatString(char const* what,
   os << what << ": " << status.error_message() << " [" << status.error_code()
      << "=";
   int const index = status.error_code();
-  if (0 <= index and index < kKnownCodesSize) {
-    os << kKnownCodes[status.error_code()];
+  if (0 <= index and index < KNOWN_STATUS_CODES_SIZE) {
+    os << KNOWN_STATUS_CODES[status.error_code()];
   } else {
     os << "(UNKNOWN CODE)";
   }

--- a/bigtable/client/internal/endian.cc
+++ b/bigtable/client/internal/endian.cc
@@ -29,9 +29,9 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
 
-constexpr char c[sizeof(int)] = {1};
+constexpr char ENDIAN_DETECTOR[sizeof(int)] = {1};
 constexpr bool IsBigEndian() {
-  return c[0] != 1;  // ignore different type comparison
+  return ENDIAN_DETECTOR[0] != 1;  // ignore different type comparison
 }
 
 /**

--- a/bigtable/client/metadata_update_policy.cc
+++ b/bigtable/client/metadata_update_policy.cc
@@ -67,6 +67,10 @@ MetadataUpdatePolicy::MetadataUpdatePolicy(
   value_ = std::move(value);
 }
 
+// This should be Setup(), because it is "more than an accessor or modifier",
+// but barely so.  More importantly, the other policies use setup() (lowercase),
+// and we like the consistency.
+// NOLINTNEXTLINE(readability-identifier-naming)
 void MetadataUpdatePolicy::setup(grpc::ClientContext& context) const {
   context.AddMetadata(std::string("x-goog-request-params"), value());
 }

--- a/bigtable/client/mutations.cc
+++ b/bigtable/client/mutations.cc
@@ -60,7 +60,7 @@ Mutation DeleteFromRow() {
   return m;
 }
 
-grpc::Status FailedMutation::to_grpc_status(google::rpc::Status const& status) {
+grpc::Status FailedMutation::ToGrpcStatus(google::rpc::Status const &status) {
   std::string details;
   if (not google::protobuf::TextFormat::PrintToString(status, &details)) {
     details = "error [could not print details as string]";

--- a/bigtable/client/mutations.cc
+++ b/bigtable/client/mutations.cc
@@ -60,7 +60,7 @@ Mutation DeleteFromRow() {
   return m;
 }
 
-grpc::Status FailedMutation::ToGrpcStatus(google::rpc::Status const &status) {
+grpc::Status FailedMutation::ToGrpcStatus(google::rpc::Status const& status) {
   std::string details;
   if (not google::protobuf::TextFormat::PrintToString(status, &details)) {
     details = "error [could not print details as string]";

--- a/bigtable/client/mutations.h
+++ b/bigtable/client/mutations.h
@@ -305,7 +305,7 @@ class FailedMutation {
       : FailedMutation(std::move(mut), std::move(status), -1) {}
   FailedMutation(SingleRowMutation mut, google::rpc::Status status, int index)
       : mutation_(std::move(mut)),
-        status_(to_grpc_status(status)),
+        status_(ToGrpcStatus(status)),
         original_index_(index) {}
 
   FailedMutation(FailedMutation&&) = default;
@@ -323,7 +323,7 @@ class FailedMutation {
   friend class BulkMutation;
 
  private:
-  static grpc::Status to_grpc_status(google::rpc::Status const& status);
+  static grpc::Status ToGrpcStatus(google::rpc::Status const &status);
 
  private:
   SingleRowMutation mutation_;

--- a/bigtable/client/mutations.h
+++ b/bigtable/client/mutations.h
@@ -323,7 +323,7 @@ class FailedMutation {
   friend class BulkMutation;
 
  private:
-  static grpc::Status ToGrpcStatus(google::rpc::Status const &status);
+  static grpc::Status ToGrpcStatus(google::rpc::Status const& status);
 
  private:
   SingleRowMutation mutation_;

--- a/bigtable/client/row_reader.cc
+++ b/bigtable/client/row_reader.cc
@@ -110,6 +110,8 @@ RowReader::RowReader(
       raise_on_error_(raise_on_error),
       error_retrieved_(raise_on_error) {}
 
+// The name must be all lowercase to work with range-for loops.
+// NOLINTNEXTLINE(readability-identifier-naming)
 RowReader::iterator RowReader::begin() {
   if (operation_cancelled_) {
     if (raise_on_error_) {
@@ -127,6 +129,8 @@ RowReader::iterator RowReader::begin() {
   return ++internal::RowReaderIterator(this, false);
 }
 
+// The name must be all lowercase to work with range-for loops.
+// NOLINTNEXTLINE(readability-identifier-naming)
 RowReader::iterator RowReader::end() {
   return internal::RowReaderIterator(this, true);
 }

--- a/bigtable/client/rpc_backoff_policy.cc
+++ b/bigtable/client/rpc_backoff_policy.cc
@@ -26,20 +26,20 @@ namespace {
 #define BIGTABLE_CLIENT_DEFAULT_MAXIMUM_DELAY std::chrono::minutes(5)
 #endif  // BIGTABLE_CLIENT_DEFAULT_MAXIMUM_DELAY
 
-const auto default_initial_delay = BIGTABLE_CLIENT_DEFAULT_INITIAL_DELAY;
-const auto default_maximum_delay = BIGTABLE_CLIENT_DEFAULT_MAXIMUM_DELAY;
+auto const DEFAULT_INITIAL_DELAY = BIGTABLE_CLIENT_DEFAULT_INITIAL_DELAY;
+auto const DEFAULT_MAXIMUM_DELAY = BIGTABLE_CLIENT_DEFAULT_MAXIMUM_DELAY;
 }  // anonymous namespace
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 std::unique_ptr<RPCBackoffPolicy> DefaultRPCBackoffPolicy() {
   return std::unique_ptr<RPCBackoffPolicy>(new ExponentialBackoffPolicy(
-      default_initial_delay, default_maximum_delay));
+      DEFAULT_INITIAL_DELAY, DEFAULT_MAXIMUM_DELAY));
 }
 
 ExponentialBackoffPolicy::ExponentialBackoffPolicy()
-    : current_delay_range_(default_initial_delay),
-      maximum_delay_(default_maximum_delay) {}
+    : current_delay_range_(DEFAULT_INITIAL_DELAY),
+      maximum_delay_(DEFAULT_MAXIMUM_DELAY) {}
 
 std::unique_ptr<RPCBackoffPolicy> ExponentialBackoffPolicy::clone() const {
   return std::unique_ptr<RPCBackoffPolicy>(new ExponentialBackoffPolicy(*this));

--- a/bigtable/client/rpc_retry_policy.cc
+++ b/bigtable/client/rpc_retry_policy.cc
@@ -24,7 +24,7 @@ namespace {
 #define BIGTABLE_CLIENT_DEFAULT_MAXIMUM_RETRY_PERIOD std::chrono::hours(1)
 #endif  // BIGTABLE_CLIENT_DEFAULT_MAXIMUM_RETRY_PERIOD
 
-const auto maximum_retry_period = BIGTABLE_CLIENT_DEFAULT_MAXIMUM_RETRY_PERIOD;
+auto const MAXIMUM_RETRY_PERIOD = BIGTABLE_CLIENT_DEFAULT_MAXIMUM_RETRY_PERIOD;
 
 }  // anonymous namespace
 
@@ -32,11 +32,11 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 std::unique_ptr<RPCRetryPolicy> DefaultRPCRetryPolicy() {
   return std::unique_ptr<RPCRetryPolicy>(
-      new LimitedTimeRetryPolicy(maximum_retry_period));
+      new LimitedTimeRetryPolicy(MAXIMUM_RETRY_PERIOD));
 }
 
 LimitedTimeRetryPolicy::LimitedTimeRetryPolicy()
-    : maximum_duration_(maximum_retry_period),
+    : maximum_duration_(MAXIMUM_RETRY_PERIOD),
       deadline_(std::chrono::system_clock::now() + maximum_duration_) {}
 
 std::unique_ptr<RPCRetryPolicy> LimitedErrorCountRetryPolicy::clone() const {

--- a/bigtable/client/testing/table_test_fixture.cc
+++ b/bigtable/client/testing/table_test_fixture.cc
@@ -20,7 +20,7 @@ namespace bigtable {
 namespace testing {
 
 google::bigtable::v2::ReadRowsResponse ReadRowsResponseFromString(
-    std::string repr) {
+    std::string const& repr) {
   google::bigtable::v2::ReadRowsResponse response;
   if (!google::protobuf::TextFormat::ParseFromString(repr, &response)) {
     google::cloud::internal::RaiseRuntimeError("Failed to parse " + repr);

--- a/bigtable/client/testing/table_test_fixture.h
+++ b/bigtable/client/testing/table_test_fixture.h
@@ -46,7 +46,7 @@ class TableTestFixture : public ::testing::Test {
 };
 
 google::bigtable::v2::ReadRowsResponse ReadRowsResponseFromString(
-    std::string repr);
+    std::string const& repr);
 
 }  // namespace testing
 }  // namespace bigtable

--- a/bigtable/client/version.cc
+++ b/bigtable/client/version.cc
@@ -18,14 +18,14 @@
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+// NOLINTNEXTLINE(readability-identifier-naming)
 std::string version_string() {
-  auto create_version = []() -> std::string {
+  static std::string const version = [] {
     std::ostringstream os;
     os << "v" << version_major() << "." << version_minor() << "."
-       << version_patch() << "+" << google::cloud::internal::gitrev;
+       << version_patch() << "+" << google::cloud::internal::GITREV;
     return os.str();
-  };
-  static std::string const version = create_version();
+  }();
   return version;
 }
 }  // namespace BIGTABLE_CLIENT_NS

--- a/cmake/EnableClangTidy.cmake
+++ b/cmake/EnableClangTidy.cmake
@@ -12,6 +12,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+option(GOOGLE_CLOUD_CPP_CLANG_TIDY
+        "If set compiles the Cloud Cloud C++ Libraries with clang-tidy."
+        "")
+
 if (${CMAKE_VERSION} VERSION_LESS "3.6")
     message(STATUS "clang-tidy is not enabled because cmake version is too old")
 else ()

--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -96,3 +96,12 @@ function(google_cloud_cpp_add_common_options target)
         target_compile_options(${target} INTERFACE "-Werror")
     endif ()
 endfunction()
+
+function (google_cloud_cpp_add_clang_tidy target)
+    if (CLANG_TIDY_EXE AND GOOGLE_CLOUD_CPP_CLANG_TIDY)
+        set_target_properties(
+                ${target} PROPERTIES
+                CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
+        )
+    endif ()
+endfunction ()

--- a/firestore/client/CMakeLists.txt
+++ b/firestore/client/CMakeLists.txt
@@ -32,17 +32,7 @@ add_library(firestore::client ALIAS firestore_client)
 
 include(CreateBazelConfig)
 create_bazel_config(firestore_client)
-
-option(FIRESTORE_CLIENT_CLANG_TIDY
-    "If set compiles the Cloud Firestore client with clang-tidy."
-    "")
-if (CLANG_TIDY_EXE AND FIRESTORE_CLIENT_CLANG_TIDY)
-    message(STATUS "clang-tidy build enabled.")
-    set_target_properties(
-        firestore_client PROPERTIES
-        CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
-    )
-endif ()
+google_cloud_cpp_add_clang_tidy(firestore_client)
 
 # List the unit tests, then setup the targets and dependencies.
 set(firestore_client_unit_tests

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -75,6 +75,7 @@ target_compile_options(google_cloud_cpp_common PUBLIC
 
 include(CreateBazelConfig)
 create_bazel_config(google_cloud_cpp_common)
+google_cloud_cpp_add_clang_tidy(google_cloud_cpp_common)
 
 set(google_cloud_cpp_common_unit_tests
     internal/throw_delegate_test.cc)

--- a/google/cloud/internal/build_info.cc.in
+++ b/google/cloud/internal/build_info.cc.in
@@ -19,11 +19,11 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 
-char const compiler[] = R"""(@CMAKE_CXX_COMPILER_ID@ @CMAKE_CXX_COMPILER_VERSION@)""";
+char const COMPILER[] = R"""(@CMAKE_CXX_COMPILER_ID@ @CMAKE_CXX_COMPILER_VERSION@)""";
 
-char const compiler_flags[] = R"""(@CMAKE_CXX_FLAGS@ ${CMAKE_CXX_FLAGS_${BUILD_TYPE_UPPER}})""";
+char const COMPILER_FLAGS[] = R"""(@CMAKE_CXX_FLAGS@ ${CMAKE_CXX_FLAGS_${BUILD_TYPE_UPPER}})""";
 
-char const gitrev[] = R"""(@GIT_HEAD@)""";
+char const GITREV[] = R"""(@GIT_HEAD@)""";
 
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS

--- a/google/cloud/internal/build_info.h
+++ b/google/cloud/internal/build_info.h
@@ -21,14 +21,14 @@ namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
-/// The git revision at compile time
-extern char const gitrev[];
-
 /// The compiler version
-extern char const compiler[];
+extern char const COMPILER[];
 
 /// The compiler flags
-extern char const compiler_flags[];
+extern char const COMPILER_FLAGS[];
+
+/// The git revision at compile time
+extern char const GITREV[];
 
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS

--- a/google/cloud/internal/setenv.cc
+++ b/google/cloud/internal/setenv.cc
@@ -18,7 +18,7 @@
 #include <stdlib.h>
 #else
 // On Unix-like systems we need setenv()/unsetenv(), which are defined here:
-#include <stdlib.h>
+#include <cstdlib>
 #endif  // WIN32
 
 namespace google {

--- a/storage/client/CMakeLists.txt
+++ b/storage/client/CMakeLists.txt
@@ -77,18 +77,8 @@ target_compile_options(storage_client_testing PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIO
 
 include(CreateBazelConfig)
 create_bazel_config(storage_client)
+google_cloud_cpp_add_clang_tidy(storage_client)
 create_bazel_config(storage_client_testing)
-
-option(STORAGE_CLIENT_CLANG_TIDY
-    "If set compiles the Google Cloud Storage client with clang-tidy."
-    "")
-if (CLANG_TIDY_EXE AND STORAGE_CLIENT_CLANG_TIDY)
-    message(STATUS "clang-tidy build enabled.")
-    set_target_properties(
-        storage_client PROPERTIES
-        CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
-    )
-endif ()
 
 # List the unit tests, then setup the targets and dependencies.
 set(storage_client_unit_tests

--- a/storage/client/internal/curl_request.cc
+++ b/storage/client/internal/curl_request.cc
@@ -76,11 +76,6 @@ void CurlRequest::PrepareRequest(std::string payload) {
   }
 }
 
-void CurlRequest::PrepareRequest(nl::json data) {
-  std::string payload = data.dump();
-  PrepareRequest(std::move(payload));
-}
-
 HttpResponse CurlRequest::MakeRequest() {
   response_payload_.Attach(curl_);
   response_headers_.Attach(curl_);

--- a/storage/client/internal/curl_request.h
+++ b/storage/client/internal/curl_request.h
@@ -70,13 +70,6 @@ class CurlRequest {
   void PrepareRequest(std::string payload);
 
   /**
-   * Make a request with the given payload.
-   *
-   * @param payload The JSON object to send as part of the request.
-   */
-  void PrepareRequest(nl::json payload);
-
-  /**
    * Make the prepared request.
    *
    * @return The response HTTP error code and the response payload.

--- a/storage/client/internal/curl_wrappers.cc
+++ b/storage/client/internal/curl_wrappers.cc
@@ -23,7 +23,7 @@ class CurlInitializer {
   ~CurlInitializer() { curl_global_cleanup(); }
 };
 
-CurlInitializer CURL_INITIALIZER;
+CurlInitializer const CURL_INITIALIZER;
 
 extern "C" std::size_t WriteCallback(void* contents, std::size_t size,
                                      std::size_t nmemb, void* dest) {

--- a/storage/client/internal/curl_wrappers.h
+++ b/storage/client/internal/curl_wrappers.h
@@ -55,7 +55,7 @@ class CurlHeaders {
   }
 
   /// Add a new header line to the contents.
-  void Append(char* header, std::size_t size);
+  void Append(char* data, std::size_t size);
 
  private:
   std::multimap<std::string, std::string> contents_;

--- a/storage/client/internal/parse_rfc3339.cc
+++ b/storage/client/internal/parse_rfc3339.cc
@@ -127,7 +127,7 @@ std::chrono::system_clock::duration ParseFractionalSeconds(
   // Skip any other digits. This loses precision for sub-nanosecond timestamps,
   // but we do not consider this a problem for Internet timestamps.
   buffer += pos;
-  while (std::isdigit(buffer[0])) {
+  while (std::isdigit(buffer[0]) != 0) {
     ++buffer;
   }
   return std::chrono::duration_cast<std::chrono::system_clock::duration>(
@@ -180,7 +180,7 @@ std::chrono::system_clock::time_point ParseRfc3339(
   // does not change during the lifetime of the program.  This function takes
   // the current time, converts to UTC and then convert back to a time_t.  The
   // difference is the offset.
-  static std::chrono::seconds const LOCALTIME_OFFSET = []() {
+  static std::chrono::seconds const localtime_offset = []() {
     auto now = std::time(nullptr);
     std::tm lcl;
 // The standard C++ function to convert time_t to a struct tm is not thread
@@ -204,7 +204,7 @@ std::chrono::system_clock::time_point ParseRfc3339(
 
   time_point += fractional_seconds;
   time_point -= offset;
-  time_point -= LOCALTIME_OFFSET;
+  time_point -= localtime_offset;
   return time_point;
 }
 

--- a/storage/client/version.cc
+++ b/storage/client/version.cc
@@ -18,14 +18,14 @@
 
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
+// NOLINTNEXTLINE(readability-identifier-naming)
 std::string version_string() {
-  auto create_version = []() -> std::string {
+  static std::string const version = [] {
     std::ostringstream os;
     os << "v" << version_major() << "." << version_minor() << "."
-       << version_patch() << "+" << google::cloud::internal::gitrev;
+       << version_patch() << "+" << google::cloud::internal::GITREV;
     return os.str();
-  };
-  static std::string const version = create_version();
+  }();
   return version;
 }
 }  // namespace STORAGE_CLIENT_NS

--- a/storage/tests/curl_request_integration_test.cc
+++ b/storage/tests/curl_request_integration_test.cc
@@ -73,29 +73,6 @@ TEST(CurlRequestTest, RepeatedGET) {
   EXPECT_EQ("bar1==bar2=", args["bar"].get<std::string>());
 }
 
-TEST(CurlRequestTest, SimpleJSON) {
-  // TODO(#542) - use a local server to make tests more hermetic.
-  storage::internal::CurlRequest request("https://nghttp2.org/httpbin/post");
-  request.AddQueryParameter("foo", "bar&baz");
-  request.AddQueryParameter("qux", "quux-123");
-  request.AddHeader("Accept: application/json");
-  request.AddHeader("Content-Type: application/json");
-  request.AddHeader("charsets: utf-8");
-
-  request.PrepareRequest(nl::json{{"int", 42}, {"string", "value"}});
-  auto response = request.MakeRequest();
-  EXPECT_EQ(200, response.status_code);
-  nl::json parsed = nl::json::parse(response.payload);
-  nl::json args = parsed["args"];
-  EXPECT_EQ("bar&baz", args["foo"].get<std::string>());
-  EXPECT_EQ("quux-123", args["qux"].get<std::string>());
-
-  std::string data_text = parsed["data"].get<std::string>();
-  nl::json data = nl::json::parse(data_text);
-  EXPECT_EQ(42, data["int"].get<int>());
-  EXPECT_EQ("value", data["string"].get<std::string>());
-}
-
 TEST(CurlRequestTest, SimplePOST) {
   // TODO(#542) - use a local server to make tests more hermetic.
   storage::internal::CurlRequest request("https://nghttp2.org/httpbin/post");


### PR DESCRIPTION
Fix the existing warnings, then turn warnings into errors.  Also enabled `clang-tidy`
for all libraries, not just Bigtable.  This fixes #339.
