### PR TITLE
Disable ccache on coverage builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,7 @@ matrix:
       os: linux
       compiler: gcc
       env:
+        CMAKE_FLAGS=-DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=no
         BUILD_TYPE=Coverage
         DISTRO=ubuntu
         DISTRO_VERSION=18.04


### PR DESCRIPTION
The coverage stats went to almost 0, evidently a bug in how
we are using ccache.  Disable it for now until we figure it out.
