### PR TITLE
Preserve error messages in grpc::Status.

### DIFF
--- a/bigtable/client/internal/instance_admin_test.cc
+++ b/bigtable/client/internal/instance_admin_test.cc
@@ -138,10 +138,9 @@ struct MockRpcFactory {
 
 }  // anonymous namespace
 
-/// @test Verify basic functionality in the `bigtable::InstanceAdmin` class.
-
 using namespace ::testing;
 
+/// @test Verify basic functionality in the `bigtable::InstanceAdmin` class.
 TEST_F(InstanceAdminTest, Default) {
   bigtable::noex::InstanceAdmin tested(client_);
   EXPECT_EQ("the-project", tested.project_id());

--- a/bigtable/client/internal/instance_admin_test.cc
+++ b/bigtable/client/internal/instance_admin_test.cc
@@ -259,6 +259,7 @@ TEST_F(InstanceAdminTest, ListInstancesUnrecoverableFailures) {
   grpc::Status status;
   tested.ListInstances(status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
 }
 
 /// @test Verify that `bigtable::InstanceAdmin::GetInstance` works in the simple
@@ -314,6 +315,7 @@ TEST_F(InstanceAdminTest, GetInstanceUnrecoverableFailures) {
   std::string instance_id = "t0";
   auto actual = tested.GetInstance(instance_id, status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
 }
 
 /// @test Verify positive scenario for DeleteInstance
@@ -344,6 +346,7 @@ TEST_F(InstanceAdminTest, DeleteInstanceUnrecoverableError) {
   grpc::Status status;
   tested.DeleteInstance("the-instance", status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
 }
 
 /// @test Verify recoverable errors for DeleteInstance
@@ -356,6 +359,7 @@ TEST_F(InstanceAdminTest, DeleteInstanceRecoverableError) {
   grpc::Status status;
   tested.DeleteInstance("the-instance", status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
 }
 
 /// @test Verify that `bigtable::InstanceAdmin::ListClusters` works in the easy
@@ -432,6 +436,7 @@ TEST_F(InstanceAdminTest, ListClustersUnrecoverableFailures) {
   grpc::Status status;
   tested.ListClusters("the-instance", status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
 }
 
 /// @test Verify positive scenario for DeleteCluster
@@ -466,6 +471,7 @@ TEST_F(InstanceAdminTest, DeleteClusterUnrecoverableError) {
   // After all the setup, make the actual call we want to test.
   tested.DeleteCluster(instance_id, cluster_id, status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
 }
 
 /// @test Verify recoverable errors for DeleteCluster
@@ -480,4 +486,5 @@ TEST_F(InstanceAdminTest, DeleteClusterRecoverableError) {
   // After all the setup, make the actual call we want to test.
   tested.DeleteCluster(instance_id, cluster_id, status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
 }

--- a/bigtable/client/internal/instance_admin_test.cc
+++ b/bigtable/client/internal/instance_admin_test.cc
@@ -139,9 +139,10 @@ struct MockRpcFactory {
 }  // anonymous namespace
 
 /// @test Verify basic functionality in the `bigtable::InstanceAdmin` class.
-TEST_F(InstanceAdminTest, Default) {
-  using namespace ::testing;
 
+using namespace ::testing;
+
+TEST_F(InstanceAdminTest, Default) {
   bigtable::noex::InstanceAdmin tested(client_);
   EXPECT_EQ("the-project", tested.project_id());
 }
@@ -193,8 +194,6 @@ TEST_F(InstanceAdminTest, MoveAssignment) {
 /// @test Verify that `bigtable::InstanceAdmin::ListInstances` works in the easy
 /// case.
 TEST_F(InstanceAdminTest, ListInstances) {
-  using namespace ::testing;
-
   bigtable::noex::InstanceAdmin tested(client_);
   auto mock_list_instances = create_list_instances_lambda("", "", {"t0", "t1"});
   EXPECT_CALL(*client_, ListInstances(_, _, _))
@@ -212,8 +211,6 @@ TEST_F(InstanceAdminTest, ListInstances) {
 
 /// @test Verify that `bigtable::InstanceAdmin::ListInstances` handles failures.
 TEST_F(InstanceAdminTest, ListInstancesRecoverableFailures) {
-  using namespace ::testing;
-
   bigtable::noex::InstanceAdmin tested(client_);
   auto mock_recoverable_failure =
       [](grpc::ClientContext* ctx, btproto::ListInstancesRequest const& request,
@@ -246,8 +243,6 @@ TEST_F(InstanceAdminTest, ListInstancesRecoverableFailures) {
  * unrecoverable failures.
  */
 TEST_F(InstanceAdminTest, ListInstancesUnrecoverableFailures) {
-  using namespace ::testing;
-
   bigtable::noex::InstanceAdmin tested(client_);
   EXPECT_CALL(*client_, ListInstances(_, _, _))
       .WillOnce(
@@ -259,14 +254,12 @@ TEST_F(InstanceAdminTest, ListInstancesUnrecoverableFailures) {
   grpc::Status status;
   tested.ListInstances(status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
+  EXPECT_THAT(status.error_message(), HasSubstr("uh oh"));
 }
 
 /// @test Verify that `bigtable::InstanceAdmin::GetInstance` works in the simple
 /// case.
 TEST_F(InstanceAdminTest, GetInstance) {
-  using namespace ::testing;
-
   bigtable::noex::InstanceAdmin tested(client_);
   auto mock_instances = create_instance("", "");
   EXPECT_CALL(*client_, GetInstance(_, _, _)).WillOnce(Invoke(mock_instances));
@@ -281,7 +274,6 @@ TEST_F(InstanceAdminTest, GetInstance) {
 
 /// @test Verify recoverable errors for GetInstance
 TEST_F(InstanceAdminTest, GetInstanceRecoverableFailures) {
-  using namespace ::testing;
   bigtable::noex::InstanceAdmin tested(client_);
   auto mock_recoverable_failure = [](grpc::ClientContext* ctx,
                                      btproto::GetInstanceRequest const& request,
@@ -304,7 +296,6 @@ TEST_F(InstanceAdminTest, GetInstanceRecoverableFailures) {
 
 /// @test Verify unrecoverable error for GetInstance
 TEST_F(InstanceAdminTest, GetInstanceUnrecoverableFailures) {
-  using namespace ::testing;
   bigtable::noex::InstanceAdmin tested(client_);
   EXPECT_CALL(*client_, GetInstance(_, _, _))
       .WillOnce(
@@ -315,12 +306,11 @@ TEST_F(InstanceAdminTest, GetInstanceUnrecoverableFailures) {
   std::string instance_id = "t0";
   auto actual = tested.GetInstance(instance_id, status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
+  EXPECT_THAT(status.error_message(), HasSubstr("uh oh"));
 }
 
 /// @test Verify positive scenario for DeleteInstance
 TEST_F(InstanceAdminTest, DeleteInstance) {
-  using namespace ::testing;
   using google::protobuf::Empty;
   bigtable::noex::InstanceAdmin tested(client_);
   std::string expected_text = R"""(
@@ -337,7 +327,6 @@ TEST_F(InstanceAdminTest, DeleteInstance) {
 
 /// @test Verify unrecoverable error for DeleteInstance
 TEST_F(InstanceAdminTest, DeleteInstanceUnrecoverableError) {
-  using namespace ::testing;
   bigtable::noex::InstanceAdmin tested(client_);
   EXPECT_CALL(*client_, DeleteInstance(_, _, _))
       .WillOnce(
@@ -346,12 +335,11 @@ TEST_F(InstanceAdminTest, DeleteInstanceUnrecoverableError) {
   grpc::Status status;
   tested.DeleteInstance("the-instance", status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
+  EXPECT_THAT(status.error_message(), HasSubstr("uh oh"));
 }
 
 /// @test Verify recoverable errors for DeleteInstance
 TEST_F(InstanceAdminTest, DeleteInstanceRecoverableError) {
-  using namespace ::testing;
   bigtable::noex::InstanceAdmin tested(client_);
   EXPECT_CALL(*client_, DeleteInstance(_, _, _))
       .WillOnce(Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "uh oh")));
@@ -359,14 +347,12 @@ TEST_F(InstanceAdminTest, DeleteInstanceRecoverableError) {
   grpc::Status status;
   tested.DeleteInstance("the-instance", status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
+  EXPECT_THAT(status.error_message(), HasSubstr("uh oh"));
 }
 
 /// @test Verify that `bigtable::InstanceAdmin::ListClusters` works in the easy
 /// case.
 TEST_F(InstanceAdminTest, ListClusters) {
-  using namespace ::testing;
-
   bigtable::noex::InstanceAdmin tested(client_);
   std::string const& instance_id = "the-instance";
   auto mock_list_clusters =
@@ -386,7 +372,6 @@ TEST_F(InstanceAdminTest, ListClusters) {
 
 /// @test Verify that `bigtable::InstanceAdmin::ListClusters` handles failures.
 TEST_F(InstanceAdminTest, ListClustersRecoverableFailures) {
-  using namespace ::testing;
   auto const instance_id = "the-instance";
 
   bigtable::noex::InstanceAdmin tested(client_);
@@ -423,8 +408,6 @@ TEST_F(InstanceAdminTest, ListClustersRecoverableFailures) {
  * unrecoverable failures.
  */
 TEST_F(InstanceAdminTest, ListClustersUnrecoverableFailures) {
-  using namespace ::testing;
-
   bigtable::noex::InstanceAdmin tested(client_);
   EXPECT_CALL(*client_, ListClusters(_, _, _))
       .WillOnce(
@@ -436,12 +419,11 @@ TEST_F(InstanceAdminTest, ListClustersUnrecoverableFailures) {
   grpc::Status status;
   tested.ListClusters("the-instance", status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
+  EXPECT_THAT(status.error_message(), HasSubstr("uh oh"));
 }
 
 /// @test Verify positive scenario for DeleteCluster
 TEST_F(InstanceAdminTest, DeleteCluster) {
-  using namespace ::testing;
   using google::protobuf::Empty;
   bigtable::noex::InstanceAdmin tested(client_);
   std::string expected_text = R"""(
@@ -460,7 +442,6 @@ TEST_F(InstanceAdminTest, DeleteCluster) {
 
 /// @test Verify unrecoverable error for DeleteCluster
 TEST_F(InstanceAdminTest, DeleteClusterUnrecoverableError) {
-  using namespace ::testing;
   bigtable::noex::InstanceAdmin tested(client_);
   EXPECT_CALL(*client_, DeleteCluster(_, _, _))
       .WillOnce(
@@ -471,12 +452,11 @@ TEST_F(InstanceAdminTest, DeleteClusterUnrecoverableError) {
   // After all the setup, make the actual call we want to test.
   tested.DeleteCluster(instance_id, cluster_id, status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
+  EXPECT_THAT(status.error_message(), HasSubstr("uh oh"));
 }
 
 /// @test Verify recoverable errors for DeleteCluster
 TEST_F(InstanceAdminTest, DeleteClusterRecoverableError) {
-  using namespace ::testing;
   bigtable::noex::InstanceAdmin tested(client_);
   EXPECT_CALL(*client_, DeleteCluster(_, _, _))
       .WillOnce(Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "uh oh")));
@@ -486,5 +466,5 @@ TEST_F(InstanceAdminTest, DeleteClusterRecoverableError) {
   // After all the setup, make the actual call we want to test.
   tested.DeleteCluster(instance_id, cluster_id, status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
+  EXPECT_THAT(status.error_message(), HasSubstr("uh oh"));
 }

--- a/bigtable/client/internal/table_admin_test.cc
+++ b/bigtable/client/internal/table_admin_test.cc
@@ -206,7 +206,7 @@ TEST_F(TableAdminTest, ListTablesUnrecoverableFailures) {
   grpc::Status status;
   tested.ListTables(btproto::Table::FULL, status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
+  EXPECT_THAT(status.error_message(), HasSubstr("uh oh"));
 }
 
 /**
@@ -232,7 +232,7 @@ TEST_F(TableAdminTest, ListTablesTooManyFailures) {
   // After all the setup, make the actual call we want to test.
   tested.ListTables(btproto::Table::FULL, status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("try-again"));
+  EXPECT_THAT(status.error_message(), HasSubstr("try-again"));
 }
 
 /// @test Verify that `bigtable::TableAdmin::Create` works in the easy case.
@@ -291,7 +291,7 @@ TEST_F(TableAdminTest, CreateTableFailure) {
   // After all the setup, make the actual call we want to test.
   tested.CreateTable("other-table", bigtable::TableConfig(), status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
+  EXPECT_THAT(status.error_message(), HasSubstr("uh oh"));
 }
 
 /**
@@ -336,7 +336,7 @@ TEST_F(TableAdminTest, CopyConstructibleAssignablePolicyTest) {
   // After all the setup, make the actual call we want to test.
   table_admin.GetTable("other-table", status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("try-again"));
+  EXPECT_THAT(status.error_message(), HasSubstr("try-again"));
 
   bigtable::noex::TableAdmin table_admin_assign(client_, "the-assign-instance");
   table_admin_assign = tested;
@@ -348,7 +348,7 @@ TEST_F(TableAdminTest, CopyConstructibleAssignablePolicyTest) {
   // After all the setup, make the actual call we want to test.
   table_admin_assign.GetTable("other-table", status_assign);
   EXPECT_FALSE(status_assign.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("try-again"));
+  EXPECT_THAT(status.error_message(), HasSubstr("try-again"));
 }
 
 /// @test Verify that `bigtable::TableAdmin::GetTable` works in the easy case.
@@ -390,7 +390,7 @@ TEST_F(TableAdminTest, GetTableUnrecoverableFailures) {
   // After all the setup, make the actual call we want to test.
   tested.GetTable("other-table", status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
+  EXPECT_THAT(status.error_message(), HasSubstr("uh oh"));
 }
 
 /**
@@ -412,7 +412,7 @@ TEST_F(TableAdminTest, GetTableTooManyFailures) {
   // After all the setup, make the actual call we want to test.
   tested.GetTable("other-table", status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("try-again"));
+  EXPECT_THAT(status.error_message(), HasSubstr("try-again"));
 }
 
 /// @test Verify that bigtable::TableAdmin::DeleteTable works as expected.
@@ -450,7 +450,7 @@ TEST_F(TableAdminTest, DeleteTableFailure) {
   grpc::Status status;
   tested.DeleteTable("other-table", status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
+  EXPECT_THAT(status.error_message(), HasSubstr("uh oh"));
 }
 
 /**
@@ -511,7 +511,7 @@ TEST_F(TableAdminTest, ModifyColumnFamiliesFailure) {
   grpc::Status status;
   tested.ModifyColumnFamilies("other-table", std::move(changes), status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
+  EXPECT_THAT(status.error_message(), HasSubstr("uh oh"));
 }
 
 /// @test Verify that bigtable::TableAdmin::DropRowsByPrefix works as expected.
@@ -549,7 +549,7 @@ TEST_F(TableAdminTest, DropRowsByPrefixFailure) {
   grpc::Status status;
   tested.DropRowsByPrefix("other-table", "prefix", status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
+  EXPECT_THAT(status.error_message(), HasSubstr("uh oh"));
 }
 
 /// @test Verify that bigtable::TableAdmin::DropRowsByPrefix works as expected.
@@ -589,7 +589,7 @@ TEST_F(TableAdminTest, DropAllRowsFailure) {
   // After all the setup, make the actual call we want to test.
   tested.DropAllRows("other-table", status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
+  EXPECT_THAT(status.error_message(), HasSubstr("uh oh"));
 }
 
 /**
@@ -632,7 +632,7 @@ TEST_F(TableAdminTest, GenerateConsistencyTokenFailure) {
   grpc::Status status;
   tested.GenerateConsistencyToken("other-table", status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
+  EXPECT_THAT(status.error_message(), HasSubstr("uh oh"));
 }
 
 /**
@@ -680,7 +680,7 @@ TEST_F(TableAdminTest, CheckConsistencyFailure) {
   bigtable::ConsistencyToken consistency_token("other-token");
   tested.CheckConsistency(table_id, consistency_token, status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
+  EXPECT_THAT(status.error_message(), HasSubstr("uh oh"));
 }
 
 /**
@@ -726,7 +726,7 @@ TEST_F(TableAdminTest, GetSnapshotUnrecoverableFailures) {
   bigtable::SnapshotId snapshot_id("other-snapshot");
   tested.GetSnapshot(cluster_id, snapshot_id, status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("No snapshot."));
+  EXPECT_THAT(status.error_message(), HasSubstr("No snapshot."));
 }
 
 /**
@@ -790,7 +790,7 @@ TEST_F(TableAdminTest, DeleteSnapshotFailure) {
   bigtable::SnapshotId snapshot_id("other-snapshot");
   tested.DeleteSnapshot(cluster_id, snapshot_id, status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
+  EXPECT_THAT(status.error_message(), HasSubstr("uh oh"));
 }
 
 /**
@@ -901,5 +901,5 @@ TEST_F(TableAdminTest, ListSnapshots_UnrecoverableFailures) {
   bigtable::ClusterId cluster_id("other-cluster");
   tested.ListSnapshots(status, cluster_id);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
+  EXPECT_THAT(status.error_message(), HasSubstr("uh oh"));
 }

--- a/bigtable/client/internal/table_admin_test.cc
+++ b/bigtable/client/internal/table_admin_test.cc
@@ -206,6 +206,7 @@ TEST_F(TableAdminTest, ListTablesUnrecoverableFailures) {
   grpc::Status status;
   tested.ListTables(btproto::Table::FULL, status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
 }
 
 /**
@@ -231,6 +232,7 @@ TEST_F(TableAdminTest, ListTablesTooManyFailures) {
   // After all the setup, make the actual call we want to test.
   tested.ListTables(btproto::Table::FULL, status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("try-again"));
 }
 
 /// @test Verify that `bigtable::TableAdmin::Create` works in the easy case.
@@ -289,6 +291,7 @@ TEST_F(TableAdminTest, CreateTableFailure) {
   // After all the setup, make the actual call we want to test.
   tested.CreateTable("other-table", bigtable::TableConfig(), status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
 }
 
 /**
@@ -333,6 +336,7 @@ TEST_F(TableAdminTest, CopyConstructibleAssignablePolicyTest) {
   // After all the setup, make the actual call we want to test.
   table_admin.GetTable("other-table", status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("try-again"));
 
   bigtable::noex::TableAdmin table_admin_assign(client_, "the-assign-instance");
   table_admin_assign = tested;
@@ -344,6 +348,7 @@ TEST_F(TableAdminTest, CopyConstructibleAssignablePolicyTest) {
   // After all the setup, make the actual call we want to test.
   table_admin_assign.GetTable("other-table", status_assign);
   EXPECT_FALSE(status_assign.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("try-again"));
 }
 
 /// @test Verify that `bigtable::TableAdmin::GetTable` works in the easy case.
@@ -385,6 +390,7 @@ TEST_F(TableAdminTest, GetTableUnrecoverableFailures) {
   // After all the setup, make the actual call we want to test.
   tested.GetTable("other-table", status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
 }
 
 /**
@@ -406,6 +412,7 @@ TEST_F(TableAdminTest, GetTableTooManyFailures) {
   // After all the setup, make the actual call we want to test.
   tested.GetTable("other-table", status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("try-again"));
 }
 
 /// @test Verify that bigtable::TableAdmin::DeleteTable works as expected.
@@ -443,6 +450,7 @@ TEST_F(TableAdminTest, DeleteTableFailure) {
   grpc::Status status;
   tested.DeleteTable("other-table", status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
 }
 
 /**
@@ -503,6 +511,7 @@ TEST_F(TableAdminTest, ModifyColumnFamiliesFailure) {
   grpc::Status status;
   tested.ModifyColumnFamilies("other-table", std::move(changes), status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
 }
 
 /// @test Verify that bigtable::TableAdmin::DropRowsByPrefix works as expected.
@@ -540,6 +549,7 @@ TEST_F(TableAdminTest, DropRowsByPrefixFailure) {
   grpc::Status status;
   tested.DropRowsByPrefix("other-table", "prefix", status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
 }
 
 /// @test Verify that bigtable::TableAdmin::DropRowsByPrefix works as expected.
@@ -579,6 +589,7 @@ TEST_F(TableAdminTest, DropAllRowsFailure) {
   // After all the setup, make the actual call we want to test.
   tested.DropAllRows("other-table", status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
 }
 
 /**
@@ -621,6 +632,7 @@ TEST_F(TableAdminTest, GenerateConsistencyTokenFailure) {
   grpc::Status status;
   tested.GenerateConsistencyToken("other-table", status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
 }
 
 /**
@@ -668,6 +680,7 @@ TEST_F(TableAdminTest, CheckConsistencyFailure) {
   bigtable::ConsistencyToken consistency_token("other-token");
   tested.CheckConsistency(table_id, consistency_token, status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
 }
 
 /**
@@ -713,6 +726,7 @@ TEST_F(TableAdminTest, GetSnapshotUnrecoverableFailures) {
   bigtable::SnapshotId snapshot_id("other-snapshot");
   tested.GetSnapshot(cluster_id, snapshot_id, status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("No snapshot."));
 }
 
 /**
@@ -776,6 +790,7 @@ TEST_F(TableAdminTest, DeleteSnapshotFailure) {
   bigtable::SnapshotId snapshot_id("other-snapshot");
   tested.DeleteSnapshot(cluster_id, snapshot_id, status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
 }
 
 /**
@@ -886,4 +901,5 @@ TEST_F(TableAdminTest, ListSnapshots_UnrecoverableFailures) {
   bigtable::ClusterId cluster_id("other-cluster");
   tested.ListSnapshots(status, cluster_id);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("uh oh"));
 }

--- a/bigtable/client/internal/table_test.cc
+++ b/bigtable/client/internal/table_test.cc
@@ -22,7 +22,7 @@ using testing::_;
 using testing::Invoke;
 using testing::Return;
 using testing::SetArgPointee;
-using namespace bigtable::chrono_literals;
+ut-using namespace bigtable::chrono_literals;
 namespace btproto = google::bigtable::v2;
 
 /// Define types and functions used in the tests.
@@ -745,7 +745,7 @@ TEST_F(NoexTableTest, BulkApplyTooManyFailures) {
                            "bar", {bt::SetCell("fam", "col", 0_ms, "qux")})),
       status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("yikes"));
+  EXPECT_THAT(status.error_message(), HasSubstr("yikes"));
 }
 
 /// @test Verify that Table::BulkApply() retries only idempotent mutations.
@@ -870,7 +870,7 @@ TEST_F(NoexTableTest, CheckAndMutateRowFailure) {
       {bigtable::SetCell("fam", "col", 0_ms, "it was true")},
       {bigtable::SetCell("fam", "col", 0_ms, "it was false")}, status);
   EXPECT_FALSE(status.ok());
-  EXPECT_NE(std::string::npos, status.error_message().find("try-again"));
+  EXPECT_THAT(status.error_message(), HasSubstr("try-again"));
 }
 
 /// @test Verify that Table::SampleRows<T>() works for default parameter.

--- a/bigtable/client/internal/table_test.cc
+++ b/bigtable/client/internal/table_test.cc
@@ -22,7 +22,7 @@ using testing::_;
 using testing::Invoke;
 using testing::Return;
 using testing::SetArgPointee;
-ut-using namespace bigtable::chrono_literals;
+using namespace bigtable::chrono_literals;
 namespace btproto = google::bigtable::v2;
 
 /// Define types and functions used in the tests.

--- a/bigtable/client/internal/table_test.cc
+++ b/bigtable/client/internal/table_test.cc
@@ -722,14 +722,14 @@ TEST_F(NoexTableTest, BulkApplyTooManyFailures) {
       }))
       .WillOnce(Return(false));
   EXPECT_CALL(*r1, Finish())
-      .WillOnce(Return(grpc::Status(grpc::StatusCode::ABORTED, "")));
+      .WillOnce(Return(grpc::Status(grpc::StatusCode::ABORTED, "yikes")));
 
   auto create_cancelled_stream = [&](grpc::ClientContext*,
                                      btproto::MutateRowsRequest const&) {
     auto stream = bigtable::internal::make_unique<MockMutateRowsReader>();
     EXPECT_CALL(*stream, Read(_)).WillOnce(Return(false));
     EXPECT_CALL(*stream, Finish())
-        .WillOnce(Return(grpc::Status(grpc::StatusCode::ABORTED, "")));
+        .WillOnce(Return(grpc::Status(grpc::StatusCode::ABORTED, "yikes")));
     return stream.release()->AsUniqueMocked();
   };
 
@@ -745,6 +745,7 @@ TEST_F(NoexTableTest, BulkApplyTooManyFailures) {
                            "bar", {bt::SetCell("fam", "col", 0_ms, "qux")})),
       status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("yikes"));
 }
 
 /// @test Verify that Table::BulkApply() retries only idempotent mutations.
@@ -869,6 +870,7 @@ TEST_F(NoexTableTest, CheckAndMutateRowFailure) {
       {bigtable::SetCell("fam", "col", 0_ms, "it was true")},
       {bigtable::SetCell("fam", "col", 0_ms, "it was false")}, status);
   EXPECT_FALSE(status.ok());
+  EXPECT_NE(std::string::npos, status.error_message().find("try-again"));
 }
 
 /// @test Verify that Table::SampleRows<T>() works for default parameter.

--- a/bigtable/client/internal/unary_client_utils.h
+++ b/bigtable/client/internal/unary_client_utils.h
@@ -180,8 +180,10 @@ struct UnaryClientUtils {
       }
       if (not rpc_policy.on_failure(status)) {
         std::string full_message = error_message;
-        full_message += "(" + metadata_update_policy.value() + ")";
-        status = grpc::Status(status.error_code(), full_message);
+        full_message += "(" + metadata_update_policy.value() + ") ";
+        full_message += status.error_message();
+        status = grpc::Status(status.error_code(), full_message,
+                              status.error_details());
         break;
       }
       auto delay = backoff_policy.on_completion(status);
@@ -233,6 +235,13 @@ struct UnaryClientUtils {
     // Call the pointer to member function.
     status = (client.*function)(&client_context, request, &response);
 
+    if (not status.ok()) {
+      std::string full_message = error_message;
+      full_message += "(" + metadata_update_policy.value() + ") ";
+      full_message += status.error_message();
+      status = grpc::Status(status.error_code(), full_message,
+                            status.error_details());
+    }
     return response;
   }
 };


### PR DESCRIPTION
On idempotent operations we were not preserving the error message
returned by the server, that left the users with poor errors.

On non-idempotent operations we were not inserting the library
call that produce the error, which is also not great.