### PR TITLE
Rename storage credential classes

### DIFF
--- a/storage/client/CMakeLists.txt
+++ b/storage/client/CMakeLists.txt
@@ -26,16 +26,17 @@ add_library(storage_client
     client.cc
     credentials.h
     credentials.cc
+    internal/authorized_user_credentials.h
     internal/curl_request.h
     internal/curl_request.cc
     internal/curl_wrappers.h
     internal/curl_wrappers.cc
     internal/default_client.h
+    internal/google_application_default_credentials_file.h
+    internal/google_application_default_credentials_file.cc
     internal/nljson.h
     internal/parse_rfc3339.h
     internal/parse_rfc3339.cc
-    internal/service_account_credentials.h
-    internal/service_account_credentials.cc
     status.h
     version.h
     version.cc)
@@ -86,10 +87,11 @@ create_bazel_config(storage_client_testing)
 set(storage_client_unit_tests
     bucket_metadata_test.cc
     bucket_test.cc
+    internal/authorized_user_credentials_test.cc
     internal/default_client_test.cc
+    internal/google_application_default_credentials_file_test.cc
     internal/nljson_test.cc
     internal/parse_rfc3339_test.cc
-    internal/service_account_credentials_test.cc
     link_test.cc)
 
 foreach (fname ${storage_client_unit_tests})

--- a/storage/client/internal/authorized_user_credentials.h
+++ b/storage/client/internal/authorized_user_credentials.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_STORAGE_CLIENT_INTERNAL_SERVICE_ACCOUNT_CREDENTIALS_H_
-#define GOOGLE_CLOUD_CPP_STORAGE_CLIENT_INTERNAL_SERVICE_ACCOUNT_CREDENTIALS_H_
+#ifndef GOOGLE_CLOUD_CPP_STORAGE_CLIENT_INTERNAL_AUTHORIZED_USER_CREDENTIALS_H_
+#define GOOGLE_CLOUD_CPP_STORAGE_CLIENT_INTERNAL_AUTHORIZED_USER_CREDENTIALS_H_
 
 #include "storage/client/credentials.h"
 #include "storage/client/internal/curl_request.h"
@@ -26,7 +26,7 @@
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
-
+/// The endpoint to create an access token from the
 constexpr static char GOOGLE_OAUTH_REFRESH_ENDPOINT[] =
     "https://accounts.google.com/o/oauth2/token";
 
@@ -35,24 +35,15 @@ constexpr static auto REFRESH_TIME_SLACK_PERCENT = 5;
 /// Minimum time before the token expiration to start refreshing tokens.
 constexpr static auto REFRESH_TIME_SLACK_MIN = std::chrono::seconds(10);
 
-/// Return the path for the default service account credentials file.
-std::string DefaultServiceAccountCredentialsFile();
-
-/// The name of the environment variable to configure `HOME`.
-char const* DefaultServiceAccountCredentialsHomeVariable();
-
 /**
- * A C++ wrapper for Google Service Account Credentials.
+ * A C++ wrapper for Google's Authorized User Credentials.
  *
- * This class parses the contents of a Google Service Account credentials file,
- * and creates a credentials object from those contents. It automatically
- * handles refreshing the credentials when needed, as well as creating the
- * appropriate header for authorization.
+ * Takes a JSON object with the authorized user client id, secret, and access
+ * token and uses Google's OAuth2 service to obtain an access token.
  *
  * @par Warning
  * The current implementation is a placeholder to unblock development of the
- * Google Cloud Storage client libraries.  Currently it can only use Google's
- * Application Default Credentials file.  There is substantial work needed
+ * Google Cloud Storage client libraries. There is substantial work needed
  * before this class is complete, in fact, we do not even have a complete set of
  * requirements for it.
  *
@@ -63,25 +54,22 @@ char const* DefaultServiceAccountCredentialsHomeVariable();
  * @tparam HttpRequestType a dependency injection point to make HTTP requests.
  */
 template <typename HttpRequestType = CurlRequest>
-class ServiceAccountCredentials : public storage::Credentials {
+class AuthorizedUserCredentials : public storage::Credentials {
  public:
-  explicit ServiceAccountCredentials(std::string token)
-      : ServiceAccountCredentials(std::move(token),
-                                  GOOGLE_OAUTH_REFRESH_ENDPOINT) {}
+  explicit AuthorizedUserCredentials(std::string const& contents)
+      : AuthorizedUserCredentials(contents, GOOGLE_OAUTH_REFRESH_ENDPOINT) {}
 
-  explicit ServiceAccountCredentials(std::string token,
+  explicit AuthorizedUserCredentials(std::string const& content,
                                      std::string oauth_server)
-      : refresh_token_(std::move(token)),
-        requestor_(std::move(oauth_server)),
-        expiration_time_() {
-    auto refresh = nl::json::parse(refresh_token_);
+      : requestor_(std::move(oauth_server)), expiration_time_() {
+    auto credentials = nl::json::parse(content);
     std::string payload("grant_type=refresh_token");
     payload += "&client_id=";
-    payload += requestor_.MakeEscapedString(refresh["client_id"]).get();
+    payload += requestor_.MakeEscapedString(credentials["client_id"]).get();
     payload += "&client_secret=";
-    payload += requestor_.MakeEscapedString(refresh["client_secret"]).get();
+    payload += requestor_.MakeEscapedString(credentials["client_secret"]).get();
     payload += "&refresh_token=";
-    payload += requestor_.MakeEscapedString(refresh["refresh_token"]).get();
+    payload += requestor_.MakeEscapedString(credentials["refresh_token"]).get();
     requestor_.PrepareRequest(std::move(payload));
   }
 
@@ -120,7 +108,6 @@ class ServiceAccountCredentials : public storage::Credentials {
   }
 
  private:
-  std::string refresh_token_;
   HttpRequestType requestor_;
   std::mutex mu_;
   std::condition_variable cv_;
@@ -132,4 +119,4 @@ class ServiceAccountCredentials : public storage::Credentials {
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 
-#endif  // GOOGLE_CLOUD_CPP_STORAGE_CLIENT_INTERNAL_SERVICE_ACCOUNT_CREDENTIALS_H_
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_CLIENT_INTERNAL_AUTHORIZED_USER_CREDENTIALS_H_

--- a/storage/client/internal/google_application_default_credentials_file.cc
+++ b/storage/client/internal/google_application_default_credentials_file.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "storage/client/internal/service_account_credentials.h"
+#include "storage/client/internal/google_application_default_credentials_file.h"
 #include "google/cloud/internal/throw_delegate.h"
 #include <sstream>
 
@@ -38,11 +38,11 @@ std::string const& GoogleCredentialsSuffix() {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
-char const* DefaultServiceAccountCredentialsHomeVariable() {
+char const* GoogleApplicationDefaultCredentialsHomeVariable() {
   return CREDENTIALS_HOME_VAR;
 }
 
-std::string DefaultServiceAccountCredentialsFile() {
+std::string GoogleApplicationDefaultCredentialsFile() {
   auto override_value = std::getenv("GOOGLE_APPLICATION_CREDENTIALS");
   if (override_value != nullptr) {
     return override_value;

--- a/storage/client/internal/google_application_default_credentials_file.h
+++ b/storage/client/internal/google_application_default_credentials_file.h
@@ -1,0 +1,33 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_STORAGE_CLIENT_INTERNAL_GOOGLE_APPLICATION_DEFAULT_CREDENTIALS_FILE_H_
+#define GOOGLE_CLOUD_CPP_STORAGE_CLIENT_INTERNAL_GOOGLE_APPLICATION_DEFAULT_CREDENTIALS_FILE_H_
+
+#include "storage/client/credentials.h"
+
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+/// Return the path for the default service account credentials file.
+std::string GoogleApplicationDefaultCredentialsFile();
+
+/// The name of the environment variable to configure `HOME`.
+char const* GoogleApplicationDefaultCredentialsHomeVariable();
+
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_CLIENT_INTERNAL_GOOGLE_APPLICATION_DEFAULT_CREDENTIALS_FILE_H_

--- a/storage/client/internal/google_application_default_credentials_file_test.cc
+++ b/storage/client/internal/google_application_default_credentials_file_test.cc
@@ -87,7 +87,7 @@ TEST_F(DefaultServiceAccountFileTest, HomeNotSet) {
                std::runtime_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::DefaultServiceAccountCredentialsFile(),
+      storage::internal::GoogleApplicationDefaultCredentialsFile(),
       "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }

--- a/storage/client/internal/google_application_default_credentials_file_test.cc
+++ b/storage/client/internal/google_application_default_credentials_file_test.cc
@@ -1,0 +1,93 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/client/internal/google_application_default_credentials_file.h"
+#include "google/cloud/internal/setenv.h"
+#include <gmock/gmock.h>
+
+class EnvironmentVariableRestore {
+ public:
+  explicit EnvironmentVariableRestore(char const* variable_name)
+      : EnvironmentVariableRestore(std::string(variable_name)) {}
+
+  explicit EnvironmentVariableRestore(std::string variable_name)
+      : variable_name_(std::move(variable_name)) {}
+
+  void SetUp() { previous_ = std::getenv(variable_name_.c_str()); }
+  void TearDown() {
+    google::cloud::internal::SetEnv(variable_name_.c_str(), previous_);
+  }
+
+ private:
+  std::string variable_name_;
+  char const* previous_;
+};
+
+class DefaultServiceAccountFileTest : public ::testing::Test {
+ public:
+  DefaultServiceAccountFileTest()
+      : home_(storage::internal::
+                  GoogleApplicationDefaultCredentialsHomeVariable()),
+        override_variable_("GOOGLE_APPLICATION_CREDENTIALS") {}
+
+ protected:
+  void SetUp() override {
+    home_.SetUp();
+    override_variable_.SetUp();
+  }
+  void TearDown() override {
+    override_variable_.TearDown();
+    home_.TearDown();
+  }
+
+ protected:
+  EnvironmentVariableRestore home_;
+  EnvironmentVariableRestore override_variable_;
+};
+
+/// @test Verify that the application can override the default credentials.
+TEST_F(DefaultServiceAccountFileTest, EnvironmentVariableSet) {
+  google::cloud::internal::SetEnv("GOOGLE_APPLICATION_CREDENTIALS",
+                                  "/foo/bar/baz");
+  auto actual = storage::internal::GoogleApplicationDefaultCredentialsFile();
+  EXPECT_EQ("/foo/bar/baz", actual);
+}
+
+/// @test Verify that the file path works as expected when using HOME.
+TEST_F(DefaultServiceAccountFileTest, HomeSet) {
+  google::cloud::internal::SetEnv("GOOGLE_APPLICATION_CREDENTIALS", nullptr);
+  char const* home =
+      storage::internal::GoogleApplicationDefaultCredentialsHomeVariable();
+  google::cloud::internal::SetEnv(home, "/foo/bar/baz");
+  auto actual = storage::internal::GoogleApplicationDefaultCredentialsFile();
+  using testing::HasSubstr;
+  EXPECT_THAT(actual, HasSubstr("/foo/bar/baz"));
+  EXPECT_THAT(actual, HasSubstr(".json"));
+}
+
+/// @test Verify that the service account file path fails when HOME is not set.
+TEST_F(DefaultServiceAccountFileTest, HomeNotSet) {
+  google::cloud::internal::SetEnv("GOOGLE_APPLICATION_CREDENTIALS", nullptr);
+  char const* home =
+      storage::internal::GoogleApplicationDefaultCredentialsHomeVariable();
+  google::cloud::internal::UnsetEnv(home);
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(storage::internal::GoogleApplicationDefaultCredentialsFile(),
+               std::runtime_error);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(
+      storage::internal::DefaultServiceAccountCredentialsFile(),
+      "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}

--- a/storage/client/storage_client.bzl
+++ b/storage/client/storage_client.bzl
@@ -4,12 +4,13 @@ storage_client_HDRS = [
     "bucket_metadata.h",
     "client.h",
     "credentials.h",
+    "internal/authorized_user_credentials.h",
     "internal/curl_request.h",
     "internal/curl_wrappers.h",
     "internal/default_client.h",
+    "internal/google_application_default_credentials_file.h",
     "internal/nljson.h",
     "internal/parse_rfc3339.h",
-    "internal/service_account_credentials.h",
     "status.h",
     "version.h",
 ]
@@ -21,8 +22,8 @@ storage_client_SRCS = [
     "credentials.cc",
     "internal/curl_request.cc",
     "internal/curl_wrappers.cc",
+    "internal/google_application_default_credentials_file.cc",
     "internal/parse_rfc3339.cc",
-    "internal/service_account_credentials.cc",
     "version.cc",
 ]
 

--- a/storage/client/storage_client_unit_tests.bzl
+++ b/storage/client/storage_client_unit_tests.bzl
@@ -2,10 +2,11 @@
 storage_client_unit_tests = [
     "bucket_metadata_test.cc",
     "bucket_test.cc",
+    "internal/authorized_user_credentials_test.cc",
     "internal/default_client_test.cc",
+    "internal/google_application_default_credentials_file_test.cc",
     "internal/nljson_test.cc",
     "internal/parse_rfc3339_test.cc",
-    "internal/service_account_credentials_test.cc",
     "link_test.cc",
 ]
 


### PR DESCRIPTION
This is part of the fixes for #656.  Move the old classes to the right (or at least) better names.
