### PR TITLE
Use grpcpp/grpcpp.h for the gRPC libraries.

### DIFF
--- a/bigtable/client/client_options.h
+++ b/bigtable/client/client_options.h
@@ -17,7 +17,7 @@
 
 #include "bigtable/client/version.h"
 #include "google/cloud/internal/throw_delegate.h"
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {

--- a/bigtable/client/grpc_error.h
+++ b/bigtable/client/grpc_error.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_GRPC_ERROR_H_
 
 #include "bigtable/client/version.h"
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 #include <stdexcept>
 
 namespace bigtable {

--- a/bigtable/client/internal/common_client.h
+++ b/bigtable/client/internal/common_client.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_COMMON_CLIENT_H_
 
 #include "bigtable/client/client_options.h"
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {

--- a/bigtable/client/internal/throw_delegate.h
+++ b/bigtable/client/internal/throw_delegate.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_INTERNAL_THROW_DELEGATE_H_
 
 #include "bigtable/client/version.h"
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {

--- a/bigtable/client/metadata_update_policy.h
+++ b/bigtable/client/metadata_update_policy.h
@@ -17,7 +17,7 @@
 
 #include "bigtable/client/bigtable_strong_types.h"
 #include "bigtable/client/version.h"
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 #include <memory>
 
 namespace bigtable {

--- a/bigtable/client/mutations.h
+++ b/bigtable/client/mutations.h
@@ -20,7 +20,7 @@
 
 #include <google/bigtable/v2/bigtable.pb.h>
 #include <google/bigtable/v2/data.pb.h>
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 #include <chrono>
 #include <type_traits>
 

--- a/bigtable/client/polling_policy.h
+++ b/bigtable/client/polling_policy.h
@@ -18,7 +18,7 @@
 #include "bigtable/client/rpc_backoff_policy.h"
 #include "bigtable/client/rpc_retry_policy.h"
 #include "bigtable/client/version.h"
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {

--- a/bigtable/client/row_reader.h
+++ b/bigtable/client/row_reader.h
@@ -27,7 +27,7 @@
 #include "bigtable/client/rpc_retry_policy.h"
 #include "bigtable/client/table_strong_types.h"
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 #include <cinttypes>
 #include <iterator>
 

--- a/bigtable/client/rpc_backoff_policy.h
+++ b/bigtable/client/rpc_backoff_policy.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_RPC_BACKOFF_POLICY_H_
 
 #include "bigtable/client/version.h"
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 #include <chrono>
 #include <memory>
 #include <random>

--- a/bigtable/client/rpc_retry_policy.h
+++ b/bigtable/client/rpc_retry_policy.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_BIGTABLE_CLIENT_RPC_RETRY_POLICY_H_
 
 #include "bigtable/client/version.h"
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 #include <chrono>
 #include <memory>
 

--- a/bigtable/tests/instance_admin_emulator.cc
+++ b/bigtable/tests/instance_admin_emulator.cc
@@ -15,7 +15,7 @@
 #include "bigtable/client/internal/make_unique.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h>
 #include <google/longrunning/operations.grpc.pb.h>
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 
 namespace btadmin = google::bigtable::admin::v2;
 

--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -71,11 +71,23 @@ find google/cloud bigtable firestore storage -name '*.h' -print0 \
   }'
 
 # This script assumes it is running the top-level google-cloud-cpp directory.
+
+# Apply clang-format(1) to fix whitespace and other formatting rules.
+# The version of clang-format is important, different versions have slightly
+# different formatting output (sigh).
 find . \( -path ./.git -prune -o -path ./third_party -prune \
           -o -path './cmake-build-*' -o -path ./build-output -prune \
           -o -name '*.pb.h' -prune -o -name '*.pb.cc' -prune \) \
      -o \( -name '*.cc' -o -name '*.h' \) -print0 \
      | xargs -0 clang-format -i
+
+# Replace any #include for grpc++/ files with grpcpp/.  The former are obsoleted
+# so we should not use them in our code.
+find . \( -path ./.git -prune -o -path ./third_party -prune \
+          -o -path './cmake-build-*' -o -path ./build-output -prune \
+          -o -name '*.pb.h' -prune -o -name '*.pb.cc' -prune \) \
+     -o \( -name '*.cc' -o -name '*.h' \) -print0 \
+     |  xargs -0 sed -i 's;#include <grpc\\+\\+/;#include <grpcpp/;'
 
 # Report any differences created by running clang-format.
 git diff --ignore-submodules=all --color --exit-code .

--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -81,8 +81,14 @@ find . \( -path ./.git -prune -o -path ./third_party -prune \
      -o \( -name '*.cc' -o -name '*.h' \) -print0 \
      | xargs -0 clang-format -i
 
-# Replace any #include for grpc++/ files with grpcpp/.  The former are obsoleted
-# so we should not use them in our code.
+# Replace any #include for grpc++/grpc++.h with grpcpp/grpcpp.h, and in general,
+# any include of grpc++/ files with grpcpp/.  The paths with grpc++ are
+# obsoleted by the gRPC team, so we should not use them in our code.
+find . \( -path ./.git -prune -o -path ./third_party -prune \
+          -o -path './cmake-build-*' -o -path ./build-output -prune \
+          -o -name '*.pb.h' -prune -o -name '*.pb.cc' -prune \) \
+     -o \( -name '*.cc' -o -name '*.h' \) -print0 \
+     |  xargs -0 sed -i 's;#include <grpc\\+\\+/grpc\+\+.h>;#include <grpcpp/grpcpp.h>;'
 find . \( -path ./.git -prune -o -path ./third_party -prune \
           -o -path './cmake-build-*' -o -path ./build-output -prune \
           -o -name '*.pb.h' -prune -o -name '*.pb.cc' -prune \) \

--- a/tests/grpc-crash/client.cc
+++ b/tests/grpc-crash/client.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "echo.grpc.pb.h"
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 #include <future>
 
 void MakeStreamPing(Echo::Stub& echo, std::int32_t count) {

--- a/tests/grpc-crash/server.cc
+++ b/tests/grpc-crash/server.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "echo.grpc.pb.h"
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 #include <future>
 #include <iostream>
 

--- a/tests/grpc-round-robin-freeze/client.cc
+++ b/tests/grpc-round-robin-freeze/client.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "echo.grpc.pb.h"
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 #include <future>
 
 void MakeStreamPing(Echo::Stub& echo, std::int32_t count) {

--- a/tests/grpc-round-robin-freeze/server.cc
+++ b/tests/grpc-round-robin-freeze/server.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "echo.grpc.pb.h"
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 #include <future>
 #include <iostream>
 


### PR DESCRIPTION
This fixes #488. The old headers (grpc++/*.h) have been obsoleted
by gRPC, so we should not use them.