### PR TITLE
Fix `TableAdmin::WaitForConsistencyCheck()`

### DIFF
--- a/bigtable/client/internal/table_admin.cc
+++ b/bigtable/client/internal/table_admin.cc
@@ -206,10 +206,13 @@ bool TableAdmin::WaitForConsistencyCheckHelper(
         metadata_update_policy, &AdminClient::CheckConsistency, request,
         "CheckConsistency", status, true);
 
-    if (response.consistent()) {
-      return true;
+    if (status.ok()) {
+      if (response.consistent()) {
+        return true;
+      }
+    } else if (polling_policy->IsPermanentError(status)) {
+      return false;
     }
-
   } while (not polling_policy->Exhausted());
 
   return false;

--- a/bigtable/client/table_admin_test.cc
+++ b/bigtable/client/table_admin_test.cc
@@ -745,13 +745,7 @@ TEST_F(TableAdminTest, AsyncCheckConsistencySimple) {
   using namespace ::testing;
   using namespace bigtable::chrono_literals;
 
-  bigtable::LimitedTimeRetryPolicy retry_policy(std::chrono::milliseconds(10));
-  bigtable::ExponentialBackoffPolicy backoff_policy;
-  bigtable::GenericPollingPolicy<> polling_policy(retry_policy, backoff_policy);
-
-  bigtable::TableAdmin tested(
-      client_, "the-async-instance", std::move(retry_policy),
-      std::move(backoff_policy), std::move(polling_policy));
+  bigtable::TableAdmin tested(client_, "the-async-instance");
   std::string expected_text = R"""(
       name: 'projects/the-project/instances/the-async-instance/tables/the-async-table'
       consistency_token: 'test-async-token'
@@ -787,13 +781,7 @@ TEST_F(TableAdminTest, AsyncCheckConsistencyFailure) {
   using namespace ::testing;
   using namespace bigtable::chrono_literals;
 
-  bigtable::LimitedTimeRetryPolicy retry_policy(std::chrono::milliseconds(10));
-  bigtable::ExponentialBackoffPolicy backoff_policy;
-  bigtable::GenericPollingPolicy<> polling_policy(retry_policy, backoff_policy);
-
-  bigtable::TableAdmin tested(
-      client_, "the-async-instance", std::move(retry_policy),
-      std::move(backoff_policy), std::move(polling_policy));
+  bigtable::TableAdmin tested(client_, "the-async-instance");
   EXPECT_CALL(*client_, CheckConsistency(_, _, _))
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));


### PR DESCRIPTION
The implementation should abort the wait loop on the first unrecoverable error, it
was not doing so.  The tests were passing only because they had short timeouts,
and that was actually a problem because sometimes they would fail.
