### PR TITLE
Move `bigtable::` namespace to the `google::cloud::` namespace 

### DIFF
--- a/ci/test-install/install_integration_test.cc
+++ b/ci/test-install/install_integration_test.cc
@@ -19,6 +19,8 @@
 #include <google/protobuf/text_format.h>
 #include <sstream>
 
+namespace bigtable = google::cloud::bigtable;
+
 int main(int argc, char* argv[]) try {
   // Make sure the arguments are valid.
   if (argc != 4) {

--- a/google/cloud/bigtable/admin_client.cc
+++ b/google/cloud/bigtable/admin_client.cc
@@ -151,7 +151,7 @@ namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 std::shared_ptr<AdminClient> CreateDefaultAdminClient(
-    std::string project, google::cloud::bigtable::ClientOptions options) {
+    std::string project, ClientOptions options) {
   return std::make_shared<DefaultAdminClient>(std::move(project),
                                               std::move(options));
 }

--- a/google/cloud/bigtable/admin_client.cc
+++ b/google/cloud/bigtable/admin_client.cc
@@ -150,8 +150,8 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-std::shared_ptr<AdminClient> CreateDefaultAdminClient(
-    std::string project, ClientOptions options) {
+std::shared_ptr<AdminClient> CreateDefaultAdminClient(std::string project,
+                                                      ClientOptions options) {
   return std::make_shared<DefaultAdminClient>(std::move(project),
                                               std::move(options));
 }

--- a/google/cloud/bigtable/admin_client.cc
+++ b/google/cloud/bigtable/admin_client.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/bigtable/admin_client.h"
 #include "google/cloud/bigtable/internal/common_client.h"
 
+class CommonClient;
 namespace {
 namespace btadmin = google::bigtable::admin::v2;
 
@@ -31,23 +32,25 @@ namespace btadmin = google::bigtable::admin::v2;
  * should only reconnect on those errors that indicate the credentials or
  * connections need refreshing.
  */
-class DefaultAdminClient : public bigtable::AdminClient {
+class DefaultAdminClient : public google::cloud::bigtable::AdminClient {
  private:
   // Introduce an early `private:` section because this type is used to define
   // the public interface, it should not be part of the public interface.
   struct AdminTraits {
-    static std::string const& Endpoint(bigtable::ClientOptions& options) {
+    static std::string const& Endpoint(
+        google::cloud::bigtable::ClientOptions& options) {
       return options.admin_endpoint();
     }
   };
 
-  using Impl = bigtable::internal::CommonClient<AdminTraits,
-                                                btadmin::BigtableTableAdmin>;
+  using Impl = google::cloud::bigtable::internal::CommonClient<
+      AdminTraits, btadmin::BigtableTableAdmin>;
 
  public:
   using AdminStubPtr = Impl::StubPtr;
 
-  DefaultAdminClient(std::string project, bigtable::ClientOptions options)
+  DefaultAdminClient(std::string project,
+                     google::cloud::bigtable::ClientOptions options)
       : project_(std::move(project)), impl_(std::move(options)) {}
 
   std::string const& project() const override { return project_; }
@@ -144,13 +147,17 @@ class DefaultAdminClient : public bigtable::AdminClient {
 };
 }  // anonymous namespace
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 std::shared_ptr<AdminClient> CreateDefaultAdminClient(
-    std::string project, bigtable::ClientOptions options) {
+    std::string project, google::cloud::bigtable::ClientOptions options) {
   return std::make_shared<DefaultAdminClient>(std::move(project),
                                               std::move(options));
 }
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/admin_client.cc
+++ b/google/cloud/bigtable/admin_client.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/bigtable/admin_client.h"
 #include "google/cloud/bigtable/internal/common_client.h"
 
-class CommonClient;
 namespace {
 namespace btadmin = google::bigtable::admin::v2;
 

--- a/google/cloud/bigtable/admin_client.h
+++ b/google/cloud/bigtable/admin_client.h
@@ -16,12 +16,12 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_ADMIN_CLIENT_H_
 
 #include "google/cloud/bigtable/client_options.h"
-
+#include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
 #include <memory>
 #include <string>
 
-#include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
-
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 // Forward declare some classes so we can be friends.
@@ -133,10 +133,12 @@ class AdminClient {
 };
 
 /// Create a new admin client configured via @p options.
-std::shared_ptr<AdminClient> CreateDefaultAdminClient(
-    std::string project, bigtable::ClientOptions options);
+std::shared_ptr<AdminClient> CreateDefaultAdminClient(std::string project,
+                                                      ClientOptions options);
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_ADMIN_CLIENT_H_

--- a/google/cloud/bigtable/admin_client_test.cc
+++ b/google/cloud/bigtable/admin_client_test.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/bigtable/admin_client.h"
 #include <gmock/gmock.h>
 
+namespace bigtable = google::cloud::bigtable;
+
 TEST(AdminClientTest, Default) {
   auto admin_client = bigtable::CreateDefaultAdminClient(
       "test-project", bigtable::ClientOptions().set_connection_pool_size(1));

--- a/google/cloud/bigtable/benchmarks/apply_read_latency_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/apply_read_latency_benchmark.cc
@@ -73,7 +73,7 @@
 
 /// Helper functions and types for the apply_read_latency_benchmark.
 namespace {
-using namespace bigtable::benchmarks;
+using namespace google::cloud::bigtable::benchmarks;
 
 struct LatencyBenchmarkResult {
   BenchmarkResult apply_results;
@@ -81,7 +81,7 @@ struct LatencyBenchmarkResult {
 };
 
 /// Run an iteration of the test.
-LatencyBenchmarkResult RunBenchmark(bigtable::benchmarks::Benchmark& benchmark,
+LatencyBenchmarkResult RunBenchmark(Benchmark& benchmark,
                                     std::string const& table_id,
                                     std::chrono::seconds test_duration);
 
@@ -94,7 +94,7 @@ constexpr int kBenchmarkProgressMarks = 4;
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) try {
-  bigtable::benchmarks::BenchmarkSetup setup("perf", argc, argv);
+  BenchmarkSetup setup("perf", argc, argv);
 
   Benchmark benchmark(setup);
 
@@ -158,7 +158,7 @@ int main(int argc, char* argv[]) try {
   benchmark.PrintLatencyResult(std::cout, "perf", "ReadRow()",
                                combined.read_results);
 
-  std::cout << bigtable::benchmarks::Benchmark::ResultsCsvHeader() << std::endl;
+  std::cout << Benchmark::ResultsCsvHeader() << std::endl;
   benchmark.PrintResultCsv(std::cout, "perf", "BulkApply()", "Latency",
                            populate_results);
   benchmark.PrintResultCsv(std::cout, "perf", "Apply()", "Latency",
@@ -175,6 +175,8 @@ int main(int argc, char* argv[]) try {
 }
 
 namespace {
+namespace bigtable = google::cloud::bigtable;
+
 OperationResult RunOneApply(bigtable::Table& table, std::string row_key,
                             std::mt19937_64& generator) {
   bigtable::SingleRowMutation mutation(std::move(row_key));
@@ -194,7 +196,7 @@ OperationResult RunOneReadRow(bigtable::Table& table, std::string row_key) {
   return Benchmark::TimeOperation(std::move(op));
 }
 
-LatencyBenchmarkResult RunBenchmark(bigtable::benchmarks::Benchmark& benchmark,
+LatencyBenchmarkResult RunBenchmark(Benchmark& benchmark,
                                     std::string const& table_id,
                                     std::chrono::seconds test_duration) {
   LatencyBenchmarkResult result = {};

--- a/google/cloud/bigtable/benchmarks/apply_read_latency_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/apply_read_latency_benchmark.cc
@@ -73,7 +73,8 @@
 
 /// Helper functions and types for the apply_read_latency_benchmark.
 namespace {
-using namespace google::cloud::bigtable::benchmarks;
+namespace bigtable = google::cloud::bigtable;
+using namespace bigtable::benchmarks;
 
 struct LatencyBenchmarkResult {
   BenchmarkResult apply_results;
@@ -81,7 +82,7 @@ struct LatencyBenchmarkResult {
 };
 
 /// Run an iteration of the test.
-LatencyBenchmarkResult RunBenchmark(Benchmark& benchmark,
+LatencyBenchmarkResult RunBenchmark(bigtable::benchmarks::Benchmark& benchmark,
                                     std::string const& table_id,
                                     std::chrono::seconds test_duration);
 
@@ -94,7 +95,7 @@ constexpr int kBenchmarkProgressMarks = 4;
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) try {
-  BenchmarkSetup setup("perf", argc, argv);
+  bigtable::benchmarks::BenchmarkSetup setup("perf", argc, argv);
 
   Benchmark benchmark(setup);
 
@@ -158,7 +159,7 @@ int main(int argc, char* argv[]) try {
   benchmark.PrintLatencyResult(std::cout, "perf", "ReadRow()",
                                combined.read_results);
 
-  std::cout << Benchmark::ResultsCsvHeader() << std::endl;
+  std::cout << bigtable::benchmarks::Benchmark::ResultsCsvHeader() << std::endl;
   benchmark.PrintResultCsv(std::cout, "perf", "BulkApply()", "Latency",
                            populate_results);
   benchmark.PrintResultCsv(std::cout, "perf", "Apply()", "Latency",
@@ -175,8 +176,6 @@ int main(int argc, char* argv[]) try {
 }
 
 namespace {
-namespace bigtable = google::cloud::bigtable;
-
 OperationResult RunOneApply(bigtable::Table& table, std::string row_key,
                             std::mt19937_64& generator) {
   bigtable::SingleRowMutation mutation(std::move(row_key));
@@ -196,7 +195,7 @@ OperationResult RunOneReadRow(bigtable::Table& table, std::string row_key) {
   return Benchmark::TimeOperation(std::move(op));
 }
 
-LatencyBenchmarkResult RunBenchmark(Benchmark& benchmark,
+LatencyBenchmarkResult RunBenchmark(bigtable::benchmarks::Benchmark& benchmark,
                                     std::string const& table_id,
                                     std::chrono::seconds test_duration) {
   LatencyBenchmarkResult result = {};

--- a/google/cloud/bigtable/benchmarks/benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark.cc
@@ -23,6 +23,8 @@ namespace {
 double const kResultPercentiles[] = {0, 50, 90, 95, 99, 99.9, 100};
 }  // anonymous namespace
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace benchmarks {
 Benchmark::Benchmark(BenchmarkSetup const& setup)
@@ -342,3 +344,5 @@ std::ostream& operator<<(std::ostream& os, FormatDuration duration) {
 
 }  // namespace benchmarks
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/benchmarks/benchmark.h
+++ b/google/cloud/bigtable/benchmarks/benchmark.h
@@ -23,6 +23,8 @@
 #include <deque>
 #include <thread>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace benchmarks {
 /// The result of a single operation.
@@ -163,5 +165,7 @@ std::ostream& operator<<(std::ostream& os, FormatDuration duration);
 
 }  // namespace benchmarks
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_BENCHMARKS_BENCHMARK_H_

--- a/google/cloud/bigtable/benchmarks/bigtable_benchmark_test.cc
+++ b/google/cloud/bigtable/benchmarks/bigtable_benchmark_test.cc
@@ -178,17 +178,9 @@ TEST(BenchmarkTest, PrintCsv) {
   // fairly minimal.
 
   // The output includes the version and compiler info.
-<<<<<<< HEAD
-  EXPECT_THAT(output, HasSubstr(bigtable::version_string()));
+  EXPECT_THAT(output, HasSubstr(google::cloud::bigtable::version_string()));
   EXPECT_THAT(output, HasSubstr(google::cloud::internal::COMPILER));
   EXPECT_THAT(output, HasSubstr(google::cloud::internal::COMPILER_FLAGS));
-=======
-  EXPECT_NE(std::string::npos,
-            output.find(google::cloud::bigtable::version_string()));
-  EXPECT_NE(std::string::npos, output.find(google::cloud::internal::COMPILER));
-  EXPECT_NE(std::string::npos,
-            output.find(google::cloud::internal::COMPILER_FLAGS));
->>>>>>> Move bigtable namespace to google::cloud::
 
   // The output includes the latency results.
   EXPECT_THAT(output, HasSubstr(",100,"));    // p0

--- a/google/cloud/bigtable/benchmarks/bigtable_benchmark_test.cc
+++ b/google/cloud/bigtable/benchmarks/bigtable_benchmark_test.cc
@@ -16,7 +16,7 @@
 #include "google/cloud/internal/build_info.h"
 #include <gmock/gmock.h>
 
-using namespace bigtable::benchmarks;
+using namespace google::cloud::bigtable::benchmarks;
 using testing::HasSubstr;
 
 namespace {
@@ -69,7 +69,7 @@ TEST(BenchmarkTest, MakeRandomKey) {
   BenchmarkSetup setup("key", argc, argv);
 
   Benchmark bm(setup);
-  auto gen = bigtable::testing::MakeDefaultPRNG();
+  auto gen = google::cloud::bigtable::testing::MakeDefaultPRNG();
 
   // First make sure that the keys are not always the same.
   auto make_some_keys = [&bm, &gen]() {
@@ -178,9 +178,17 @@ TEST(BenchmarkTest, PrintCsv) {
   // fairly minimal.
 
   // The output includes the version and compiler info.
+<<<<<<< HEAD
   EXPECT_THAT(output, HasSubstr(bigtable::version_string()));
   EXPECT_THAT(output, HasSubstr(google::cloud::internal::COMPILER));
   EXPECT_THAT(output, HasSubstr(google::cloud::internal::COMPILER_FLAGS));
+=======
+  EXPECT_NE(std::string::npos,
+            output.find(google::cloud::bigtable::version_string()));
+  EXPECT_NE(std::string::npos, output.find(google::cloud::internal::COMPILER));
+  EXPECT_NE(std::string::npos,
+            output.find(google::cloud::internal::COMPILER_FLAGS));
+>>>>>>> Move bigtable namespace to google::cloud::
 
   // The output includes the latency results.
   EXPECT_THAT(output, HasSubstr(",100,"));    // p0

--- a/google/cloud/bigtable/benchmarks/constants.h
+++ b/google/cloud/bigtable/benchmarks/constants.h
@@ -15,6 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_BENCHMARKS_CONSTANTS_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_BENCHMARKS_CONSTANTS_H_
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 /// Supporting classes and functions to implement benchmarks.
 namespace benchmarks {
@@ -58,5 +60,7 @@ constexpr int kTableIdRandomLetters = 8;
 
 }  // namespace benchmarks
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_BENCHMARKS_CONSTANTS_H_

--- a/google/cloud/bigtable/benchmarks/embedded_server.cc
+++ b/google/cloud/bigtable/benchmarks/embedded_server.cc
@@ -24,6 +24,8 @@
 namespace btproto = google::bigtable::v2;
 namespace adminproto = google::bigtable::admin::v2;
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace benchmarks {
 /**
@@ -208,3 +210,5 @@ std::unique_ptr<EmbeddedServer> CreateEmbeddedServer() {
 
 }  // namespace benchmarks
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/benchmarks/embedded_server.h
+++ b/google/cloud/bigtable/benchmarks/embedded_server.h
@@ -18,6 +18,8 @@
 #include <memory>
 #include <string>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace benchmarks {
 /**
@@ -49,5 +51,7 @@ std::unique_ptr<EmbeddedServer> CreateEmbeddedServer();
 
 }  // namespace benchmarks
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_BENCHMARKS_EMBEDDED_SERVER_H_

--- a/google/cloud/bigtable/benchmarks/embedded_server_test.cc
+++ b/google/cloud/bigtable/benchmarks/embedded_server_test.cc
@@ -18,7 +18,8 @@
 #include <gmock/gmock.h>
 #include <thread>
 
-using namespace bigtable::benchmarks;
+using namespace google::cloud::bigtable::benchmarks;
+namespace bigtable = google::cloud::bigtable;
 using std::chrono::milliseconds;
 
 TEST(EmbeddedServer, WaitAndShutdown) {

--- a/google/cloud/bigtable/benchmarks/embedded_server_test.cc
+++ b/google/cloud/bigtable/benchmarks/embedded_server_test.cc
@@ -18,8 +18,8 @@
 #include <gmock/gmock.h>
 #include <thread>
 
-using namespace google::cloud::bigtable::benchmarks;
 namespace bigtable = google::cloud::bigtable;
+using namespace bigtable::benchmarks;
 using std::chrono::milliseconds;
 
 TEST(EmbeddedServer, WaitAndShutdown) {

--- a/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
@@ -55,16 +55,18 @@
 
 /// Helper functions and types for the apply_read_latency_benchmark.
 namespace {
-using namespace google::cloud::bigtable::benchmarks;
+namespace bigtable = google::cloud::bigtable;
+using namespace bigtable::benchmarks;
 
 /// Run an iteration of the test, returns the number of operations.
-long RunBenchmark(Benchmark& benchmark, std::string const& table_id,
+long RunBenchmark(bigtable::benchmarks::Benchmark& benchmark,
+                  std::string const& table_id,
                   std::chrono::seconds test_duration);
 
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) try {
-  BenchmarkSetup setup("long", argc, argv);
+  bigtable::benchmarks::BenchmarkSetup setup("long", argc, argv);
   Benchmark benchmark(setup);
   // Create and populate the table for the benchmark.
   benchmark.CreateTable();
@@ -112,8 +114,6 @@ int main(int argc, char* argv[]) try {
 }
 
 namespace {
-namespace bigtable = google::cloud::bigtable;
-
 OperationResult RunOneApply(bigtable::Table& table, Benchmark const& benchmark,
                             bigtable::testing::DefaultPRNG& generator) {
   auto row_key = benchmark.MakeRandomKey(generator);

--- a/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
@@ -55,17 +55,16 @@
 
 /// Helper functions and types for the apply_read_latency_benchmark.
 namespace {
-using namespace bigtable::benchmarks;
+using namespace google::cloud::bigtable::benchmarks;
 
 /// Run an iteration of the test, returns the number of operations.
-long RunBenchmark(bigtable::benchmarks::Benchmark& benchmark,
-                  std::string const& table_id,
+long RunBenchmark(Benchmark& benchmark, std::string const& table_id,
                   std::chrono::seconds test_duration);
 
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) try {
-  bigtable::benchmarks::BenchmarkSetup setup("long", argc, argv);
+  BenchmarkSetup setup("long", argc, argv);
   Benchmark benchmark(setup);
   // Create and populate the table for the benchmark.
   benchmark.CreateTable();
@@ -113,6 +112,8 @@ int main(int argc, char* argv[]) try {
 }
 
 namespace {
+namespace bigtable = google::cloud::bigtable;
+
 OperationResult RunOneApply(bigtable::Table& table, Benchmark const& benchmark,
                             bigtable::testing::DefaultPRNG& generator) {
   auto row_key = benchmark.MakeRandomKey(generator);

--- a/google/cloud/bigtable/benchmarks/format_duration_test.cc
+++ b/google/cloud/bigtable/benchmarks/format_duration_test.cc
@@ -15,7 +15,7 @@
 #include "google/cloud/bigtable/benchmarks/benchmark.h"
 #include <gmock/gmock.h>
 
-using namespace bigtable::benchmarks;
+using namespace google::cloud::bigtable::benchmarks;
 using namespace std::chrono;
 
 TEST(BenchmarksFormatDuration, NanoSeconds) {

--- a/google/cloud/bigtable/benchmarks/random_mutation.cc
+++ b/google/cloud/bigtable/benchmarks/random_mutation.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/bigtable/benchmarks/random_mutation.h"
 #include "google/cloud/bigtable/benchmarks/constants.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace benchmarks {
 bigtable::Mutation MakeRandomMutation(bigtable::testing::DefaultPRNG& gen,
@@ -31,3 +33,5 @@ std::string MakeRandomValue(bigtable::testing::DefaultPRNG& generator) {
 }
 }  // namespace benchmarks
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/benchmarks/random_mutation.h
+++ b/google/cloud/bigtable/benchmarks/random_mutation.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/testing/random.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace benchmarks {
 
@@ -30,5 +32,7 @@ std::string MakeRandomValue(bigtable::testing::DefaultPRNG& gen);
 
 }  // namespace benchmarks
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_BENCHMARKS_RANDOM_MUTATION_H_

--- a/google/cloud/bigtable/benchmarks/scan_throughput_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/scan_throughput_benchmark.cc
@@ -56,8 +56,8 @@
 
 /// Helper functions and types for the scan_throughput_benchmark.
 namespace {
-using namespace google::cloud::bigtable::benchmarks;
 namespace bigtable = google::cloud::bigtable;
+using namespace bigtable::benchmarks;
 
 constexpr int kScanSizes[] = {100, 1000, 10000};
 

--- a/google/cloud/bigtable/benchmarks/scan_throughput_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/scan_throughput_benchmark.cc
@@ -56,7 +56,8 @@
 
 /// Helper functions and types for the scan_throughput_benchmark.
 namespace {
-using namespace bigtable::benchmarks;
+using namespace google::cloud::bigtable::benchmarks;
+namespace bigtable = google::cloud::bigtable;
 
 constexpr int kScanSizes[] = {100, 1000, 10000};
 

--- a/google/cloud/bigtable/benchmarks/setup.cc
+++ b/google/cloud/bigtable/benchmarks/setup.cc
@@ -35,7 +35,7 @@ std::string FormattedStartTime() {
 }
 
 std::string FormattedAnnotations() {
-  std::string notes = bigtable::version_string() + ";" +
+  std::string notes = google::cloud::bigtable::version_string() + ";" +
                       google::cloud::internal::COMPILER + ";" +
                       google::cloud::internal::COMPILER_FLAGS;
   std::transform(notes.begin(), notes.end(), notes.begin(),
@@ -44,15 +44,18 @@ std::string FormattedAnnotations() {
 }
 
 std::string MakeRandomTableId(std::string const& prefix) {
+  namespace cbt = google::cloud::bigtable;
   static std::string const table_id_chars(
       "ABCDEFGHIJLKMNOPQRSTUVWXYZabcdefghijlkmnopqrstuvwxyz0123456789_");
-  auto gen = bigtable::testing::MakeDefaultPRNG();
+  auto gen = cbt::testing::MakeDefaultPRNG();
   return prefix + "-" +
-         bigtable::testing::Sample(
-             gen, bigtable::benchmarks::kTableIdRandomLetters, table_id_chars);
+         cbt::testing::Sample(gen, cbt::benchmarks::kTableIdRandomLetters,
+                              table_id_chars);
 }
 }  // anonymous namespace
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace benchmarks {
 BenchmarkSetup::BenchmarkSetup(std::string const& prefix, int& argc,
@@ -123,3 +126,5 @@ BenchmarkSetup::BenchmarkSetup(std::string const& prefix, int& argc,
 
 }  // namespace benchmarks
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/benchmarks/setup.h
+++ b/google/cloud/bigtable/benchmarks/setup.h
@@ -20,6 +20,8 @@
 #include <string>
 #include <vector>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace benchmarks {
 /**
@@ -59,5 +61,7 @@ class BenchmarkSetup {
 
 }  // namespace benchmarks
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_BENCHMARKS_SETUP_H_

--- a/google/cloud/bigtable/benchmarks/setup_test.cc
+++ b/google/cloud/bigtable/benchmarks/setup_test.cc
@@ -15,7 +15,7 @@
 #include "google/cloud/bigtable/benchmarks/setup.h"
 #include <gmock/gmock.h>
 
-using namespace bigtable::benchmarks;
+using namespace google::cloud::bigtable::benchmarks;
 
 namespace {
 char arg0[] = "program";
@@ -35,7 +35,7 @@ TEST(BenchmarksSetup, Basic) {
   EXPECT_EQ("foo", setup.project_id());
   EXPECT_EQ("bar", setup.instance_id());
   EXPECT_EQ(0U, setup.table_id().find("pre"));
-  std::size_t expected = 4 + bigtable::benchmarks::kTableIdRandomLetters;
+  std::size_t expected = 4 + kTableIdRandomLetters;
   EXPECT_EQ(expected, setup.table_id().size());
 
   EXPECT_EQ(kDefaultTableSize, setup.table_size());

--- a/google/cloud/bigtable/bigtable_strong_types.h
+++ b/google/cloud/bigtable/bigtable_strong_types.h
@@ -17,6 +17,8 @@
 
 #include "google/cloud/bigtable/internal/strong_type.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 using ConsistencyToken =
@@ -28,5 +30,7 @@ using TableId = internal::StrongType<std::string, struct TableParam>;
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_BIGTABLE_STRONG_TYPES_H_

--- a/google/cloud/bigtable/cell.h
+++ b/google/cloud/bigtable/cell.h
@@ -21,6 +21,8 @@
 #include <chrono>
 #include <vector>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -50,12 +52,12 @@ class Cell {
   /// Create a Cell and fill it with bigendian 64 bit value.
   Cell(std::string row_key, std::string family_name,
        std::string column_qualifier, std::int64_t timestamp,
-       bigtable::bigendian64_t value, std::vector<std::string> labels)
+       bigendian64_t value, std::vector<std::string> labels)
       : row_key_(std::move(row_key)),
         family_name_(std::move(family_name)),
         column_qualifier_(std::move(column_qualifier)),
         timestamp_(timestamp),
-        value_(bigtable::internal::AsBigEndian64(value)),
+        value_(google::cloud::bigtable::internal::AsBigEndian64(value)),
         labels_(std::move(labels)) {}
 
   /// Return the row key this cell belongs to. The returned value is not valid
@@ -90,7 +92,7 @@ class Cell {
    */
   template <typename T>
   T value_as() const {
-    return bigtable::internal::Encoder<T>::Decode(value_);
+    return google::cloud::bigtable::internal::Encoder<T>::Decode(value_);
   }
 
   /// Return the labels applied to this cell by label transformer read filters.
@@ -107,5 +109,7 @@ class Cell {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_CELL_H_

--- a/google/cloud/bigtable/cell_test.cc
+++ b/google/cloud/bigtable/cell_test.cc
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+namespace bigtable = google::cloud::bigtable;
+
 /// @test Verify Cell instantiation and trivial accessors.
 TEST(CellTest, Simple) {
   using namespace ::testing;

--- a/google/cloud/bigtable/client_options.cc
+++ b/google/cloud/bigtable/client_options.cc
@@ -28,6 +28,8 @@ std::shared_ptr<grpc::ChannelCredentials> BigtableDefaultCredentials() {
 }
 }  // anonymous namespace
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 ClientOptions::ClientOptions(std::shared_ptr<grpc::ChannelCredentials> creds)
@@ -49,3 +51,5 @@ ClientOptions::ClientOptions() : ClientOptions(BigtableDefaultCredentials()) {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/client_options.h
+++ b/google/cloud/bigtable/client_options.h
@@ -19,6 +19,8 @@
 #include "google/cloud/internal/throw_delegate.h"
 #include <grpcpp/grpcpp.h>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -282,5 +284,7 @@ class ClientOptions {
 };
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_CLIENT_OPTIONS_H_

--- a/google/cloud/bigtable/client_options_test.cc
+++ b/google/cloud/bigtable/client_options_test.cc
@@ -17,6 +17,8 @@
 #include <gmock/gmock.h>
 #include <cstdlib>
 
+namespace bigtable = google::cloud::bigtable;
+
 TEST(ClientOptionsTest, ClientOptionsDefaultSettings) {
   bigtable::ClientOptions client_options_object = bigtable::ClientOptions();
   EXPECT_EQ("bigtable.googleapis.com", client_options_object.data_endpoint());

--- a/google/cloud/bigtable/cluster_config.cc
+++ b/google/cloud/bigtable/cluster_config.cc
@@ -13,6 +13,8 @@
 
 #include "google/cloud/bigtable/cluster_config.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 constexpr ClusterConfig::StorageType ClusterConfig::STORAGE_TYPE_UNSPECIFIED;
@@ -20,3 +22,5 @@ constexpr ClusterConfig::StorageType ClusterConfig::SSD;
 constexpr ClusterConfig::StorageType ClusterConfig::HDD;
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/cluster_config.h
+++ b/google/cloud/bigtable/cluster_config.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/version.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin.pb.h>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /// Specify the initial configuration for a new cluster.
@@ -57,5 +59,7 @@ class ClusterConfig {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_CLUSTER_CONFIG_H_

--- a/google/cloud/bigtable/cluster_config_test.cc
+++ b/google/cloud/bigtable/cluster_config_test.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/bigtable/cluster_config.h"
 #include <gmock/gmock.h>
 
+namespace bigtable = google::cloud::bigtable;
+
 TEST(ClusterConfigTest, Constructor) {
   bigtable::ClusterConfig config("somewhere", 7, bigtable::ClusterConfig::SSD);
   auto proto = config.as_proto();

--- a/google/cloud/bigtable/column_family.h
+++ b/google/cloud/bigtable/column_family.h
@@ -25,6 +25,8 @@
 
 #include "google/cloud/bigtable/internal/conjunction.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -223,5 +225,7 @@ class ColumnFamilyModification {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_COLUMN_FAMILY_H_

--- a/google/cloud/bigtable/column_family_test.cc
+++ b/google/cloud/bigtable/column_family_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/bigtable/testing/chrono_literals.h"
 #include <gmock/gmock.h>
 
+namespace bigtable = google::cloud::bigtable;
 using namespace bigtable::chrono_literals;
 
 TEST(GcRule, MaxNumVersions) {

--- a/google/cloud/bigtable/data_client.cc
+++ b/google/cloud/bigtable/data_client.cc
@@ -17,6 +17,8 @@
 
 namespace btproto = google::bigtable::v2;
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -111,3 +113,5 @@ std::shared_ptr<DataClient> CreateDefaultDataClient(std::string project_id,
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/data_client.h
+++ b/google/cloud/bigtable/data_client.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/client_options.h"
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 // Forward declare some classes so we can be friends.
@@ -119,5 +121,7 @@ inline std::string InstanceName(std::shared_ptr<DataClient> client) {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_DATA_CLIENT_H_

--- a/google/cloud/bigtable/data_client_test.cc
+++ b/google/cloud/bigtable/data_client_test.cc
@@ -16,6 +16,8 @@
 
 #include <gmock/gmock.h>
 
+namespace bigtable = google::cloud::bigtable;
+
 TEST(DataClientTest, Default) {
   auto data_client = bigtable::CreateDefaultDataClient(
       "test-project", "test-instance",

--- a/google/cloud/bigtable/examples/bigtable_hello_world.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_world.cc
@@ -34,15 +34,16 @@ int main(int argc, char* argv[]) try {
 
   // Connect to the Cloud Bigtable Admin API.
   //! [connect admin]
-  bigtable::TableAdmin table_admin(
-      bigtable::CreateDefaultAdminClient(project_id, bigtable::ClientOptions()),
+  google::cloud::bigtable::TableAdmin table_admin(
+      google::cloud::bigtable::CreateDefaultAdminClient(
+          project_id, google::cloud::bigtable::ClientOptions()),
       instance_id);
   //! [connect admin]
 
   //! [create table]
   // Define the desired schema for the Table.
-  auto gc_rule = bigtable::GcRule::MaxNumVersions(1);
-  bigtable::TableConfig schema({{"family", gc_rule}}, {});
+  auto gc_rule = google::cloud::bigtable::GcRule::MaxNumVersions(1);
+  google::cloud::bigtable::TableConfig schema({{"family", gc_rule}}, {});
 
   // Create a table.
   auto returned_schema = table_admin.CreateTable(table_id, schema);
@@ -50,9 +51,10 @@ int main(int argc, char* argv[]) try {
 
   // Create an object to access the Cloud Bigtable Data API.
   //! [connect data]
-  bigtable::Table table(bigtable::CreateDefaultDataClient(
-                            project_id, instance_id, bigtable::ClientOptions()),
-                        table_id);
+  google::cloud::bigtable::Table table(
+      google::cloud::bigtable::CreateDefaultDataClient(
+          project_id, instance_id, google::cloud::bigtable::ClientOptions()),
+      table_id);
   //! [connect data]
 
   // Modify (and create if necessary) a row.
@@ -73,8 +75,9 @@ int main(int argc, char* argv[]) try {
     //
     //     https://cloud.google.com/bigtable/docs/schema-design
     std::string row_key = "key-" + std::to_string(i);
-    table.Apply(bigtable::SingleRowMutation(
-        std::move(row_key), bigtable::SetCell("family", "c0", greeting)));
+    table.Apply(google::cloud::bigtable::SingleRowMutation(
+        std::move(row_key),
+        google::cloud::bigtable::SetCell("family", "c0", greeting)));
     ++i;
   }
   //! [write rows]
@@ -82,7 +85,8 @@ int main(int argc, char* argv[]) try {
   // Read a single row.
   //! [read row]
   auto result = table.ReadRow(
-      "key-0", bigtable::Filter::ColumnRangeClosed("family", "c0", "c0"));
+      "key-0",
+      google::cloud::bigtable::Filter::ColumnRangeClosed("family", "c0", "c0"));
   if (not result.first) {
     std::cout << "Cannot find row 'key-0' in the table: " << table.table_name()
               << std::endl;
@@ -96,8 +100,9 @@ int main(int argc, char* argv[]) try {
 
   // Read a single row.
   //! [scan all]
-  for (auto& row : table.ReadRows(bigtable::RowRange::InfiniteRange(),
-                                  bigtable::Filter::PassAllFilter())) {
+  for (auto& row :
+       table.ReadRows(google::cloud::bigtable::RowRange::InfiniteRange(),
+                      google::cloud::bigtable::Filter::PassAllFilter())) {
     std::cout << row.row_key() << ":\n";
     for (auto& cell : row.cells()) {
       std::cout << "\t" << cell.family_name() << ":" << cell.column_qualifier()

--- a/google/cloud/bigtable/examples/bigtable_samples.cc
+++ b/google/cloud/bigtable/examples/bigtable_samples.cc
@@ -30,17 +30,20 @@ namespace {
 const std::string MAGIC_ROW_KEY = "key-000009";
 
 //! [create table]
-void CreateTable(bigtable::TableAdmin& admin, std::string const& table_id) {
+void CreateTable(google::cloud::bigtable::TableAdmin& admin,
+                 std::string const& table_id) {
   auto schema = admin.CreateTable(
-      table_id, bigtable::TableConfig(
-                    {{"fam", bigtable::GcRule::MaxNumVersions(10)},
-                     {"foo", bigtable::GcRule::MaxAge(std::chrono::hours(72))}},
-                    {}));
+      table_id,
+      google::cloud::bigtable::TableConfig(
+          {{"fam", google::cloud::bigtable::GcRule::MaxNumVersions(10)},
+           {"foo",
+            google::cloud::bigtable::GcRule::MaxAge(std::chrono::hours(72))}},
+          {}));
 }
 //! [create table]
 
 //! [list tables]
-void ListTables(bigtable::TableAdmin& admin) {
+void ListTables(google::cloud::bigtable::TableAdmin& admin) {
   auto tables =
       admin.ListTables(google::bigtable::admin::v2::Table::VIEW_UNSPECIFIED);
   for (auto const& table : tables) {
@@ -50,7 +53,8 @@ void ListTables(bigtable::TableAdmin& admin) {
 //! [list tables]
 
 //! [get table]
-void GetTable(bigtable::TableAdmin& admin, std::string const& table_id) {
+void GetTable(google::cloud::bigtable::TableAdmin& admin,
+              std::string const& table_id) {
   auto table =
       admin.GetTable(table_id, google::bigtable::admin::v2::Table::FULL);
   std::cout << table.name() << "\n";
@@ -65,24 +69,28 @@ void GetTable(bigtable::TableAdmin& admin, std::string const& table_id) {
 //! [get table]
 
 //! [delete table]
-void DeleteTable(bigtable::TableAdmin& admin, std::string const& table_id) {
+void DeleteTable(google::cloud::bigtable::TableAdmin& admin,
+                 std::string const& table_id) {
   admin.DeleteTable(table_id);
 }
 //! [delete table]
 
 //! [modify table]
-void ModifyTable(bigtable::TableAdmin& admin, std::string const& table_id) {
+void ModifyTable(google::cloud::bigtable::TableAdmin& admin,
+                 std::string const& table_id) {
   auto schema = admin.ModifyColumnFamilies(
       table_id,
-      {bigtable::ColumnFamilyModification::Drop("foo"),
-       bigtable::ColumnFamilyModification::Update(
-           "fam", bigtable::GcRule::Union(
-                      bigtable::GcRule::MaxNumVersions(5),
-                      bigtable::GcRule::MaxAge(std::chrono::hours(24 * 7)))),
-       bigtable::ColumnFamilyModification::Create(
-           "bar", bigtable::GcRule::Intersection(
-                      bigtable::GcRule::MaxNumVersions(3),
-                      bigtable::GcRule::MaxAge(std::chrono::hours(72))))});
+      {google::cloud::bigtable::ColumnFamilyModification::Drop("foo"),
+       google::cloud::bigtable::ColumnFamilyModification::Update(
+           "fam", google::cloud::bigtable::GcRule::Union(
+                      google::cloud::bigtable::GcRule::MaxNumVersions(5),
+                      google::cloud::bigtable::GcRule::MaxAge(
+                          std::chrono::hours(24 * 7)))),
+       google::cloud::bigtable::ColumnFamilyModification::Create(
+           "bar", google::cloud::bigtable::GcRule::Intersection(
+                      google::cloud::bigtable::GcRule::MaxNumVersions(3),
+                      google::cloud::bigtable::GcRule::MaxAge(
+                          std::chrono::hours(72))))});
 
   std::string formatted;
   google::protobuf::TextFormat::PrintToString(schema, &formatted);
@@ -91,20 +99,21 @@ void ModifyTable(bigtable::TableAdmin& admin, std::string const& table_id) {
 //! [modify table]
 
 //! [drop all rows]
-void DropAllRows(bigtable::TableAdmin& admin, std::string const& table_id) {
+void DropAllRows(google::cloud::bigtable::TableAdmin& admin,
+                 std::string const& table_id) {
   admin.DropAllRows(table_id);
 }
 //! [drop all rows]
 
 //! [drop rows by prefix]
-void DropRowsByPrefix(bigtable::TableAdmin& admin,
+void DropRowsByPrefix(google::cloud::bigtable::TableAdmin& admin,
                       std::string const& table_id) {
   admin.DropRowsByPrefix(table_id, "key-00004");
 }
 //! [drop rows by prefix]
 
 //! [apply]
-void Apply(bigtable::Table& table) {
+void Apply(google::cloud::bigtable::Table& table) {
   // Write several rows with some trivial data.
   for (int i = 0; i != 20; ++i) {
     // Note: This example uses sequential numeric IDs for simplicity, but
@@ -118,24 +127,24 @@ void Apply(bigtable::Table& table) {
     //     https://cloud.google.com/bigtable/docs/schema-design
     char buf[32];
     snprintf(buf, sizeof(buf), "key-%06d", i);
-    bigtable::SingleRowMutation mutation(buf);
-    mutation.emplace_back(
-        bigtable::SetCell("fam", "col0", "value0-" + std::to_string(i)));
-    mutation.emplace_back(
-        bigtable::SetCell("fam", "col1", "value2-" + std::to_string(i)));
-    mutation.emplace_back(
-        bigtable::SetCell("fam", "col2", "value3-" + std::to_string(i)));
-    mutation.emplace_back(
-        bigtable::SetCell("fam", "col3", "value4-" + std::to_string(i)));
+    google::cloud::bigtable::SingleRowMutation mutation(buf);
+    mutation.emplace_back(google::cloud::bigtable::SetCell(
+        "fam", "col0", "value0-" + std::to_string(i)));
+    mutation.emplace_back(google::cloud::bigtable::SetCell(
+        "fam", "col1", "value2-" + std::to_string(i)));
+    mutation.emplace_back(google::cloud::bigtable::SetCell(
+        "fam", "col2", "value3-" + std::to_string(i)));
+    mutation.emplace_back(google::cloud::bigtable::SetCell(
+        "fam", "col3", "value4-" + std::to_string(i)));
     table.Apply(std::move(mutation));
   }
 }
 //! [apply]
 
 //! [bulk apply]
-void BulkApply(bigtable::Table& table) {
+void BulkApply(google::cloud::bigtable::Table& table) {
   // Write several rows in a single operation, each row has some trivial data.
-  bigtable::BulkMutation bulk;
+  google::cloud::bigtable::BulkMutation bulk;
   for (int i = 0; i != 5000; ++i) {
     // Note: This example uses sequential numeric IDs for simplicity, but
     // this can result in poor performance in a production application.
@@ -148,15 +157,15 @@ void BulkApply(bigtable::Table& table) {
     //     https://cloud.google.com/bigtable/docs/schema-design
     char buf[32];
     snprintf(buf, sizeof(buf), "key-%06d", i);
-    bigtable::SingleRowMutation mutation(buf);
-    mutation.emplace_back(
-        bigtable::SetCell("fam", "col0", "value0-" + std::to_string(i)));
-    mutation.emplace_back(
-        bigtable::SetCell("fam", "col1", "value2-" + std::to_string(i)));
-    mutation.emplace_back(
-        bigtable::SetCell("fam", "col2", "value3-" + std::to_string(i)));
-    mutation.emplace_back(
-        bigtable::SetCell("fam", "col3", "value4-" + std::to_string(i)));
+    google::cloud::bigtable::SingleRowMutation mutation(buf);
+    mutation.emplace_back(google::cloud::bigtable::SetCell(
+        "fam", "col0", "value0-" + std::to_string(i)));
+    mutation.emplace_back(google::cloud::bigtable::SetCell(
+        "fam", "col1", "value2-" + std::to_string(i)));
+    mutation.emplace_back(google::cloud::bigtable::SetCell(
+        "fam", "col2", "value3-" + std::to_string(i)));
+    mutation.emplace_back(google::cloud::bigtable::SetCell(
+        "fam", "col3", "value4-" + std::to_string(i)));
     bulk.emplace_back(std::move(mutation));
   }
   table.BulkApply(std::move(bulk));
@@ -164,11 +173,11 @@ void BulkApply(bigtable::Table& table) {
 //! [bulk apply]
 
 //! [read row]
-void ReadRow(bigtable::Table& table) {
+void ReadRow(google::cloud::bigtable::Table& table) {
   // Filter the results, only include the latest value on each cell.
-  auto filter = bigtable::Filter::Latest(1);
+  auto filter = google::cloud::bigtable::Filter::Latest(1);
   // Read a row, this returns a tuple (bool, row)
-  std::pair<bool, bigtable::Row> tuple =
+  std::pair<bool, google::cloud::bigtable::Row> tuple =
       table.ReadRow(MAGIC_ROW_KEY, std::move(filter));
   if (not tuple.first) {
     std::cout << "Row " << MAGIC_ROW_KEY << " not found" << std::endl;
@@ -181,7 +190,8 @@ void ReadRow(bigtable::Table& table) {
     if (cell.column_qualifier() == "counter") {
       // This example uses "counter" to store 64-bit numbers in BigEndian
       // format, extract them as follows:
-      std::cout << cell.value_as<bigtable::bigendian64_t>().get();
+      std::cout
+          << cell.value_as<google::cloud::bigtable::bigendian64_t>().get();
     } else {
       std::cout << cell.value();
     }
@@ -192,14 +202,15 @@ void ReadRow(bigtable::Table& table) {
 //! [read row]
 
 //! [read rows]
-void ReadRows(bigtable::Table& table) {
+void ReadRows(google::cloud::bigtable::Table& table) {
   // Create the range of rows to read.
-  auto range = bigtable::RowRange::Range("key-000010", "key-000020");
+  auto range =
+      google::cloud::bigtable::RowRange::Range("key-000010", "key-000020");
   // Filter the results, only include values from the "col0" column in the
   // "fam" column family, and only get the latest value.
-  auto filter = bigtable::Filter::Chain(
-      bigtable::Filter::ColumnRangeClosed("fam", "col0", "col0"),
-      bigtable::Filter::Latest(1));
+  auto filter = google::cloud::bigtable::Filter::Chain(
+      google::cloud::bigtable::Filter::ColumnRangeClosed("fam", "col0", "col0"),
+      google::cloud::bigtable::Filter::Latest(1));
   // Read and print the rows.
   for (auto const& row : table.ReadRows(range, filter)) {
     if (row.cells().size() != 1) {
@@ -215,14 +226,15 @@ void ReadRows(bigtable::Table& table) {
 //! [read rows]
 
 //! [read rows with limit]
-void ReadRowsWithLimit(bigtable::Table& table) {
+void ReadRowsWithLimit(google::cloud::bigtable::Table& table) {
   // Create the range of rows to read.
-  auto range = bigtable::RowRange::Range("key-000010", "key-000020");
+  auto range =
+      google::cloud::bigtable::RowRange::Range("key-000010", "key-000020");
   // Filter the results, only include values from the "col0" column in the
   // "fam" column family, and only get the latest value.
-  auto filter = bigtable::Filter::Chain(
-      bigtable::Filter::ColumnRangeClosed("fam", "col0", "col0"),
-      bigtable::Filter::Latest(1));
+  auto filter = google::cloud::bigtable::Filter::Chain(
+      google::cloud::bigtable::Filter::ColumnRangeClosed("fam", "col0", "col0"),
+      google::cloud::bigtable::Filter::Latest(1));
   // Read and print the first 5 rows in the range.
   for (auto const& row : table.ReadRows(range, 5, filter)) {
     if (row.cells().size() != 1) {
@@ -238,28 +250,33 @@ void ReadRowsWithLimit(bigtable::Table& table) {
 //! [read rows with limit]
 
 //! [check and mutate]
-void CheckAndMutate(bigtable::Table& table) {
+void CheckAndMutate(google::cloud::bigtable::Table& table) {
   // Check if the latest value of the flip-flop column is "on".
-  auto predicate = bigtable::Filter::Chain(
-      bigtable::Filter::ColumnRangeClosed("fam", "flip-flop", "flip-flop"),
-      bigtable::Filter::Latest(1), bigtable::Filter::ValueRegex("on"));
+  auto predicate = google::cloud::bigtable::Filter::Chain(
+      google::cloud::bigtable::Filter::ColumnRangeClosed("fam", "flip-flop",
+                                                         "flip-flop"),
+      google::cloud::bigtable::Filter::Latest(1),
+      google::cloud::bigtable::Filter::ValueRegex("on"));
   // If the predicate matches, change the latest value to "off", otherwise,
   // change the latest value to "on".  Modify the "flop-flip" column at the
   // same time.
-  table.CheckAndMutateRow(MAGIC_ROW_KEY, std::move(predicate),
-                          {bigtable::SetCell("fam", "flip-flop", "off"),
-                           bigtable::SetCell("fam", "flop-flip", "on")},
-                          {bigtable::SetCell("fam", "flip-flop", "on"),
-                           bigtable::SetCell("fam", "flop-flip", "off")});
+  table.CheckAndMutateRow(
+      MAGIC_ROW_KEY, std::move(predicate),
+      {google::cloud::bigtable::SetCell("fam", "flip-flop", "off"),
+       google::cloud::bigtable::SetCell("fam", "flop-flip", "on")},
+      {google::cloud::bigtable::SetCell("fam", "flip-flop", "on"),
+       google::cloud::bigtable::SetCell("fam", "flop-flip", "off")});
 }
 //! [check and mutate]
 
 //! [read modify write]
-void ReadModifyWrite(bigtable::Table& table) {
+void ReadModifyWrite(google::cloud::bigtable::Table& table) {
   auto row = table.ReadModifyWriteRow(
       MAGIC_ROW_KEY,
-      bigtable::ReadModifyWriteRule::IncrementAmount("fam", "counter", 1),
-      bigtable::ReadModifyWriteRule::AppendValue("fam", "list", ";element"));
+      google::cloud::bigtable::ReadModifyWriteRule::IncrementAmount(
+          "fam", "counter", 1),
+      google::cloud::bigtable::ReadModifyWriteRule::AppendValue("fam", "list",
+                                                                ";element"));
   std::cout << row.row_key() << "\n";
   for (auto const& cell : row.cells()) {
   }
@@ -267,7 +284,7 @@ void ReadModifyWrite(bigtable::Table& table) {
 //! [read modify write]
 
 //! [sample row keys]
-void SampleRows(bigtable::Table& table) {
+void SampleRows(google::cloud::bigtable::Table& table) {
   auto samples = table.SampleRows<>();
   for (auto const& sample : samples) {
     std::cout << "key=" << sample.row_key << " - " << sample.offset_bytes
@@ -278,7 +295,7 @@ void SampleRows(bigtable::Table& table) {
 //! [sample row keys]
 
 //! [sample row keys collections]
-void SampleRowsCollections(bigtable::Table& table) {
+void SampleRowsCollections(google::cloud::bigtable::Table& table) {
   auto list_samples = table.SampleRows<std::list>();
   for (auto const& sample : list_samples) {
     std::cout << "key=" << sample.row_key << " - " << sample.offset_bytes
@@ -322,16 +339,18 @@ int main(int argc, char* argv[]) try {
 
   // Connect to the Cloud Bigtable admin endpoint.
   //! [connect admin]
-  bigtable::TableAdmin admin(
-      bigtable::CreateDefaultAdminClient(project_id, bigtable::ClientOptions()),
+  google::cloud::bigtable::TableAdmin admin(
+      google::cloud::bigtable::CreateDefaultAdminClient(
+          project_id, google::cloud::bigtable::ClientOptions()),
       instance_id);
   //! [connect admin]
 
   // Connect to the Cloud Bigtable endpoint.
   //! [connect data]
-  bigtable::Table table(bigtable::CreateDefaultDataClient(
-                            project_id, instance_id, bigtable::ClientOptions()),
-                        table_id);
+  google::cloud::bigtable::Table table(
+      google::cloud::bigtable::CreateDefaultDataClient(
+          project_id, instance_id, google::cloud::bigtable::ClientOptions()),
+      table_id);
   //! [connect data]
 
   if (command == "create-table") {

--- a/google/cloud/bigtable/examples/bigtable_samples_instance_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_samples_instance_admin.cc
@@ -48,21 +48,22 @@ void PrintUsage(int argc, char* argv[], std::string const& msg) {
 }
 
 //! [create instance]
-void CreateInstance(bigtable::InstanceAdmin instance_admin, int argc,
-                    char* argv[]) {
+void CreateInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
+                    int argc, char* argv[]) {
   if (argc != 3) {
     throw Usage{"create-instance: <instance-id> <zone>"};
   }
   std::string const instance_id = ConsumeArg(argc, argv);
   std::string const zone = ConsumeArg(argc, argv);
 
-  bigtable::DisplayName display_name("Put description here");
+  google::cloud::bigtable::DisplayName display_name("Put description here");
   std::string cluster_id = instance_id + "-c1";
-  auto cluster_config =
-      bigtable::ClusterConfig(zone, 0, bigtable::ClusterConfig::HDD);
-  bigtable::InstanceConfig config(bigtable::InstanceId(instance_id),
-                                  display_name, {{cluster_id, cluster_config}});
-  config.set_type(bigtable::InstanceConfig::DEVELOPMENT);
+  auto cluster_config = google::cloud::bigtable::ClusterConfig(
+      zone, 0, google::cloud::bigtable::ClusterConfig::HDD);
+  google::cloud::bigtable::InstanceConfig config(
+      google::cloud::bigtable::InstanceId(instance_id), display_name,
+      {{cluster_id, cluster_config}});
+  config.set_type(google::cloud::bigtable::InstanceConfig::DEVELOPMENT);
 
   auto future = instance_admin.CreateInstance(config);
   // Most applications would simply call future.get(), here we show how to
@@ -80,15 +81,16 @@ void CreateInstance(bigtable::InstanceAdmin instance_admin, int argc,
 //! [create instance]
 
 //! [update instance]
-void UpdateInstance(bigtable::InstanceAdmin instance_admin, int argc,
-                    char* argv[]) {
+void UpdateInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
+                    int argc, char* argv[]) {
   if (argc != 2) {
     throw Usage{"update-instance: <project-id> <instance-id>"};
   }
   std::string instance_id = ConsumeArg(argc, argv);
   auto instance = instance_admin.GetInstance(instance_id);
   // Modify the instance and prepare the mask with modified field
-  bigtable::InstanceUpdateConfig instance_update_config(std::move(instance));
+  google::cloud::bigtable::InstanceUpdateConfig instance_update_config(
+      std::move(instance));
   instance_update_config.set_display_name("Modified Display Name");
 
   auto future =
@@ -100,8 +102,8 @@ void UpdateInstance(bigtable::InstanceAdmin instance_admin, int argc,
 //! [update instance]
 
 //! [list instances]
-void ListInstances(bigtable::InstanceAdmin instance_admin, int argc,
-                   char* argv[]) {
+void ListInstances(google::cloud::bigtable::InstanceAdmin instance_admin,
+                   int argc, char* argv[]) {
   auto instances = instance_admin.ListInstances();
   for (auto const& instance : instances) {
     std::cout << instance.name() << std::endl;
@@ -110,8 +112,8 @@ void ListInstances(bigtable::InstanceAdmin instance_admin, int argc,
 //! [list instances]
 
 //! [get instance]
-void GetInstance(bigtable::InstanceAdmin instance_admin, int argc,
-                 char* argv[]) {
+void GetInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
+                 int argc, char* argv[]) {
   if (argc != 2) {
     throw Usage{"get-instance: <project-id> <instance-id>"};
   }
@@ -124,8 +126,8 @@ void GetInstance(bigtable::InstanceAdmin instance_admin, int argc,
 //! [get instance]
 
 //! [delete instance]
-void DeleteInstance(bigtable::InstanceAdmin instance_admin, int argc,
-                    char* argv[]) {
+void DeleteInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
+                    int argc, char* argv[]) {
   if (argc != 2) {
     throw Usage{"delete-instance: <project-id> <instance-id>"};
   }
@@ -135,8 +137,8 @@ void DeleteInstance(bigtable::InstanceAdmin instance_admin, int argc,
 //! [delete instance]
 
 //! [list clusters]
-void ListClusters(bigtable::InstanceAdmin instance_admin, int argc,
-                  char* argv[]) {
+void ListClusters(google::cloud::bigtable::InstanceAdmin instance_admin,
+                  int argc, char* argv[]) {
   if (argc != 2) {
     throw Usage{"list-clusters <project-id> <instance-id>"};
   }
@@ -150,23 +152,24 @@ void ListClusters(bigtable::InstanceAdmin instance_admin, int argc,
 //! [list clusters]
 
 //! [update cluster]
-void UpdateCluster(bigtable::InstanceAdmin instance_admin, int argc,
-                   char* argv[]) {
+void UpdateCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
+                   int argc, char* argv[]) {
   if (argc != 2) {
     throw Usage{"update-cluster: <project-id> <instance-id> <cluster-id>"};
   }
   // CreateCluster or GetCluster first and then modify it
-  bigtable::InstanceId instance_id(ConsumeArg(argc, argv));
-  bigtable::ClusterId cluster_id(ConsumeArg(argc, argv));
-  auto cluster_config =
-      bigtable::ClusterConfig("us-central1-f", 0, bigtable::ClusterConfig::HDD);
+  google::cloud::bigtable::InstanceId instance_id(ConsumeArg(argc, argv));
+  google::cloud::bigtable::ClusterId cluster_id(ConsumeArg(argc, argv));
+  auto cluster_config = google::cloud::bigtable::ClusterConfig(
+      "us-central1-f", 0, google::cloud::bigtable::ClusterConfig::HDD);
   auto cluster =
       instance_admin.CreateCluster(cluster_config, instance_id, cluster_id)
           .get();
 
   // Modify the cluster
   cluster.set_serve_nodes(2);
-  auto modified_config = bigtable::ClusterConfig(std::move(cluster));
+  auto modified_config =
+      google::cloud::bigtable::ClusterConfig(std::move(cluster));
 
   auto modified_cluster = instance_admin.UpdateCluster(cluster_config).get();
 
@@ -178,13 +181,13 @@ void UpdateCluster(bigtable::InstanceAdmin instance_admin, int argc,
 //! [update cluster]
 
 //! [delete cluster]
-void DeleteCluster(bigtable::InstanceAdmin instance_admin, int argc,
-                   char* argv[]) {
+void DeleteCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
+                   int argc, char* argv[]) {
   if (argc != 3) {
     throw Usage{"delete-cluster: <project-id> <instance-id> <cluster-id>"};
   }
-  bigtable::InstanceId instance_id(ConsumeArg(argc, argv));
-  bigtable::ClusterId cluster_id(ConsumeArg(argc, argv));
+  google::cloud::bigtable::InstanceId instance_id(ConsumeArg(argc, argv));
+  google::cloud::bigtable::ClusterId cluster_id(ConsumeArg(argc, argv));
   instance_admin.DeleteCluster(instance_id, cluster_id);
 }
 //! [delete cluster]
@@ -202,14 +205,14 @@ int main(int argc, char* argv[]) try {
 
   // Connect to the Cloud Bigtable admin endpoint.
   //! [connect instance admin client]
-  std::shared_ptr<bigtable::InstanceAdminClient> instance_admin_client(
-      bigtable::CreateDefaultInstanceAdminClient(project_id,
-                                                 bigtable::ClientOptions()));
+  auto instance_admin_client(
+      google::cloud::bigtable::CreateDefaultInstanceAdminClient(
+          project_id, google::cloud::bigtable::ClientOptions()));
   //! [connect instance admin client]
 
   // Connect to the Cloud Bigtable endpoint.
   //! [connect instance admin]
-  bigtable::InstanceAdmin instance_admin(instance_admin_client);
+  google::cloud::bigtable::InstanceAdmin instance_admin(instance_admin_client);
   //! [connect instance admin]
 
   if (command == "create-instance") {

--- a/google/cloud/bigtable/filters.h
+++ b/google/cloud/bigtable/filters.h
@@ -19,6 +19,8 @@
 #include <google/bigtable/v2/data.pb.h>
 #include <chrono>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -606,5 +608,7 @@ class Filter {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_FILTERS_H_

--- a/google/cloud/bigtable/filters_test.cc
+++ b/google/cloud/bigtable/filters_test.cc
@@ -18,6 +18,7 @@
 #include <gmock/gmock.h>
 
 namespace btproto = ::google::bigtable::v2;
+namespace bigtable = google::cloud::bigtable;
 
 TEST(FiltersTest, PassAllFilter) {
   auto proto = bigtable::Filter::PassAllFilter().as_proto();

--- a/google/cloud/bigtable/grpc_error.cc
+++ b/google/cloud/bigtable/grpc_error.cc
@@ -39,6 +39,8 @@ constexpr int KNOWN_STATUS_CODES_SIZE =
     sizeof(KNOWN_STATUS_CODES) / sizeof(KNOWN_STATUS_CODES[0]);
 }  // anonymous namespace
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 GRpcError::GRpcError(char const* what, grpc::Status const& status)
@@ -64,3 +66,5 @@ std::string GRpcError::CreateWhatString(char const* what,
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/grpc_error.h
+++ b/google/cloud/bigtable/grpc_error.h
@@ -19,6 +19,8 @@
 #include <grpcpp/grpcpp.h>
 #include <stdexcept>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -63,5 +65,7 @@ class GRpcError : public std::runtime_error {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_GRPC_ERROR_H_

--- a/google/cloud/bigtable/grpc_error_test.cc
+++ b/google/cloud/bigtable/grpc_error_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/bigtable/grpc_error.h"
 #include <gmock/gmock.h>
 
+namespace bigtable = google::cloud::bigtable;
 using testing::HasSubstr;
 
 TEST(GRpcErrorTest, Simple) {

--- a/google/cloud/bigtable/idempotent_mutation_policy.cc
+++ b/google/cloud/bigtable/idempotent_mutation_policy.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/bigtable/idempotent_mutation_policy.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 std::unique_ptr<IdempotentMutationPolicy> DefaultIdempotentMutationPolicy() {
@@ -47,3 +49,5 @@ bool AlwaysRetryMutationPolicy::is_idempotent(
 }
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/idempotent_mutation_policy.h
+++ b/google/cloud/bigtable/idempotent_mutation_policy.h
@@ -19,6 +19,8 @@
 #include "google/cloud/bigtable/version.h"
 #include <memory>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -73,5 +75,7 @@ class AlwaysRetryMutationPolicy : public IdempotentMutationPolicy {
 };
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_IDEMPOTENT_MUTATION_POLICY_H_

--- a/google/cloud/bigtable/idempotent_mutation_policy_test.cc
+++ b/google/cloud/bigtable/idempotent_mutation_policy_test.cc
@@ -16,6 +16,8 @@
 #include "google/cloud/bigtable/testing/chrono_literals.h"
 #include <gmock/gmock.h>
 
+namespace bigtable = google::cloud::bigtable;
+
 /// @test Verify that the default policy works as expected.
 TEST(IdempotentMutationPolicyTest, Simple) {
   using namespace bigtable::chrono_literals;

--- a/google/cloud/bigtable/instance_admin.cc
+++ b/google/cloud/bigtable/instance_admin.cc
@@ -22,6 +22,8 @@
 
 namespace btproto = ::google::bigtable::admin::v2;
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 static_assert(std::is_copy_assignable<bigtable::InstanceAdmin>::value,
@@ -361,3 +363,5 @@ google::bigtable::admin::v2::Cluster InstanceAdmin::CreateClusterImpl(
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -23,6 +23,8 @@
 #include <future>
 #include <memory>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -225,5 +227,7 @@ class InstanceAdmin {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INSTANCE_ADMIN_H_

--- a/google/cloud/bigtable/instance_admin_client.cc
+++ b/google/cloud/bigtable/instance_admin_client.cc
@@ -16,6 +16,8 @@
 #include "google/cloud/bigtable/internal/common_client.h"
 #include <google/longrunning/operations.grpc.pb.h>
 
+namespace bigtable = google::cloud::bigtable;
+
 namespace {
 /**
  * An AdminClient for single-threaded programs that refreshes credentials on all
@@ -135,13 +137,17 @@ class DefaultInstanceAdminClient : public bigtable::InstanceAdminClient {
 };
 }  // anonymous namespace
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 std::shared_ptr<InstanceAdminClient> CreateDefaultInstanceAdminClient(
-    std::string project, bigtable::ClientOptions options) {
+    std::string project, ClientOptions options) {
   return std::make_shared<DefaultInstanceAdminClient>(std::move(project),
                                                       std::move(options));
 }
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/instance_admin_client.h
+++ b/google/cloud/bigtable/instance_admin_client.h
@@ -20,6 +20,8 @@
 #include <memory>
 #include <string>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 // Forward declare some classes so we can be friends.
@@ -129,9 +131,11 @@ class InstanceAdminClient {
 
 /// Create a new admin client configured via @p options.
 std::shared_ptr<InstanceAdminClient> CreateDefaultInstanceAdminClient(
-    std::string project, bigtable::ClientOptions options);
+    std::string project, ClientOptions options);
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INSTANCE_ADMIN_CLIENT_H_

--- a/google/cloud/bigtable/instance_admin_client_test.cc
+++ b/google/cloud/bigtable/instance_admin_client_test.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/bigtable/instance_admin_client.h"
 #include <gmock/gmock.h>
 
+namespace bigtable = google::cloud::bigtable;
+
 TEST(InstanceAdminClientTest, Default) {
   auto admin_client = bigtable::CreateDefaultInstanceAdminClient(
       "test-project", bigtable::ClientOptions().set_connection_pool_size(1));

--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -21,7 +21,8 @@
 #include <gmock/gmock.h>
 
 namespace {
-namespace btproto = ::google::bigtable::admin::v2;
+namespace btproto = google::bigtable::admin::v2;
+namespace bigtable = google::cloud::bigtable;
 
 using MockAdminClient = bigtable::testing::MockInstanceAdminClient;
 

--- a/google/cloud/bigtable/instance_config.cc
+++ b/google/cloud/bigtable/instance_config.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/bigtable/instance_config.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 constexpr InstanceConfig::InstanceType InstanceConfig::TYPE_UNSPECIFIED;
@@ -21,3 +23,5 @@ constexpr InstanceConfig::InstanceType InstanceConfig::PRODUCTION;
 constexpr InstanceConfig::InstanceType InstanceConfig::DEVELOPMENT;
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/instance_config.h
+++ b/google/cloud/bigtable/instance_config.h
@@ -22,6 +22,8 @@
 #include <map>
 #include <vector>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 using InstanceId = internal::StrongType<std::string, struct InstanceTag>;
@@ -82,5 +84,7 @@ class InstanceConfig {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INSTANCE_CONFIG_H_

--- a/google/cloud/bigtable/instance_config_test.cc
+++ b/google/cloud/bigtable/instance_config_test.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/bigtable/instance_config.h"
 #include <gmock/gmock.h>
 
+namespace bigtable = google::cloud::bigtable;
+
 TEST(InstanceConfigTest, Constructor) {
   bigtable::InstanceConfig config(
       bigtable::InstanceId("my-instance"), bigtable::DisplayName("pretty name"),

--- a/google/cloud/bigtable/instance_update_config.cc
+++ b/google/cloud/bigtable/instance_update_config.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/bigtable/instance_update_config.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 constexpr InstanceUpdateConfig::InstanceType
@@ -26,3 +28,5 @@ constexpr InstanceUpdateConfig::StateType InstanceUpdateConfig::READY;
 constexpr InstanceUpdateConfig::StateType InstanceUpdateConfig::CREATING;
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/instance_update_config.h
+++ b/google/cloud/bigtable/instance_update_config.h
@@ -22,6 +22,8 @@
 #include <map>
 #include <vector>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 using Instance = ::google::bigtable::admin::v2::Instance;
@@ -121,5 +123,7 @@ class InstanceUpdateConfig {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INSTANCE_UPDATE_CONFIG_H_

--- a/google/cloud/bigtable/instance_update_config_test.cc
+++ b/google/cloud/bigtable/instance_update_config_test.cc
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 
 namespace btproto = ::google::bigtable::admin::v2;
+namespace bigtable = google::cloud::bigtable;
 
 TEST(InstanceUpdateConfigTest, Constructor) {
   std::string instance_text = R"(

--- a/google/cloud/bigtable/internal/bulk_mutator.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator.cc
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/table_strong_types.h"
 #include <numeric>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
@@ -157,3 +159,5 @@ std::vector<FailedMutation> BulkMutator::ExtractFinalFailures() {
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -20,6 +20,8 @@
 #include "google/cloud/bigtable/idempotent_mutation_policy.h"
 #include "google/cloud/bigtable/table_strong_types.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
@@ -91,5 +93,7 @@ class BulkMutator {
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_BULK_MUTATOR_H_

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -21,6 +21,7 @@
 /// Define types and functions used in the tests.
 namespace {
 namespace btproto = google::bigtable::v2;
+namespace bigtable = google::cloud::bigtable;
 namespace bt = ::bigtable;
 using namespace ::testing;
 using namespace bigtable::chrono_literals;

--- a/google/cloud/bigtable/internal/common_client.cc
+++ b/google/cloud/bigtable/internal/common_client.cc
@@ -13,6 +13,8 @@
 
 #include "google/cloud/bigtable/internal/common_client.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
@@ -36,3 +38,5 @@ std::vector<std::shared_ptr<grpc::Channel>> CreateChannelPool(
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/internal/common_client.h
+++ b/google/cloud/bigtable/internal/common_client.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/client_options.h"
 #include <grpcpp/grpcpp.h>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
@@ -133,5 +135,7 @@ class CommonClient {
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_COMMON_CLIENT_H_

--- a/google/cloud/bigtable/internal/conjunction.h
+++ b/google/cloud/bigtable/internal/conjunction.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/version.h"
 #include <type_traits>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
@@ -40,5 +42,7 @@ struct conjunction<B1, Bn...>
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_CONJUNCTION_H_

--- a/google/cloud/bigtable/internal/encoder.h
+++ b/google/cloud/bigtable/internal/encoder.h
@@ -17,6 +17,8 @@
 
 #include "google/cloud/bigtable/internal/strong_type.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
@@ -115,5 +117,7 @@ struct Encoder {
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ENCODER_H_

--- a/google/cloud/bigtable/internal/endian.cc
+++ b/google/cloud/bigtable/internal/endian.cc
@@ -25,6 +25,8 @@
 #include <byteswap.h>
 #endif
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
@@ -104,3 +106,5 @@ std::string AsBigEndian64(bigtable::bigendian64_t value) {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/internal/endian.h
+++ b/google/cloud/bigtable/internal/endian.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/internal/encoder.h"
 #include "google/cloud/bigtable/internal/strong_type.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 using bigendian64_t = internal::StrongType<std::int64_t, struct BigEndianType>;
@@ -37,5 +39,7 @@ std::string AsBigEndian64(bigtable::bigendian64_t value);
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ENDIAN_H_

--- a/google/cloud/bigtable/internal/grpc_error_delegate.cc
+++ b/google/cloud/bigtable/internal/grpc_error_delegate.cc
@@ -16,6 +16,8 @@
 #include "google/cloud/bigtable/grpc_error.h"
 #include <sstream>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
@@ -38,3 +40,5 @@ void RaiseRpcError(grpc::Status const& status, std::string const& msg) {
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/internal/grpc_error_delegate.h
+++ b/google/cloud/bigtable/internal/grpc_error_delegate.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/version.h"
 #include <grpcpp/grpcpp.h>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
@@ -41,5 +43,7 @@ namespace internal {
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_GRPC_ERROR_DELEGATE_H_

--- a/google/cloud/bigtable/internal/grpc_error_delegate_test.cc
+++ b/google/cloud/bigtable/internal/grpc_error_delegate_test.cc
@@ -16,7 +16,7 @@
 #include "google/cloud/bigtable/grpc_error.h"
 #include <gtest/gtest.h>
 
-using namespace bigtable::internal;
+using namespace google::cloud::bigtable::internal;
 
 namespace {
 std::string const cmsg("testing with std::string const&");
@@ -26,8 +26,8 @@ char const* msg = "testing with char const*";
 TEST(ThrowDelegateTest, RpcError) {
   grpc::Status status(grpc::StatusCode::UNAVAILABLE, "try-again");
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(RaiseRpcError(status, msg), bigtable::GRpcError);
-  EXPECT_THROW(RaiseRpcError(status, cmsg), bigtable::GRpcError);
+  EXPECT_THROW(RaiseRpcError(status, msg), google::cloud::bigtable::GRpcError);
+  EXPECT_THROW(RaiseRpcError(status, cmsg), google::cloud::bigtable::GRpcError);
 #else
   EXPECT_DEATH_IF_SUPPORTED(RaiseRpcError(status, msg), msg);
   EXPECT_DEATH_IF_SUPPORTED(RaiseRpcError(status, cmsg), cmsg);

--- a/google/cloud/bigtable/internal/instance_admin.cc
+++ b/google/cloud/bigtable/internal/instance_admin.cc
@@ -18,6 +18,8 @@
 
 namespace btproto = ::google::bigtable::admin::v2;
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace noex {
@@ -135,3 +137,5 @@ void InstanceAdmin::DeleteCluster(bigtable::InstanceId const& instance_id,
 }  // namespace noex
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/internal/instance_admin.h
+++ b/google/cloud/bigtable/internal/instance_admin.h
@@ -21,6 +21,8 @@
 #include "google/cloud/bigtable/rpc_retry_policy.h"
 #include <memory>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 class InstanceAdmin;
@@ -115,5 +117,7 @@ class InstanceAdmin {
 }  // namespace noex
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_INSTANCE_ADMIN_H_

--- a/google/cloud/bigtable/internal/instance_admin_test.cc
+++ b/google/cloud/bigtable/internal/instance_admin_test.cc
@@ -20,6 +20,7 @@
 
 namespace {
 namespace btproto = ::google::bigtable::admin::v2;
+namespace bigtable = google::cloud::bigtable;
 
 using MockAdminClient = bigtable::testing::MockInstanceAdminClient;
 

--- a/google/cloud/bigtable/internal/make_unique.h
+++ b/google/cloud/bigtable/internal/make_unique.h
@@ -19,6 +19,8 @@
 
 #include <memory>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
@@ -46,5 +48,7 @@ std::unique_ptr<T> make_unique(Args&&... a) {
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_MAKE_UNIQUE_H_

--- a/google/cloud/bigtable/internal/prefix_range_end.cc
+++ b/google/cloud/bigtable/internal/prefix_range_end.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/bigtable/internal/prefix_range_end.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
@@ -38,3 +40,5 @@ std::string PrefixRangeEnd(std::string const& key) {
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/internal/prefix_range_end.h
+++ b/google/cloud/bigtable/internal/prefix_range_end.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/version.h"
 #include <string>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
@@ -34,5 +36,7 @@ std::string PrefixRangeEnd(std::string const& key);
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_PREFIX_RANGE_END_H_

--- a/google/cloud/bigtable/internal/prefix_range_end_test.cc
+++ b/google/cloud/bigtable/internal/prefix_range_end_test.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/bigtable/internal/prefix_range_end.h"
 #include <gmock/gmock.h>
 
+namespace bigtable = google::cloud::bigtable;
+
 TEST(PrefixRangeEndTest, Simple) {
   // This test assumes ASCII.
   EXPECT_EQ("foo0", bigtable::internal::PrefixRangeEnd("foo/"));

--- a/google/cloud/bigtable/internal/readrowsparser.cc
+++ b/google/cloud/bigtable/internal/readrowsparser.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/bigtable/internal/readrowsparser.h"
 #include "google/cloud/bigtable/internal/grpc_error_delegate.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
@@ -170,3 +172,5 @@ Cell ReadRowsParser::MovePartialToCell() {
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/internal/readrowsparser.h
+++ b/google/cloud/bigtable/internal/readrowsparser.h
@@ -21,6 +21,8 @@
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
 #include <vector>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
@@ -150,5 +152,7 @@ class ReadRowsParserFactory {
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_READROWSPARSER_H_

--- a/google/cloud/bigtable/internal/readrowsparser_test.cc
+++ b/google/cloud/bigtable/internal/readrowsparser_test.cc
@@ -21,8 +21,8 @@
 #include <sstream>
 #include <vector>
 
-using bigtable::internal::ReadRowsParser;
 using google::bigtable::v2::ReadRowsResponse_CellChunk;
+using google::cloud::bigtable::internal::ReadRowsParser;
 
 TEST(ReadRowsParserTest, NoChunksNoRowsSucceeds) {
   grpc::Status status;
@@ -77,7 +77,7 @@ TEST(ReadRowsParserTest, SingleChunkSucceeds) {
   EXPECT_TRUE(status.ok());
   EXPECT_TRUE(parser.HasNext());
 
-  std::vector<bigtable::Row> rows;
+  std::vector<google::cloud::bigtable::Row> rows;
   rows.emplace_back(parser.Next(status));
   EXPECT_TRUE(status.ok());
   EXPECT_FALSE(parser.HasNext());
@@ -155,7 +155,7 @@ TEST(ReadRowsParserTest, SingleChunkValueIsMoved) {
   parser.HandleChunk(std::move(chunk), status);
   EXPECT_TRUE(status.ok());
   ASSERT_TRUE(parser.HasNext());
-  bigtable::Row r = parser.Next(status);
+  google::cloud::bigtable::Row r = parser.Next(status);
   ASSERT_EQ(1U, r.cells().size());
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(data_ptr, r.cells().begin()->value().data());
@@ -163,6 +163,8 @@ TEST(ReadRowsParserTest, SingleChunkValueIsMoved) {
 
 // **** Acceptance tests helpers ****
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 
 // Can also be used by gtest to print Cell values
@@ -188,6 +190,8 @@ std::string CellToString(Cell const& cell) {
 }
 
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 class AcceptanceTest : public ::testing::Test {
  protected:
@@ -196,7 +200,8 @@ class AcceptanceTest : public ::testing::Test {
 
     for (auto const& r : rows_) {
       std::transform(r.cells().begin(), r.cells().end(),
-                     std::back_inserter(cells), bigtable::CellToString);
+                     std::back_inserter(cells),
+                     google::cloud::bigtable::CellToString);
     }
     return cells;
   }
@@ -239,7 +244,7 @@ class AcceptanceTest : public ::testing::Test {
 
  private:
   ReadRowsParser parser_;
-  std::vector<bigtable::Row> rows_;
+  std::vector<google::cloud::bigtable::Row> rows_;
 };
 
 // Auto-generated acceptance tests

--- a/google/cloud/bigtable/internal/rowreaderiterator.cc
+++ b/google/cloud/bigtable/internal/rowreaderiterator.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/bigtable/internal/rowreaderiterator.h"
 #include "google/cloud/bigtable/row_reader.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
@@ -27,3 +29,5 @@ RowReaderIterator& RowReaderIterator::operator++() {
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/internal/rowreaderiterator.h
+++ b/google/cloud/bigtable/internal/rowreaderiterator.h
@@ -19,6 +19,8 @@
 #include "google/cloud/internal/throw_delegate.h"
 #include <iterator>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 // Forward declare the owner class of this iterator.
@@ -107,5 +109,7 @@ class RowReaderIterator : public std::iterator<std::input_iterator_tag, Row> {
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ROWREADERITERATOR_H_

--- a/google/cloud/bigtable/internal/strong_type.h
+++ b/google/cloud/bigtable/internal/strong_type.h
@@ -17,6 +17,8 @@
 
 #include "google/cloud/bigtable/version.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
@@ -66,5 +68,7 @@ class StrongType {
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_STRONG_TYPE_H_

--- a/google/cloud/bigtable/internal/table.cc
+++ b/google/cloud/bigtable/internal/table.cc
@@ -21,6 +21,8 @@
 
 namespace btproto = ::google::bigtable::v2;
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace noex {
@@ -267,3 +269,5 @@ void Table::SampleRowsImpl(
 }  // namespace noex
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/internal/table.h
+++ b/google/cloud/bigtable/internal/table.h
@@ -29,6 +29,8 @@
 #include "google/cloud/bigtable/table_strong_types.h"
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -225,5 +227,7 @@ class Table {
 }  // namespace noex
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_TABLE_H_

--- a/google/cloud/bigtable/internal/table_admin.cc
+++ b/google/cloud/bigtable/internal/table_admin.cc
@@ -18,6 +18,8 @@
 
 namespace btproto = ::google::bigtable::admin::v2;
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace noex {
@@ -267,3 +269,5 @@ void TableAdmin::ListSnapshotsImpl(
 }  // namespace noex
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/internal/table_admin.h
+++ b/google/cloud/bigtable/internal/table_admin.h
@@ -26,6 +26,8 @@
 #include <future>
 #include <memory>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace noex {
@@ -230,5 +232,7 @@ class TableAdmin {
 }  // namespace noex
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_TABLE_ADMIN_H_

--- a/google/cloud/bigtable/internal/table_admin_test.cc
+++ b/google/cloud/bigtable/internal/table_admin_test.cc
@@ -23,6 +23,7 @@
 
 namespace {
 namespace btproto = ::google::bigtable::admin::v2;
+namespace bigtable = google::cloud::bigtable;
 
 using MockAdminClient = bigtable::testing::MockAdminClient;
 

--- a/google/cloud/bigtable/internal/table_test.cc
+++ b/google/cloud/bigtable/internal/table_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/bigtable/testing/mock_read_rows_reader.h"
 #include "google/cloud/bigtable/testing/mock_sample_row_keys_reader.h"
 
+namespace bigtable = google::cloud::bigtable;
 using testing::_;
 using testing::Invoke;
 using testing::Return;

--- a/google/cloud/bigtable/internal/unary_client_utils.h
+++ b/google/cloud/bigtable/internal/unary_client_utils.h
@@ -21,6 +21,8 @@
 #include "google/cloud/bigtable/rpc_retry_policy.h"
 #include <thread>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
@@ -250,5 +252,7 @@ struct UnaryClientUtils {
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_UNARY_CLIENT_UTILS_H_

--- a/google/cloud/bigtable/metadata_update_policy.cc
+++ b/google/cloud/bigtable/metadata_update_policy.cc
@@ -17,6 +17,8 @@
 
 #include <sstream>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 MetadataParamTypes const MetadataParamTypes::PARENT("parent");
@@ -77,3 +79,5 @@ void MetadataUpdatePolicy::setup(grpc::ClientContext& context) const {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/metadata_update_policy.h
+++ b/google/cloud/bigtable/metadata_update_policy.h
@@ -20,6 +20,8 @@
 #include <grpcpp/grpcpp.h>
 #include <memory>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -119,5 +121,7 @@ class MetadataUpdatePolicy {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_METADATA_UPDATE_POLICY_H_

--- a/google/cloud/bigtable/metadata_update_policy_test.cc
+++ b/google/cloud/bigtable/metadata_update_policy_test.cc
@@ -23,6 +23,7 @@
 
 namespace btproto = google::bigtable::v2;
 namespace adminproto = google::bigtable::admin::v2;
+namespace bigtable = google::cloud::bigtable;
 
 namespace {
 class MetadataUpdatePolicyTest

--- a/google/cloud/bigtable/mutations.cc
+++ b/google/cloud/bigtable/mutations.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/bigtable/mutations.h"
 #include <google/protobuf/text_format.h>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 Mutation SetCell(std::string family, std::string column,
@@ -71,3 +73,5 @@ grpc::Status FailedMutation::ToGrpcStatus(google::rpc::Status const& status) {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/mutations.h
+++ b/google/cloud/bigtable/mutations.h
@@ -23,6 +23,8 @@
 #include <chrono>
 #include <type_traits>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -464,5 +466,7 @@ class BulkMutation {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_MUTATIONS_H_

--- a/google/cloud/bigtable/mutations_test.cc
+++ b/google/cloud/bigtable/mutations_test.cc
@@ -17,6 +17,7 @@
 #include <google/rpc/error_details.pb.h>
 #include <gmock/gmock.h>
 
+namespace bigtable = google::cloud::bigtable;
 using namespace bigtable::chrono_literals;
 
 /// @test Verify that SetCell() works as expected.

--- a/google/cloud/bigtable/polling_policy.cc
+++ b/google/cloud/bigtable/polling_policy.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/bigtable/polling_policy.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 std::unique_ptr<PollingPolicy> DefaultPollingPolicy() {
@@ -22,3 +24,5 @@ std::unique_ptr<PollingPolicy> DefaultPollingPolicy() {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/polling_policy.h
+++ b/google/cloud/bigtable/polling_policy.h
@@ -20,6 +20,8 @@
 #include "google/cloud/bigtable/version.h"
 #include <grpcpp/grpcpp.h>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -101,5 +103,7 @@ std::unique_ptr<PollingPolicy> DefaultPollingPolicy();
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_POLLING_POLICY_H_

--- a/google/cloud/bigtable/polling_policy_test.cc
+++ b/google/cloud/bigtable/polling_policy_test.cc
@@ -25,6 +25,7 @@ grpc::Status CreatePermanentError() {
   return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "failed");
 }
 
+namespace bigtable = google::cloud::bigtable;
 using namespace bigtable::chrono_literals;
 auto const kLimitedTimeTestPeriod = 50_ms;
 auto const kLimitedTimeTolerance = 10_ms;

--- a/google/cloud/bigtable/read_modify_write_rule.h
+++ b/google/cloud/bigtable/read_modify_write_rule.h
@@ -19,6 +19,8 @@
 #include <google/bigtable/v2/data.pb.h>
 #include <chrono>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -81,5 +83,7 @@ class ReadModifyWriteRule {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_READ_MODIFY_WRITE_RULE_H_

--- a/google/cloud/bigtable/read_modify_write_rule_test.cc
+++ b/google/cloud/bigtable/read_modify_write_rule_test.cc
@@ -16,6 +16,7 @@
 #include <gmock/gmock.h>
 
 namespace btproto = ::google::bigtable::v2;
+namespace bigtable = google::cloud::bigtable;
 
 TEST(ReadModifyWriteRuleTest, AppendValue) {
   auto const proto =

--- a/google/cloud/bigtable/row.h
+++ b/google/cloud/bigtable/row.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/cell.h"
 #include <vector>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -47,5 +49,7 @@ class Row {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_ROW_H_

--- a/google/cloud/bigtable/row_range.cc
+++ b/google/cloud/bigtable/row_range.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/bigtable/row_range.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace btproto = ::google::bigtable::v2;
@@ -248,3 +250,5 @@ std::ostream& operator<<(std::ostream& os, RowRange const& x) {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/row_range.h
+++ b/google/cloud/bigtable/row_range.h
@@ -19,6 +19,8 @@
 #include <google/bigtable/v2/data.pb.h>
 #include <chrono>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -173,5 +175,7 @@ class RowRange {
 std::ostream& operator<<(std::ostream& os, RowRange const& x);
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_ROW_RANGE_H_

--- a/google/cloud/bigtable/row_range_test.cc
+++ b/google/cloud/bigtable/row_range_test.cc
@@ -16,6 +16,7 @@
 #include <gmock/gmock.h>
 
 namespace btproto = ::google::bigtable::v2;
+namespace bigtable = google::cloud::bigtable;
 
 TEST(RowRangeTest, InfiniteRange) {
   auto proto = bigtable::RowRange::InfiniteRange().as_proto();

--- a/google/cloud/bigtable/row_reader.cc
+++ b/google/cloud/bigtable/row_reader.cc
@@ -18,6 +18,8 @@
 #include "google/cloud/internal/throw_delegate.h"
 #include <thread>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 // RowReader::iterator must satisfy the requirements of an InputIterator.
@@ -285,3 +287,5 @@ RowReader::~RowReader() {
 }
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/row_reader.h
+++ b/google/cloud/bigtable/row_reader.h
@@ -31,6 +31,8 @@
 #include <cinttypes>
 #include <iterator>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -186,5 +188,7 @@ class RowReader {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_ROW_READER_H_

--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -36,6 +36,7 @@ using google::bigtable::v2::ReadRowsRequest;
 using google::bigtable::v2::ReadRowsResponse;
 using google::bigtable::v2::ReadRowsResponse_CellChunk;
 
+namespace bigtable = google::cloud::bigtable;
 using bigtable::Row;
 using bigtable::testing::MockReadRowsReader;
 

--- a/google/cloud/bigtable/row_set.cc
+++ b/google/cloud/bigtable/row_set.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/bigtable/row_set.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace btproto = ::google::bigtable::v2;
@@ -61,3 +63,5 @@ bool RowSet::IsEmpty() const {
 }
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/row_set.h
+++ b/google/cloud/bigtable/row_set.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/internal/conjunction.h"
 #include "google/cloud/bigtable/row_range.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -109,5 +111,7 @@ class RowSet {
 };
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_ROW_SET_H_

--- a/google/cloud/bigtable/row_set_test.cc
+++ b/google/cloud/bigtable/row_set_test.cc
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 
 namespace btproto = ::google::bigtable::v2;
+namespace bigtable = google::cloud::bigtable;
 
 TEST(RowSetTest, DefaultConstructor) {
   auto proto = bigtable::RowSet().as_proto();

--- a/google/cloud/bigtable/row_test.cc
+++ b/google/cloud/bigtable/row_test.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/bigtable/row.h"
 #include <gtest/gtest.h>
 
+namespace bigtable = google::cloud::bigtable;
+
 /// @test Verify Row instantiation and trivial accessors.
 TEST(RowTest, RowInstantiation) {
   std::string row_key = "row";

--- a/google/cloud/bigtable/rpc_backoff_policy.cc
+++ b/google/cloud/bigtable/rpc_backoff_policy.cc
@@ -30,6 +30,8 @@ auto const DEFAULT_INITIAL_DELAY = BIGTABLE_CLIENT_DEFAULT_INITIAL_DELAY;
 auto const DEFAULT_MAXIMUM_DELAY = BIGTABLE_CLIENT_DEFAULT_MAXIMUM_DELAY;
 }  // anonymous namespace
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 std::unique_ptr<RPCBackoffPolicy> DefaultRPCBackoffPolicy() {
@@ -64,3 +66,5 @@ std::chrono::milliseconds ExponentialBackoffPolicy::on_completion(
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/rpc_backoff_policy.h
+++ b/google/cloud/bigtable/rpc_backoff_policy.h
@@ -21,6 +21,8 @@
 #include <memory>
 #include <random>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -106,5 +108,7 @@ class ExponentialBackoffPolicy : public RPCBackoffPolicy {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_RPC_BACKOFF_POLICY_H_

--- a/google/cloud/bigtable/rpc_backoff_policy_test.cc
+++ b/google/cloud/bigtable/rpc_backoff_policy_test.cc
@@ -18,6 +18,8 @@
 #include <chrono>
 #include <vector>
 
+namespace bigtable = google::cloud::bigtable;
+
 namespace {
 /// Create a grpc::Status with a status code for transient errors.
 grpc::Status CreateTransientError() {

--- a/google/cloud/bigtable/rpc_retry_policy.cc
+++ b/google/cloud/bigtable/rpc_retry_policy.cc
@@ -27,6 +27,8 @@ auto const MAXIMUM_RETRY_PERIOD = BIGTABLE_CLIENT_DEFAULT_MAXIMUM_RETRY_PERIOD;
 
 }  // anonymous namespace
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 std::unique_ptr<RPCRetryPolicy> DefaultRPCRetryPolicy() {
@@ -82,3 +84,5 @@ bool LimitedTimeRetryPolicy::can_retry(grpc::StatusCode code) const {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/rpc_retry_policy.h
+++ b/google/cloud/bigtable/rpc_retry_policy.h
@@ -20,6 +20,8 @@
 #include <chrono>
 #include <memory>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -121,5 +123,7 @@ constexpr bool IsRetryableStatusCode(grpc::StatusCode code) {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_RPC_RETRY_POLICY_H_

--- a/google/cloud/bigtable/rpc_retry_policy_test.cc
+++ b/google/cloud/bigtable/rpc_retry_policy_test.cc
@@ -29,6 +29,7 @@ grpc::Status CreatePermanentError() {
   return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "failed");
 }
 
+namespace bigtable = google::cloud::bigtable;
 using namespace bigtable::chrono_literals;
 auto const kLimitedTimeTestPeriod = 50_ms;
 auto const kLimitedTimeTolerance = 10_ms;

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -24,9 +24,10 @@ namespace btproto = ::google::bigtable::v2;
 namespace {
 [[noreturn]] void ReportPermanentFailures(
     char const* msg, grpc::Status const& status,
-    std::vector<bigtable::FailedMutation> failures) {
+    std::vector<google::cloud::bigtable::FailedMutation> failures) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  throw bigtable::PermanentMutationFailure(msg, status, std::move(failures));
+  throw google::cloud::bigtable::PermanentMutationFailure(msg, status,
+                                                          std::move(failures));
 #else
   std::cerr << msg << "\n"
             << "Status: " << status.error_message() << " ["
@@ -43,6 +44,8 @@ namespace {
 }
 }  // namespace
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 static_assert(std::is_copy_assignable<bigtable::Table>::value,
@@ -99,3 +102,5 @@ bool Table::CheckAndMutateRow(std::string row_key, Filter filter,
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/internal/grpc_error_delegate.h"
 #include "google/cloud/bigtable/internal/table.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -350,5 +352,7 @@ class Table {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TABLE_H_

--- a/google/cloud/bigtable/table_admin.cc
+++ b/google/cloud/bigtable/table_admin.cc
@@ -18,6 +18,8 @@
 
 namespace btproto = ::google::bigtable::admin::v2;
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 static_assert(std::is_copy_constructible<bigtable::TableAdmin>::value,
@@ -148,3 +150,5 @@ void TableAdmin::DeleteSnapshot(bigtable::ClusterId const& cluster_id,
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -25,6 +25,8 @@
 #include <future>
 #include <memory>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
@@ -326,5 +328,7 @@ class TableAdmin {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TABLE_ADMIN_H_

--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -23,6 +23,7 @@
 
 namespace {
 namespace btproto = ::google::bigtable::admin::v2;
+namespace bigtable = google::cloud::bigtable;
 
 using MockAdminClient = bigtable::testing::MockAdminClient;
 

--- a/google/cloud/bigtable/table_apply_test.cc
+++ b/google/cloud/bigtable/table_apply_test.cc
@@ -16,14 +16,15 @@
 #include "google/cloud/bigtable/testing/chrono_literals.h"
 #include "google/cloud/bigtable/testing/table_test_fixture.h"
 
+namespace bigtable = google::cloud::bigtable;
+using namespace bigtable::chrono_literals;
+
 /// Define helper types and functions for this test.
 namespace {
 class TableApplyTest : public bigtable::testing::TableTestFixture {};
 }  // anonymous namespace
 
 /// @test Verify that Table::Apply() works in a simplest case.
-
-using namespace bigtable::chrono_literals;
 
 TEST_F(TableApplyTest, Simple) {
   using namespace ::testing;

--- a/google/cloud/bigtable/table_bulk_apply_test.cc
+++ b/google/cloud/bigtable/table_bulk_apply_test.cc
@@ -18,6 +18,12 @@
 #include "google/cloud/bigtable/testing/mock_mutate_rows_reader.h"
 #include "google/cloud/bigtable/testing/table_test_fixture.h"
 
+namespace btproto = google::bigtable::v2;
+namespace bigtable = google::cloud::bigtable;
+using namespace bigtable::chrono_literals;
+using namespace testing;
+namespace bt = google::cloud::bigtable;
+
 /// Define types and functions used in the tests.
 namespace {
 class TableBulkApplyTest : public bigtable::testing::TableTestFixture {};
@@ -25,11 +31,6 @@ using bigtable::testing::MockMutateRowsReader;
 }  // anonymous namespace
 
 /// @test Verify that Table::BulkApply() works in the easy case.
-
-using namespace bigtable::chrono_literals;
-using namespace testing;
-namespace btproto = google::bigtable::v2;
-namespace bt = bigtable;
 
 TEST_F(TableBulkApplyTest, Simple) {
   auto reader = bigtable::internal::make_unique<MockMutateRowsReader>();

--- a/google/cloud/bigtable/table_check_and_mutate_row_test.cc
+++ b/google/cloud/bigtable/table_check_and_mutate_row_test.cc
@@ -16,13 +16,14 @@
 #include "google/cloud/bigtable/testing/chrono_literals.h"
 #include "google/cloud/bigtable/testing/table_test_fixture.h"
 
+namespace bigtable = google::cloud::bigtable;
+using namespace bigtable::chrono_literals;
+
 /// Define helper types and functions for this test.
 namespace {
 class TableCheckAndMutateRowTest : public bigtable::testing::TableTestFixture {
 };
 }  // anonymous namespace
-
-using namespace bigtable::chrono_literals;
 
 /// @test Verify that Table::CheckAndMutateRow() works in a simplest case.
 TEST_F(TableCheckAndMutateRowTest, Simple) {

--- a/google/cloud/bigtable/table_config.cc
+++ b/google/cloud/bigtable/table_config.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/bigtable/table_config.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 // NOLINTNEXTLINE(readability-identifier-naming)
@@ -62,3 +64,5 @@ constexpr TableConfig::TimestampGranularity
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/table_config.h
+++ b/google/cloud/bigtable/table_config.h
@@ -20,6 +20,8 @@
 #include <map>
 #include <vector>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /// Specify the initial schema for a new table.
@@ -89,5 +91,7 @@ class TableConfig {
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TABLE_CONFIG_H_

--- a/google/cloud/bigtable/table_config_test.cc
+++ b/google/cloud/bigtable/table_config_test.cc
@@ -18,6 +18,7 @@
 #include <gmock/gmock.h>
 
 namespace btproto = ::google::bigtable::admin::v2;
+namespace bigtable = google::cloud::bigtable;
 
 TEST(TableConfig, Simple) {
   bigtable::TableConfig config;

--- a/google/cloud/bigtable/table_readmodifywriterow_test.cc
+++ b/google/cloud/bigtable/table_readmodifywriterow_test.cc
@@ -18,6 +18,7 @@
 #include <gmock/gmock.h>
 
 namespace btproto = ::google::bigtable::v2;
+namespace bigtable = google::cloud::bigtable;
 
 /// Define helper types and functions for this test.
 namespace {

--- a/google/cloud/bigtable/table_readrow_test.cc
+++ b/google/cloud/bigtable/table_readrow_test.cc
@@ -17,6 +17,8 @@
 #include "google/cloud/bigtable/testing/mock_read_rows_reader.h"
 #include "google/cloud/bigtable/testing/table_test_fixture.h"
 
+namespace bigtable = google::cloud::bigtable;
+
 /// Define helper types and functions for this test.
 namespace {
 class TableReadRowTest : public bigtable::testing::TableTestFixture {};

--- a/google/cloud/bigtable/table_readrows_test.cc
+++ b/google/cloud/bigtable/table_readrows_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/bigtable/testing/mock_read_rows_reader.h"
 #include "google/cloud/bigtable/testing/table_test_fixture.h"
 
+namespace bigtable = google::cloud::bigtable;
 using testing::_;
 using testing::DoAll;
 using testing::Invoke;

--- a/google/cloud/bigtable/table_sample_row_keys_test.cc
+++ b/google/cloud/bigtable/table_sample_row_keys_test.cc
@@ -19,6 +19,8 @@
 #include "google/cloud/bigtable/testing/table_test_fixture.h"
 #include <typeinfo>
 
+namespace bigtable = google::cloud::bigtable;
+
 /// Define types and functions used for this tests.
 namespace {
 class TableSampleRowKeysTest : public bigtable::testing::TableTestFixture {};

--- a/google/cloud/bigtable/table_strong_types.h
+++ b/google/cloud/bigtable/table_strong_types.h
@@ -17,6 +17,8 @@
 
 #include "google/cloud/bigtable/internal/strong_type.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 using AppProfileId =
@@ -24,5 +26,7 @@ using AppProfileId =
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TABLE_STRONG_TYPES_H_

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/testing/table_test_fixture.h"
 
+namespace bigtable = google::cloud::bigtable;
+
 /// Define types and functions used in the tests.
 namespace {
 class TableTest : public bigtable::testing::TableTestFixture {};

--- a/google/cloud/bigtable/testing/chrono_literals.h
+++ b/google/cloud/bigtable/testing/chrono_literals.h
@@ -18,6 +18,8 @@
 #include <chrono>
 
 // TODO(#109) - these are generally useful, consider submitting to abseil.io
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace chrono_literals {
 constexpr std::chrono::hours operator"" _h(unsigned long long h) {
@@ -46,5 +48,7 @@ constexpr std::chrono::nanoseconds operator"" _ns(unsigned long long ns) {
 
 }  // namespace chrono_literals
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_CHRONO_LITERALS_H_

--- a/google/cloud/bigtable/testing/embedded_server_test_fixture.cc
+++ b/google/cloud/bigtable/testing/embedded_server_test_fixture.cc
@@ -16,6 +16,8 @@
 #include "google/cloud/bigtable/internal/grpc_error_delegate.h"
 #include <thread>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 
@@ -57,3 +59,5 @@ void EmbeddedServerTestFixture::TearDown() {
 
 }  // namespace testing
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/testing/embedded_server_test_fixture.h
+++ b/google/cloud/bigtable/testing/embedded_server_test_fixture.h
@@ -23,6 +23,8 @@
 #include <gtest/gtest.h>
 #include <thread>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 
@@ -123,5 +125,7 @@ class EmbeddedServerTestFixture : public ::testing::Test {
 
 }  // namespace testing
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_EMBEDDED_SERVER_TEST_FIXTURE_H_

--- a/google/cloud/bigtable/testing/inprocess_admin_client.cc
+++ b/google/cloud/bigtable/testing/inprocess_admin_client.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/bigtable/testing/inprocess_admin_client.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 
@@ -103,3 +105,5 @@ grpc::Status InProcessAdminClient::DeleteSnapshot(
 
 }  // namespace testing
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/testing/inprocess_admin_client.h
+++ b/google/cloud/bigtable/testing/inprocess_admin_client.h
@@ -19,6 +19,8 @@
 #include "google/cloud/bigtable/client_options.h"
 #include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 
@@ -111,5 +113,7 @@ class InProcessAdminClient : public bigtable::AdminClient {
 
 }  // namespace testing
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_INPROCESS_ADMIN_CLIENT_H_

--- a/google/cloud/bigtable/testing/inprocess_data_client.cc
+++ b/google/cloud/bigtable/testing/inprocess_data_client.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/bigtable/testing/inprocess_data_client.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 
@@ -60,3 +62,5 @@ InProcessDataClient::MutateRows(grpc::ClientContext* context,
 
 }  // namespace testing
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/testing/inprocess_data_client.h
+++ b/google/cloud/bigtable/testing/inprocess_data_client.h
@@ -19,6 +19,8 @@
 #include "google/cloud/bigtable/data_client.h"
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 
@@ -87,5 +89,7 @@ class InProcessDataClient : public bigtable::DataClient {
 
 }  // namespace testing
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_INPROCESS_DATA_CLIENT_H_

--- a/google/cloud/bigtable/testing/internal_table_test_fixture.cc
+++ b/google/cloud/bigtable/testing/internal_table_test_fixture.cc
@@ -16,6 +16,8 @@
 #include "google/cloud/bigtable/internal/grpc_error_delegate.h"
 #include <google/protobuf/text_format.h>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 namespace internal {
@@ -41,3 +43,5 @@ std::shared_ptr<MockDataClient> TableTestFixture::SetupMockClient() {
 }  // namespace internal
 }  // namespace testing
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/testing/internal_table_test_fixture.h
+++ b/google/cloud/bigtable/testing/internal_table_test_fixture.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/internal/table.h"
 #include "google/cloud/bigtable/testing/mock_data_client.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 namespace internal {
@@ -52,5 +54,7 @@ google::bigtable::v2::ReadRowsResponse ReadRowsResponseFromString(
 }  // namespace internal
 }  // namespace testing
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_INTERNAL_TABLE_TEST_FIXTURE_H_

--- a/google/cloud/bigtable/testing/mock_admin_client.h
+++ b/google/cloud/bigtable/testing/mock_admin_client.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/admin_client.h"
 #include <gmock/gmock.h>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 
@@ -108,5 +110,7 @@ class MockAdminClient : public bigtable::AdminClient {
 
 }  // namespace testing
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_MOCK_ADMIN_CLIENT_H_

--- a/google/cloud/bigtable/testing/mock_data_client.h
+++ b/google/cloud/bigtable/testing/mock_data_client.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/table.h"
 #include <gmock/gmock.h>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 
@@ -65,5 +67,7 @@ class MockDataClient : public bigtable::DataClient {
 
 }  // namespace testing
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_MOCK_DATA_CLIENT_H_

--- a/google/cloud/bigtable/testing/mock_instance_admin_client.h
+++ b/google/cloud/bigtable/testing/mock_instance_admin_client.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/instance_admin_client.h"
 #include <gmock/gmock.h>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 
@@ -87,5 +89,7 @@ class MockInstanceAdminClient : public bigtable::InstanceAdminClient {
 
 }  // namespace testing
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_MOCK_INSTANCE_ADMIN_CLIENT_H_

--- a/google/cloud/bigtable/testing/mock_mutate_rows_reader.h
+++ b/google/cloud/bigtable/testing/mock_mutate_rows_reader.h
@@ -19,6 +19,8 @@
 #include <google/bigtable/v2/bigtable.pb.h>
 #include <gmock/gmock.h>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 using MockMutateRowsReader =
@@ -27,5 +29,7 @@ using MockMutateRowsReader =
 
 }  // namespace testing
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_MOCK_MUTATE_ROWS_READER_H_

--- a/google/cloud/bigtable/testing/mock_read_rows_reader.h
+++ b/google/cloud/bigtable/testing/mock_read_rows_reader.h
@@ -19,6 +19,8 @@
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
 #include <gmock/gmock.h>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 using MockReadRowsReader =
@@ -27,5 +29,7 @@ using MockReadRowsReader =
 
 }  // namespace testing
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_MOCK_READ_ROWS_READER_H_

--- a/google/cloud/bigtable/testing/mock_response_reader.h
+++ b/google/cloud/bigtable/testing/mock_response_reader.h
@@ -19,6 +19,8 @@
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/impl/codegen/sync_stream.h>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 /**
@@ -64,5 +66,7 @@ class MockResponseReader : public grpc::ClientReaderInterface<Response> {
 
 }  // namespace testing
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_MOCK_RESPONSE_READER_H_

--- a/google/cloud/bigtable/testing/mock_sample_row_keys_reader.h
+++ b/google/cloud/bigtable/testing/mock_sample_row_keys_reader.h
@@ -19,6 +19,8 @@
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
 #include <gmock/gmock.h>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 using MockSampleRowKeysReader =
@@ -27,5 +29,7 @@ using MockSampleRowKeysReader =
 
 }  // namespace testing
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_MOCK_SAMPLE_ROW_KEYS_READER_H_

--- a/google/cloud/bigtable/testing/random.cc
+++ b/google/cloud/bigtable/testing/random.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/bigtable/testing/random.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 std::string Sample(DefaultPRNG& gen, int n, std::string const& population) {
@@ -27,3 +29,5 @@ std::string Sample(DefaultPRNG& gen, int n, std::string const& population) {
 
 }  // namespace testing
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/testing/random.h
+++ b/google/cloud/bigtable/testing/random.h
@@ -18,6 +18,8 @@
 #include <algorithm>
 #include <random>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 // While std::mt19937_64 is not the best PRNG ever, it is fairly good for
@@ -79,5 +81,7 @@ std::string Sample(DefaultPRNG& gen, int n, std::string const& population);
 
 }  // namespace testing
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_RANDOM_H_

--- a/google/cloud/bigtable/testing/random_test.cc
+++ b/google/cloud/bigtable/testing/random_test.cc
@@ -15,7 +15,7 @@
 #include "google/cloud/bigtable/testing/random.h"
 #include <gmock/gmock.h>
 
-using namespace bigtable::testing;
+using namespace google::cloud::bigtable::testing;
 
 TEST(BenchmarksRandom, Basic) {
   // This is not a statistical test for PRNG, basically we want to make

--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -18,6 +18,8 @@
 #include <algorithm>
 #include <cctype>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 
@@ -26,14 +28,12 @@ std::string TableTestEnvironment::instance_id_;
 
 void TableIntegrationTest::SetUp() {
   admin_client_ = bigtable::CreateDefaultAdminClient(
-      ::bigtable::testing::TableTestEnvironment::project_id(),
-      bigtable::ClientOptions());
+      TableTestEnvironment::project_id(), ClientOptions());
   table_admin_ = bigtable::internal::make_unique<bigtable::TableAdmin>(
-      admin_client_, ::bigtable::testing::TableTestEnvironment::instance_id());
+      admin_client_, TableTestEnvironment::instance_id());
   data_client_ = bigtable::CreateDefaultDataClient(
-      ::bigtable::testing::TableTestEnvironment::project_id(),
-      ::bigtable::testing::TableTestEnvironment::instance_id(),
-      bigtable::ClientOptions());
+      TableTestEnvironment::project_id(), TableTestEnvironment::instance_id(),
+      ClientOptions());
 }
 
 std::unique_ptr<bigtable::Table> TableIntegrationTest::CreateTable(
@@ -223,3 +223,5 @@ void PrintTo(bigtable::Cell const& cell, std::ostream* os) {
 //@}
 
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/testing/table_integration_test.h
+++ b/google/cloud/bigtable/testing/table_integration_test.h
@@ -23,6 +23,8 @@
 #include "google/cloud/bigtable/testing/random.h"
 #include <gmock/gmock.h>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 
@@ -106,5 +108,7 @@ class TableIntegrationTest : public ::testing::Test {
 };
 }  // namespace testing
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_TABLE_INTEGRATION_TEST_H_

--- a/google/cloud/bigtable/testing/table_test_fixture.cc
+++ b/google/cloud/bigtable/testing/table_test_fixture.cc
@@ -16,6 +16,8 @@
 #include "google/cloud/internal/throw_delegate.h"
 #include <google/protobuf/text_format.h>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 
@@ -39,3 +41,5 @@ std::shared_ptr<MockDataClient> TableTestFixture::SetupMockClient() {
 
 }  // namespace testing
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/testing/table_test_fixture.h
+++ b/google/cloud/bigtable/testing/table_test_fixture.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/testing/mock_data_client.h"
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 namespace testing {
 
@@ -50,5 +52,7 @@ google::bigtable::v2::ReadRowsResponse ReadRowsResponseFromString(
 
 }  // namespace testing
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_TABLE_TEST_FIXTURE_H_

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -21,7 +21,8 @@
 #include <vector>
 
 namespace {
-namespace admin_proto = ::google::bigtable::admin::v2;
+namespace admin_proto = google::bigtable::admin::v2;
+namespace bigtable = google::cloud::bigtable;
 
 class AdminIntegrationTest : public bigtable::testing::TableIntegrationTest {
  protected:

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -17,7 +17,8 @@
 #include "google/cloud/bigtable/testing/table_integration_test.h"
 
 namespace {
-namespace admin_proto = ::google::bigtable::admin::v2;
+namespace admin_proto = google::bigtable::admin::v2;
+namespace bigtable = google::cloud::bigtable;
 
 class DataIntegrationTest : public bigtable::testing::TableIntegrationTest {
  protected:

--- a/google/cloud/bigtable/tests/filters_integration_test.cc
+++ b/google/cloud/bigtable/tests/filters_integration_test.cc
@@ -16,8 +16,9 @@
 #include "google/cloud/bigtable/testing/table_integration_test.h"
 
 namespace {
-namespace btproto = ::google::bigtable::v2;
-namespace admin_proto = ::google::bigtable::admin::v2;
+namespace btproto = google::bigtable::v2;
+namespace admin_proto = google::bigtable::admin::v2;
+namespace bigtable = google::cloud::bigtable;
 
 class FilterIntegrationTest : public bigtable::testing::TableIntegrationTest {
  protected:

--- a/google/cloud/bigtable/tests/instance_admin_emulator.cc
+++ b/google/cloud/bigtable/tests/instance_admin_emulator.cc
@@ -18,6 +18,7 @@
 #include <grpcpp/grpcpp.h>
 
 namespace btadmin = google::bigtable::admin::v2;
+namespace bigtable = google::cloud::bigtable;
 
 /**
  * In-memory implementation of `google.bigtable.admin.v2.InstanceAdmin`.

--- a/google/cloud/bigtable/tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_integration_test.cc
@@ -20,6 +20,7 @@
 #include <gmock/gmock.h>
 
 namespace btadmin = google::bigtable::admin::v2;
+namespace bigtable = google::cloud::bigtable;
 using testing::HasSubstr;
 
 namespace {

--- a/google/cloud/bigtable/tests/mutations_integration_test.cc
+++ b/google/cloud/bigtable/tests/mutations_integration_test.cc
@@ -19,7 +19,8 @@
 
 namespace {
 
-namespace admin_proto = ::google::bigtable::admin::v2;
+namespace admin_proto = google::bigtable::admin::v2;
+namespace bigtable = google::cloud::bigtable;
 using namespace bigtable::chrono_literals;
 
 class MutationIntegrationTest : public bigtable::testing::TableIntegrationTest {

--- a/google/cloud/bigtable/version.cc
+++ b/google/cloud/bigtable/version.cc
@@ -16,6 +16,8 @@
 #include "google/cloud/internal/build_info.h"
 #include <sstream>
 
+namespace google {
+namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 // NOLINTNEXTLINE(readability-identifier-naming)
@@ -30,3 +32,5 @@ std::string version_string() {
 }
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/version.h
+++ b/google/cloud/bigtable/version.h
@@ -26,6 +26,8 @@
 /**
  * Contains all the Cloud Bigtable C++ client APIs.
  */
+namespace google {
+namespace cloud {
 namespace bigtable {
 /**
  * The inlined, versioned namespace for the Cloud Bigtable C++ client APIs.
@@ -71,5 +73,7 @@ std::string version_string();
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_VERSION_H_


### PR DESCRIPTION
This fixes #628. In general, I chose to alias the namespace in
tests (i.e. `namespace bigtable = google:cloud:bigtable`). I
think this is what I would have done if writing the tests from
scratch anyway.  I preferred to use the full namespace in
examples, while that is very verbose I would rather be explicit
in them.