### PR TITLE
Return "" for auth header of InsecureCredentials.

### DIFF
--- a/google/cloud/storage/credentials.cc
+++ b/google/cloud/storage/credentials.cc
@@ -39,7 +39,7 @@ std::shared_ptr<Credentials> GoogleDefaultCredentials() {
                                              type + ")");
 }
 
-std::string InsecureCredentials::AuthorizationHeader() { return "none"; }
+std::string InsecureCredentials::AuthorizationHeader() { return ""; }
 
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/credentials.h
+++ b/google/cloud/storage/credentials.h
@@ -40,8 +40,7 @@ std::shared_ptr<Credentials> GoogleDefaultCredentials();
  *
  * This is only useful in two cases: (a) in testing, where you want to access
  * a test bench without having to worry about authentication or SSL setup, and
- * (b) when accessing some public buckets where the bucket owner pays for
- * network egress.
+ * (b) when accessing publicly readable buckets or objects without credentials.
  */
 class InsecureCredentials : public storage::Credentials {
  public:

--- a/google/cloud/storage/internal/authorized_user_credentials.h
+++ b/google/cloud/storage/internal/authorized_user_credentials.h
@@ -91,7 +91,8 @@ class AuthorizedUserCredentials : public storage::Credentials {
       return false;
     }
     nl::json access_token = nl::json::parse(response.payload);
-    std::string header = access_token["token_type"];
+    std::string header = "Authorization: ";
+    header += access_token["token_type"].get_ref<std::string const&>();
     header += ' ';
     header += access_token["access_token"].get_ref<std::string const&>();
     std::string new_id = access_token["id_token"];

--- a/google/cloud/storage/internal/authorized_user_credentials_test.cc
+++ b/google/cloud/storage/internal/authorized_user_credentials_test.cc
@@ -67,7 +67,8 @@ TEST_F(AuthorizedUserCredentialsTest, Simple) {
       .WillOnce(Return(storage::internal::HttpResponse{200, response, {}}));
 
   AuthorizedUserCredentials<MockHttpRequest> credentials(jwt);
-  EXPECT_EQ("Type access-token-value", credentials.AuthorizationHeader());
+  EXPECT_EQ("Authorization: Type access-token-value",
+            credentials.AuthorizationHeader());
 }
 
 /// @test Verify that we can refresh service account credentials.
@@ -110,7 +111,10 @@ TEST_F(AuthorizedUserCredentialsTest, Refresh) {
       .WillOnce(Return(storage::internal::HttpResponse{200, r2, {}}));
 
   AuthorizedUserCredentials<MockHttpRequest> credentials(jwt);
-  EXPECT_EQ("Type access-token-r1", credentials.AuthorizationHeader());
-  EXPECT_EQ("Type access-token-r2", credentials.AuthorizationHeader());
-  EXPECT_EQ("Type access-token-r2", credentials.AuthorizationHeader());
+  EXPECT_EQ("Authorization: Type access-token-r1",
+            credentials.AuthorizationHeader());
+  EXPECT_EQ("Authorization: Type access-token-r2",
+            credentials.AuthorizationHeader());
+  EXPECT_EQ("Authorization: Type access-token-r2",
+            credentials.AuthorizationHeader());
 }

--- a/google/cloud/storage/internal/default_client.h
+++ b/google/cloud/storage/internal/default_client.h
@@ -37,8 +37,7 @@ class DefaultClient : public Client {
     // Assume the bucket name is validated by the caller.
     HttpRequestor requestor(storage_endpoint_ + "/b/" + request.bucket_name());
     requestor.AddWellKnownParameters(request.well_known_parameters());
-    requestor.AddHeader("Authorization: " +
-                        options_.credentials()->AuthorizationHeader());
+    requestor.AddHeader(options_.credentials()->AuthorizationHeader());
     requestor.PrepareRequest(std::string{});
     auto payload = requestor.MakeRequest();
     if (200 != payload.status_code) {

--- a/google/cloud/storage/internal/default_client_test.cc
+++ b/google/cloud/storage/internal/default_client_test.cc
@@ -33,7 +33,7 @@ class DefaultClientTest : public ::testing::Test {
     MockHttpRequest::Clear();
     credentials_ = std::make_shared<MockCredentials>();
     EXPECT_CALL(*credentials_, AuthorizationHeader())
-        .WillRepeatedly(Return("some-secret-credential"));
+        .WillRepeatedly(Return("Authorization: some-secret-credential"));
   }
   void TearDown() {
     credentials_.reset();


### PR DESCRIPTION
Previously, this returned the header "Authorization: none". For
anonymous API calls, we should be omitting the "Authorization" header.
As a result, this change makes other credential types include the
"Authorization: " prefix in their AuthorizationHeader() return value.