### PR TITLE
Refactor retry loop for install step.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,13 +46,13 @@ matrix:
         - git submodule update --init
               third_party/googleapis
               third_party/googletest
-        - ci/install-linux.sh
+        - ci/install-retry.sh ci/install-linux.sh
       if: repo =~ ^GoogleCloudPlatform/ or head_repo =~ ^GoogleCloudPlatform/
     - # This is the only macOS entry in the matrix.  It is disabled on pull
       # requests because Travis often has long backlogs for macOS.
       os: osx
       compiler: clang
-      install: ci/install-macosx.sh
+      install: ci/install-retry.sh ci/install-macosx.sh
       script: ci/build-macosx.sh
       cache: ccache
       if: type != pull_request
@@ -61,7 +61,7 @@ matrix:
       compiler: gcc
       git:
         submodules: false
-      install: ci/install-bazel.sh
+      install: ci/install-retry.sh ci/install-bazel.sh
       script: ci/build-bazel.sh
     - # Compile on Travis' native environment with Bazel
       os: linux
@@ -70,7 +70,7 @@ matrix:
         TEST_BAZEL_AS_DEPENDENCY=yes
       git:
         submodules: false
-      install: ci/install-bazel.sh
+      install: ci/install-retry.sh ci/install-bazel.sh
       script: ci/build-bazel.sh
       if: repo =~ ^GoogleCloudPlatform/ or head_repo =~ ^GoogleCloudPlatform/
     - # Install the google-cloud-cpp libraries and test that one can use the
@@ -90,7 +90,7 @@ matrix:
         - git submodule update --init
               third_party/googleapis
               third_party/googletest
-        - ci/install-linux.sh
+        - ci/install-retry.sh ci/install-linux.sh
       if: repo =~ ^GoogleCloudPlatform/ or head_repo =~ ^GoogleCloudPlatform/
     - # Run clang-tidy, clang-format, and generate the documentation.
       os: linux
@@ -153,7 +153,7 @@ script:
   - ci/build-linux.sh
 
 install:
-  - ci/install-linux.sh
+  - ci/install-retry.sh ci/install-linux.sh
 
 after_success:
   - ci/upload-codecov.sh

--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -16,50 +16,25 @@
 
 set -eu
 
-function install_dependencies {
-  sudo apt-get update
-  sudo apt-get install -y software-properties-common
-  sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  sudo apt-get update
-  sudo apt-get install -y \
-       gcc-4.9 \
-       g++-4.9 \
-       libcurl4-openssl-dev \
-       libssl-dev \
-       unzip \
-       wget \
-       zip \
-       zlib1g-dev
+sudo apt-get update
+sudo apt-get install -y software-properties-common
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+sudo apt-get update
+sudo apt-get install -y \
+     gcc-4.9 \
+     g++-4.9 \
+     libcurl4-openssl-dev \
+     libssl-dev \
+     unzip \
+     wget \
+     zip \
+     zlib1g-dev
 
-  sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 100
-  sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 100
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 100
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 100
 
-  readonly BAZEL_VERSION=0.12.0
-  readonly GITHUB_DL="https://github.com/bazelbuild/bazel/releases/download"
-  wget -q "${GITHUB_DL}/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
-  chmod +x "bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
-  ./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh --user
-}
-
-# Make three attempts to install the dependencies. It is rare, but from time to
-# time the downloading the packages and/or the Bazel installer fails. To make
-# the CI build more robust, try again when that happens.
-
-# Initially, wait at least 3 minutes (the times are in seconds), because it
-# makes no sense to try faster.  We currently have 20+ minutes of remaining
-# budget to complete a build, and we should be as nice as possible to the
-# servers that provide the packages.
-min_wait=180
-# Do not exit on failures for this loop.
-set +e
-for i in 1 2 3; do
-  install_dependencies
-  if [ $? -eq 0 ]; then
-    exit 0
-  fi
-  # Sleep for a few minutes before trying again.
-  period=$[ (${RANDOM} % 60) + min_wait ]
-  echo "Fetch failed; trying again in ${period} seconds."
-  sleep ${period}s
-  min_wait=$[ min_wait * 2 ]
-done
+readonly BAZEL_VERSION=0.12.0
+readonly GITHUB_DL="https://github.com/bazelbuild/bazel/releases/download"
+wget -q "${GITHUB_DL}/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
+chmod +x "bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
+./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh --user

--- a/ci/install-linux.sh
+++ b/ci/install-linux.sh
@@ -24,28 +24,7 @@ if [ "${TRAVIS_OS_NAME}" != "linux" ]; then
 fi
 
 readonly IMAGE="cached-${DISTRO}-${DISTRO_VERSION}"
-# Make three attempts to build the Docker image.  From time to time, the image
-# creation fails because some apt server times out, and more often than not,
-# restarting the build is successful.
-
-# Initially, wait at least 3 minutes (the times are in seconds), because it
-# makes no sense to try faster.  We currently have 20+ minutes of remaining
-# budget to complete a build, and we should be as nice as possible to the
-# servers that provide the packages.
-min_wait=180
-# Do not exit on failures for this loop.
-set +e
-for i in 1 2 3; do
-  sudo docker build -t "${IMAGE}:tip" \
-       --build-arg NCPU="${NCPU:-2}" \
-       --build-arg DISTRO_VERSION="${DISTRO_VERSION}" \
-       -f "ci/Dockerfile.${DISTRO}" ci
-  if [ $? -eq 0 ]; then
-    exit 0
-  fi
-  # Sleep for a few minutes before trying again.
-  period=$[ (${RANDOM} % 60) + min_wait ]
-  echo "Fetch failed; trying again in ${period} seconds."
-  sleep ${period}s
-  min_wait=$[ min_wait * 2 ]
-done
+sudo docker build -t "${IMAGE}:tip" \
+     --build-arg NCPU="${NCPU:-2}" \
+     --build-arg DISTRO_VERSION="${DISTRO_VERSION}" \
+     -f "ci/Dockerfile.${DISTRO}" ci

--- a/ci/install-macosx.sh
+++ b/ci/install-macosx.sh
@@ -21,25 +21,5 @@ if [ "${TRAVIS_OS_NAME}" != "osx" ]; then
   exit 0
 fi
 
-# Make three attempts to install the dependencies. It is rare, but from time to
-# time the downloading the packages fails. To make the CI build more robust, try
-# again when that happens.
-
-# Initially, wait at least 3 minutes (the times are in seconds), because it
-# makes no sense to try faster.  We currently have 20+ minutes of remaining
-# budget to complete a build, and we should be as nice as possible to the
-# servers that provide the packages.
-min_wait=180
-# Do not exit on failures for this loop.
-set +e
-for i in 1 2 3; do
-  brew update && brew install curl openssl c-ares ccache
-  if [ $? -eq 0 ]; then
-    exit 0
-  fi
-  # Sleep for a few minutes before trying again.
-  period=$[ (${RANDOM} % 60) + min_wait ]
-  echo "Fetch failed; trying again in ${period} seconds."
-  sleep ${period}s
-  min_wait=$[ min_wait * 2 ]
-done
+brew update
+brew install curl openssl c-ares ccache

--- a/ci/install-retry.sh
+++ b/ci/install-retry.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# Make three attempts to install the dependencies. It is rare, but from time to
+# time the downloading the packages, building the Docker images, or an installer
+# Bazel, or the Google Cloud SDK fails. To make the CI build more robust, try
+# again when that happens.
+
+if (( $# < 1 )); then
+  echo "Usage: $(basename $0) program [arguments]"
+  exit 1
+fi
+readonly PROGRAM=${1}
+shift
+
+# Initially, wait at least 2 minutes (the times are in seconds), because it
+# makes no sense to try faster. This used to be 180 seconds, but that ends with
+# sleeps close to 10 minutes, and Travis aborts builds that do not output in
+# 10m.
+min_wait=120
+# Do not exit on failures for this loop.
+set +e
+for i in 1 2 3; do
+  ${PROGRAM} $*
+  if [ $? -eq 0 ]; then
+    exit 0
+  fi
+  # Sleep for a few minutes before trying again.
+  period=$[ (${RANDOM} % 60) + min_wait ]
+  echo "${PROGRAM} failed; trying again in ${period} seconds."
+  sleep ${period}s
+  min_wait=$[ min_wait * 2 ]
+done


### PR DESCRIPTION
Just remove duplication in the CI scripts.

Incidentally, I noticed the Bazel scripts had partial failures of their install phase sometimes, this fixes that too.
