### PR TITLE
Use cache for Bazel builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,5 +153,17 @@ after_success:
 after_failure:
   - ci/dump-logs.sh
 
+cache:
+  directories:
+    # Cache the Bazel directories, in builds that do not use Bazel this is
+    # empty and trivial to cache.
+    - $HOME/.cache/bazel
+  timeout: 900
+
+before_cache:
+  # Do not save the Bazel installation, reinstall each time, it fails to install
+  # if the installation is in the cache.
+  - rm -fr ${HOME}/.cache/bazel/_bazel_${USER}/install
+
 notifications:
   email: false


### PR DESCRIPTION
Cache the build directories for Bazel.  This improves the build times for
Bazel from 15-20min to 4-6min:

Before:
https://travis-ci.org/coryan/google-cloud-cpp/builds/385692690

After:
https://travis-ci.org/coryan/google-cloud-cpp/builds/385738171

While we only have two builds using Bazel right now, we plan to have
more, and this frees up bandwidth for the other builds anyway.

I am going to say that #19 motivated this change.
