### PR TITLE
Use functions to get build-time config.

### DIFF
--- a/google/cloud/bigtable/benchmarks/bigtable_benchmark_test.cc
+++ b/google/cloud/bigtable/benchmarks/bigtable_benchmark_test.cc
@@ -179,8 +179,8 @@ TEST(BenchmarkTest, PrintCsv) {
 
   // The output includes the version and compiler info.
   EXPECT_THAT(output, HasSubstr(google::cloud::bigtable::version_string()));
-  EXPECT_THAT(output, HasSubstr(google::cloud::internal::COMPILER));
-  EXPECT_THAT(output, HasSubstr(google::cloud::internal::COMPILER_FLAGS));
+  EXPECT_THAT(output, HasSubstr(google::cloud::internal::compiler()));
+  EXPECT_THAT(output, HasSubstr(google::cloud::internal::compiler_flags()));
 
   // The output includes the latency results.
   EXPECT_THAT(output, HasSubstr(",100,"));    // p0

--- a/google/cloud/bigtable/benchmarks/setup.cc
+++ b/google/cloud/bigtable/benchmarks/setup.cc
@@ -36,8 +36,8 @@ std::string FormattedStartTime() {
 
 std::string FormattedAnnotations() {
   std::string notes = google::cloud::bigtable::version_string() + ";" +
-                      google::cloud::internal::COMPILER + ";" +
-                      google::cloud::internal::COMPILER_FLAGS;
+                      google::cloud::internal::compiler() + ";" +
+                      google::cloud::internal::compiler_flags();
   std::transform(notes.begin(), notes.end(), notes.begin(),
                  [](char c) { return c == '\n' ? ';' : c; });
   return notes;

--- a/google/cloud/bigtable/version.cc
+++ b/google/cloud/bigtable/version.cc
@@ -25,7 +25,7 @@ std::string version_string() {
   static std::string const version = [] {
     std::ostringstream os;
     os << "v" << version_major() << "." << version_minor() << "."
-       << version_patch() << "+" << google::cloud::internal::GITREV;
+       << version_patch() << "+" << google::cloud::internal::gitrev();
     return os.str();
   }();
   return version;

--- a/google/cloud/internal/build_info.cc.in
+++ b/google/cloud/internal/build_info.cc.in
@@ -14,17 +14,21 @@
 
 #include "google/cloud/internal/build_info.h"
 
-namespace google {
-namespace cloud {
-inline namespace GOOGLE_CLOUD_CPP_NS {
-namespace internal {
-
+namespace {
 char const COMPILER[] = R"""(@CMAKE_CXX_COMPILER_ID@ @CMAKE_CXX_COMPILER_VERSION@)""";
 
 char const COMPILER_FLAGS[] = R"""(@CMAKE_CXX_FLAGS@ ${CMAKE_CXX_FLAGS_${BUILD_TYPE_UPPER}})""";
 
 char const GITREV[] = R"""(@GIT_HEAD@)""";
+}  // namespace
 
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+std::string compiler() { return COMPILER; }  // NOLINT
+std::string compiler_flags() { return COMPILER_FLAGS; } // NOLINT
+std::string gitrev() { return GITREV; } // NOLINT
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/internal/build_info.h
+++ b/google/cloud/internal/build_info.h
@@ -22,13 +22,13 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 /// The compiler version
-extern char const COMPILER[];
+std::string compiler();
 
 /// The compiler flags
-extern char const COMPILER_FLAGS[];
+std::string compiler_flags();
 
 /// The git revision at compile time
-extern char const GITREV[];
+std::string gitrev();
 
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS

--- a/google/cloud/storage/version.cc
+++ b/google/cloud/storage/version.cc
@@ -23,7 +23,7 @@ std::string version_string() {
   static std::string const version = [] {
     std::ostringstream os;
     os << "v" << version_major() << "." << version_minor() << "."
-       << version_patch() << "+" << google::cloud::internal::GITREV;
+       << version_patch() << "+" << google::cloud::internal::gitrev();
     return os.str();
   }();
   return version;


### PR DESCRIPTION
Using global (or extern) arrays is not binary compatible between
releases, the length of the array may change from one release to
the next. This should fix the ABI warnings.