### PR TITLE
Enable codecov comments for pull requests.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,3 @@
-# Don't post a comment on pull requests.
-comment: off
-
 # Disable commit statuses
 coverage:
   status:

--- a/ci/upload-codecov.sh
+++ b/ci/upload-codecov.sh
@@ -16,19 +16,9 @@
 
 set -eu
 
-if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
-    echo "Skipping code coverage as it is disabled for pull requests."
-    exit 0
-fi
-
 if [ "${BUILD_TYPE:-Release}" != "Coverage" ]; then
     echo "Skipping code coverage as it is disabled for this build."
     exit 0
-fi
-
-if [ -z "${CODECOV_TOKEN:-}" ]; then
-    echo "CODECOV_TOKEN not configured in Coverage build, exit with error."
-    exit 1
 fi
 
 # Upload the results using the script from codecov.io


### PR DESCRIPTION
This will prevent future problems where we dramatically
change the coverage due to CI changes and/or code changes.