### PR TITLE
Use EXPECT_THAT to test for substrings.

### DIFF
--- a/google/cloud/bigtable/benchmarks/benchmark_test.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark_test.cc
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 
 using namespace bigtable::benchmarks;
+using testing::HasSubstr;
 
 namespace {
 char arg0[] = "program";
@@ -109,10 +110,10 @@ TEST(BenchmarkTest, PrintThroughputResult) {
   // fairly minimal.
 
   // The output includes "XX ops/s" where XX is the operations count.
-  EXPECT_NE(std::string::npos, output.find("345 ops/s"));
+  EXPECT_THAT(output, HasSubstr("345 ops/s"));
 
   // The output includes "YY rows/s" where YY is the row count.
-  EXPECT_NE(std::string::npos, output.find("123 rows/s"));
+  EXPECT_THAT(output, HasSubstr("123 rows/s"));
 }
 
 TEST(BenchmarkTest, PrintLatencyResult) {
@@ -138,14 +139,14 @@ TEST(BenchmarkTest, PrintLatencyResult) {
   // fairly minimal.
 
   // The output includes "XX ops/s" where XX is the operations count.
-  EXPECT_NE(std::string::npos, output.find("100 ops/s"));
+  EXPECT_THAT(output, HasSubstr("100 ops/s"));
 
   // And the percentiles are easy to estimate for the generated data. Note that
   // this test depends on the duration formatting as specified by the absl::time
   // library.
-  EXPECT_NE(std::string::npos, output.find("p0=100.000us"));
-  EXPECT_NE(std::string::npos, output.find("p95=9.500ms"));
-  EXPECT_NE(std::string::npos, output.find("p100=10.000ms"));
+  EXPECT_THAT(output, HasSubstr("p0=100.000us"));
+  EXPECT_THAT(output, HasSubstr("p95=9.500ms"));
+  EXPECT_THAT(output, HasSubstr("p100=10.000ms"));
 }
 
 TEST(BenchmarkTest, PrintCsv) {
@@ -177,16 +178,15 @@ TEST(BenchmarkTest, PrintCsv) {
   // fairly minimal.
 
   // The output includes the version and compiler info.
-  EXPECT_NE(std::string::npos, output.find(bigtable::version_string()));
-  EXPECT_NE(std::string::npos, output.find(google::cloud::internal::COMPILER));
-  EXPECT_NE(std::string::npos,
-            output.find(google::cloud::internal::COMPILER_FLAGS));
+  EXPECT_THAT(output, HasSubstr(bigtable::version_string()));
+  EXPECT_THAT(output, HasSubstr(google::cloud::internal::COMPILER));
+  EXPECT_THAT(output, HasSubstr(google::cloud::internal::COMPILER_FLAGS));
 
   // The output includes the latency results.
-  EXPECT_NE(std::string::npos, output.find(",100,"));    // p0
-  EXPECT_NE(std::string::npos, output.find(",9500,"));   // p95
-  EXPECT_NE(std::string::npos, output.find(",10000,"));  // p100
+  EXPECT_THAT(output, HasSubstr(",100,"));    // p0
+  EXPECT_THAT(output, HasSubstr(",9500,"));   // p95
+  EXPECT_THAT(output, HasSubstr(",10000,"));  // p100
 
   // The output includes the throughput.
-  EXPECT_NE(std::string::npos, output.find(",123,"));
+  EXPECT_THAT(output, HasSubstr(",123,"));
 }

--- a/google/cloud/bigtable/grpc_error_test.cc
+++ b/google/cloud/bigtable/grpc_error_test.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/bigtable/grpc_error.h"
 #include <gmock/gmock.h>
 
+using testing::HasSubstr;
+
 TEST(GRpcErrorTest, Simple) {
   bigtable::GRpcError cancelled("Test()", grpc::Status::CANCELLED);
   EXPECT_EQ(grpc::Status::CANCELLED.error_code(), cancelled.error_code());
@@ -28,35 +30,34 @@ TEST(GRpcErrorTest, Simple) {
   EXPECT_EQ("too-busy", test.error_details());
 
   std::string what(test.what());
-  EXPECT_NE(std::string::npos, what.find("Test()"));
-  EXPECT_NE(std::string::npos, what.find("try-again"));
-  EXPECT_NE(std::string::npos, what.find("too-busy"));
-  EXPECT_NE(std::string::npos, what.find("UNAVAILABLE"));
+  EXPECT_THAT(what, HasSubstr("Test()"));
+  EXPECT_THAT(what, HasSubstr("try-again"));
+  EXPECT_THAT(what, HasSubstr("too-busy"));
+  EXPECT_THAT(what, HasSubstr("UNAVAILABLE"));
 }
 
 TEST(GRpcErrorTest, KnownCode_UNAUTHENTICATED) {
   bigtable::GRpcError ex(
       "T()", grpc::Status(grpc::StatusCode::UNAUTHENTICATED, "", ""));
   EXPECT_EQ(grpc::StatusCode::UNAUTHENTICATED, ex.error_code());
-  EXPECT_NE(std::string::npos, std::string(ex.what()).find("UNAUTHENTICATED"));
+  EXPECT_THAT(std::string(ex.what()), HasSubstr("UNAUTHENTICATED"));
 }
 
 TEST(GRpcErrorTest, KnownCode_DATA_LOSS) {
   bigtable::GRpcError ex("T()",
                          grpc::Status(grpc::StatusCode::DATA_LOSS, "", ""));
   EXPECT_EQ(grpc::StatusCode::DATA_LOSS, ex.error_code());
-  EXPECT_NE(std::string::npos, std::string(ex.what()).find("DATA_LOSS"));
+  EXPECT_THAT(std::string(ex.what()), HasSubstr("DATA_LOSS"));
 }
 
 TEST(GRpcErrorTest, KnownCode_NOT_FOUND) {
   bigtable::GRpcError ex("T()",
                          grpc::Status(grpc::StatusCode::NOT_FOUND, "", ""));
   EXPECT_EQ(grpc::StatusCode::NOT_FOUND, ex.error_code());
-  EXPECT_NE(std::string::npos, std::string(ex.what()).find("NOT_FOUND"));
+  EXPECT_THAT(std::string(ex.what()), HasSubstr("NOT_FOUND"));
 }
 
 TEST(GRpcErrorTest, UnknownCode) {
-  using ::testing::HasSubstr;
   bigtable::GRpcError ex(
       "T()", grpc::Status(static_cast<grpc::StatusCode>(-1), "", ""));
   EXPECT_THAT(std::string(ex.what()), HasSubstr("(UNKNOWN CODE)"));

--- a/google/cloud/bigtable/tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_integration_test.cc
@@ -20,6 +20,7 @@
 #include <gmock/gmock.h>
 
 namespace btadmin = google::bigtable::admin::v2;
+using testing::HasSubstr;
 
 namespace {
 class InstanceTestEnvironment : public ::testing::Environment {
@@ -99,10 +100,10 @@ TEST_F(InstanceAdminIntegrationTest, CreateInstanceTest) {
   instance_admin_->DeleteInstance(instance_id);
   EXPECT_FALSE(IsInstancePresent(instances_before, instance.name()));
   EXPECT_TRUE(IsInstancePresent(instances_after, instance.name()));
-  EXPECT_NE(std::string::npos, instance.name().find(instance_id));
-  EXPECT_NE(std::string::npos,
-            instance.name().find(InstanceTestEnvironment::project_id()));
-  EXPECT_NE(std::string::npos, instance.display_name().find(instance_id));
+  EXPECT_THAT(instance.name(), HasSubstr(instance_id));
+  EXPECT_THAT(instance.name(),
+              HasSubstr(InstanceTestEnvironment::project_id()));
+  EXPECT_THAT(instance.display_name(), HasSubstr(instance_id));
 }
 
 /// @test Verify that InstanceAdmin::UpdateInstance works as expected.
@@ -127,11 +128,11 @@ TEST_F(InstanceAdminIntegrationTest, UpdateInstanceTest) {
   instance_admin_->DeleteInstance(instance_id);
   EXPECT_FALSE(IsInstancePresent(instances_before, instance_copy.name()));
   EXPECT_TRUE(IsInstancePresent(instances_after, instance_copy.name()));
-  EXPECT_NE(std::string::npos, instance_copy.name().find(instance_id));
-  EXPECT_NE(std::string::npos,
-            instance_copy.name().find(InstanceTestEnvironment::project_id()));
+  EXPECT_THAT(instance_copy.name(), HasSubstr(instance_id));
+  EXPECT_THAT(instance_copy.name(),
+              HasSubstr(InstanceTestEnvironment::project_id()));
   EXPECT_EQ(updated_display_name, instance_after.display_name());
-  EXPECT_NE(std::string::npos, instance_copy.display_name().find(instance_id));
+  EXPECT_THAT(instance_copy.display_name(), HasSubstr(instance_id));
 }
 /// @test Verify that InstanceAdmin::ListInstances works as expected.
 TEST_F(InstanceAdminIntegrationTest, ListInstancesTest) {
@@ -269,9 +270,9 @@ TEST_F(InstanceAdminIntegrationTest, UpdateClusterTest) {
   instance_admin_->DeleteInstance(id);
   EXPECT_FALSE(IsClusterPresent(clusters_before, cluster_copy.name()));
   EXPECT_TRUE(IsClusterPresent(clusters_after, cluster_copy.name()));
-  EXPECT_NE(std::string::npos, cluster_copy.name().find(id));
-  EXPECT_NE(std::string::npos,
-            cluster_copy.name().find(InstanceTestEnvironment::project_id()));
+  EXPECT_THAT(cluster_copy.name(), HasSubstr(id));
+  EXPECT_THAT(cluster_copy.name(),
+              HasSubstr(InstanceTestEnvironment::project_id()));
   EXPECT_EQ(3, cluster_copy.serve_nodes());
   EXPECT_EQ(4, cluster_after.serve_nodes());
 }

--- a/storage/client/internal/service_account_credentials_test.cc
+++ b/storage/client/internal/service_account_credentials_test.cc
@@ -169,8 +169,8 @@ TEST_F(DefaultServiceAccountFileTest, HomeSet) {
       storage::internal::DefaultServiceAccountCredentialsHomeVariable();
   google::cloud::internal::SetEnv(home, "/foo/bar/baz");
   auto actual = storage::internal::DefaultServiceAccountCredentialsFile();
-  EXPECT_NE(std::string::npos, actual.find("/foo/bar/baz"));
-  EXPECT_NE(std::string::npos, actual.find(".json"));
+  EXPECT_THAT(actual, HasSubstr("/foo/bar/baz"));
+  EXPECT_THAT(actual, HasSubstr(".json"));
 }
 
 /// @test Verify that the service account file path fails when HOME is not set.

--- a/storage/tests/curl_request_integration_test.cc
+++ b/storage/tests/curl_request_integration_test.cc
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 #include "storage/client/internal/curl_request.h"
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <cstdlib>
 #include <vector>
 
 namespace nl = storage::internal::nl;
+using testing::HasSubstr;
 
 namespace {
 std::string HttpBinEndpoint() {
@@ -131,8 +132,7 @@ TEST(CurlRequestTest, HandleTeapot) {
   request.PrepareRequest(std::string{});
   auto response = request.MakeRequest();
   EXPECT_EQ(418, response.status_code);
-  auto pos = response.payload.find("[ teapot ]");
-  EXPECT_NE(std::string::npos, pos);
+  EXPECT_THAT(response.payload, HasSubstr("[ teapot ]"));
 }
 
 /// @test Verify the response includes the header values.


### PR DESCRIPTION
This fixes #653. Replaced tests that used:

EXPECT_NE(std::string::npos, string.find(substring))

with

EXPECT_THAT(string, HasSubstr(substring))