### PR TITLE
Refactor macOS install steps to a script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,7 @@ matrix:
       # requests because Travis often has long backlogs for macOS.
       os: osx
       compiler: clang
-      before_install:
-        - brew update
-      install:
-        - brew install curl openssl c-ares
+      install: ci/install-macosx.sh
       script: ci/build-macosx.sh
       if: type != pull_request
     - # Compile on Travis' native environment with Bazel

--- a/ci/install-macosx.sh
+++ b/ci/install-macosx.sh
@@ -21,4 +21,5 @@ if [ "${TRAVIS_OS_NAME}" != "osx" ]; then
   exit 0
 fi
 
-brew update && brew install curl openssl c-ares
+brew update
+brew install curl openssl c-ares

--- a/ci/install-macosx.sh
+++ b/ci/install-macosx.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [ "${TRAVIS_OS_NAME}" != "osx" ]; then
+  echo "Not a Mac OS X build, exit successfully"
+  exit 0
+fi
+
+brew update && brew install curl openssl c-ares


### PR DESCRIPTION
We have scripts for all other platforms, no reason why macOS
should be different.