### PR TITLE
Use ccache for Travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,10 +56,6 @@ matrix:
       compiler: gcc
       git:
         submodules: false
-      apt:
-        sources:
-          - ubuntu-toolchain-r-test
-        packages:
       install: ci/install-bazel.sh
       script: ci/build-bazel.sh
     - # Compile on Travis' native environment with Bazel
@@ -155,6 +151,8 @@ cache:
     # Cache the Bazel directories, in builds that do not use Bazel this is
     # empty and trivial to cache.
     - $HOME/.cache/bazel
+    - build-output/cache
+    - build-output/ccache
   timeout: 900
 
 before_cache:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,19 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     endif ()
 endif ()
 
+# If ccache is installed use it for the build. This makes the Travis
+# configuration agnostic as to wether ccache is installed or not.
+option(GOOGLE_CLOUD_CPP_ENABLE_CCACHE "Automatically use ccache if available" ON)
+
+if ("${GOOGLE_CLOUD_CPP_ENABLE_CCACHE}")
+    find_program(CCACHE_FOUND ccache NAMES /usr/bin/ccache)
+    if (CCACHE_FOUND)
+        message(STATUS "ccache found: ${CCACHE_FOUND}")
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+    endif ()
+endif ()
+
 set(PROJECT_THIRD_PARTY_DIR "${PROJECT_SOURCE_DIR}/third_party")
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 

--- a/ci/Dockerfile.centos
+++ b/ci/Dockerfile.centos
@@ -26,6 +26,7 @@ RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
 RUN yum makecache && yum install -y \
     devtoolset-7 \
     c-ares-devel \
+    ccache \
     cmake3 \
     curl \
     curl-devel \

--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -20,6 +20,7 @@ RUN dnf makecache && dnf install -y \
     autoconf \
     automake \
     c-ares-devel \
+    ccache \
     clang \
     clang-tools-extra \
     cmake \

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -20,6 +20,7 @@ RUN apt update && \
     apt install -y \
         automake \
         build-essential \
+        ccache \
         clang \
         clang-format \
         cmake \

--- a/ci/Dockerfile.ubuntu-trusty
+++ b/ci/Dockerfile.ubuntu-trusty
@@ -25,6 +25,7 @@ RUN apt update && apt install -y software-properties-common && \
     apt install -y \
         automake \
         build-essential \
+        ccache \
         clang-3.8 \
         cmake3 \
         curl \

--- a/ci/build-docker.sh
+++ b/ci/build-docker.sh
@@ -99,7 +99,7 @@ fi
 
 # If document generation is enabled, run it now.
 if [ "${GENERATE_DOCS}" = "yes" ]; then
-  make doxygen-docs
+  cmake --build . --target doxygen-docs
 fi
 
 # Some of the sanitizers only emit errors and do not change the error code
@@ -140,4 +140,12 @@ _EOF_
     echo
     echo "${COLOR_GREEN}scan-build completed without errors.${COLOR_RESET}"
   fi
+fi
+
+# If ccache is enabled we want to zero out the statistics because otherwise
+# Travis needs to rebuild the cache each time, and that slows down the build
+# unnecessarily.
+if ccache -s >/dev/null 2>&1; then
+  ccache --show-stats
+  ccache --zero-stats
 fi

--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -35,6 +35,11 @@ if [ "${TEST_INSTALL:-}" != "yes" ]; then
   docker_uid="${UID:-0}"
 fi
 
+# Use a volume to store the any cache files, so we save the cache for future
+# Travis builds.
+test -d "${PWD}/build-output/cache" || mkdir -p "${PWD}/build-output/cache"
+test -d "${PWD}/build-output/ccache" || mkdir -p "${PWD}/build-output/ccache"
+
 sudo docker run \
      --cap-add SYS_PTRACE \
      -it \
@@ -54,6 +59,8 @@ sudo docker run \
      --env TERM="${TERM:-dumb}" \
      --user "${docker_uid}" \
      --volume "${PWD}":/v \
+     --volume "${PWD}/build-output/cache":/.cache \
+     --volume "${PWD}/build-output/ccache":/.ccache \
      --workdir /v \
      "${IMAGE}:tip" \
      ${build_script}

--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -35,8 +35,8 @@ if [ "${TEST_INSTALL:-}" != "yes" ]; then
   docker_uid="${UID:-0}"
 fi
 
-# Use a volume to store the any cache files, so we save the cache for future
-# Travis builds.
+# Use a volume to store the cache files. This exports the cache files from the
+# Docker container, and then we can save them for future Travis builds.
 test -d "${PWD}/build-output/cache" || mkdir -p "${PWD}/build-output/cache"
 test -d "${PWD}/build-output/ccache" || mkdir -p "${PWD}/build-output/ccache"
 


### PR DESCRIPTION
With this change the Travis builds on Linux+CMake use ccache, speeding up many of the builds.  For example, the clang-tidy build goes from ~24m to ~13m:

Before:
https://travis-ci.org/GoogleCloudPlatform/google-cloud-cpp/jobs/386452738

After (with a warm cache):
https://travis-ci.org/GoogleCloudPlatform/google-cloud-cpp/jobs/386477710

In general, branches and PRs use the cache from the master branch, so most builds should experience an improvement.

The total build time did not improve that much because it is dominated by the TEST_INSTALL=yes build:

After (with a warm cache):
https://travis-ci.org/GoogleCloudPlatform/google-cloud-cpp/jobs/386477709

I would rather address that problem in a future PR, because I would rather see the current gains deployed.

