### PR TITLE
Introduce basic logging

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -67,6 +67,8 @@ add_library(google_cloud_cpp_common
     internal/setenv.cc
     internal/throw_delegate.h
     internal/throw_delegate.cc
+    log.h
+    log.cc
     version.h)
 target_link_libraries(google_cloud_cpp_common PUBLIC Threads::Threads
     PRIVATE google_cloud_cpp_common_options)
@@ -82,7 +84,8 @@ create_bazel_config(google_cloud_cpp_common)
 google_cloud_cpp_add_clang_tidy(google_cloud_cpp_common)
 
 set(google_cloud_cpp_common_unit_tests
-    internal/throw_delegate_test.cc)
+    internal/throw_delegate_test.cc
+    log_test.cc)
 
 # Export the list of unit tests so the Bazel BUILD file can pick it up.
 export_list_to_bazel("google_cloud_cpp_common_unit_tests.bzl"

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -4,11 +4,13 @@ google_cloud_cpp_common_HDRS = [
     "internal/port_platform.h",
     "internal/setenv.h",
     "internal/throw_delegate.h",
+    "log.h",
     "version.h",
 ]
 
 google_cloud_cpp_common_SRCS = [
     "internal/setenv.cc",
     "internal/throw_delegate.cc",
+    "log.cc",
 ]
 

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -1,5 +1,6 @@
 # DO NOT EDIT -- GENERATED CODE
 google_cloud_cpp_common_unit_tests = [
     "internal/throw_delegate_test.cc",
+    "log_test.cc",
 ]
 

--- a/google/cloud/log.cc
+++ b/google/cloud/log.cc
@@ -101,7 +101,7 @@ class StdClogBackend : public LogBackend {
  public:
   StdClogBackend() = default;
 
-  void Process(LogRecord const &lr) override {
+  void Process(LogRecord const& lr) override {
     std::clog << lr << "\n";
     if (lr.severity >= Severity::WARNING) {
       std::clog << std::flush;
@@ -111,7 +111,6 @@ class StdClogBackend : public LogBackend {
 };
 }  // namespace
 
-/// Enable `std::clog` on the default LogSink.
 long LogSink::EnableStdClog() {
   return Instance().AddBackend(std::make_shared<StdClogBackend>());
 }

--- a/google/cloud/log.cc
+++ b/google/cloud/log.cc
@@ -96,6 +96,26 @@ void LogSink::Log(LogRecord log_record) {
   }
 }
 
+namespace {
+class StdClogBackend : public LogBackend {
+ public:
+  StdClogBackend() = default;
+
+  void Process(LogRecord const &lr) override {
+    std::clog << lr << "\n";
+    if (lr.severity >= Severity::WARNING) {
+      std::clog << std::flush;
+    }
+  }
+  void ProcessWithOwnership(LogRecord lr) override { Process(lr); }
+};
+}  // namespace
+
+/// Enable `std::clog` on the default LogSink.
+long LogSink::EnableStdClog() {
+  return Instance().AddBackend(std::make_shared<StdClogBackend>());
+}
+
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/log.cc
+++ b/google/cloud/log.cc
@@ -1,0 +1,30 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/log.h"
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+std::ostream& operator<<(std::ostream& os, Severity x) {
+  char const* names[] = {
+      "TRACE", "DEBUG",    "INFO",  "NOTICE", "WARNING",
+      "ERROR", "CRITICAL", "ALERT", "FATAL",
+  };
+  auto index = static_cast<int>(x);
+  return os << names[index];
+}
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/log.h
+++ b/google/cloud/log.h
@@ -27,7 +27,7 @@
  *   instructed, the libraries produce no output to the console.
  * - Logging should have very low cost:
  *   - It should be possible to disable logs at compile time, they should
- *     disappear as-if there were `#ifdef/#endif` directives around them.
+ *     disappear as-if there were `#%ifdef`/`#%endif` directives around them.
  *   - A log line at a disabled log level should be about as expensive as an
  *     extra if() statement. At the very least it should not incur additional
  *     memory allocations or locks.

--- a/google/cloud/log.h
+++ b/google/cloud/log.h
@@ -378,6 +378,7 @@ class Logger {
 template <>
 class Logger<false> {
  public:
+  Logger<false>() = default;
   Logger<false>(Severity, char const*, char const*, int, LogSink&) {}
 
   //@{

--- a/google/cloud/log.h
+++ b/google/cloud/log.h
@@ -93,7 +93,7 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 #define GOOGLE_CLOUD_CPP_PP_CONCAT(a, b) a##b
 
 /**
- * Create a unique, or mostly-likely unique identifier.
+ * Create a unique, or most likely unique identifier.
  *
  * In GCP_LOG() we need an identifier for the logger, we can easily create a C++
  * scope to make it work with any name, say "foo".  However the user may have a
@@ -323,7 +323,7 @@ struct NullStream {
  *
  * @tparam compile_time_enabled this represents whether the severity has been
  *   disabled at compile-time. The class is specialized for `false` to minimize
- *   the run-time impact of (and in practice completely elide) disabled logs.
+ *   the run-time impact of (and, in practice, completely elide) disabled logs.
  */
 template <bool compile_time_enabled>
 class Logger {

--- a/google/cloud/log.h
+++ b/google/cloud/log.h
@@ -131,14 +131,14 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
  * is to prevent problems if anybody uses this macro in a context where `Logger`
  * is defined by the enclosing namespaces.
  */
-#define GOOGLE_CLOUD_CPP_LOG_I(level, sink)                                    \
-  for (auto GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER =                               \
-           ::google::cloud::Logger<::google::cloud::Log::CompileTimeEnabled(   \
-               ::google::cloud::Severity::level)>(                             \
-               ::google::cloud::Severity::level, __func__, __FILE__, __LINE__, \
-               sink);                                                          \
-       GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER.enabled();                           \
-       GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER.LogTo(sink))                         \
+#define GOOGLE_CLOUD_CPP_LOG_I(level, sink)                                \
+  for (auto GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER = ::google::cloud::Logger<  \
+           ::google::cloud::LogSink::CompileTimeEnabled(                   \
+               ::google::cloud::Severity::level)>(                         \
+           ::google::cloud::Severity::level, __func__, __FILE__, __LINE__, \
+           sink);                                                          \
+       GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER.enabled();                       \
+       GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER.LogTo(sink))                     \
   GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER.Stream()
 
 /**
@@ -268,7 +268,7 @@ class LogSink {
   void RemoveBackend(long id);
   void ClearBackends();
 
-  void Log(LogRecord const& log_record);
+  void Log(LogRecord log_record);
 
  private:
   std::atomic<bool> empty_;
@@ -328,7 +328,7 @@ class Logger {
     record.lineno = lineno_;
     record.timestamp = std::chrono::system_clock::now();
     record.message = stream_->str();
-    sink.Log(record);
+    sink.Log(std::move(record));
   }
 
   /// Return the iostream that captures the log message.

--- a/google/cloud/log.h
+++ b/google/cloud/log.h
@@ -1,0 +1,263 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_LOG_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_LOG_H_
+/**
+ * @file log.h
+ *
+ * Google Cloud Platform C++ Libraries logging framework.
+ *
+ * Some of the libraries need to log information to simplify troubleshooting.
+ * The functions and macros used for logging are defined in this file. In
+ * general, we abide by the following principles:
+ *
+ * - Logging should controlled by the application developer, unless explicitly
+ *   instructed, the libraries produce no output to the console.
+ * - Logging should have very low cost:
+ *   - It should be possible to disable logs at compile time, they should
+ *     disappear as-if there were `#ifdef/#endif` directives around them.
+ *   - A log line at a disabled log level should be about as expensive as an
+ *     extra if() statement. At the very least it should not incur additional
+ *     memory allocations or locks.
+ * - It should be easy to log complex objects: the logging library should play
+ *   well with the C++ iostream classes.
+ * - The application should be able to intercept log records and re-direct them
+ *   to their own logging framework.
+ *
+ * @par Example: Logging From Library
+ * Use the `GCP_LOG()` macro to log from a Google Cloud Platform C++ library:
+ *
+ * @code
+ * void LibraryCode(ComplexThing const& thing) {
+ *   GCP_LOG(INFO) << "I am here";
+ *   if (thing.is_bad()) {
+ *     GCP_LOG(ERROR) << "Poor thing is bad: " << thing;
+ *   }
+ * }
+ * @endcode
+ *
+ * @par Example: Enable Logs to `std::clog`
+ * To enable logs to `std::clog` the application can call:
+ *
+ * @code
+ * void AppCode() {
+ *   google::cloud::Log::EnableStdClog();
+ * }
+ * @endcode
+ *
+ * Note that while `std::clog` is buffered, the framework will flush any log
+ * message at severity `WARNING` or higher.
+ *
+ * @par Example: Capture Logs
+ * The application can capture logs by providing a functor:
+ *
+ * @code
+ * void AppCode() {
+ *   auto id = google::cloud::Log::CaptureLogs(
+ *       [](google::cloud::LogRecord const& record) {
+ *           if (record.severity >= google::cloud::Severity::CRITICAL) {
+ *             std::cerr << record << std::endl;
+ *           }
+ *       });
+ *   // Use "id" to remove the capture.
+ * }
+ * @endcode
+ */
+
+#include "google/cloud/version.h"
+#include <iostream>
+#include <memory>
+#include <sstream>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+/// Concatenate two pre-processor tokens.
+#define GOOGLE_CLOUD_CPP_PP_CONCAT(a, b) a##b
+
+/**
+ * Create a unique, or mostly-likely unique identifier.
+ *
+ * In GCP_LOG() we need an identifier for the logger, we can easily create a C++
+ * scope to make it work with any name, say "foo".  However the user may have a
+ * variable called "foo" that they want to use in the scope (for example, to log
+ * the value of "foo".  We try to make it unlikely that there will be collision
+ * by using an identifier that has a long prefix and depends on the line number.
+ */
+#define GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER \
+  GOOGLE_CLOUD_CPP_PP_CONCAT(google_cloud_cpp_log_, __LINE__)
+
+/**
+ * The main entry point for the Google Cloud Platform C++ Library loggers.
+ *
+ * Typically this used only in tests, applications should use GCP_LOG(). This
+ * macro introduces a new scope (via the for-loop) with a single new identifier:
+ *   GOOGLE_CLOUD_CPP_LOG_RECORD_IDENTIFIER
+ * We use a for-loop (as opposed to an if-statement, or a do-while), because
+ * then we can say:
+ *
+ * @code
+ * GCP_LOG(WARNING) << a << b << c;
+ * @endcode
+ *
+ * and the variables are scoped correctly. The for-loop also affords us an
+ * opportunity to check that the log level is enabled before entering the body
+ * of the loop, and if disabled we can minimize the cost of the log. For
+ * example, disable logs do not create an iostream at all.  Finally, the type
+ * of the GOOGLE_CLOUD_CPP_LOG_RECORD_IDENTIFIER changes if the log level is
+ * disabled at compile-time. For compile-time disabled log levels the compiler
+ * should be able to determine that the loop will not execute at all, and
+ * completely eliminate it.
+ */
+#define GOOGLE_CLOUD_CPP_LOG_I(level, sink)                                    \
+  for (auto GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER =                           \
+           ::google::cloud::LogRecord<                                         \
+               ::google::cloud::Log::CompileTimeEnabled(                       \
+                   ::google::cloud::Severity::level)>(                         \
+               ::google::cloud::Severity::level, __func__, __FILE__, __LINE__, \
+               sink);                                                          \
+       GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER.Enabled();                       \
+       GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER.Dump(sink))                      \
+  GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER.Stream()
+
+/**
+ * Log a message with the Google Cloud Platform C++ Libraries logging framework.
+ *
+ *
+ */
+#define GCP_LOG(level) NullStream()
+
+#ifndef GOOGLE_CLOUD_CPP_LOGGING_MIN_SEVERITY_ENABLED
+#define GOOGLE_CLOUD_CPP_LOGGING_MIN_SEVERITY_ENABLED NOTICE
+#endif  // GOOGLE_CLOUD_CPP_LOGGING_MIN_SEVERITY_ENABLED
+
+/**
+ * Define the severity levels for Gee-H logging.
+ *
+ * These are modelled after the severity level in syslog(1) and many derived
+ * tools.
+ */
+enum class Severity {
+  /// Use this level for messages that indicate the code is entering and leaving
+  /// functions.
+  TRACE,
+  /// Use this level for debug messages that should not be present in
+  /// production.
+  DEBUG,
+  /// Informational messages, such as normal progress.
+  INFO,
+  /// Informational messages, such as unusual, but expected conditions.
+  NOTICE,
+  /// An indication of problems, users may need to take action.
+  WARNING,
+  /// An error has been detected.  Do not use for normal conditions, such as
+  /// remote servers disconnecting.
+  ERROR,
+  /// The system is in a critical state, such as running out of local resources.
+  CRITICAL,
+  /// The system is at risk of immediate failure.
+  ALERT,
+  /// The system is about to crash or terminate.
+  FATAL,
+  /// The highest possible severity level.
+  HIGHEST = int(FATAL),
+  /// The lowest possible severity level.
+  LOWEST = int(TRACE),
+  /// The lowest level that is enabled at compile-time.
+  LOWEST_ENABLED = int(GOOGLE_CLOUD_CPP_LOGGING_MIN_SEVERITY_ENABLED),
+};
+
+/// Streaming operator, writes a human readable representation.
+std::ostream& operator<<(std::ostream& os, Severity x);
+
+class Log {
+ public:
+  Log() : minimum_severity_(Severity::LOWEST_ENABLED) {}
+
+  bool has_sinks() { return false; }
+  void set_minimum_severity(Severity minimum) { minimum_severity_ = minimum; }
+  Severity minimum_severity() const { return minimum_severity_; }
+
+  constexpr static bool CompileTimeEnabled(Severity level) {
+    return level >= Severity::LOWEST_ENABLED;
+  }
+
+ private:
+  Severity minimum_severity_;
+};
+
+/**
+ * Implements operator<< for all types, without any effect.
+ *
+ * It is desirable to disable at compile-time tracing, debugging, and other low
+ * severity messages.  The Google Cloud Platform C++ Libraries logging adaptors
+ * return an object of this class when the particular log-line is disabled at
+ * compile-time.
+ */
+struct NullStream {
+  /// Generic do-nothing streaming operator
+  template <typename T>
+  NullStream& operator<<(T) {
+    return *this;
+  }
+};
+
+/**
+ * Define the class to capture a log message.
+ */
+template <bool enabled>
+class Logger {
+ public:
+  Logger(Severity severity, char const* function, char const* filename, int lineno, Log& sink)
+  : severity_(severity), function_(function), filename_(filename), lineno_(lineno) {
+    enabled_ = true;
+  }
+
+  bool Enabled() const { return enabled_; }
+  void Dump(Log&) {}
+  std::ostream& Stream() {
+    if (not stream_) {
+      stream_.reset(new std::ostringstream);
+    }
+    return *stream_;
+  }
+
+ private:
+  Severity severity_;
+  char const* function_;
+  char const* filename_;
+  int lineno_;
+  bool enabled_;
+  std::unique_ptr<std::ostringstream> stream_;
+};
+
+/**
+ * Define the logger for a disabled log level.
+ */
+template <>
+class Logger<false> {
+ public:
+  Logger<false>(Severity, char const*, char const*, int, Log&) {}
+
+  constexpr bool Enabled() const { return false; }
+  void Dump(Log&) {}
+  NullStream Stream() { return NullStream(); }
+};
+
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_LOG_H_

--- a/google/cloud/log.h
+++ b/google/cloud/log.h
@@ -153,12 +153,16 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 #endif  // GOOGLE_CLOUD_CPP_LOGGING_MIN_SEVERITY_ENABLED
 
 /**
- * Define the severity levels for Gee-H logging.
+ * Define the severity levels for Google Cloud Platform C++ Libraries logging.
  *
  * These are modelled after the severity level in syslog(1) and many derived
  * tools.
+ *
+ * We force the enum to be represented as an `int` because we will store the
+ * values in an `std::atomic<>` and the implementations usually optimize
+ * `std::atomic<int>` but not `std::atomic<Foo>`
  */
-enum class Severity {
+enum class Severity : int {
   /// Use this level for messages that indicate the code is entering and leaving
   /// functions.
   TRACE,
@@ -203,6 +207,9 @@ struct LogRecord {
   std::string message;
 };
 
+/// Default formatting of a LogRecord.
+std::ostream& operator<<(std::ostream& os, LogRecord const& rhs);
+
 /**
  * A sink to receive log records.
  */
@@ -211,6 +218,7 @@ class LogBackend {
   virtual ~LogBackend() = default;
 
   virtual void Process(LogRecord const& log_record) = 0;
+  virtual void ProcessWithOwnership(LogRecord log_record) = 0;
 };
 
 /**

--- a/google/cloud/log_test.cc
+++ b/google/cloud/log_test.cc
@@ -95,6 +95,27 @@ TEST(LogSinkTest, LogEnabledMultipleBackends) {
   GOOGLE_CLOUD_CPP_LOG_I(WARNING, sink) << "test message";
 }
 
+TEST(LogSinkTest, LogDefaultInstance) {
+  auto backend = std::make_shared<MockLogBackend>();
+  EXPECT_CALL(*backend, ProcessWithOwnership(_))
+      .WillOnce(Invoke([](LogRecord lr) {
+        EXPECT_EQ(Severity::WARNING, lr.severity);
+        EXPECT_EQ("test message", lr.message);
+      }));
+  LogSink::Instance().AddBackend(backend);
+
+  GCP_LOG(WARNING) << "test message";
+  LogSink::Instance().ClearBackends();
+}
+
+TEST(LogSinkTest, LogToClog) {
+  LogSink::EnableStdClog();
+  EXPECT_FALSE(LogSink::Instance().empty());
+  LogSink::Instance().set_minimum_severity(Severity::NOTICE);
+  GCP_LOG(NOTICE) << "test message";
+  LogSink::Instance().ClearBackends();
+}
+
 namespace {
 /// A class to count calls to IOStream operator.
 struct IOStreamCounter {

--- a/google/cloud/log_test.cc
+++ b/google/cloud/log_test.cc
@@ -1,0 +1,31 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/log.h"
+#include <gtest/gtest.h>
+
+using namespace google::cloud;
+
+TEST(LogTest, Streaming) {
+  std::ostringstream os;
+  os << Severity::TRACE;
+  EXPECT_EQ("TRACE", os.str());
+}
+
+TEST(LogTest, CompileTimeEnabled) {
+  EXPECT_TRUE(Log::CompileTimeEnabled(Severity::CRITICAL));
+  if (Severity::LOWEST_ENABLED >= Severity::TRACE) {
+    EXPECT_FALSE(Log::CompileTimeEnabled(Severity::TRACE));
+  }
+}


### PR DESCRIPTION
Sorry, this got a little too big.  In any case, here is a min-library / mini-framework for logging.
@houglum and @coryan discussed that this would be needed in the Google Cloud Storage client.

The library is pretty easy to use (there is documentation and examples);

```C++
LOG(INFO) << "Some informational message: a=" << a << " b=" << b;
```

For log levels that are disabled at compile-time (`TRACE`, `DEBUG`) the compiler emits no code, and for log levels disabled at run-time (by default, all of them), this converts to a couple of loads and an if statement.  The expression is only evaluated if the log is enabled.

