### PR TITLE
Run Docker builds with the user id.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,6 @@ matrix:
       compiler: clang
       env:
         TEST_INSTALL=yes
-        CMAKE_FLAGS=-DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=package
         DISTRO=ubuntu-with-dependencies
         DISTRO_VERSION=17.10
       install:

--- a/ci/build-docker.sh
+++ b/ci/build-docker.sh
@@ -35,8 +35,19 @@ if [ "${SCAN_BUILD}" = "yes" ]; then
   CMAKE_COMMAND="scan-build cmake"
 fi
 
+# Tweak configuration for TEST_INSTALL=yes builds.
+cmake_install_flags=""
+if [ "${TEST_INSTALL}" = "yes" ]; then
+  cmake_install_flags=-DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=package
+fi
+
 echo "travis_fold:start:configure-cmake"
-${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" ${CMAKE_FLAGS:-} -H. -B"${BUILD_DIR}"
+${CMAKE_COMMAND} \
+    -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+    ${cmake_install_flags} \
+    ${CMAKE_FLAGS:-} \
+    -H. \
+    -B"${BUILD_DIR}"
 echo "travis_fold:end:configure-cmake"
 
 # If scan-build is enabled, we need to manually compile the dependencies;
@@ -83,7 +94,7 @@ if [ "${TEST_INSTALL}" = "yes" ]; then
   echo
   echo "${COLOR_YELLOW}Test installed libraries using make(1).${COLOR_RESET}"
   mkdir -p "${TEST_INSTALL_MAKE_OUTPUT_DIR}"
-  make -C "${TEST_INSTALL_CMAKE_OUTPUT_DIR}" -f"${TEST_INSTALL_DIR}/Makefile" VPATH="${TEST_INSTALL_DIR}"
+  make -C "${TEST_INSTALL_MAKE_OUTPUT_DIR}" -f"${TEST_INSTALL_DIR}/Makefile" VPATH="${TEST_INSTALL_DIR}"
 fi
 
 # If document generation is enabled, run it now.

--- a/ci/build-docker.sh
+++ b/ci/build-docker.sh
@@ -37,7 +37,7 @@ fi
 
 # Tweak configuration for TEST_INSTALL=yes builds.
 cmake_install_flags=""
-if [ "${TEST_INSTALL}" = "yes" ]; then
+if [ "${TEST_INSTALL:-}" = "yes" ]; then
   cmake_install_flags=-DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=package
 fi
 
@@ -80,7 +80,7 @@ for subdir in bigtable storage; do
 done
 
 # Test the install rule and that the installation works.
-if [ "${TEST_INSTALL}" = "yes" ]; then
+if [ "${TEST_INSTALL:-}" = "yes" ]; then
   echo
   echo "${COLOR_YELLOW}Testing install rule.${COLOR_RESET}"
   cmake --build . --target install

--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -32,7 +32,7 @@ fi
 # creating root-owned files in the build directory.
 docker_uid=0
 if [ "${TEST_INSTALL:-}" != "yes" ]; then
-  docker_uid=${UID:-0}
+  docker_uid="${UID:-0}"
 fi
 
 sudo docker run \

--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -28,7 +28,16 @@ else
   build_script="/v/ci/build-docker.sh";
 fi
 
-sudo docker run --cap-add SYS_PTRACE -it \
+# TEST_INSTALL=yes builds work better as root, but other builds should avoid
+# creating root-owned files in the build directory.
+docker_uid=0
+if [ "${TEST_INSTALL:-}" != "yes" ]; then
+  docker_uid=${UID:-0}
+fi
+
+sudo docker run \
+     --cap-add SYS_PTRACE \
+     -it \
      --env DISTRO="${DISTRO}" \
      --env DISTRO_VERSION="${DISTRO_VERSION}" \
      --env CXX="${CXX}" \
@@ -42,5 +51,9 @@ sudo docker run --cap-add SYS_PTRACE -it \
      --env CMAKE_FLAGS="${CMAKE_FLAGS:-}" \
      --env CBT=/usr/local/google-cloud-sdk/bin/cbt \
      --env CBT_EMULATOR=/usr/local/google-cloud-sdk/platform/bigtable-emulator/cbtemulator \
-     --env TERM=${TERM:-dumb} \
-     --volume $PWD:/v --workdir /v "${IMAGE}:tip" ${build_script}
+     --env TERM="${TERM:-dumb}" \
+     --user "${docker_uid}" \
+     --volume "${PWD}":/v \
+     --workdir /v \
+     "${IMAGE}:tip" \
+     ${build_script}


### PR DESCRIPTION
By default Docker containers run as root.  Our build scripts
execute inside the container, but mount the user's workspace to
read the code and to output build artifacts (both `.o` files and
final outputs). That is annoying because any files need to be
removed with `sudo`.  With this change the docker script uses the
user's uid for most builds.

The only exception are the TEST_INSTALL=yes builds, where it is
useful to run as a user with permissions to write in `/usr/local/`.
Note that this is the `/usr/local` directories inside the Docker
image, so none of these changes leak to the user's workstation.