### PR TITLE
Fix retry loop in install scripts.

### DIFF
--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -58,8 +58,8 @@ for i in 1 2 3; do
     exit 0
   fi
   # Sleep for a few minutes before trying again.
-  readonly PERIOD=$[ (${RANDOM} % 60) + min_wait ]
-  echo "Fetch failed; trying again in ${PERIOD} seconds."
-  sleep ${PERIOD}s
+  period=$[ (${RANDOM} % 60) + min_wait ]
+  echo "Fetch failed; trying again in ${period} seconds."
+  sleep ${period}s
   min_wait=$[ min_wait * 2 ]
 done

--- a/ci/install-linux.sh
+++ b/ci/install-linux.sh
@@ -44,8 +44,8 @@ for i in 1 2 3; do
     exit 0
   fi
   # Sleep for a few minutes before trying again.
-  readonly PERIOD=$[ (${RANDOM} % 60) + min_wait ]
-  echo "Fetch failed; trying again in ${PERIOD} seconds."
-  sleep ${PERIOD}s
+  period=$[ (${RANDOM} % 60) + min_wait ]
+  echo "Fetch failed; trying again in ${period} seconds."
+  sleep ${period}s
   min_wait=$[ min_wait * 2 ]
 done

--- a/ci/install-macosx.sh
+++ b/ci/install-macosx.sh
@@ -39,8 +39,8 @@ for i in 1 2 3; do
     exit 0
   fi
   # Sleep for a few minutes before trying again.
-  readonly PERIOD=$[ (${RANDOM} % 60) + min_wait ]
-  echo "Fetch failed; trying again in ${PERIOD} seconds."
-  sleep ${PERIOD}s
+  period=$[ (${RANDOM} % 60) + min_wait ]
+  echo "Fetch failed; trying again in ${period} seconds."
+  sleep ${period}s
   min_wait=$[ min_wait * 2 ]
 done


### PR DESCRIPTION
This is somewhat embarrassing. The loop had been "in production"
for ages, but only after I cut&paste it to another script it
actually fails :-(