### PR TITLE
Run a local httpbin server for integration tests.

### DIFF
--- a/ci/Dockerfile.centos
+++ b/ci/Dockerfile.centos
@@ -36,11 +36,15 @@ RUN yum makecache && yum install -y \
     openssl-devel \
     pkgconfig \
     python \
+    python-pip \
+    python-gunicorn \
     shtool \
     unzip \
     wget \
     which \
     zlib-devel
+
+RUN pip install httpbin
 
 # Install cmake3 + ctest3 as cmake + ctest.
 RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && \

--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -39,6 +39,8 @@ RUN dnf makecache && dnf install -y \
     openssl-devel \
     pkgconfig \
     python \
+    python-gunicorn \
+    python-httpbin \
     shtool \
     unzip \
     wget \

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -37,6 +37,8 @@ RUN apt update && \
         libtool \
         lsb-release \
         make \
+        python-gunicorn \
+        python-httpbin \
         tar \
         wget \
         zlib1g-dev

--- a/ci/Dockerfile.ubuntu-trusty
+++ b/ci/Dockerfile.ubuntu-trusty
@@ -39,6 +39,8 @@ RUN apt update && apt install -y software-properties-common && \
         libtool \
         lsb-release \
         make \
+        python-dev \
+        python-pip \
         tar \
         wget \
         zlib1g-dev \
@@ -47,6 +49,8 @@ RUN apt update && apt install -y software-properties-common && \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.8 100 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 100 && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 100
+
+RUN pip install gunicorn httpbin
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.

--- a/ci/kokoro/ubuntu/build.sh
+++ b/ci/kokoro/ubuntu/build.sh
@@ -24,7 +24,7 @@ export GOPATH="${KOKORO_ROOT}/golang"
 go get -u cloud.google.com/go/bigtable/cmd/cbt
 
 echo "Getting python dependencies"
-pip install gunicorn httpbin
+sudo python2 -m pip install gunicorn httpbin
 
 echo "Running build and tests"
 cd "$(dirname $0)/../../.."

--- a/ci/kokoro/ubuntu/build.sh
+++ b/ci/kokoro/ubuntu/build.sh
@@ -23,6 +23,9 @@ echo "Getting cbt tool"
 export GOPATH="${KOKORO_ROOT}/golang"
 go get -u cloud.google.com/go/bigtable/cmd/cbt
 
+echo "Getting python dependencies"
+pip install gunicorn httpbin
+
 echo "Running build and tests"
 cd "$(dirname $0)/../../.."
 readonly PROJECT_ROOT="${PWD}"

--- a/storage/tests/run_integration_tests.sh
+++ b/storage/tests/run_integration_tests.sh
@@ -41,7 +41,7 @@ function start_httpbin {
   gunicorn -b "0.0.0.0:${PORT}" httpbin:app >emulator.log 2>&1 </dev/null &
   HTTPBIN_PID=$!
 
-  export HTTPBIN_ENDPOINT="http://localhost:${PORT}/"
+  export HTTPBIN_ENDPOINT="http://localhost:${PORT}"
 
   delay=1
   connected=no

--- a/storage/tests/run_integration_tests.sh
+++ b/storage/tests/run_integration_tests.sh
@@ -16,27 +16,59 @@
 
 set -eu
 
-delay=1
-connected=no
-readonly ATTEMPTS=$(seq 1 8)
-for attempt in $ATTEMPTS; do
-  if curl "https://nghttp2.org/httpbin/get" >/dev/null 2>&1; then
-    connected=yes
-    break
-  fi
-  sleep $delay
-  delay=$((delay * 2))
-done
+readonly BINDIR="$(dirname $0)"
+source "${BINDIR}/../../ci/colors.sh"
 
-if [ "${connected}" = "no" ]; then
-  # TODO(..) - use a local server for the integration tests.
-  echo "Cannot connect to nghttp2.org; exit test with success." >&2
-  exit 0
-else
-  echo "Successfully connected to nghttp2.org."
-fi
+HTTPBIN_PID=0
+
+function kill_httpbin {
+  echo "${COLOR_GREEN}[ -------- ]${COLOR_RESET} Integration test environment tear-down."
+  echo -n "Killing httpbin server [${HTTPBIN_PID}] ... "
+  kill "${HTTPBIN_PID}"
+  wait >/dev/null 2>&1
+  echo "done."
+  echo "${COLOR_GREEN}[ ======== ]${COLOR_RESET} Integration test environment tear-down."
+}
+
+function start_httpbin {
+  echo "${COLOR_GREEN}[ -------- ]${COLOR_RESET} Integration test environment set-up"
+  echo "Launching httpbin emulator in the background"
+  trap kill_httpbin EXIT
+
+  # The tests typically run in a Docker container, where the ports are largely
+  # free; when using in manual tests, you can set EMULATOR_PORT.
+  readonly PORT=${HTTPBIN_PORT:-8000}
+  gunicorn -b "0.0.0.0:${PORT}" httpbin:app >emulator.log 2>&1 </dev/null &
+  HTTPBIN_PID=$!
+
+  export HTTPBIN_ENDPOINT="http://localhost:${PORT}/"
+
+  delay=1
+  connected=no
+  readonly ATTEMPTS=$(seq 1 8)
+  for attempt in $ATTEMPTS; do
+    if curl "${HTTPBIN_ENDPOINT}/get" >/dev/null 2>&1; then
+      connected=yes
+      break
+    fi
+    sleep $delay
+    delay=$((delay * 2))
+  done
+
+  if [ "${connected}" = "no" ]; then
+    echo "Cannot connect to httpbin; aborting test." >&2
+    exit 1
+  else
+    echo "Successfully connected to httpbin"
+  fi
+
+  echo "${COLOR_GREEN}[ ======== ]${COLOR_RESET} Integration test environment set-up."
+}
 
 echo
+echo "Running Storage integration tests against local servers."
+start_httpbin
+
 echo "Running storage::internal::CurlRequest integration test."
 ./curl_request_integration_test
 


### PR DESCRIPTION
This fixes #542. The Docker images install gunicorn and httpbin,
and we use those installed versions in the integration tests.