### PR TITLE
Format with clang-format-6.0 on ubuntu:18.04.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,15 +88,15 @@ matrix:
           # with gRPC already compiled and installed.
         - DISTRO=ubuntu ./ci/install-linux.sh
         - ./ci/install-linux.sh
-    - # Check the code formatting using clang-format, and generate the Doxygen
-      # documentation.
+    - # Run clang-tidy, clang-format, and generate the documentation.
       os: linux
-      compiler: gcc
+      compiler: clang
       env:
         CHECK_STYLE=yes
         GENERATE_DOCS=yes
+        CMAKE_FLAGS=-DGOOGLE_CLOUD_CPP_CLANG_TIDY=yes
         DISTRO=ubuntu
-        DISTRO_VERSION=17.10
+        DISTRO_VERSION=18.04
     - # Build with the AddressSanitizer.
       os: linux
       compiler: clang
@@ -112,21 +112,14 @@ matrix:
         CMAKE_FLAGS=-DSANITIZE_UNDEFINED=yes
         BUILD_TYPE=Debug
         DISTRO=ubuntu
-        DISTRO_VERSION=16.04
-    - # Compile with clang-tidy enabled.
-      os: linux
-      compiler: clang
-      env:
-        CMAKE_FLAGS=-DGOOGLE_CLOUD_CPP_CLANG_TIDY=yes
-        BUILD_TYPE=Debug
-        DISTRO=ubuntu
         DISTRO_VERSION=18.04
     - # Generate code coverage information and upload to codecov.io.
       os: linux
       compiler: gcc
       env:
         BUILD_TYPE=Coverage
-        DISTRO=ubuntu DISTRO_VERSION=18.04
+        DISTRO=ubuntu
+        DISTRO_VERSION=18.04
     - # Compile with exceptions disabled.
       os: linux
       compiler: gcc

--- a/bigtable/benchmarks/embedded_server_test.cc
+++ b/bigtable/benchmarks/embedded_server_test.cc
@@ -69,9 +69,8 @@ TEST(EmbeddedServer, TableApply) {
                         "fake-table");
 
   bigtable::SingleRowMutation mutation(
-      "row1",
-      {bigtable::SetCell("fam", "col", milliseconds(0), "val"),
-       bigtable::SetCell("fam", "col", milliseconds(0), "val")});
+      "row1", {bigtable::SetCell("fam", "col", milliseconds(0), "val"),
+               bigtable::SetCell("fam", "col", milliseconds(0), "val")});
 
   EXPECT_EQ(0, server->mutate_row_count());
   table.Apply(std::move(mutation));

--- a/bigtable/client/internal/bulk_mutator_test.cc
+++ b/bigtable/client/internal/bulk_mutator_test.cc
@@ -113,11 +113,12 @@ TEST(MultipleRowsMutatorTest, BulkApply_AppProfileId) {
   std::string expected_id = "test-id";
   bigtable::testing::MockDataClient client;
   EXPECT_CALL(client, MutateRows(_, _))
-      .WillOnce(Invoke([expected_id, &reader](
-          grpc::ClientContext* ctx, btproto::MutateRowsRequest const& req) {
-        EXPECT_EQ(expected_id, req.app_profile_id());
-        return reader.release()->AsUniqueMocked();
-      }));
+      .WillOnce(
+          Invoke([expected_id, &reader](grpc::ClientContext* ctx,
+                                        btproto::MutateRowsRequest const& req) {
+            EXPECT_EQ(expected_id, req.app_profile_id());
+            return reader.release()->AsUniqueMocked();
+          }));
 
   auto policy = bt::DefaultIdempotentMutationPolicy();
   bt::internal::BulkMutator mutator(bigtable::AppProfileId("test-id"),

--- a/bigtable/client/internal/instance_admin_test.cc
+++ b/bigtable/client/internal/instance_admin_test.cc
@@ -44,8 +44,9 @@ auto create_list_instances_lambda = [](std::string expected_token,
                                        std::string returned_token,
                                        std::vector<std::string> instance_ids) {
   return [expected_token, returned_token, instance_ids](
-      grpc::ClientContext* ctx, btproto::ListInstancesRequest const& request,
-      btproto::ListInstancesResponse* response) {
+             grpc::ClientContext* ctx,
+             btproto::ListInstancesRequest const& request,
+             btproto::ListInstancesResponse* response) {
     auto const project_name = "projects/" + kProjectId;
     EXPECT_EQ(project_name, request.parent());
     EXPECT_EQ(expected_token, request.page_token());
@@ -65,38 +66,40 @@ auto create_list_instances_lambda = [](std::string expected_token,
 // lambda twice without this thing.
 auto create_instance = [](std::string expected_token,
                           std::string returned_token) {
-  return [expected_token, returned_token](
-      grpc::ClientContext* ctx, btproto::GetInstanceRequest const& request,
-      btproto::Instance* response) {
-    EXPECT_NE(nullptr, response);
-    response->set_name(request.name());
-    return grpc::Status::OK;
-  };
+  return
+      [expected_token, returned_token](
+          grpc::ClientContext* ctx, btproto::GetInstanceRequest const& request,
+          btproto::Instance* response) {
+        EXPECT_NE(nullptr, response);
+        response->set_name(request.name());
+        return grpc::Status::OK;
+      };
 };
 
 // A lambda to create lambdas.  Basically we would be rewriting the same
 // lambda twice without this thing.
-auto create_list_clusters_lambda = [](
-    std::string expected_token, std::string returned_token,
-    std::string instance_id, std::vector<std::string> cluster_ids) {
-  return [expected_token, returned_token, instance_id, cluster_ids](
-      grpc::ClientContext* ctx, btproto::ListClustersRequest const& request,
-      btproto::ListClustersResponse* response) {
-    auto const instance_name =
-        "projects/" + kProjectId + "/instances/" + instance_id;
-    EXPECT_EQ(instance_name, request.parent());
-    EXPECT_EQ(expected_token, request.page_token());
+auto create_list_clusters_lambda =
+    [](std::string expected_token, std::string returned_token,
+       std::string instance_id, std::vector<std::string> cluster_ids) {
+      return [expected_token, returned_token, instance_id, cluster_ids](
+                 grpc::ClientContext* ctx,
+                 btproto::ListClustersRequest const& request,
+                 btproto::ListClustersResponse* response) {
+        auto const instance_name =
+            "projects/" + kProjectId + "/instances/" + instance_id;
+        EXPECT_EQ(instance_name, request.parent());
+        EXPECT_EQ(expected_token, request.page_token());
 
-    EXPECT_NE(nullptr, response);
-    for (auto const& cluster_id : cluster_ids) {
-      auto& cluster = *response->add_clusters();
-      cluster.set_name(instance_name + "/clusters/" + cluster_id);
-    }
-    // Return the right token.
-    response->set_next_page_token(returned_token);
-    return grpc::Status::OK;
-  };
-};
+        EXPECT_NE(nullptr, response);
+        for (auto const& cluster_id : cluster_ids) {
+          auto& cluster = *response->add_clusters();
+          cluster.set_name(instance_name + "/clusters/" + cluster_id);
+        }
+        // Return the right token.
+        response->set_next_page_token(returned_token);
+        return grpc::Status::OK;
+      };
+    };
 
 /**
  * Helper class to create the expectations for a simple RPC call.
@@ -212,11 +215,11 @@ TEST_F(InstanceAdminTest, ListInstancesRecoverableFailures) {
   using namespace ::testing;
 
   bigtable::noex::InstanceAdmin tested(client_);
-  auto mock_recoverable_failure = [](
-      grpc::ClientContext* ctx, btproto::ListInstancesRequest const& request,
-      btproto::ListInstancesResponse* response) {
-    return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
-  };
+  auto mock_recoverable_failure =
+      [](grpc::ClientContext* ctx, btproto::ListInstancesRequest const& request,
+         btproto::ListInstancesResponse* response) {
+        return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
+      };
   auto batch0 = create_list_instances_lambda("", "token-001", {"t0", "t1"});
   auto batch1 = create_list_instances_lambda("token-001", "", {"t2", "t3"});
   EXPECT_CALL(*client_, ListInstances(_, _, _))
@@ -383,11 +386,11 @@ TEST_F(InstanceAdminTest, ListClustersRecoverableFailures) {
   auto const instance_id = "the-instance";
 
   bigtable::noex::InstanceAdmin tested(client_);
-  auto mock_recoverable_failure = [](
-      grpc::ClientContext* ctx, btproto::ListClustersRequest const& request,
-      btproto::ListClustersResponse* response) {
-    return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
-  };
+  auto mock_recoverable_failure =
+      [](grpc::ClientContext* ctx, btproto::ListClustersRequest const& request,
+         btproto::ListClustersResponse* response) {
+        return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
+      };
   auto batch0 =
       create_list_clusters_lambda("", "token-001", instance_id, {"t0", "t1"});
   auto batch1 =

--- a/bigtable/client/internal/rowreaderiterator.h
+++ b/bigtable/client/internal/rowreaderiterator.h
@@ -86,9 +86,9 @@ class RowReaderIterator : public std::iterator<std::input_iterator_tag, Row> {
   Row const* operator->() const { return row_.get(); }
   Row* operator->() { return row_.get(); }
 
-  Row const& operator*() const & { return row_.value(); }
+  Row const& operator*() const& { return row_.value(); }
   Row& operator*() & { return row_.value(); }
-  Row const&& operator*() const && { return std::move(row_.value()); }
+  Row const&& operator*() const&& { return std::move(row_.value()); }
   Row&& operator*() && { return std::move(row_.value()); }
 
   bool operator==(RowReaderIterator const& that) const {

--- a/bigtable/client/internal/table_admin_test.cc
+++ b/bigtable/client/internal/table_admin_test.cc
@@ -47,49 +47,52 @@ class TableAdminTest : public ::testing::Test {
 auto create_list_tables_lambda = [](std::string expected_token,
                                     std::string returned_token,
                                     std::vector<std::string> table_names) {
-  return [expected_token, returned_token, table_names](
-      grpc::ClientContext* ctx, btproto::ListTablesRequest const& request,
-      btproto::ListTablesResponse* response) {
-    auto const instance_name =
-        "projects/" + kProjectId + "/instances/" + kInstanceId;
-    EXPECT_EQ(instance_name, request.parent());
-    EXPECT_EQ(btproto::Table::FULL, request.view());
-    EXPECT_EQ(expected_token, request.page_token());
+  return
+      [expected_token, returned_token, table_names](
+          grpc::ClientContext* ctx, btproto::ListTablesRequest const& request,
+          btproto::ListTablesResponse* response) {
+        auto const instance_name =
+            "projects/" + kProjectId + "/instances/" + kInstanceId;
+        EXPECT_EQ(instance_name, request.parent());
+        EXPECT_EQ(btproto::Table::FULL, request.view());
+        EXPECT_EQ(expected_token, request.page_token());
 
-    EXPECT_NE(nullptr, response);
-    for (auto const& table_name : table_names) {
-      auto& table = *response->add_tables();
-      table.set_name(instance_name + "/tables/" + table_name);
-      table.set_granularity(btproto::Table::MILLIS);
-    }
-    // Return the right token.
-    response->set_next_page_token(returned_token);
-    return grpc::Status::OK;
-  };
+        EXPECT_NE(nullptr, response);
+        for (auto const& table_name : table_names) {
+          auto& table = *response->add_tables();
+          table.set_name(instance_name + "/tables/" + table_name);
+          table.set_granularity(btproto::Table::MILLIS);
+        }
+        // Return the right token.
+        response->set_next_page_token(returned_token);
+        return grpc::Status::OK;
+      };
 };
 
 // A lambda to generate snapshot list.
-auto create_list_snapshots_lambda = [](
-    std::string expected_token, std::string returned_token,
-    std::vector<std::string> snapshot_names) {
-  return [expected_token, returned_token, snapshot_names](
-      grpc::ClientContext* ctx, btproto::ListSnapshotsRequest const& request,
-      btproto::ListSnapshotsResponse* response) {
-    auto cluster_name = "projects/" + kProjectId + "/instances/" + kInstanceId;
-    cluster_name += "/clusters/" + kClusterId;
-    EXPECT_EQ(cluster_name, request.parent());
-    EXPECT_EQ(expected_token, request.page_token());
+auto create_list_snapshots_lambda =
+    [](std::string expected_token, std::string returned_token,
+       std::vector<std::string> snapshot_names) {
+      return [expected_token, returned_token, snapshot_names](
+                 grpc::ClientContext* ctx,
+                 btproto::ListSnapshotsRequest const& request,
+                 btproto::ListSnapshotsResponse* response) {
+        auto cluster_name =
+            "projects/" + kProjectId + "/instances/" + kInstanceId;
+        cluster_name += "/clusters/" + kClusterId;
+        EXPECT_EQ(cluster_name, request.parent());
+        EXPECT_EQ(expected_token, request.page_token());
 
-    EXPECT_NE(nullptr, response);
-    for (auto const& snapshot_name : snapshot_names) {
-      auto& snapshot = *response->add_snapshots();
-      snapshot.set_name(cluster_name + "/snapshots/" + snapshot_name);
-    }
-    // Return the right token.
-    response->set_next_page_token(returned_token);
-    return grpc::Status::OK;
-  };
-};
+        EXPECT_NE(nullptr, response);
+        for (auto const& snapshot_name : snapshot_names) {
+          auto& snapshot = *response->add_snapshots();
+          snapshot.set_name(cluster_name + "/snapshots/" + snapshot_name);
+        }
+        // Return the right token.
+        response->set_next_page_token(returned_token);
+        return grpc::Status::OK;
+      };
+    };
 
 /**
  * Helper class to create the expectations for a simple RPC call.
@@ -837,11 +840,11 @@ TEST_F(TableAdminTest, ListSnapshots_RecoverableFailure) {
   using namespace bigtable::chrono_literals;
 
   bigtable::noex::TableAdmin tested(client_, "the-instance");
-  auto mock_recoverable_failure = [](
-      grpc::ClientContext* ctx, btproto::ListSnapshotsRequest const& request,
-      btproto::ListSnapshotsResponse* response) {
-    return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
-  };
+  auto mock_recoverable_failure =
+      [](grpc::ClientContext* ctx, btproto::ListSnapshotsRequest const& request,
+         btproto::ListSnapshotsResponse* response) {
+        return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
+      };
 
   auto list0 = create_list_snapshots_lambda("", "token-001", {"s0", "s1"});
   auto list1 = create_list_snapshots_lambda("token-001", "", {"s2", "s3"});

--- a/bigtable/client/internal/throw_delegate.cc
+++ b/bigtable/client/internal/throw_delegate.cc
@@ -19,7 +19,7 @@
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
-[[noreturn]] void RaiseRpcError(grpc::Status const& status, char const* msg) {
+void RaiseRpcError(grpc::Status const& status, char const* msg) {
 #ifdef GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   throw bigtable::GRpcError(msg, status);
 #else
@@ -31,8 +31,7 @@ namespace internal {
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
-[[noreturn]] void RaiseRpcError(grpc::Status const& status,
-                                std::string const& msg) {
+void RaiseRpcError(grpc::Status const& status, std::string const& msg) {
   RaiseRpcError(status, msg.c_str());
 }
 

--- a/bigtable/client/row_reader_test.cc
+++ b/bigtable/client/row_reader_test.cc
@@ -36,8 +36,8 @@ using google::bigtable::v2::ReadRowsRequest;
 using google::bigtable::v2::ReadRowsResponse;
 using google::bigtable::v2::ReadRowsResponse_CellChunk;
 
-using bigtable::testing::MockReadRowsReader;
 using bigtable::Row;
+using bigtable::testing::MockReadRowsReader;
 
 namespace {
 class ReadRowsParserMock : public bigtable::internal::ReadRowsParser {

--- a/bigtable/client/table_admin_test.cc
+++ b/bigtable/client/table_admin_test.cc
@@ -47,49 +47,52 @@ class TableAdminTest : public ::testing::Test {
 auto create_list_tables_lambda = [](std::string expected_token,
                                     std::string returned_token,
                                     std::vector<std::string> table_names) {
-  return [expected_token, returned_token, table_names](
-      grpc::ClientContext* ctx, btproto::ListTablesRequest const& request,
-      btproto::ListTablesResponse* response) {
-    auto const instance_name =
-        "projects/" + kProjectId + "/instances/" + kInstanceId;
-    EXPECT_EQ(instance_name, request.parent());
-    EXPECT_EQ(btproto::Table::FULL, request.view());
-    EXPECT_EQ(expected_token, request.page_token());
+  return
+      [expected_token, returned_token, table_names](
+          grpc::ClientContext* ctx, btproto::ListTablesRequest const& request,
+          btproto::ListTablesResponse* response) {
+        auto const instance_name =
+            "projects/" + kProjectId + "/instances/" + kInstanceId;
+        EXPECT_EQ(instance_name, request.parent());
+        EXPECT_EQ(btproto::Table::FULL, request.view());
+        EXPECT_EQ(expected_token, request.page_token());
 
-    EXPECT_NE(nullptr, response);
-    for (auto const& table_name : table_names) {
-      auto& table = *response->add_tables();
-      table.set_name(instance_name + "/tables/" + table_name);
-      table.set_granularity(btproto::Table::MILLIS);
-    }
-    // Return the right token.
-    response->set_next_page_token(returned_token);
-    return grpc::Status::OK;
-  };
+        EXPECT_NE(nullptr, response);
+        for (auto const& table_name : table_names) {
+          auto& table = *response->add_tables();
+          table.set_name(instance_name + "/tables/" + table_name);
+          table.set_granularity(btproto::Table::MILLIS);
+        }
+        // Return the right token.
+        response->set_next_page_token(returned_token);
+        return grpc::Status::OK;
+      };
 };
 
 // A lambda to generate snapshot list.
-auto create_list_snapshots_lambda = [](
-    std::string expected_token, std::string returned_token,
-    std::vector<std::string> snapshot_names) {
-  return [expected_token, returned_token, snapshot_names](
-      grpc::ClientContext* ctx, btproto::ListSnapshotsRequest const& request,
-      btproto::ListSnapshotsResponse* response) {
-    auto cluster_name = "projects/" + kProjectId + "/instances/" + kInstanceId;
-    cluster_name += "/clusters/" + kClusterId;
-    EXPECT_EQ(cluster_name, request.parent());
-    EXPECT_EQ(expected_token, request.page_token());
+auto create_list_snapshots_lambda =
+    [](std::string expected_token, std::string returned_token,
+       std::vector<std::string> snapshot_names) {
+      return [expected_token, returned_token, snapshot_names](
+                 grpc::ClientContext* ctx,
+                 btproto::ListSnapshotsRequest const& request,
+                 btproto::ListSnapshotsResponse* response) {
+        auto cluster_name =
+            "projects/" + kProjectId + "/instances/" + kInstanceId;
+        cluster_name += "/clusters/" + kClusterId;
+        EXPECT_EQ(cluster_name, request.parent());
+        EXPECT_EQ(expected_token, request.page_token());
 
-    EXPECT_NE(nullptr, response);
-    for (auto const& snapshot_name : snapshot_names) {
-      auto& snapshot = *response->add_snapshots();
-      snapshot.set_name(cluster_name + "/snapshots/" + snapshot_name);
-    }
-    // Return the right token.
-    response->set_next_page_token(returned_token);
-    return grpc::Status::OK;
-  };
-};
+        EXPECT_NE(nullptr, response);
+        for (auto const& snapshot_name : snapshot_names) {
+          auto& snapshot = *response->add_snapshots();
+          snapshot.set_name(cluster_name + "/snapshots/" + snapshot_name);
+        }
+        // Return the right token.
+        response->set_next_page_token(returned_token);
+        return grpc::Status::OK;
+      };
+    };
 
 /**
  * Helper class to create the expectations for a simple RPC call.
@@ -860,11 +863,11 @@ TEST_F(TableAdminTest, ListSnapshots_RecoverableFailure) {
   using namespace bigtable::chrono_literals;
 
   bigtable::TableAdmin tested(client_, "the-instance");
-  auto mock_recoverable_failure = [](
-      grpc::ClientContext* ctx, btproto::ListSnapshotsRequest const& request,
-      btproto::ListSnapshotsResponse* response) {
-    return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
-  };
+  auto mock_recoverable_failure =
+      [](grpc::ClientContext* ctx, btproto::ListSnapshotsRequest const& request,
+         btproto::ListSnapshotsResponse* response) {
+        return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
+      };
 
   auto list0 = create_list_snapshots_lambda("", "token-001", {"s0", "s1"});
   auto list1 = create_list_snapshots_lambda("token-001", "", {"s2", "s3"});

--- a/bigtable/client/table_readmodifywriterow_test.cc
+++ b/bigtable/client/table_readmodifywriterow_test.cc
@@ -29,10 +29,9 @@ using namespace testing;
 auto create_rules_lambda = [](std::string expected_request_string,
                               std::string generated_response_string) {
   return [expected_request_string, generated_response_string](
-      grpc::ClientContext* ctx,
-      btproto::ReadModifyWriteRowRequest const& request,
-      btproto::ReadModifyWriteRowResponse* response) {
-
+             grpc::ClientContext* ctx,
+             btproto::ReadModifyWriteRowRequest const& request,
+             btproto::ReadModifyWriteRowResponse* response) {
     btproto::ReadModifyWriteRowRequest expected_request;
     EXPECT_TRUE(::google::protobuf::TextFormat::ParseFromString(
         expected_request_string, &expected_request));

--- a/bigtable/tests/data_integration_test.cc
+++ b/bigtable/tests/data_integration_test.cc
@@ -402,13 +402,14 @@ TEST_F(DataIntegrationTest, TableReadModifyWriteAppendValueTest) {
       {row_key1, family3, "column-id3", 2000, add_suffix3, {}}};
 
   CreateCells(*table, created);
-  auto result_row = table->ReadModifyWriteRow(
-      row_key1, bigtable::ReadModifyWriteRule::AppendValue(
-                    family1, "column-id1", add_suffix1),
-      bigtable::ReadModifyWriteRule::AppendValue(family2, "column-id2",
-                                                 add_suffix2),
-      bigtable::ReadModifyWriteRule::AppendValue(family3, "column-id3",
-                                                 add_suffix3));
+  auto result_row =
+      table->ReadModifyWriteRow(row_key1,
+                                bigtable::ReadModifyWriteRule::AppendValue(
+                                    family1, "column-id1", add_suffix1),
+                                bigtable::ReadModifyWriteRule::AppendValue(
+                                    family2, "column-id2", add_suffix2),
+                                bigtable::ReadModifyWriteRule::AppendValue(
+                                    family3, "column-id3", add_suffix3));
 
   // Returned cells contains timestamp in microseconds which is
   // not matching with the timestamp in expected cells, So creating

--- a/bigtable/tests/filters_integration_test.cc
+++ b/bigtable/tests/filters_integration_test.cc
@@ -65,7 +65,7 @@ class FilterIntegrationTest : public bigtable::testing::TableIntegrationTest {
 /// Return true if connected to the Cloud Bigtable Emulator.
 bool UsingCloudBigtableEmulator();
 
-}  // namespace anonymous
+}  // namespace
 
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
@@ -607,22 +607,19 @@ void FilterIntegrationTest::CreateComplexRows(bigtable::Table& table,
   // column families.
   mutation.emplace_back(bt::SingleRowMutation(
       prefix + "/one-cell", {bt::SetCell("fam0", "c", 3_ms, "foo")}));
-  mutation.emplace_back(
-      bt::SingleRowMutation(prefix + "/two-cells",
-                            {bt::SetCell("fam0", "c", 3_ms, "foo"),
-                             bt::SetCell("fam0", "c2", 3_ms, "foo")}));
-  mutation.emplace_back(
-      bt::SingleRowMutation(prefix + "/many",
-                            {bt::SetCell("fam0", "c", 0_ms, "foo"),
-                             bt::SetCell("fam0", "c", 1_ms, "foo"),
-                             bt::SetCell("fam0", "c", 2_ms, "foo"),
-                             bt::SetCell("fam0", "c", 3_ms, "foo")}));
-  mutation.emplace_back(
-      bt::SingleRowMutation(prefix + "/many-columns",
-                            {bt::SetCell("fam0", "c0", 3_ms, "foo"),
-                             bt::SetCell("fam0", "c1", 3_ms, "foo"),
-                             bt::SetCell("fam0", "c2", 3_ms, "foo"),
-                             bt::SetCell("fam0", "c3", 3_ms, "foo")}));
+  mutation.emplace_back(bt::SingleRowMutation(
+      prefix + "/two-cells", {bt::SetCell("fam0", "c", 3_ms, "foo"),
+                              bt::SetCell("fam0", "c2", 3_ms, "foo")}));
+  mutation.emplace_back(bt::SingleRowMutation(
+      prefix + "/many", {bt::SetCell("fam0", "c", 0_ms, "foo"),
+                         bt::SetCell("fam0", "c", 1_ms, "foo"),
+                         bt::SetCell("fam0", "c", 2_ms, "foo"),
+                         bt::SetCell("fam0", "c", 3_ms, "foo")}));
+  mutation.emplace_back(bt::SingleRowMutation(
+      prefix + "/many-columns", {bt::SetCell("fam0", "c0", 3_ms, "foo"),
+                                 bt::SetCell("fam0", "c1", 3_ms, "foo"),
+                                 bt::SetCell("fam0", "c2", 3_ms, "foo"),
+                                 bt::SetCell("fam0", "c3", 3_ms, "foo")}));
   // This one is complicated: create a mutation with several families and
   // columns.
   bt::SingleRowMutation complex(prefix + "/complex");
@@ -641,4 +638,4 @@ void FilterIntegrationTest::CreateComplexRows(bigtable::Table& table,
 bool UsingCloudBigtableEmulator() {
   return std::getenv("BIGTABLE_EMULATOR_HOST") != nullptr;
 }
-}  // namespace anonymous
+}  // namespace

--- a/google/cloud/internal/throw_delegate.cc
+++ b/google/cloud/internal/throw_delegate.cc
@@ -29,42 +29,38 @@ template <typename Exception>
   std::abort();
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
-}
+}  // namespace
 
 namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 
-[[noreturn]] void RaiseInvalidArgument(char const* msg) {
+void RaiseInvalidArgument(char const* msg) {
   RaiseException<std::invalid_argument>(msg);
 }
 
-[[noreturn]] void RaiseInvalidArgument(std::string const& msg) {
+void RaiseInvalidArgument(std::string const& msg) {
   RaiseException<std::invalid_argument>(msg.c_str());
 }
 
-[[noreturn]] void RaiseRangeError(char const* msg) {
-  RaiseException<std::range_error>(msg);
-}
+void RaiseRangeError(char const* msg) { RaiseException<std::range_error>(msg); }
 
-[[noreturn]] void RaiseRangeError(std::string const& msg) {
+void RaiseRangeError(std::string const& msg) {
   RaiseException<std::range_error>(msg.c_str());
 }
 
-[[noreturn]] void RaiseRuntimeError(char const* msg) {
+void RaiseRuntimeError(char const* msg) {
   RaiseException<std::runtime_error>(msg);
 }
 
-[[noreturn]] void RaiseRuntimeError(std::string const& msg) {
+void RaiseRuntimeError(std::string const& msg) {
   RaiseException<std::runtime_error>(msg.c_str());
 }
 
-[[noreturn]] void RaiseLogicError(char const* msg) {
-  RaiseException<std::logic_error>(msg);
-}
+void RaiseLogicError(char const* msg) { RaiseException<std::logic_error>(msg); }
 
-[[noreturn]] void RaiseLogicError(std::string const& msg) {
+void RaiseLogicError(std::string const& msg) {
   RaiseException<std::logic_error>(msg.c_str());
 }
 

--- a/google/cloud/internal/throw_delegate_test.cc
+++ b/google/cloud/internal/throw_delegate_test.cc
@@ -20,7 +20,7 @@ using namespace google::cloud::internal;
 namespace {
 std::string const cmsg("testing with std::string const&");
 char const* msg = "testing with char const*";
-}
+}  // namespace
 
 TEST(ThrowDelegateTest, InvalidArgument) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS

--- a/storage/client/bucket_metadata_test.cc
+++ b/storage/client/bucket_metadata_test.cc
@@ -46,14 +46,12 @@ TEST(BucketMetadataTest, Parse) {
             actual.storage_class());
   // Use `date -u +%s --date='2018-05-19T19:31:14Z'` to get the magic number:
   using std::chrono::duration_cast;
-  EXPECT_EQ(1526758274L,
-            duration_cast<std::chrono::seconds>(
-                actual.time_created().time_since_epoch())
-                .count());
-  EXPECT_EQ(1526758284L,
-            duration_cast<std::chrono::seconds>(
-                actual.time_updated().time_since_epoch())
-                .count());
+  EXPECT_EQ(1526758274L, duration_cast<std::chrono::seconds>(
+                             actual.time_created().time_since_epoch())
+                             .count());
+  EXPECT_EQ(1526758284L, duration_cast<std::chrono::seconds>(
+                             actual.time_updated().time_since_epoch())
+                             .count());
 }
 
 /// @test Verify that we parse JSON objects into BucketMetadata objects.

--- a/storage/client/internal/curl_request.cc
+++ b/storage/client/internal/curl_request.cc
@@ -97,4 +97,4 @@ HttpResponse CurlRequest::MakeRequest() {
 
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
-}  // storage
+}  // namespace storage

--- a/storage/client/internal/curl_wrappers.cc
+++ b/storage/client/internal/curl_wrappers.cc
@@ -78,4 +78,4 @@ void CurlHeaders::Append(char* data, std::size_t size) {
 }
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
-}  // storage
+}  // namespace storage

--- a/storage/tests/curl_request_integration_test.cc
+++ b/storage/tests/curl_request_integration_test.cc
@@ -77,7 +77,9 @@ TEST(CurlRequestTest, SimplePOST) {
   // TODO(#542) - use a local server to make tests more hermetic.
   storage::internal::CurlRequest request("https://nghttp2.org/httpbin/post");
   std::vector<std::pair<std::string, std::string>> form_parameters = {
-      {"foo", "foo1&foo2 foo3"}, {"bar", "bar1-bar2"}, {"baz", "baz=baz2"},
+      {"foo", "foo1&foo2 foo3"},
+      {"bar", "bar1-bar2"},
+      {"baz", "baz=baz2"},
   };
   std::string data;
   char const* sep = "";


### PR DESCRIPTION
Moving the clang-format build to ubuntu:18.04 allows us to merge
he clang-tidy and clang-format builds, saving a build for more
useful stuff.  Part of the fixes for #19.

If you are curious, the newer clang-format enforces the comments
when closing a namespace (`}  // namespace foo`), highlighted
that we were using `[[noreturn]]` attributes on a function
definition (where they have no effect), and has very different
opinions about formatting complex lambdas.

As usual I do not care about what clang-format produces, just
happy it is close enough to what a human would type, and we can
reproducibly run it.