### PR TITLE
Introduce API to create GCS Objects

### DIFF
--- a/google/cloud/storage/bucket.h
+++ b/google/cloud/storage/bucket.h
@@ -38,7 +38,7 @@ class Bucket {
   /**
    * Fetch the bucket metadata and return it.
    *
-   * @param modifier a variadic list. Valid types for this operation include
+   * @param modifiers a variadic list. Valid types for this operation include
    *   `IfMetagenerationMatch`, `IfMetagenerationNotMatch`, `UserProject`,
    *   `Projection`.
    *
@@ -49,9 +49,9 @@ class Bucket {
    * @snippet storage_bucket_samples.cc get metadata
    */
   template <typename... Modifiers>
-  BucketMetadata GetMetadata(Modifiers&&... modifier) {
+  BucketMetadata GetMetadata(Modifiers&&... modifiers) {
     GetBucketMetadataRequest request(bucket_name());
-    request.ApplyModifiers(std::forward<Modifiers>(modifier)...);
+    request.ApplyModifiers(std::forward<Modifiers>(modifiers)...);
     return GetMetadataImpl(request);
   }
 

--- a/google/cloud/storage/bucket.h
+++ b/google/cloud/storage/bucket.h
@@ -65,9 +65,9 @@ class Bucket {
    */
   template <typename... Modifiers>
   ObjectMetadata InsertObject(std::string const& object_name,
-                              std::string contents,
-                              Modifiers&&... modifier) {
-    InsertObjectMediaRequest request(bucket_name(), object_name, std::move(contents));
+                              std::string contents, Modifiers&&... modifier) {
+    InsertObjectMediaRequest request(bucket_name(), object_name,
+                                     std::move(contents));
     request.ApplyModifiers(std::forward<Modifiers>(modifier)...);
     return InsertObjectMediaImpl(request);
   }

--- a/google/cloud/storage/bucket.h
+++ b/google/cloud/storage/bucket.h
@@ -15,7 +15,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BUCKET_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BUCKET_H_
 
-#include "google/cloud/storage/bucket_metadata.h"
 #include "google/cloud/storage/client.h"
 
 namespace storage {
@@ -56,10 +55,28 @@ class Bucket {
     return GetMetadataImpl(request);
   }
 
+  /**
+   * Create an object given its name and media (contents).
+   *
+   * @par Example
+   * @snippet storage_bucket_samples.cc insert object
+   *
+   * TODO(#682) - prototype modifiers for the request.
+   */
+  template <typename... Modifiers>
+  ObjectMetadata InsertObject(std::string const& object_name,
+                              std::string contents,
+                              Modifiers&&... modifier) {
+    InsertObjectMediaRequest request(bucket_name(), object_name, std::move(contents));
+    request.ApplyModifiers(std::forward<Modifiers>(modifier)...);
+    return InsertObjectMediaImpl(request);
+  }
+
   static void ValidateBucketName(std::string const& bucket_name);
 
  private:
   BucketMetadata GetMetadataImpl(GetBucketMetadataRequest const& request);
+  ObjectMetadata InsertObjectMediaImpl(InsertObjectMediaRequest const& request);
 
  private:
   std::shared_ptr<Client> client_;

--- a/google/cloud/storage/bucket_test.cc
+++ b/google/cloud/storage/bucket_test.cc
@@ -121,7 +121,7 @@ TEST(BucketTest, InsertObjectMediaPermanentFailure) {
 #else
   // With EXPECT_DEATH*() the mocking framework cannot detect how many times the
   // operation is called.
-  EXPECT_CALL(*mock, InsertObjectMedia(_, _, _))
+  EXPECT_CALL(*mock, InsertObjectMedia(_))
       .WillRepeatedly(Return(std::make_pair(NOT_FOUND(), ObjectMetadata{})));
   EXPECT_DEATH_IF_SUPPORTED(bucket.InsertObject("baz", "blah blah"),
                             "exceptions are disabled");

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/bucket_metadata.h"
 #include "google/cloud/storage/client_options.h"
 #include "google/cloud/storage/credentials.h"
+#include "google/cloud/storage/object_metadata.h"
 #include "google/cloud/storage/status.h"
 #include "google/cloud/storage/well_known_parameters.h"
 
@@ -95,6 +96,101 @@ class GetBucketMetadataRequest {
   WellKnownParameters well_known_parameters_;
 };
 
+class InsertObjectMediaRequest {
+ public:
+  InsertObjectMediaRequest() = default;
+  explicit InsertObjectMediaRequest(std::string bucket_name,
+                                    std::string object_name,
+                                    std::string contents)
+      : bucket_name_(std::move(bucket_name)),
+        object_name_(std::move(object_name)),
+        contents_(std::move(contents)) {}
+
+  std::string const& bucket_name() const { return bucket_name_; }
+  InsertObjectMediaRequest& set_bucket_name(std::string bucket_name) {
+    bucket_name_ = std::move(bucket_name);
+    return *this;
+  }
+  std::string const& object_name() const { return object_name_; }
+  InsertObjectMediaRequest& set_object_name(std::string object_name) {
+    object_name_ = std::move(object_name);
+    return *this;
+  }
+  std::string const& contents() const { return contents_; }
+  InsertObjectMediaRequest& set_contents(std::string contents) {
+    contents_ = std::move(contents);
+    return *this;
+  }
+
+  /**
+   * Apply a list of modifiers to a CreateObjectMediaRequest.
+   *
+   * This is a shorthand to replace:
+   *
+   * @code
+   * request.ApplyModifier(m1).ApplyModifier(m2).ApplyModifier(m3)
+   * @endcode
+   *
+   * with:
+   *
+   * @code
+   * request.ApplyModifiers(m1, m2, m3)
+   * @endcode
+   *
+   * @tparam H the first modifier type
+   * @tparam T the types of the remaining modifiers.
+   * @param head the first modifier in the list.
+   * @param tail the remaining modifiers in the list.
+   */
+  template <typename H, typename... T>
+  InsertObjectMediaRequest& ApplyModifiers(H&& head, T&&... tail) {
+    ApplyModifier(std::forward<H>(head));
+    return ApplyModifiers(std::forward<T>(tail)...);
+  }
+
+  //@{
+  /// @name Apply a single modifier to the request.
+  InsertObjectMediaRequest& ApplyModifier(IfGenerationMatch&& p) {
+    well_known_parameters_.Apply(std::move(p));
+    return *this;
+  }
+  InsertObjectMediaRequest& ApplyModifier(IfGenerationNotMatch&& p) {
+    well_known_parameters_.Apply(std::move(p));
+    return *this;
+  }
+  InsertObjectMediaRequest& ApplyModifier(IfMetaGenerationMatch&& p) {
+    well_known_parameters_.Apply(std::move(p));
+    return *this;
+  }
+  InsertObjectMediaRequest& ApplyModifier(IfMetaGenerationNotMatch&& p) {
+    well_known_parameters_.Apply(std::move(p));
+    return *this;
+  }
+  InsertObjectMediaRequest& ApplyModifier(Projection&& p) {
+    well_known_parameters_.Apply(std::move(p));
+    return *this;
+  }
+  InsertObjectMediaRequest& ApplyModifier(UserProject&& p) {
+    well_known_parameters_.Apply(std::move(p));
+    return *this;
+  }
+  //@}
+
+  /**
+   * Apply an empty list of modifiers to a InsertObjectMediaRequest.
+   */
+  InsertObjectMediaRequest& ApplyModifiers() { return *this; }
+
+  WellKnownParameters const& well_known_parameters() const {
+    return well_known_parameters_;
+  }
+ private:
+  std::string bucket_name_;
+  std::string object_name_;
+  std::string contents_;
+  WellKnownParameters well_known_parameters_;
+};
+
 /**
  * Define the interface used to communicate with Google Cloud Storage.
  *
@@ -118,6 +214,10 @@ class Client {
    */
   virtual std::pair<Status, BucketMetadata> GetBucketMetadata(
       GetBucketMetadataRequest const& request) = 0;
+
+  // TODO(#682) - prototype modifiers for the request.
+  virtual std::pair<Status, ObjectMetadata> InsertObjectMedia(
+      InsertObjectMediaRequest const&) = 0;
 };
 
 /**

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -184,6 +184,7 @@ class InsertObjectMediaRequest {
   WellKnownParameters const& well_known_parameters() const {
     return well_known_parameters_;
   }
+
  private:
   std::string bucket_name_;
   std::string object_name_;

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -141,6 +141,8 @@ class InsertObjectMediaRequest {
    * @tparam T the types of the remaining modifiers.
    * @param head the first modifier in the list.
    * @param tail the remaining modifiers in the list.
+   *
+   * TODO(#710) - implement all other modifiers applicable to Objects: insert
    */
   template <typename H, typename... T>
   InsertObjectMediaRequest& ApplyModifiers(H&& head, T&&... tail) {

--- a/google/cloud/storage/examples/run_examples_production.sh
+++ b/google/cloud/storage/examples/run_examples_production.sh
@@ -26,8 +26,12 @@ function run_all_bucket_examples {
   shift
 
   echo
-  echo "Running bucket get-metadata examples"
+  echo "Running bucket get-metadata example"
   ./storage_bucket_samples get-metadata "${bucket_name}"
+
+  echo
+  echo "Running bucket insert-object example"
+  ./storage_bucket_samples insert-object "${bucket_name}"
 }
 
 # Run the examples against the production environment:

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -39,7 +39,9 @@ void PrintUsage(int argc, char* argv[], std::string const& msg) {
   auto program = cmd.substr(last_slash + 1);
   std::cerr << msg << "\nUsage: " << program << " <command> [arguments]\n\n"
             << "Examples:\n";
-  for (auto example : {"get-metadata <bucket_name>"}) {
+  for (auto const& example :
+       {"get-metadata <bucket_name>",
+        "insert-object <object name> <object contents>"}) {
     std::cerr << "  " << program << " " << example << "\n";
   }
   std::cerr << std::flush;
@@ -52,12 +54,22 @@ void GetMetadata(storage::Bucket bucket, int& argc, char* argv[]) {
 }
 //! [get metadata]
 
+//! [insert object]
+void InsertObject(storage::Bucket bucket, int& argc, char* argv[]) {
+  auto object_name = ConsumeArg(argc, argv);
+  auto contents = ConsumeArg(argc, argv);
+  auto meta = bucket.InsertObject(object_name, std::move(contents));
+  std::cout << "The new object metadata is " << meta << std::endl;
+}
+//! [insert object]
+
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) try {
   using CommandType = std::function<void(storage::Bucket, int&, char* [])>;
   std::map<std::string, CommandType> commands = {
       {"get-metadata", &GetMetadata},
+      {"insert-object", &InsertObject},
   };
 
   if (argc < 2) {

--- a/google/cloud/storage/internal/default_client.h
+++ b/google/cloud/storage/internal/default_client.h
@@ -53,14 +53,14 @@ class DefaultClient : public Client {
       InsertObjectMediaRequest const& request) override {
     // Assume the bucket name is validated by the caller.
     HttpRequestor requestor("https://www.googleapis.com/upload/storage/v1/b/" +
-                          request.bucket_name() + "/o");
+                            request.bucket_name() + "/o");
     requestor.AddQueryParameter("uploadType", "media");
     requestor.AddQueryParameter("name", request.object_name());
     requestor.AddWellKnownParameters(request.well_known_parameters());
     requestor.AddHeader(options_.credentials()->AuthorizationHeader());
     requestor.AddHeader("Content-Type: application/octet-stream");
-    requestor.AddHeader(
-        "Content-Length: " + std::to_string(request.contents().size()));
+    requestor.AddHeader("Content-Length: " +
+                        std::to_string(request.contents().size()));
     requestor.PrepareRequest(std::move(request.contents()));
     auto payload = requestor.MakeRequest();
     if (200 != payload.status_code) {

--- a/google/cloud/storage/internal/default_client.h
+++ b/google/cloud/storage/internal/default_client.h
@@ -49,6 +49,29 @@ class DefaultClient : public Client {
                           BucketMetadata::ParseFromJson(payload.payload));
   }
 
+  std::pair<Status, ObjectMetadata> InsertObjectMedia(
+      InsertObjectMediaRequest const& request) override {
+    // Assume the bucket name is validated by the caller.
+    HttpRequestor requestor("https://www.googleapis.com/upload/storage/v1/b/" +
+                          request.bucket_name() + "/o");
+    requestor.AddQueryParameter("uploadType", "media");
+    requestor.AddQueryParameter("name", request.object_name());
+    requestor.AddWellKnownParameters(request.well_known_parameters());
+    requestor.AddHeader(options_.credentials()->AuthorizationHeader());
+    requestor.AddHeader("Content-Type: application/octet-stream");
+    requestor.AddHeader(
+        "Content-Length: " + std::to_string(request.contents().size()));
+    requestor.PrepareRequest(std::move(request.contents()));
+    auto payload = requestor.MakeRequest();
+    if (200 != payload.status_code) {
+      return std::make_pair(
+          Status{payload.status_code, std::move(payload.payload)},
+          ObjectMetadata{});
+    }
+    return std::make_pair(Status(),
+                          ObjectMetadata::ParseFromJson(payload.payload));
+  }
+
  private:
   ClientOptions options_;
   std::string storage_endpoint_;

--- a/google/cloud/storage/internal/default_client.h
+++ b/google/cloud/storage/internal/default_client.h
@@ -52,8 +52,8 @@ class DefaultClient : public Client {
   std::pair<Status, ObjectMetadata> InsertObjectMedia(
       InsertObjectMediaRequest const& request) override {
     // Assume the bucket name is validated by the caller.
-    HttpRequestor requestor("https://www.googleapis.com/upload/storage/v1/b/" +
-                            request.bucket_name() + "/o");
+    HttpRequestor requestor(storage_endpoint_ + "/b/" + request.bucket_name() +
+                            "/o");
     requestor.AddQueryParameter("uploadType", "media");
     requestor.AddQueryParameter("name", request.object_name());
     requestor.AddWellKnownParameters(request.well_known_parameters());

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_MOCK_CLIENT_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_MOCK_CLIENT_H_
 
-#include <gmock/gmock.h>
 #include "google/cloud/storage/client.h"
+#include <gmock/gmock.h>
 
 namespace storage {
 namespace testing {

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -15,16 +15,20 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_MOCK_CLIENT_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_MOCK_CLIENT_H_
 
-#include "google/cloud/storage/client.h"
 #include <gmock/gmock.h>
+#include "google/cloud/storage/client.h"
 
 namespace storage {
 namespace testing {
 class MockClient : public storage::Client {
  public:
   using BucketGetResult = std::pair<storage::Status, storage::BucketMetadata>;
+  using ObjectInsertResult =
+      std::pair<storage::Status, storage::ObjectMetadata>;
   MOCK_METHOD1(GetBucketMetadata,
                BucketGetResult(GetBucketMetadataRequest const&));
+  MOCK_METHOD1(InsertObjectMedia,
+               ObjectInsertResult(InsertObjectMediaRequest const&));
 };
 }  // namespace testing
 }  // namespace storage

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -90,8 +90,7 @@ TEST_F(BucketIntegrationTest, GetMetadataIfMetaGenerationNotMatch_Failure) {
 }
 
 TEST_F(BucketIntegrationTest, InsertObjectMedia) {
-  auto client =
-      storage::CreateDefaultClient(storage::GoogleDefaultCredentials());
+  auto client = storage::CreateDefaultClient();
   // TODO(#681) - use random names for the object and buckets in the tests.
   auto bucket_name = BucketTestEnvironment::bucket_name();
   storage::Bucket bucket(client, bucket_name);
@@ -107,8 +106,7 @@ TEST_F(BucketIntegrationTest, InsertObjectMedia) {
 }
 
 TEST_F(BucketIntegrationTest, InsertObjectMediaIfGenerationMatch) {
-  auto client =
-      storage::CreateDefaultClient(storage::GoogleDefaultCredentials());
+  auto client = storage::CreateDefaultClient();
   // TODO(#681) - use random names for the object and buckets in the tests.
   auto bucket_name = BucketTestEnvironment::bucket_name();
   storage::Bucket bucket(client, bucket_name);
@@ -134,8 +132,7 @@ TEST_F(BucketIntegrationTest, InsertObjectMediaIfGenerationMatch) {
 }
 
 TEST_F(BucketIntegrationTest, InsertObjectMediaIfGenerationNotMatch) {
-  auto client =
-      storage::CreateDefaultClient(storage::GoogleDefaultCredentials());
+  auto client = storage::CreateDefaultClient();
   // TODO(#681) - use random names for the object and buckets in the tests.
   auto bucket_name = BucketTestEnvironment::bucket_name();
   storage::Bucket bucket(client, bucket_name);
@@ -162,7 +159,7 @@ int main(int argc, char* argv[]) {
   // Make sure the arguments are valid.
   if (argc != 3) {
     std::string const cmd = argv[0];
-    auto last_slash = std::string(argv[0]).find_last_of("/");
+    auto last_slash = std::string(argv[0]).find_last_of('/');
     std::cerr << "Usage: " << cmd.substr(last_slash + 1)
               << " <project> <bucket>" << std::endl;
     return 1;

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -114,22 +114,22 @@ TEST_F(BucketIntegrationTest, InsertObjectMediaIfGenerationMatch) {
   storage::Bucket bucket(client, bucket_name);
   auto object_name =
       std::string("the-test-object-") +
-          std::to_string(
-              std::chrono::system_clock::now().time_since_epoch().count());
+      std::to_string(
+          std::chrono::system_clock::now().time_since_epoch().count());
 
-  auto original = bucket.InsertObject(
-      object_name, "blah blah", storage::IfGenerationMatch(0));
+  auto original = bucket.InsertObject(object_name, "blah blah",
+                                      storage::IfGenerationMatch(0));
   EXPECT_EQ(bucket_name, original.bucket());
   EXPECT_EQ(object_name, original.name());
   EXPECT_EQ("storage#object", original.kind());
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(bucket.InsertObject(
-      object_name, "blah blah", storage::IfGenerationMatch(0)),
+  EXPECT_THROW(bucket.InsertObject(object_name, "blah blah",
+                                   storage::IfGenerationMatch(0)),
                std::exception);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(bucket.InsertObject(
-      object_name, "blah blah", storage::IfGenerationMatch(0)),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(bucket.InsertObject(object_name, "blah blah",
+                                                storage::IfGenerationMatch(0)),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -141,17 +141,17 @@ TEST_F(BucketIntegrationTest, InsertObjectMediaIfGenerationNotMatch) {
   storage::Bucket bucket(client, bucket_name);
   auto object_name =
       std::string("the-test-object-") +
-          std::to_string(
-              std::chrono::system_clock::now().time_since_epoch().count());
+      std::to_string(
+          std::chrono::system_clock::now().time_since_epoch().count());
 
-  auto original = bucket.InsertObject(
-      object_name, "blah blah", storage::IfGenerationMatch(0));
+  auto original = bucket.InsertObject(object_name, "blah blah",
+                                      storage::IfGenerationMatch(0));
   EXPECT_EQ(bucket_name, original.bucket());
   EXPECT_EQ(object_name, original.name());
   EXPECT_EQ("storage#object", original.kind());
 
-  auto metadata = bucket.InsertObject(
-      object_name, "more blah blah", storage::IfGenerationNotMatch(0));
+  auto metadata = bucket.InsertObject(object_name, "more blah blah",
+                                      storage::IfGenerationNotMatch(0));
   EXPECT_EQ(object_name, metadata.name());
   EXPECT_NE(original.generation(), metadata.generation());
 }


### PR DESCRIPTION
This fixes #554.  The PR was getting too large, better to send it now.

The largest change is in the GCS fake, that would benefit from somebody
with more Python expertise than I have taking a look.

The second large change is the `InsertObjectMediaRequest`, I do not like
the name much.  I also thing we will want to refactor this to some kind of
base class soon. There is too much repetition with the
`GetBucketMetadataRequest` class.
