### PR TITLE
Fix retry loop to build Docker images.

### DIFF
--- a/ci/install-linux.sh
+++ b/ci/install-linux.sh
@@ -33,6 +33,8 @@ readonly IMAGE="cached-${DISTRO}-${DISTRO_VERSION}"
 # budget to complete a build, and we should be as nice as possible to the
 # servers that provide the packages.
 min_wait=180
+# Do not exit on failures for this loop.
+set +e
 for i in 1 2 3; do
   sudo docker build -t "${IMAGE}:tip" \
        --build-arg NCPU="${NCPU:-2}" \


### PR DESCRIPTION
The loop was useless because `set -e` was active, the first
failure exited the script, when we wanted to try a few times.

Yesterday we had a lot of broken builds because the downloads
would fail, this should fix that.
