### PR TITLE
Take a new snapshot for the ABI check.

### DIFF
--- a/ci/test-abi/google_cloud_cpp_common.expected.abi.dump
+++ b/ci/test-abi/google_cloud_cpp_common.expected.abi.dump
@@ -4,8 +4,12 @@ $VAR1 = {
           'Arch' => 'x86_64',
           'Compiler' => 'GNU C++11 7.3.0 -mtune=generic -march=x86-64 -g -std=gnu++11 -fPIC -fstack-protector-strong',
           'Headers' => {
+                         'async_stream.h' => 1,
+                         'async_unary_call.h' => 1,
                          'build_info.h' => 1,
+                         'log.h' => 1,
                          'setenv.h' => 1,
+                         'shared_ptr.h' => 1,
                          'throw_delegate.h' => 1
                        },
           'Language' => 'C++',
@@ -15,10 +19,14 @@ $VAR1 = {
           'MissedRegs' => '1',
           'NameSpaces' => {
                             '__gnu_cxx' => 1,
+                            'google::cloud::v0' => 1,
                             'google::cloud::v0::internal' => 1,
                             'std' => 1,
                             'std::__cxx11' => 1,
-                            'std::__exception_ptr' => 1
+                            'std::__exception_ptr' => 1,
+                            'std::chrono' => 1,
+                            'std::chrono::_V2' => 1,
+                            'std::placeholders' => 1
                           },
           'Needed' => {
                         'libc.so.6' => 1,
@@ -28,55 +36,639 @@ $VAR1 = {
           'PublicABI' => '1',
           'Sources' => {
                          'build_info.cc' => 1,
+                         'log.cc' => 1,
                          'setenv.cc' => 1,
                          'throw_delegate.cc' => 1
                        },
           'SymbolInfo' => {
-                            '16246' => {
-                                         'Data' => 1,
+                            '105332' => {
+                                          'Class' => '105195',
+                                          'Header' => 'log.h',
+                                          'Line' => '240',
+                                          'MnglName' => '_ZN6google5cloud2v07LogSink8InstanceEv',
+                                          'Return' => '107310',
+                                          'ShortName' => 'Instance',
+                                          'Source' => 'log.cc',
+                                          'SourceLine' => '46',
+                                          'Static' => 1
+                                        },
+                            '105479' => {
+                                          'Class' => '105195',
+                                          'Header' => 'log.h',
+                                          'Line' => '288',
+                                          'MnglName' => '_ZN6google5cloud2v07LogSink10AddBackendESt10shared_ptrINS1_10LogBackendEE',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107305'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'backend',
+                                                                'type' => '85102'
+                                                              }
+                                                     },
+                                          'Return' => '20405',
+                                          'ShortName' => 'AddBackend',
+                                          'Source' => 'log.cc',
+                                          'SourceLine' => '51'
+                                        },
+                            '105515' => {
+                                          'Class' => '105195',
+                                          'Header' => 'log.h',
+                                          'Line' => '289',
+                                          'MnglName' => '_ZN6google5cloud2v07LogSink13RemoveBackendEl',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107305'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'id',
+                                                                'type' => '20405'
+                                                              }
+                                                     },
+                                          'Return' => '1',
+                                          'ShortName' => 'RemoveBackend',
+                                          'Source' => 'log.cc',
+                                          'SourceLine' => '59'
+                                        },
+                            '105547' => {
+                                          'Class' => '105195',
+                                          'Header' => 'log.h',
+                                          'Line' => '290',
+                                          'MnglName' => '_ZN6google5cloud2v07LogSink13ClearBackendsEv',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107305'
+                                                              }
+                                                     },
+                                          'Return' => '1',
+                                          'ShortName' => 'ClearBackends',
+                                          'Source' => 'log.cc',
+                                          'SourceLine' => '69'
+                                        },
+                            '105574' => {
+                                          'Class' => '105195',
+                                          'Header' => 'log.h',
+                                          'Line' => '292',
+                                          'MnglName' => '_ZN6google5cloud2v07LogSink3LogENS1_9LogRecordE',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107305'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'log_record',
+                                                                'type' => '105051'
+                                                              }
+                                                     },
+                                          'Return' => '1',
+                                          'ShortName' => 'Log',
+                                          'Source' => 'log.cc',
+                                          'SourceLine' => '75'
+                                        },
+                            '105607' => {
+                                          'Class' => '105195',
+                                          'Header' => 'log.h',
+                                          'Line' => '295',
+                                          'MnglName' => '_ZN6google5cloud2v07LogSink13EnableStdClogEv',
+                                          'Return' => '20405',
+                                          'ShortName' => 'EnableStdClog',
+                                          'Source' => 'log.cc',
+                                          'SourceLine' => '114',
+                                          'Static' => 1
+                                        },
+                            '105779' => {
+                                          'Class' => '105657',
+                                          'Header' => 'log.h',
+                                          'Line' => '221',
+                                          'MnglName' => '_ZN6google5cloud2v010LogBackend7ProcessERKNS1_9LogRecordE',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107464'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'p1',
+                                                                'type' => '108300'
+                                                              }
+                                                     },
+                                          'PureVirt' => 1,
+                                          'Return' => '1',
+                                          'ShortName' => 'Process',
+                                          'VirtPos' => '2'
+                                        },
+                            '105819' => {
+                                          'Class' => '105657',
+                                          'Header' => 'log.h',
+                                          'Line' => '222',
+                                          'MnglName' => '_ZN6google5cloud2v010LogBackend20ProcessWithOwnershipENS1_9LogRecordE',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107464'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'p1',
+                                                                'type' => '105051'
+                                                              }
+                                                     },
+                                          'PureVirt' => 1,
+                                          'Return' => '1',
+                                          'ShortName' => 'ProcessWithOwnership',
+                                          'VirtPos' => '3'
+                                        },
+                            '106080' => {
+                                          'Header' => 'log.h',
+                                          'MnglName' => '_ZN6google5cloud2v0lsERSoRKNS1_9LogRecordE',
+                                          'NameSpace' => 'google::cloud::v0',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'os',
+                                                                'type' => '124987'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'rhs',
+                                                                'type' => '108300'
+                                                              }
+                                                     },
+                                          'Return' => '124987',
+                                          'ShortName' => 'operator<<',
+                                          'Source' => 'log.cc',
+                                          'SourceLine' => '36'
+                                        },
+                            '106110' => {
+                                          'Header' => 'log.h',
+                                          'MnglName' => '_ZN6google5cloud2v0lsERSoNS1_8SeverityE',
+                                          'NameSpace' => 'google::cloud::v0',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'os',
+                                                                'type' => '124987'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'x',
+                                                                'type' => '104960'
+                                                              }
+                                                     },
+                                          'Return' => '124987',
+                                          'ShortName' => 'operator<<',
+                                          'Source' => 'log.cc',
+                                          'SourceLine' => '27'
+                                        },
+                            '109735' => {
+                                          'Artificial' => 1,
+                                          'Class' => '85102',
+                                          'Constructor' => 1,
+                                          'Header' => 'shared_ptr.h',
+                                          'InLine' => 1,
+                                          'Line' => '119',
+                                          'MnglName' => '_ZNSt10shared_ptrIN6google5cloud2v010LogBackendEEC2ERKS4_',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107481'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'p1',
+                                                                'type' => '107486'
+                                                              }
+                                                     },
+                                          'ShortName' => 'shared_ptr'
+                                        },
+                            '109736' => {
+                                          'Artificial' => 1,
+                                          'Class' => '85102',
+                                          'Constructor' => 1,
+                                          'Header' => 'shared_ptr.h',
+                                          'InLine' => 1,
+                                          'Line' => '119',
+                                          'MnglName' => '_ZNSt10shared_ptrIN6google5cloud2v010LogBackendEEC1ERKS4_',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107481'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'p1',
+                                                                'type' => '107486'
+                                                              }
+                                                     },
+                                          'ShortName' => 'shared_ptr'
+                                        },
+                            '110264' => {
+                                          'Artificial' => 1,
+                                          'Class' => '105657',
+                                          'Destructor' => 1,
+                                          'Header' => 'log.h',
+                                          'InLine' => 1,
+                                          'Line' => '219',
+                                          'MnglName' => '_ZN6google5cloud2v010LogBackendD0Ev',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107470'
+                                                              }
+                                                     },
+                                          'ShortName' => 'LogBackend',
+                                          'Virt' => 1
+                                        },
+                            '110265' => {
+                                          'Artificial' => 1,
+                                          'Class' => '105657',
+                                          'Destructor' => 1,
+                                          'Header' => 'log.h',
+                                          'InLine' => 1,
+                                          'Line' => '219',
+                                          'MnglName' => '_ZN6google5cloud2v010LogBackendD1Ev',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107470'
+                                                              }
+                                                     },
+                                          'ShortName' => 'LogBackend',
+                                          'Virt' => 1
+                                        },
+                            '110312' => {
+                                          'Artificial' => 1,
+                                          'Class' => '105657',
+                                          'Destructor' => 1,
+                                          'Header' => 'log.h',
+                                          'InLine' => 1,
+                                          'Line' => '219',
+                                          'MnglName' => '_ZN6google5cloud2v010LogBackendD2Ev',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107470'
+                                                              }
+                                                     },
+                                          'ShortName' => 'LogBackend',
+                                          'Virt' => 1
+                                        },
+                            '110386' => {
+                                          'Artificial' => 1,
+                                          'Class' => '105657',
+                                          'Constructor' => 1,
+                                          'Header' => 'log.h',
+                                          'InLine' => 1,
+                                          'Line' => '217',
+                                          'MnglName' => '_ZN6google5cloud2v010LogBackendC2Ev',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107470'
+                                                              }
+                                                     },
+                                          'ShortName' => 'LogBackend'
+                                        },
+                            '110387' => {
+                                          'Artificial' => 1,
+                                          'Class' => '105657',
+                                          'Constructor' => 1,
+                                          'Header' => 'log.h',
+                                          'InLine' => 1,
+                                          'Line' => '217',
+                                          'MnglName' => '_ZN6google5cloud2v010LogBackendC1Ev',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107470'
+                                                              }
+                                                     },
+                                          'ShortName' => 'LogBackend'
+                                        },
+                            '120563' => {
+                                          'Artificial' => 1,
+                                          'Class' => '85102',
+                                          'Constructor' => 1,
+                                          'Header' => 'shared_ptr.h',
+                                          'InLine' => 1,
+                                          'Line' => '244',
+                                          'MnglName' => '_ZNSt10shared_ptrIN6google5cloud2v010LogBackendEEC2EOS4_',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107481'
+                                                              },
+                                                       '1' => {
+                                                                'name' => '__r',
+                                                                'type' => '107492'
+                                                              }
+                                                     },
+                                          'ShortName' => 'shared_ptr'
+                                        },
+                            '120564' => {
+                                          'Artificial' => 1,
+                                          'Class' => '85102',
+                                          'Constructor' => 1,
+                                          'Header' => 'shared_ptr.h',
+                                          'InLine' => 1,
+                                          'Line' => '244',
+                                          'MnglName' => '_ZNSt10shared_ptrIN6google5cloud2v010LogBackendEEC1EOS4_',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107481'
+                                                              },
+                                                       '1' => {
+                                                                'name' => '__r',
+                                                                'type' => '107492'
+                                                              }
+                                                     },
+                                          'ShortName' => 'shared_ptr'
+                                        },
+                            '122884' => {
+                                          'Artificial' => 1,
+                                          'Class' => '85102',
+                                          'Destructor' => 1,
+                                          'Header' => 'shared_ptr.h',
+                                          'InLine' => 1,
+                                          'Line' => '93',
+                                          'MnglName' => '_ZNSt10shared_ptrIN6google5cloud2v010LogBackendEED2Ev',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107481'
+                                                              }
+                                                     },
+                                          'ShortName' => 'shared_ptr'
+                                        },
+                            '122885' => {
+                                          'Artificial' => 1,
+                                          'Class' => '85102',
+                                          'Destructor' => 1,
+                                          'Header' => 'shared_ptr.h',
+                                          'InLine' => 1,
+                                          'Line' => '93',
+                                          'MnglName' => '_ZNSt10shared_ptrIN6google5cloud2v010LogBackendEED0Ev',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107481'
+                                                              }
+                                                     },
+                                          'ShortName' => 'shared_ptr'
+                                        },
+                            '123653' => {
+                                          'Artificial' => 1,
+                                          'Class' => '105051',
+                                          'Destructor' => 1,
+                                          'Header' => 'log.h',
+                                          'InLine' => 1,
+                                          'Line' => '202',
+                                          'MnglName' => '_ZN6google5cloud2v09LogRecordD2Ev',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '123613'
+                                                              }
+                                                     },
+                                          'ShortName' => 'LogRecord'
+                                        },
+                            '123654' => {
+                                          'Artificial' => 1,
+                                          'Class' => '105051',
+                                          'Destructor' => 1,
+                                          'Header' => 'log.h',
+                                          'InLine' => 1,
+                                          'Line' => '202',
+                                          'MnglName' => '_ZN6google5cloud2v09LogRecordD0Ev',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '123613'
+                                                              }
+                                                     },
+                                          'ShortName' => 'LogRecord'
+                                        },
+                            '123738' => {
+                                          'Artificial' => 1,
+                                          'Class' => '105051',
+                                          'Constructor' => 1,
+                                          'Header' => 'log.h',
+                                          'InLine' => 1,
+                                          'Line' => '202',
+                                          'MnglName' => '_ZN6google5cloud2v09LogRecordC2EOS2_',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '123613'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'p1',
+                                                                'type' => '123701'
+                                                              }
+                                                     },
+                                          'ShortName' => 'LogRecord'
+                                        },
+                            '123739' => {
+                                          'Artificial' => 1,
+                                          'Class' => '105051',
+                                          'Constructor' => 1,
+                                          'Header' => 'log.h',
+                                          'InLine' => 1,
+                                          'Line' => '202',
+                                          'MnglName' => '_ZN6google5cloud2v09LogRecordC1EOS2_',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '123613'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'p1',
+                                                                'type' => '123701'
+                                                              }
+                                                     },
+                                          'ShortName' => 'LogRecord'
+                                        },
+                            '124339' => {
+                                          'Artificial' => 1,
+                                          'Class' => '105195',
+                                          'Destructor' => 1,
+                                          'Header' => 'log.h',
+                                          'InLine' => 1,
+                                          'Line' => '228',
+                                          'MnglName' => '_ZN6google5cloud2v07LogSinkD2Ev',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107305'
+                                                              }
+                                                     },
+                                          'ShortName' => 'LogSink'
+                                        },
+                            '124340' => {
+                                          'Artificial' => 1,
+                                          'Class' => '105195',
+                                          'Destructor' => 1,
+                                          'Header' => 'log.h',
+                                          'InLine' => 1,
+                                          'Line' => '228',
+                                          'MnglName' => '_ZN6google5cloud2v07LogSinkD0Ev',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107305'
+                                                              }
+                                                     },
+                                          'ShortName' => 'LogSink'
+                                        },
+                            '124413' => {
+                                          'Class' => '105195',
+                                          'Constructor' => 1,
+                                          'Header' => 'log.h',
+                                          'Line' => '230',
+                                          'MnglName' => '_ZN6google5cloud2v07LogSinkC2Ev',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107305'
+                                                              }
+                                                     },
+                                          'ShortName' => 'LogSink',
+                                          'Source' => 'log.cc',
+                                          'SourceLine' => '41'
+                                        },
+                            '124414' => {
+                                          'Class' => '105195',
+                                          'Constructor' => 1,
+                                          'Header' => 'log.h',
+                                          'Line' => '230',
+                                          'MnglName' => '_ZN6google5cloud2v07LogSinkC1Ev',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107305'
+                                                              }
+                                                     },
+                                          'ShortName' => 'LogSink',
+                                          'Source' => 'log.cc',
+                                          'SourceLine' => '41'
+                                        },
+                            '126466' => {
+                                          'Header' => 'async_stream.h',
+                                          'InLine' => 2,
+                                          'MnglName' => '_ZdlPvS_',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'p1',
+                                                                'type' => '20594'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'p2',
+                                                                'type' => '20594'
+                                                              }
+                                                     },
+                                          'Return' => '1',
+                                          'ShortName' => 'operator delete'
+                                        },
+                            '126517' => {
+                                          'Header' => 'async_unary_call.h',
+                                          'InLine' => 2,
+                                          'MnglName' => '_ZnwmPv',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'p1',
+                                                                'type' => '14586'
+                                                              },
+                                                       '1' => {
+                                                                'name' => '__p',
+                                                                'type' => '20594'
+                                                              }
+                                                     },
+                                          'Return' => '20594',
+                                          'ShortName' => 'operator new'
+                                        },
+                            '126528' => {
+                                          'Artificial' => 1,
+                                          'Class' => '85102',
+                                          'Destructor' => 1,
+                                          'Header' => 'shared_ptr.h',
+                                          'InLine' => 1,
+                                          'Line' => '93',
+                                          'MnglName' => '_ZNSt10shared_ptrIN6google5cloud2v010LogBackendEED1Ev',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107481'
+                                                              }
+                                                     },
+                                          'ShortName' => 'shared_ptr'
+                                        },
+                            '126530' => {
+                                          'Artificial' => 1,
+                                          'Class' => '105051',
+                                          'Destructor' => 1,
+                                          'Header' => 'log.h',
+                                          'InLine' => 1,
+                                          'Line' => '202',
+                                          'MnglName' => '_ZN6google5cloud2v09LogRecordD1Ev',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '123613'
+                                                              }
+                                                     },
+                                          'ShortName' => 'LogRecord'
+                                        },
+                            '126531' => {
+                                          'Artificial' => 1,
+                                          'Class' => '105195',
+                                          'Destructor' => 1,
+                                          'Header' => 'log.h',
+                                          'InLine' => 1,
+                                          'Line' => '228',
+                                          'MnglName' => '_ZN6google5cloud2v07LogSinkD1Ev',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'this',
+                                                                'type' => '107305'
+                                                              }
+                                                     },
+                                          'ShortName' => 'LogSink'
+                                        },
+                            '26346' => {
                                          'Header' => 'build_info.h',
-                                         'Line' => '25',
-                                         'MnglName' => '_ZN6google5cloud2v08internal8COMPILERE',
+                                         'MnglName' => '_ZN6google5cloud2v08internal6gitrevB5cxx11Ev',
                                          'NameSpace' => 'google::cloud::v0::internal',
-                                         'Return' => '16316',
-                                         'ShortName' => 'COMPILER',
+                                         'Return' => '6765',
+                                         'ShortName' => 'gitrev',
                                          'Source' => 'build_info.cc',
-                                         'SourceLine' => '22'
+                                         'SourceLine' => '31'
                                        },
-                            '16261' => {
-                                         'Data' => 1,
+                            '26361' => {
                                          'Header' => 'build_info.h',
-                                         'Line' => '28',
-                                         'MnglName' => '_ZN6google5cloud2v08internal14COMPILER_FLAGSE',
+                                         'MnglName' => '_ZN6google5cloud2v08internal14compiler_flagsB5cxx11Ev',
                                          'NameSpace' => 'google::cloud::v0::internal',
-                                         'Return' => '16316',
-                                         'ShortName' => 'COMPILER_FLAGS',
+                                         'Return' => '6765',
+                                         'ShortName' => 'compiler_flags',
                                          'Source' => 'build_info.cc',
-                                         'SourceLine' => '24'
+                                         'SourceLine' => '30'
                                        },
-                            '16276' => {
-                                         'Data' => 1,
+                            '26376' => {
                                          'Header' => 'build_info.h',
-                                         'Line' => '31',
-                                         'MnglName' => '_ZN6google5cloud2v08internal6GITREVE',
+                                         'MnglName' => '_ZN6google5cloud2v08internal8compilerB5cxx11Ev',
                                          'NameSpace' => 'google::cloud::v0::internal',
-                                         'Return' => '16316',
-                                         'ShortName' => 'GITREV',
+                                         'Return' => '6765',
+                                         'ShortName' => 'compiler',
                                          'Source' => 'build_info.cc',
-                                         'SourceLine' => '26'
+                                         'SourceLine' => '29'
                                        },
-                            '24500' => {
+                            '35571' => {
                                          'Header' => 'setenv.h',
                                          'MnglName' => '_ZN6google5cloud2v08internal6SetEnvEPKcS4_',
                                          'NameSpace' => 'google::cloud::v0::internal',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'variable',
-                                                               'type' => '11251'
+                                                               'type' => '21136'
                                                              },
                                                       '1' => {
                                                                'name' => 'value',
-                                                               'type' => '11251'
+                                                               'type' => '21136'
                                                              }
                                                     },
                                          'Return' => '1',
@@ -84,14 +676,14 @@ $VAR1 = {
                                          'Source' => 'setenv.cc',
                                          'SourceLine' => '39'
                                        },
-                            '24526' => {
+                            '35597' => {
                                          'Header' => 'setenv.h',
                                          'MnglName' => '_ZN6google5cloud2v08internal8UnsetEnvEPKc',
                                          'NameSpace' => 'google::cloud::v0::internal',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'variable',
-                                                               'type' => '11251'
+                                                               'type' => '21136'
                                                              }
                                                     },
                                          'Return' => '1',
@@ -99,14 +691,14 @@ $VAR1 = {
                                          'Source' => 'setenv.cc',
                                          'SourceLine' => '29'
                                        },
-                            '43703' => {
+                            '54774' => {
                                          'Header' => 'throw_delegate.h',
                                          'MnglName' => '_ZN6google5cloud2v08internal15RaiseLogicErrorERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE',
                                          'NameSpace' => 'google::cloud::v0::internal',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'msg',
-                                                               'type' => '43662'
+                                                               'type' => '54733'
                                                              }
                                                     },
                                          'Return' => '1',
@@ -114,14 +706,14 @@ $VAR1 = {
                                          'Source' => 'throw_delegate.cc',
                                          'SourceLine' => '63'
                                        },
-                            '43724' => {
+                            '54795' => {
                                          'Header' => 'throw_delegate.h',
                                          'MnglName' => '_ZN6google5cloud2v08internal15RaiseLogicErrorEPKc',
                                          'NameSpace' => 'google::cloud::v0::internal',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'msg',
-                                                               'type' => '11251'
+                                                               'type' => '21136'
                                                              }
                                                     },
                                          'Return' => '1',
@@ -129,14 +721,14 @@ $VAR1 = {
                                          'Source' => 'throw_delegate.cc',
                                          'SourceLine' => '61'
                                        },
-                            '43745' => {
+                            '54816' => {
                                          'Header' => 'throw_delegate.h',
                                          'MnglName' => '_ZN6google5cloud2v08internal17RaiseRuntimeErrorERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE',
                                          'NameSpace' => 'google::cloud::v0::internal',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'msg',
-                                                               'type' => '43662'
+                                                               'type' => '54733'
                                                              }
                                                     },
                                          'Return' => '1',
@@ -144,14 +736,14 @@ $VAR1 = {
                                          'Source' => 'throw_delegate.cc',
                                          'SourceLine' => '57'
                                        },
-                            '43766' => {
+                            '54837' => {
                                          'Header' => 'throw_delegate.h',
                                          'MnglName' => '_ZN6google5cloud2v08internal17RaiseRuntimeErrorEPKc',
                                          'NameSpace' => 'google::cloud::v0::internal',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'msg',
-                                                               'type' => '11251'
+                                                               'type' => '21136'
                                                              }
                                                     },
                                          'Return' => '1',
@@ -159,14 +751,14 @@ $VAR1 = {
                                          'Source' => 'throw_delegate.cc',
                                          'SourceLine' => '53'
                                        },
-                            '43787' => {
+                            '54858' => {
                                          'Header' => 'throw_delegate.h',
                                          'MnglName' => '_ZN6google5cloud2v08internal15RaiseRangeErrorERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE',
                                          'NameSpace' => 'google::cloud::v0::internal',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'msg',
-                                                               'type' => '43662'
+                                                               'type' => '54733'
                                                              }
                                                     },
                                          'Return' => '1',
@@ -174,14 +766,14 @@ $VAR1 = {
                                          'Source' => 'throw_delegate.cc',
                                          'SourceLine' => '49'
                                        },
-                            '43808' => {
+                            '54879' => {
                                          'Header' => 'throw_delegate.h',
                                          'MnglName' => '_ZN6google5cloud2v08internal15RaiseRangeErrorEPKc',
                                          'NameSpace' => 'google::cloud::v0::internal',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'msg',
-                                                               'type' => '11251'
+                                                               'type' => '21136'
                                                              }
                                                     },
                                          'Return' => '1',
@@ -189,14 +781,14 @@ $VAR1 = {
                                          'Source' => 'throw_delegate.cc',
                                          'SourceLine' => '47'
                                        },
-                            '43829' => {
+                            '54900' => {
                                          'Header' => 'throw_delegate.h',
                                          'MnglName' => '_ZN6google5cloud2v08internal20RaiseInvalidArgumentERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE',
                                          'NameSpace' => 'google::cloud::v0::internal',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'msg',
-                                                               'type' => '43662'
+                                                               'type' => '54733'
                                                              }
                                                     },
                                          'Return' => '1',
@@ -204,14 +796,14 @@ $VAR1 = {
                                          'Source' => 'throw_delegate.cc',
                                          'SourceLine' => '43'
                                        },
-                            '43850' => {
+                            '54921' => {
                                          'Header' => 'throw_delegate.h',
                                          'MnglName' => '_ZN6google5cloud2v08internal20RaiseInvalidArgumentEPKc',
                                          'NameSpace' => 'google::cloud::v0::internal',
                                          'Param' => {
                                                       '0' => {
                                                                'name' => 'msg',
-                                                               'type' => '11251'
+                                                               'type' => '21136'
                                                              }
                                                     },
                                          'Return' => '1',
@@ -223,7 +815,22 @@ $VAR1 = {
           'SymbolVersion' => {},
           'Symbols' => {
                          'libgoogle_cloud_cpp_common.so' => {
-                                                              '_ZN6google5cloud2v08internal14COMPILER_FLAGSE' => -4,
+                                                              '_ZN6google5cloud2v010LogBackendC1Ev' => 1,
+                                                              '_ZN6google5cloud2v010LogBackendC2Ev' => 1,
+                                                              '_ZN6google5cloud2v010LogBackendD0Ev' => 1,
+                                                              '_ZN6google5cloud2v010LogBackendD1Ev' => 1,
+                                                              '_ZN6google5cloud2v010LogBackendD2Ev' => 1,
+                                                              '_ZN6google5cloud2v07LogSink10AddBackendESt10shared_ptrINS1_10LogBackendEE' => 1,
+                                                              '_ZN6google5cloud2v07LogSink13ClearBackendsEv' => 1,
+                                                              '_ZN6google5cloud2v07LogSink13EnableStdClogEv' => 1,
+                                                              '_ZN6google5cloud2v07LogSink13RemoveBackendEl' => 1,
+                                                              '_ZN6google5cloud2v07LogSink3LogENS1_9LogRecordE' => 1,
+                                                              '_ZN6google5cloud2v07LogSink8InstanceEv' => 1,
+                                                              '_ZN6google5cloud2v07LogSinkC1Ev' => 1,
+                                                              '_ZN6google5cloud2v07LogSinkC2Ev' => 1,
+                                                              '_ZN6google5cloud2v07LogSinkD1Ev' => 1,
+                                                              '_ZN6google5cloud2v07LogSinkD2Ev' => 1,
+                                                              '_ZN6google5cloud2v08internal14compiler_flagsB5cxx11Ev' => 1,
                                                               '_ZN6google5cloud2v08internal15RaiseLogicErrorEPKc' => 1,
                                                               '_ZN6google5cloud2v08internal15RaiseLogicErrorERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE' => 1,
                                                               '_ZN6google5cloud2v08internal15RaiseRangeErrorEPKc' => 1,
@@ -232,172 +839,680 @@ $VAR1 = {
                                                               '_ZN6google5cloud2v08internal17RaiseRuntimeErrorERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE' => 1,
                                                               '_ZN6google5cloud2v08internal20RaiseInvalidArgumentEPKc' => 1,
                                                               '_ZN6google5cloud2v08internal20RaiseInvalidArgumentERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE' => 1,
-                                                              '_ZN6google5cloud2v08internal6GITREVE' => -9,
                                                               '_ZN6google5cloud2v08internal6SetEnvEPKcS4_' => 1,
-                                                              '_ZN6google5cloud2v08internal8COMPILERE' => -10,
+                                                              '_ZN6google5cloud2v08internal6gitrevB5cxx11Ev' => 1,
                                                               '_ZN6google5cloud2v08internal8UnsetEnvEPKc' => 1,
+                                                              '_ZN6google5cloud2v08internal8compilerB5cxx11Ev' => 1,
+                                                              '_ZN6google5cloud2v09LogRecordC1EOS2_' => 1,
+                                                              '_ZN6google5cloud2v09LogRecordC2EOS2_' => 1,
+                                                              '_ZN6google5cloud2v09LogRecordD1Ev' => 1,
+                                                              '_ZN6google5cloud2v09LogRecordD2Ev' => 1,
+                                                              '_ZN6google5cloud2v0lsERSoNS1_8SeverityE' => 1,
+                                                              '_ZN6google5cloud2v0lsERSoRKNS1_9LogRecordE' => 1,
+                                                              '_ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEE10deallocateEPSB_m' => 1,
+                                                              '_ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEE7destroyISA_EEvPT_' => 1,
+                                                              '_ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEE8allocateEmPKv' => 1,
+                                                              '_ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEE9constructISA_JRKSA_EEEvPT_DpOT0_' => 1,
+                                                              '_ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEE9constructISA_JRlS9_EEEvPT_DpOT0_' => 1,
+                                                              '_ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEEC1ERKSC_' => 1,
+                                                              '_ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEEC1Ev' => 1,
+                                                              '_ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEEC2ERKSC_' => 1,
+                                                              '_ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEEC2Ev' => 1,
+                                                              '_ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEED1Ev' => 1,
+                                                              '_ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEED2Ev' => 1,
+                                                              '_ZN9__gnu_cxx14__alloc_traitsISaISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEEE17_S_select_on_copyERKSC_' => 1,
+                                                              '_ZN9__gnu_cxx16__aligned_membufISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEE6_M_ptrEv' => 1,
+                                                              '_ZN9__gnu_cxx16__aligned_membufISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEE7_M_addrEv' => 1,
+                                                              '_ZNK9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEE8max_sizeEv' => 1,
+                                                              '_ZNK9__gnu_cxx16__aligned_membufISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEE6_M_ptrEv' => 1,
+                                                              '_ZNK9__gnu_cxx16__aligned_membufISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEE7_M_addrEv' => 1,
+                                                              '_ZNKSt10_Select1stISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEclERKS8_' => 1,
+                                                              '_ZNKSt12__shared_ptrIN6google5cloud2v010LogBackendELN9__gnu_cxx12_Lock_policyE2EE3getEv' => 1,
+                                                              '_ZNKSt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEE9_M_valptrEv' => 1,
+                                                              '_ZNKSt14__shared_countILN9__gnu_cxx12_Lock_policyE2EE14_M_get_deleterERKSt9type_info' => 1,
+                                                              '_ZNKSt17_Rb_tree_iteratorISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEdeEv' => 1,
+                                                              '_ZNKSt17_Rb_tree_iteratorISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEeqERKS9_' => 1,
+                                                              '_ZNKSt17_Rb_tree_iteratorISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEneERKS9_' => 1,
+                                                              '_ZNKSt17_Rb_tree_iteratorISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEptEv' => 1,
+                                                              '_ZNKSt19__shared_ptr_accessIN6google5cloud2v010LogBackendELN9__gnu_cxx12_Lock_policyE2ELb0ELb0EE6_M_getEv' => 1,
+                                                              '_ZNKSt19__shared_ptr_accessIN6google5cloud2v010LogBackendELN9__gnu_cxx12_Lock_policyE2ELb0ELb0EEptEv' => 1,
+                                                              '_ZNKSt3mapIlSt10shared_ptrIN6google5cloud2v010LogBackendEESt4lessIlESaISt4pairIKlS5_EEE4sizeEv' => 1,
+                                                              '_ZNKSt3mapIlSt10shared_ptrIN6google5cloud2v010LogBackendEESt4lessIlESaISt4pairIKlS5_EEE5emptyEv' => 1,
+                                                              '_ZNKSt4lessIlEclERKlS2_' => 1,
+                                                              '_ZNKSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE11_Alloc_nodeclIRKS8_EEPSt13_Rb_tree_nodeIS8_EOT_' => 1,
+                                                              '_ZNKSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE4sizeEv' => 1,
+                                                              '_ZNKSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE5emptyEv' => 1,
+                                                              '_ZNKSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE7_M_rootEv' => 1,
+                                                              '_ZNKSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE8_M_beginEv' => 1,
+                                                              '_ZNKSt9type_infoeqERKS_' => 1,
+                                                              '_ZNSaISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEEC1ERKSA_' => 1,
+                                                              '_ZNSaISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEEC1Ev' => 1,
+                                                              '_ZNSaISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEEC2ERKSA_' => 1,
+                                                              '_ZNSaISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEEC2Ev' => 1,
+                                                              '_ZNSaISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEED1Ev' => 1,
+                                                              '_ZNSaISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEED2Ev' => 1,
+                                                              '_ZNSt10shared_ptrIN6google5cloud2v010LogBackendEEC1EOS4_' => 1,
+                                                              '_ZNSt10shared_ptrIN6google5cloud2v010LogBackendEEC1ERKS4_' => 1,
+                                                              '_ZNSt10shared_ptrIN6google5cloud2v010LogBackendEEC2EOS4_' => 1,
+                                                              '_ZNSt10shared_ptrIN6google5cloud2v010LogBackendEEC2ERKS4_' => 1,
+                                                              '_ZNSt10shared_ptrIN6google5cloud2v010LogBackendEED1Ev' => 1,
+                                                              '_ZNSt10shared_ptrIN6google5cloud2v010LogBackendEED2Ev' => 1,
+                                                              '_ZNSt11unique_lockISt5mutexE4lockEv' => 1,
+                                                              '_ZNSt11unique_lockISt5mutexE6unlockEv' => 1,
+                                                              '_ZNSt11unique_lockISt5mutexEC1ERS0_' => 1,
+                                                              '_ZNSt11unique_lockISt5mutexEC2ERS0_' => 1,
+                                                              '_ZNSt11unique_lockISt5mutexED1Ev' => 1,
+                                                              '_ZNSt11unique_lockISt5mutexED2Ev' => 1,
+                                                              '_ZNSt12__mutex_baseC1Ev' => 1,
+                                                              '_ZNSt12__mutex_baseC2Ev' => 1,
+                                                              '_ZNSt12__shared_ptrIN6google5cloud2v010LogBackendELN9__gnu_cxx12_Lock_policyE2EEC1EOS6_' => 1,
+                                                              '_ZNSt12__shared_ptrIN6google5cloud2v010LogBackendELN9__gnu_cxx12_Lock_policyE2EEC1ERKS6_' => 1,
+                                                              '_ZNSt12__shared_ptrIN6google5cloud2v010LogBackendELN9__gnu_cxx12_Lock_policyE2EEC2EOS6_' => 1,
+                                                              '_ZNSt12__shared_ptrIN6google5cloud2v010LogBackendELN9__gnu_cxx12_Lock_policyE2EEC2ERKS6_' => 1,
+                                                              '_ZNSt12__shared_ptrIN6google5cloud2v010LogBackendELN9__gnu_cxx12_Lock_policyE2EED1Ev' => 1,
+                                                              '_ZNSt12__shared_ptrIN6google5cloud2v010LogBackendELN9__gnu_cxx12_Lock_policyE2EED2Ev' => 1,
+                                                              '_ZNSt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEE9_M_valptrEv' => 1,
+                                                              '_ZNSt13__atomic_baseIbEC1Eb' => 1,
+                                                              '_ZNSt13__atomic_baseIiEC1Ei' => 1,
+                                                              '_ZNSt13__atomic_baseIiEC2Ei' => 1,
+                                                              '_ZNSt14__shared_countILN9__gnu_cxx12_Lock_policyE2EE7_M_swapERS2_' => 1,
+                                                              '_ZNSt14__shared_countILN9__gnu_cxx12_Lock_policyE2EEC1ERKS2_' => 1,
+                                                              '_ZNSt14__shared_countILN9__gnu_cxx12_Lock_policyE2EEC1Ev' => 1,
+                                                              '_ZNSt14__shared_countILN9__gnu_cxx12_Lock_policyE2EEC2ERKS2_' => 1,
+                                                              '_ZNSt14__shared_countILN9__gnu_cxx12_Lock_policyE2EEC2Ev' => 1,
+                                                              '_ZNSt14__shared_countILN9__gnu_cxx12_Lock_policyE2EED1Ev' => 1,
+                                                              '_ZNSt14__shared_countILN9__gnu_cxx12_Lock_policyE2EED2Ev' => 1,
+                                                              '_ZNSt15_Rb_tree_header8_M_resetEv' => 1,
+                                                              '_ZNSt15_Rb_tree_headerC1Ev' => 1,
+                                                              '_ZNSt15_Rb_tree_headerC2Ev' => 1,
+                                                              '_ZNSt16_Sp_counted_baseILN9__gnu_cxx12_Lock_policyE2EE10_M_destroyEv' => 1,
+                                                              '_ZNSt16_Sp_counted_baseILN9__gnu_cxx12_Lock_policyE2EE10_M_releaseEv' => 1,
+                                                              '_ZNSt16_Sp_counted_baseILN9__gnu_cxx12_Lock_policyE2EE15_M_add_ref_copyEv' => 1,
+                                                              '_ZNSt16_Sp_counted_baseILN9__gnu_cxx12_Lock_policyE2EEC1Ev' => 1,
+                                                              '_ZNSt16_Sp_counted_baseILN9__gnu_cxx12_Lock_policyE2EEC2Ev' => 1,
+                                                              '_ZNSt16_Sp_counted_baseILN9__gnu_cxx12_Lock_policyE2EED0Ev' => 1,
+                                                              '_ZNSt16_Sp_counted_baseILN9__gnu_cxx12_Lock_policyE2EED1Ev' => 1,
+                                                              '_ZNSt16_Sp_counted_baseILN9__gnu_cxx12_Lock_policyE2EED2Ev' => 1,
+                                                              '_ZNSt16allocator_traitsISaISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEEE10deallocateERSB_PSA_m' => 1,
+                                                              '_ZNSt16allocator_traitsISaISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEEE37select_on_container_copy_constructionERKSB_' => 1,
+                                                              '_ZNSt16allocator_traitsISaISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEEE7destroyIS9_EEvRSB_PT_' => 1,
+                                                              '_ZNSt16allocator_traitsISaISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEEE8allocateERSB_m' => 1,
+                                                              '_ZNSt16allocator_traitsISaISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEEE9constructIS9_JRKS9_EEEvRSB_PT_DpOT0_' => 1,
+                                                              '_ZNSt16allocator_traitsISaISt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEEE9constructIS9_JRlS8_EEEvRSB_PT_DpOT0_' => 1,
+                                                              '_ZNSt17_Rb_tree_iteratorISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEC1EPSt18_Rb_tree_node_base' => 1,
+                                                              '_ZNSt17_Rb_tree_iteratorISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEC2EPSt18_Rb_tree_node_base' => 1,
+                                                              '_ZNSt17_Rb_tree_iteratorISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEmmEv' => 1,
+                                                              '_ZNSt17_Rb_tree_iteratorISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEppEv' => 1,
+                                                              '_ZNSt18_Rb_tree_node_base10_S_maximumEPS_' => 1,
+                                                              '_ZNSt18_Rb_tree_node_base10_S_minimumEPS_' => 1,
+                                                              '_ZNSt20_Rb_tree_key_compareISt4lessIlEEC1ERKS1_' => 1,
+                                                              '_ZNSt20_Rb_tree_key_compareISt4lessIlEEC1Ev' => 1,
+                                                              '_ZNSt20_Rb_tree_key_compareISt4lessIlEEC2ERKS1_' => 1,
+                                                              '_ZNSt20_Rb_tree_key_compareISt4lessIlEEC2Ev' => 1,
+                                                              '_ZNSt23_Rb_tree_const_iteratorISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEC1ERKSt17_Rb_tree_iteratorIS8_E' => 1,
+                                                              '_ZNSt23_Rb_tree_const_iteratorISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEC2ERKSt17_Rb_tree_iteratorIS8_E' => 1,
+                                                              '_ZNSt3mapIlSt10shared_ptrIN6google5cloud2v010LogBackendEESt4lessIlESaISt4pairIKlS5_EEE3endEv' => 1,
+                                                              '_ZNSt3mapIlSt10shared_ptrIN6google5cloud2v010LogBackendEESt4lessIlESaISt4pairIKlS5_EEE4findERS9_' => 1,
+                                                              '_ZNSt3mapIlSt10shared_ptrIN6google5cloud2v010LogBackendEESt4lessIlESaISt4pairIKlS5_EEE5beginEv' => 1,
+                                                              '_ZNSt3mapIlSt10shared_ptrIN6google5cloud2v010LogBackendEESt4lessIlESaISt4pairIKlS5_EEE5clearEv' => 1,
+                                                              '_ZNSt3mapIlSt10shared_ptrIN6google5cloud2v010LogBackendEESt4lessIlESaISt4pairIKlS5_EEE5eraseB5cxx11ESt17_Rb_tree_iteratorISA_E' => 1,
+                                                              '_ZNSt3mapIlSt10shared_ptrIN6google5cloud2v010LogBackendEESt4lessIlESaISt4pairIKlS5_EEE7emplaceIJRlS5_EEES8_ISt17_Rb_tree_iteratorISA_EbEDpOT_' => 1,
+                                                              '_ZNSt3mapIlSt10shared_ptrIN6google5cloud2v010LogBackendEESt4lessIlESaISt4pairIKlS5_EEEC1ERKSC_' => 1,
+                                                              '_ZNSt3mapIlSt10shared_ptrIN6google5cloud2v010LogBackendEESt4lessIlESaISt4pairIKlS5_EEEC1Ev' => 1,
+                                                              '_ZNSt3mapIlSt10shared_ptrIN6google5cloud2v010LogBackendEESt4lessIlESaISt4pairIKlS5_EEEC2ERKSC_' => 1,
+                                                              '_ZNSt3mapIlSt10shared_ptrIN6google5cloud2v010LogBackendEESt4lessIlESaISt4pairIKlS5_EEEC2Ev' => 1,
+                                                              '_ZNSt3mapIlSt10shared_ptrIN6google5cloud2v010LogBackendEESt4lessIlESaISt4pairIKlS5_EEED1Ev' => 1,
+                                                              '_ZNSt3mapIlSt10shared_ptrIN6google5cloud2v010LogBackendEESt4lessIlESaISt4pairIKlS5_EEED2Ev' => 1,
+                                                              '_ZNSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEC1ERKS7_' => 1,
+                                                              '_ZNSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEC1IRlS6_Lb1EEEOT_OT0_' => 1,
+                                                              '_ZNSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEC2ERKS7_' => 1,
+                                                              '_ZNSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEC2IRlS6_Lb1EEEOT_OT0_' => 1,
+                                                              '_ZNSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEED1Ev' => 1,
+                                                              '_ZNSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEED2Ev' => 1,
+                                                              '_ZNSt4pairIPSt18_Rb_tree_node_baseS1_EC1IRPSt13_Rb_tree_nodeIS_IKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEERS1_Lb1EEEOT_OT0_' => 1,
+                                                              '_ZNSt4pairIPSt18_Rb_tree_node_baseS1_EC1IRS1_Lb1EEEOT_RKS1_' => 1,
+                                                              '_ZNSt4pairIPSt18_Rb_tree_node_baseS1_EC2IRPSt13_Rb_tree_nodeIS_IKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEERS1_Lb1EEEOT_OT0_' => 1,
+                                                              '_ZNSt4pairIPSt18_Rb_tree_node_baseS1_EC2IRS1_Lb1EEEOT_RKS1_' => 1,
+                                                              '_ZNSt4pairISt17_Rb_tree_iteratorIS_IKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEbEC1IS9_bLb1EEEOT_OT0_' => 1,
+                                                              '_ZNSt4pairISt17_Rb_tree_iteratorIS_IKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEbEC2IS9_bLb1EEEOT_OT0_' => 1,
+                                                              '_ZNSt5mutex4lockEv' => 1,
+                                                              '_ZNSt5mutex6unlockEv' => 1,
+                                                              '_ZNSt5mutexC1Ev' => 1,
+                                                              '_ZNSt5mutexC2Ev' => 1,
+                                                              '_ZNSt6atomicIbE5storeEbSt12memory_order' => 1,
+                                                              '_ZNSt6atomicIbEC1Eb' => 1,
+                                                              '_ZNSt6atomicIbEC2Eb' => 1,
+                                                              '_ZNSt6atomicIiEC1Ei' => 1,
+                                                              '_ZNSt6atomicIiEC2Ei' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE10_S_maximumEPSt18_Rb_tree_node_base' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE10_S_minimumEPSt18_Rb_tree_node_base' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE11_Alloc_nodeC1ERSE_' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE11_Alloc_nodeC2ERSE_' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE11_M_get_nodeEv' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE11_M_leftmostEv' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE11_M_put_nodeEPSt13_Rb_tree_nodeIS8_E' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE12_M_drop_nodeEPSt13_Rb_tree_nodeIS8_E' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE12_M_erase_auxESt23_Rb_tree_const_iteratorIS8_E' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE12_M_rightmostEv' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE13_M_clone_nodeINSE_11_Alloc_nodeEEEPSt13_Rb_tree_nodeIS8_EPKSI_RT_' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE13_Rb_tree_implISC_Lb1EEC1ERKSG_' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE13_Rb_tree_implISC_Lb1EEC1Ev' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE13_Rb_tree_implISC_Lb1EEC2ERKSG_' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE13_Rb_tree_implISC_Lb1EEC2Ev' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE13_Rb_tree_implISC_Lb1EED1Ev' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE13_Rb_tree_implISC_Lb1EED2Ev' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE14_M_create_nodeIJRKS8_EEEPSt13_Rb_tree_nodeIS8_EDpOT_' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE14_M_create_nodeIJRlS7_EEEPSt13_Rb_tree_nodeIS8_EDpOT_' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE14_M_insert_nodeEPSt18_Rb_tree_node_baseSG_PSt13_Rb_tree_nodeIS8_E' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE14_M_lower_boundEPSt13_Rb_tree_nodeIS8_EPSt18_Rb_tree_node_baseRS1_' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE15_M_destroy_nodeEPSt13_Rb_tree_nodeIS8_E' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE17_M_construct_nodeIJRKS8_EEEvPSt13_Rb_tree_nodeIS8_EDpOT_' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE17_M_construct_nodeIJRlS7_EEEvPSt13_Rb_tree_nodeIS8_EDpOT_' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE17_M_emplace_uniqueIJRlS7_EEES0_ISt17_Rb_tree_iteratorIS8_EbEDpOT_' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE21_M_get_Node_allocatorEv' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE24_M_get_insert_unique_posERS1_' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE3endEv' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE4findERS1_' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE5beginEv' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE5clearEv' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE5eraseB5cxx11ESt17_Rb_tree_iteratorIS8_E' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE6_M_endEv' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE6_S_keyEPKSt13_Rb_tree_nodeIS8_E' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE6_S_keyEPKSt18_Rb_tree_node_base' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE7_M_copyERKSE_' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE7_M_copyINSE_11_Alloc_nodeEEEPSt13_Rb_tree_nodeIS8_EPKSI_PSt18_Rb_tree_node_baseRT_' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE7_M_copyINSE_11_Alloc_nodeEEEPSt13_Rb_tree_nodeIS8_ERKSE_RT_' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE7_M_rootEv' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE7_S_leftEPKSt18_Rb_tree_node_base' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE7_S_leftEPSt18_Rb_tree_node_base' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE8_M_beginEv' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE8_M_eraseEPSt13_Rb_tree_nodeIS8_E' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE8_S_rightEPKSt18_Rb_tree_node_base' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE8_S_rightEPSt18_Rb_tree_node_base' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE8_S_valueEPKSt13_Rb_tree_nodeIS8_E' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EE8_S_valueEPKSt18_Rb_tree_node_base' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EEC1ERKSE_' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EEC1Ev' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EEC2ERKSE_' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EEC2Ev' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EED1Ev' => 1,
+                                                              '_ZNSt8_Rb_treeIlSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEESt10_Select1stIS8_ESt4lessIlESaIS8_EED2Ev' => 1,
+                                                              '_ZSt11__addressofISt5mutexEPT_RS1_' => 1,
+                                                              '_ZSt4moveIRN6google5cloud2v09LogRecordEEONSt16remove_referenceIT_E4typeEOS6_' => 1,
+                                                              '_ZSt4moveIRSt10shared_ptrIN6google5cloud2v010LogBackendEEEONSt16remove_referenceIT_E4typeEOS8_' => 1,
+                                                              '_ZSt7forwardIRKSt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEOT_RNSt16remove_referenceISB_E4typeE' => 1,
+                                                              '_ZSt7forwardIRPSt13_Rb_tree_nodeISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEEOT_RNSt16remove_referenceISD_E4typeE' => 1,
+                                                              '_ZSt7forwardIRPSt18_Rb_tree_node_baseEOT_RNSt16remove_referenceIS3_E4typeE' => 1,
+                                                              '_ZSt7forwardIRlEOT_RNSt16remove_referenceIS1_E4typeE' => 1,
+                                                              '_ZSt7forwardISt10shared_ptrIN6google5cloud2v010LogBackendEEEOT_RNSt16remove_referenceIS6_E4typeE' => 1,
+                                                              '_ZSt7forwardISt17_Rb_tree_iteratorISt4pairIKlSt10shared_ptrIN6google5cloud2v010LogBackendEEEEEOT_RNSt16remove_referenceISB_E4typeE' => 1,
+                                                              '_ZSt7forwardIbEOT_RNSt16remove_referenceIS0_E4typeE' => 1,
+                                                              '_ZStanSt12memory_orderSt23__memory_order_modifier' => 1,
+                                                              '_ZTIN6google5cloud2v010LogBackendE' => -16,
+                                                              '_ZTISt11_Mutex_baseILN9__gnu_cxx12_Lock_policyE2EE' => -16,
+                                                              '_ZTISt16_Sp_counted_baseILN9__gnu_cxx12_Lock_policyE2EE' => -24,
+                                                              '_ZTISt19_Sp_make_shared_tag' => -16,
+                                                              '_ZTSN6google5cloud2v010LogBackendE' => -31,
+                                                              '_ZTSSt11_Mutex_baseILN9__gnu_cxx12_Lock_policyE2EE' => -47,
+                                                              '_ZTSSt16_Sp_counted_baseILN9__gnu_cxx12_Lock_policyE2EE' => -52,
+                                                              '_ZTSSt19_Sp_make_shared_tag' => -24,
+                                                              '_ZTVN6google5cloud2v010LogBackendE' => -48,
+                                                              '_ZTVSt16_Sp_counted_baseILN9__gnu_cxx12_Lock_policyE2EE' => -56,
+                                                              '_ZdlPvS_' => 1,
+                                                              '_ZnwmPv' => 1,
                                                               '_fini' => 1,
                                                               '_init' => 1
                                                             }
                        },
           'Target' => 'unix',
           'TypeInfo' => {
+                          '-1' => {
+                                    'Name' => '...',
+                                    'Type' => 'Intrinsic'
+                                  },
                           '1' => {
                                    'Name' => 'void',
                                    'Type' => 'Intrinsic'
                                  },
-                          '10480' => {
-                                       'Name' => 'unsigned long',
-                                       'Size' => '8',
-                                       'Type' => 'Intrinsic'
-                                     },
-                          '10806' => {
-                                       'Name' => 'char',
-                                       'Size' => '1',
-                                       'Type' => 'Intrinsic'
-                                     },
-                          '10813' => {
-                                       'BaseType' => '10806',
-                                       'Name' => 'char const',
-                                       'Size' => '1',
-                                       'Type' => 'Const'
-                                     },
-                          '11251' => {
-                                       'BaseType' => '10813',
-                                       'Name' => 'char const*',
-                                       'Size' => '8',
-                                       'Type' => 'Pointer'
-                                     },
-                          '12047' => {
-                                       'BaseType' => '10806',
-                                       'Name' => 'char*',
-                                       'Size' => '8',
-                                       'Type' => 'Pointer'
-                                     },
-                          '16316' => {
-                                       'BaseType' => '10813',
-                                       'Name' => 'char const[]',
-                                       'Size' => '8',
-                                       'Type' => 'Array'
-                                     },
-                          '24809' => {
-                                       'Header' => 'basic_string.h',
-                                       'Line' => '77',
-                                       'Memb' => {
-                                                   '0' => {
-                                                            'access' => 'private',
-                                                            'name' => '_M_dataplus',
-                                                            'offset' => '0',
-                                                            'type' => '24821'
-                                                          },
-                                                   '1' => {
-                                                            'access' => 'private',
-                                                            'name' => '_M_string_length',
-                                                            'offset' => '8',
-                                                            'type' => '24961'
-                                                          },
-                                                   '2' => {
-                                                            'access' => 'private',
-                                                            'name' => 'unnamed0',
-                                                            'offset' => '16',
-                                                            'type' => '24930'
-                                                          }
-                                                 },
-                                       'Name' => 'std::__cxx11::basic_string<char>',
-                                       'NameSpace' => 'std::__cxx11',
-                                       'PrivateABI' => 1,
-                                       'Size' => '32',
-                                       'TParam' => {
+                          '102642' => {
+                                        'Header' => 'thread-shared-types.h',
+                                        'Line' => '82',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => '__prev',
+                                                             'offset' => '0',
+                                                             'type' => '102679'
+                                                           },
+                                                    '1' => {
+                                                             'name' => '__next',
+                                                             'offset' => '8',
+                                                             'type' => '102679'
+                                                           }
+                                                  },
+                                        'Name' => 'struct __pthread_internal_list',
+                                        'PrivateABI' => 1,
+                                        'Size' => '16',
+                                        'Type' => 'Struct'
+                                      },
+                          '102679' => {
+                                        'BaseType' => '102642',
+                                        'Name' => 'struct __pthread_internal_list*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '102685' => {
+                                        'BaseType' => '102642',
+                                        'Header' => 'thread-shared-types.h',
+                                        'Line' => '86',
+                                        'Name' => '__pthread_list_t',
+                                        'PrivateABI' => 1,
+                                        'Size' => '16',
+                                        'Type' => 'Typedef'
+                                      },
+                          '102696' => {
+                                        'Header' => 'thread-shared-types.h',
+                                        'Line' => '118',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => '__lock',
+                                                             'offset' => '0',
+                                                             'type' => '20393'
+                                                           },
+                                                    '1' => {
+                                                             'name' => '__count',
+                                                             'offset' => '4',
+                                                             'type' => '20344'
+                                                           },
+                                                    '2' => {
+                                                             'name' => '__owner',
+                                                             'offset' => '8',
+                                                             'type' => '20393'
+                                                           },
+                                                    '3' => {
+                                                             'name' => '__nusers',
+                                                             'offset' => '12',
+                                                             'type' => '20344'
+                                                           },
+                                                    '4' => {
+                                                             'name' => '__kind',
+                                                             'offset' => '16',
+                                                             'type' => '20393'
+                                                           },
+                                                    '5' => {
+                                                             'name' => '__spins',
+                                                             'offset' => '20',
+                                                             'type' => '20386'
+                                                           },
+                                                    '6' => {
+                                                             'name' => '__elision',
+                                                             'offset' => '22',
+                                                             'type' => '20386'
+                                                           },
+                                                    '7' => {
+                                                             'name' => '__list',
+                                                             'offset' => '24',
+                                                             'type' => '102685'
+                                                           }
+                                                  },
+                                        'Name' => 'struct __pthread_mutex_s',
+                                        'PrivateABI' => 1,
+                                        'Size' => '40',
+                                        'Type' => 'Struct'
+                                      },
+                          '102805' => {
+                                        'Header' => 'pthreadtypes.h',
+                                        'Line' => '68',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => '__data',
+                                                             'offset' => '0',
+                                                             'type' => '102696'
+                                                           },
+                                                    '1' => {
+                                                             'name' => '__size',
+                                                             'offset' => '0',
+                                                             'type' => '102852'
+                                                           },
+                                                    '2' => {
+                                                             'name' => '__align',
+                                                             'offset' => '0',
+                                                             'type' => '20405'
+                                                           }
+                                                  },
+                                        'Name' => 'union pthread_mutex_t',
+                                        'PrivateABI' => 1,
+                                        'Size' => '40',
+                                        'Type' => 'Union'
+                                      },
+                          '102852' => {
+                                        'BaseType' => '20691',
+                                        'Name' => 'char[40]',
+                                        'Size' => '40',
+                                        'Type' => 'Array'
+                                      },
+                          '102868' => {
+                                        'BaseType' => '102805',
+                                        'Header' => 'pthreadtypes.h',
+                                        'Line' => '72',
+                                        'Name' => 'pthread_mutex_t',
+                                        'PrivateABI' => 1,
+                                        'Size' => '40',
+                                        'Type' => 'Typedef'
+                                      },
+                          '102879' => {
+                                        'BaseType' => '102868',
+                                        'Header' => 'gthr-default.h',
+                                        'Line' => '50',
+                                        'Name' => '__gthread_mutex_t',
+                                        'PrivateABI' => 1,
+                                        'Size' => '40',
+                                        'Type' => 'Typedef'
+                                      },
+                          '104960' => {
+                                        'Header' => 'log.h',
+                                        'Line' => '166',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => 'TRACE',
+                                                             'value' => '0'
+                                                           },
+                                                    '1' => {
+                                                             'name' => 'DEBUG',
+                                                             'value' => '1'
+                                                           },
+                                                    '10' => {
+                                                              'name' => 'LOWEST',
+                                                              'value' => '0'
+                                                            },
+                                                    '11' => {
+                                                              'name' => 'LOWEST_ENABLED',
+                                                              'value' => '3'
+                                                            },
+                                                    '2' => {
+                                                             'name' => 'INFO',
+                                                             'value' => '2'
+                                                           },
+                                                    '3' => {
+                                                             'name' => 'NOTICE',
+                                                             'value' => '3'
+                                                           },
+                                                    '4' => {
+                                                             'name' => 'WARNING',
+                                                             'value' => '4'
+                                                           },
+                                                    '5' => {
+                                                             'name' => 'ERROR',
+                                                             'value' => '5'
+                                                           },
+                                                    '6' => {
+                                                             'name' => 'CRITICAL',
+                                                             'value' => '6'
+                                                           },
+                                                    '7' => {
+                                                             'name' => 'ALERT',
+                                                             'value' => '7'
+                                                           },
+                                                    '8' => {
+                                                             'name' => 'FATAL',
+                                                             'value' => '8'
+                                                           },
+                                                    '9' => {
+                                                             'name' => 'HIGHEST',
+                                                             'value' => '8'
+                                                           }
+                                                  },
+                                        'Name' => 'enum google::cloud::v0::Severity',
+                                        'NameSpace' => 'google::cloud::v0',
+                                        'Size' => '4',
+                                        'Type' => 'Enum'
+                                      },
+                          '105051' => {
+                                        'Header' => 'log.h',
+                                        'Line' => '202',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => 'severity',
+                                                             'offset' => '0',
+                                                             'type' => '104960'
+                                                           },
+                                                    '1' => {
+                                                             'name' => 'function',
+                                                             'offset' => '8',
+                                                             'type' => '6765'
+                                                           },
+                                                    '2' => {
+                                                             'name' => 'filename',
+                                                             'offset' => '40',
+                                                             'type' => '6765'
+                                                           },
+                                                    '3' => {
+                                                             'name' => 'lineno',
+                                                             'offset' => '72',
+                                                             'type' => '20393'
+                                                           },
+                                                    '4' => {
+                                                             'name' => 'timestamp',
+                                                             'offset' => '80',
+                                                             'type' => '72232'
+                                                           },
+                                                    '5' => {
+                                                             'name' => 'message',
+                                                             'offset' => '88',
+                                                             'type' => '6765'
+                                                           }
+                                                  },
+                                        'Name' => 'struct google::cloud::v0::LogRecord',
+                                        'NameSpace' => 'google::cloud::v0',
+                                        'Size' => '120',
+                                        'Type' => 'Struct'
+                                      },
+                          '105190' => {
+                                        'BaseType' => '105051',
+                                        'Name' => 'struct google::cloud::v0::LogRecord const',
+                                        'Size' => '120',
+                                        'Type' => 'Const'
+                                      },
+                          '105195' => {
+                                        'Header' => 'log.h',
+                                        'Line' => '228',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'access' => 'private',
+                                                             'name' => 'empty_',
+                                                             'offset' => '0',
+                                                             'type' => '68789'
+                                                           },
+                                                    '1' => {
+                                                             'access' => 'private',
+                                                             'name' => 'minimum_severity_',
+                                                             'offset' => '4',
+                                                             'type' => '71858'
+                                                           },
+                                                    '2' => {
+                                                             'access' => 'private',
+                                                             'name' => 'mu_',
+                                                             'offset' => '8',
+                                                             'type' => '76498'
+                                                           },
+                                                    '3' => {
+                                                             'access' => 'private',
+                                                             'name' => 'next_id_',
+                                                             'offset' => '48',
+                                                             'type' => '20405'
+                                                           },
+                                                    '4' => {
+                                                             'access' => 'private',
+                                                             'name' => 'backends_',
+                                                             'offset' => '56',
+                                                             'type' => '82946'
+                                                           }
+                                                  },
+                                        'Name' => 'google::cloud::v0::LogSink',
+                                        'NameSpace' => 'google::cloud::v0',
+                                        'Size' => '104',
+                                        'Type' => 'Class'
+                                      },
+                          '105657' => {
+                                        'Header' => 'log.h',
+                                        'Line' => '217',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => '_vptr',
+                                                             'offset' => '0',
+                                                             'type' => '108318'
+                                                           }
+                                                  },
+                                        'Name' => 'google::cloud::v0::LogBackend',
+                                        'NameSpace' => 'google::cloud::v0',
+                                        'Size' => '8',
+                                        'Type' => 'Class',
+                                        'VTable' => {
+                                                      '0' => '(int (*)(...)) 0',
+                                                      '16' => '0u',
+                                                      '24' => '0u',
+                                                      '32' => '(int (*)(...)) __cxa_pure_virtual',
+                                                      '40' => '(int (*)(...)) __cxa_pure_virtual',
+                                                      '8' => '(int (*)(...)) (& typeinfo for google::cloud::v0::LogBackend) [_ZTIN6google5cloud2v010LogBackendE]'
+                                                    }
+                                      },
+                          '106757' => {
+                                        'BaseType' => '75503',
+                                        'Name' => 'struct std::_Rb_tree_node_base*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '107299' => {
+                                        'BaseType' => '105195',
+                                        'Name' => 'google::cloud::v0::LogSink*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '107305' => {
+                                        'BaseType' => '107299',
+                                        'Name' => 'google::cloud::v0::LogSink*const',
+                                        'Size' => '8',
+                                        'Type' => 'Const'
+                                      },
+                          '107310' => {
+                                        'BaseType' => '105195',
+                                        'Name' => 'google::cloud::v0::LogSink&',
+                                        'Size' => '8',
+                                        'Type' => 'Ref'
+                                      },
+                          '107361' => {
+                                        'BaseType' => '86698',
+                                        'Name' => 'std::_Sp_counted_base<4 byte block:02 00 00 00>*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '107412' => {
+                                        'BaseType' => '87674',
+                                        'Name' => 'std::__shared_ptr<google::cloud::v0::LogBackend, 4 byte block:02 00 00 00>::element_type*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '107464' => {
+                                        'BaseType' => '105657',
+                                        'Name' => 'google::cloud::v0::LogBackend*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '107470' => {
+                                        'BaseType' => '107464',
+                                        'Name' => 'google::cloud::v0::LogBackend*const',
+                                        'Size' => '8',
+                                        'Type' => 'Const'
+                                      },
+                          '107475' => {
+                                        'BaseType' => '85102',
+                                        'Name' => 'std::shared_ptr<google::cloud::v0::LogBackend>*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '107481' => {
+                                        'BaseType' => '107475',
+                                        'Name' => 'std::shared_ptr<google::cloud::v0::LogBackend>*const',
+                                        'Size' => '8',
+                                        'Type' => 'Const'
+                                      },
+                          '107486' => {
+                                        'BaseType' => '85427',
+                                        'Name' => 'std::shared_ptr<google::cloud::v0::LogBackend>const&',
+                                        'Size' => '8',
+                                        'Type' => 'Ref'
+                                      },
+                          '107492' => {
+                                        'BaseType' => '85102',
+                                        'Name' => 'std::shared_ptr<google::cloud::v0::LogBackend>&&',
+                                        'Size' => '8',
+                                        'Type' => 'RvalueRef'
+                                      },
+                          '107856' => {
+                                        'BaseType' => '20351',
+                                        'Name' => 'unsigned char[24]',
+                                        'Size' => '24',
+                                        'Type' => 'Array'
+                                      },
+                          '108300' => {
+                                        'BaseType' => '105190',
+                                        'Name' => 'struct google::cloud::v0::LogRecord const&',
+                                        'Size' => '8',
+                                        'Type' => 'Ref'
+                                      },
+                          '108318' => {
+                                        'BaseType' => '108324',
+                                        'Name' => 'int(**)(...)',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '108324' => {
+                                        'Name' => 'int(*)(...)',
+                                        'Param' => {
                                                      '0' => {
-                                                              'key' => '_CharT',
-                                                              'type' => '10806'
+                                                              'type' => '-1'
                                                             }
                                                    },
-                                       'Type' => 'Class'
+                                        'Return' => '20393',
+                                        'Size' => '8',
+                                        'Type' => 'FuncPtr'
+                                      },
+                          '123607' => {
+                                        'BaseType' => '105051',
+                                        'Name' => 'struct google::cloud::v0::LogRecord*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '123613' => {
+                                        'BaseType' => '123607',
+                                        'Name' => 'struct google::cloud::v0::LogRecord*const',
+                                        'Size' => '8',
+                                        'Type' => 'Const'
+                                      },
+                          '123701' => {
+                                        'BaseType' => '105051',
+                                        'Name' => 'struct google::cloud::v0::LogRecord&&',
+                                        'Size' => '8',
+                                        'Type' => 'RvalueRef'
+                                      },
+                          '124987' => {
+                                        'BaseType' => '46223',
+                                        'Name' => 'std::ostream&',
+                                        'Size' => '8',
+                                        'Type' => 'Ref'
+                                      },
+                          '14586' => {
+                                       'BaseType' => '20365',
+                                       'Header' => 'c++config.h',
+                                       'Line' => '231',
+                                       'Name' => 'std::size_t',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '8',
+                                       'Type' => 'Typedef'
                                      },
-                          '24821' => {
+                          '15835' => {
                                        'Base' => {
-                                                   '33791' => {
-                                                                'pos' => '0'
-                                                              }
-                                                 },
-                                       'Header' => 'basic_string.h',
-                                       'Line' => '139',
-                                       'Memb' => {
-                                                   '0' => {
-                                                            'name' => '_M_p',
-                                                            'offset' => '0',
-                                                            'type' => '24918'
-                                                          }
-                                                 },
-                                       'Name' => 'struct std::__cxx11::basic_string<char>::_Alloc_hider',
-                                       'NameSpace' => 'std::__cxx11::basic_string<char>',
-                                       'Private' => 1,
-                                       'PrivateABI' => 1,
-                                       'Size' => '8',
-                                       'Type' => 'Struct'
-                                     },
-                          '24918' => {
-                                       'BaseType' => '36054',
-                                       'Header' => 'basic_string.h',
-                                       'Line' => '92',
-                                       'Name' => 'std::__cxx11::basic_string<char>::pointer',
-                                       'NameSpace' => 'std::__cxx11::basic_string<char>',
-                                       'PrivateABI' => 1,
-                                       'Size' => '8',
-                                       'Type' => 'Typedef'
-                                     },
-                          '24930' => {
-                                       'Header' => 'basic_string.h',
-                                       'Line' => '161',
-                                       'Memb' => {
-                                                   '0' => {
-                                                            'name' => '_M_local_buf',
-                                                            'offset' => '0',
-                                                            'type' => '43586'
-                                                          },
-                                                   '1' => {
-                                                            'name' => '_M_allocated_capacity',
-                                                            'offset' => '0',
-                                                            'type' => '24961'
-                                                          }
-                                                 },
-                                       'Name' => 'std::__cxx11::basic_string<char>::anon-union-basic_string.h-161',
-                                       'NameSpace' => 'std::__cxx11::basic_string<char>',
-                                       'Private' => 1,
-                                       'PrivateABI' => 1,
-                                       'Size' => '16',
-                                       'Type' => 'Union'
-                                     },
-                          '24961' => {
-                                       'BaseType' => '36076',
-                                       'Header' => 'basic_string.h',
-                                       'Line' => '88',
-                                       'Name' => 'std::__cxx11::basic_string<char>::size_type',
-                                       'NameSpace' => 'std::__cxx11::basic_string<char>',
-                                       'PrivateABI' => 1,
-                                       'Size' => '8',
-                                       'Type' => 'Typedef'
-                                     },
-                          '31316' => {
-                                       'BaseType' => '24809',
-                                       'Header' => 'stringfwd.h',
-                                       'Line' => '74',
-                                       'Name' => 'std::__cxx11::string',
-                                       'NameSpace' => 'std::__cxx11',
-                                       'PrivateABI' => 1,
-                                       'Size' => '32',
-                                       'Type' => 'Typedef'
-                                     },
-                          '31327' => {
-                                       'BaseType' => '31316',
-                                       'Name' => 'std::__cxx11::string const',
-                                       'Size' => '32',
-                                       'Type' => 'Const'
-                                     },
-                          '33791' => {
-                                       'Base' => {
-                                                   '35503' => {
+                                                   '17588' => {
                                                                 'pos' => '0'
                                                               }
                                                  },
@@ -414,7 +1529,7 @@ $VAR1 = {
                                                    },
                                        'Type' => 'Class'
                                      },
-                          '34341' => {
+                          '16385' => {
                                        'Copied' => 1,
                                        'Header' => 'alloc_traits.h',
                                        'Line' => '384',
@@ -425,13 +1540,13 @@ $VAR1 = {
                                        'TParam' => {
                                                      '0' => {
                                                               'key' => '_Alloc',
-                                                              'type' => '33791'
+                                                              'type' => '15835'
                                                             }
                                                    },
                                        'Type' => 'Struct'
                                      },
-                          '34383' => {
-                                       'BaseType' => '12047',
+                          '16427' => {
+                                       'BaseType' => '21932',
                                        'Header' => 'alloc_traits.h',
                                        'Line' => '392',
                                        'Name' => 'std::allocator_traits<std::allocator<char> >::pointer',
@@ -440,8 +1555,8 @@ $VAR1 = {
                                        'Size' => '8',
                                        'Type' => 'Typedef'
                                      },
-                          '34419' => {
-                                       'BaseType' => '7326',
+                          '16463' => {
+                                       'BaseType' => '14586',
                                        'Header' => 'alloc_traits.h',
                                        'Line' => '407',
                                        'Name' => 'std::allocator_traits<std::allocator<char> >::size_type',
@@ -450,7 +1565,7 @@ $VAR1 = {
                                        'Size' => '8',
                                        'Type' => 'Typedef'
                                      },
-                          '35503' => {
+                          '17588' => {
                                        'Header' => 'new_allocator.h',
                                        'Line' => '58',
                                        'Name' => '__gnu_cxx::new_allocator<char>',
@@ -460,14 +1575,14 @@ $VAR1 = {
                                        'TParam' => {
                                                      '0' => {
                                                               'key' => '_Tp',
-                                                              'type' => '10806'
+                                                              'type' => '20691'
                                                             }
                                                    },
                                        'Type' => 'Class'
                                      },
-                          '35999' => {
+                          '18084' => {
                                        'Base' => {
-                                                   '34341' => {
+                                                   '16385' => {
                                                                 'pos' => '0'
                                                               }
                                                  },
@@ -481,13 +1596,13 @@ $VAR1 = {
                                        'TParam' => {
                                                      '0' => {
                                                               'key' => '_Alloc',
-                                                              'type' => '33791'
+                                                              'type' => '15835'
                                                             }
                                                    },
                                        'Type' => 'Struct'
                                      },
-                          '36054' => {
-                                       'BaseType' => '34383',
+                          '18139' => {
+                                       'BaseType' => '16427',
                                        'Header' => 'alloc_traits.h',
                                        'Line' => '59',
                                        'Name' => '__gnu_cxx::__alloc_traits<std::allocator<char> >::pointer',
@@ -496,8 +1611,8 @@ $VAR1 = {
                                        'Size' => '8',
                                        'Type' => 'Typedef'
                                      },
-                          '36076' => {
-                                       'BaseType' => '34419',
+                          '18161' => {
+                                       'BaseType' => '16463',
                                        'Header' => 'alloc_traits.h',
                                        'Line' => '61',
                                        'Name' => '__gnu_cxx::__alloc_traits<std::allocator<char> >::size_type',
@@ -506,28 +1621,1143 @@ $VAR1 = {
                                        'Size' => '8',
                                        'Type' => 'Typedef'
                                      },
-                          '43586' => {
-                                       'BaseType' => '10806',
+                          '20344' => {
+                                       'Name' => 'unsigned int',
+                                       'Size' => '4',
+                                       'Type' => 'Intrinsic'
+                                     },
+                          '20351' => {
+                                       'Name' => 'unsigned char',
+                                       'Size' => '1',
+                                       'Type' => 'Intrinsic'
+                                     },
+                          '20365' => {
+                                       'Name' => 'unsigned long',
+                                       'Size' => '8',
+                                       'Type' => 'Intrinsic'
+                                     },
+                          '20386' => {
+                                       'Name' => 'short',
+                                       'Size' => '2',
+                                       'Type' => 'Intrinsic'
+                                     },
+                          '20393' => {
+                                       'Name' => 'int',
+                                       'Size' => '4',
+                                       'Type' => 'Intrinsic'
+                                     },
+                          '204' => {
+                                     'BaseType' => '18139',
+                                     'Header' => 'basic_string.h',
+                                     'Line' => '92',
+                                     'Name' => 'std::__cxx11::basic_string<char>::pointer',
+                                     'NameSpace' => 'std::__cxx11::basic_string<char>',
+                                     'PrivateABI' => 1,
+                                     'Size' => '8',
+                                     'Type' => 'Typedef'
+                                   },
+                          '20405' => {
+                                       'Name' => 'long',
+                                       'Size' => '8',
+                                       'Type' => 'Intrinsic'
+                                     },
+                          '20440' => {
+                                       'Name' => 'bool',
+                                       'Size' => '1',
+                                       'Type' => 'Intrinsic'
+                                     },
+                          '20594' => {
+                                       'BaseType' => '1',
+                                       'Name' => 'void*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '20691' => {
+                                       'Name' => 'char',
+                                       'Size' => '1',
+                                       'Type' => 'Intrinsic'
+                                     },
+                          '20698' => {
+                                       'BaseType' => '20691',
+                                       'Name' => 'char const',
+                                       'Size' => '1',
+                                       'Type' => 'Const'
+                                     },
+                          '21136' => {
+                                       'BaseType' => '20698',
+                                       'Name' => 'char const*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '21932' => {
+                                       'BaseType' => '20691',
+                                       'Name' => 'char*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '236' => {
+                                     'Header' => 'basic_string.h',
+                                     'Line' => '161',
+                                     'Memb' => {
+                                                 '0' => {
+                                                          'name' => '_M_local_buf',
+                                                          'offset' => '0',
+                                                          'type' => '26070'
+                                                        },
+                                                 '1' => {
+                                                          'name' => '_M_allocated_capacity',
+                                                          'offset' => '0',
+                                                          'type' => '267'
+                                                        }
+                                               },
+                                     'Name' => 'std::__cxx11::basic_string<char>::anon-union-basic_string.h-161',
+                                     'NameSpace' => 'std::__cxx11::basic_string<char>',
+                                     'Private' => 1,
+                                     'PrivateABI' => 1,
+                                     'Size' => '16',
+                                     'Type' => 'Union'
+                                   },
+                          '26070' => {
+                                       'BaseType' => '20691',
                                        'Name' => 'char[16]',
                                        'Size' => '16',
                                        'Type' => 'Array'
                                      },
-                          '43662' => {
-                                       'BaseType' => '31327',
+                          '267' => {
+                                     'BaseType' => '18161',
+                                     'Header' => 'basic_string.h',
+                                     'Line' => '88',
+                                     'Name' => 'std::__cxx11::basic_string<char>::size_type',
+                                     'NameSpace' => 'std::__cxx11::basic_string<char>',
+                                     'PrivateABI' => 1,
+                                     'Size' => '8',
+                                     'Type' => 'Typedef'
+                                   },
+                          '42398' => {
+                                       'BaseType' => '6765',
+                                       'Name' => 'std::__cxx11::string const',
+                                       'Size' => '32',
+                                       'Type' => 'Const'
+                                     },
+                          '46085' => {
+                                       'Copied' => 1,
+                                       'Name' => 'std::basic_ostream<char>',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_CharT',
+                                                              'type' => '20691'
+                                                            }
+                                                   },
+                                       'Type' => 'Class'
+                                     },
+                          '46223' => {
+                                       'BaseType' => '46085',
+                                       'Header' => 'iosfwd',
+                                       'Line' => '141',
+                                       'Name' => 'std::ostream',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Type' => 'Typedef'
+                                     },
+                          '48998' => {
+                                       'BaseType' => '20405',
+                                       'Name' => 'long const',
+                                       'Size' => '8',
+                                       'Type' => 'Const'
+                                     },
+                          '52720' => {
+                                       'BaseType' => '20393',
+                                       'Header' => 'atomic_word.h',
+                                       'Line' => '32',
+                                       'Name' => '_Atomic_word',
+                                       'PrivateABI' => 1,
+                                       'Size' => '4',
+                                       'Type' => 'Typedef'
+                                     },
+                          '54733' => {
+                                       'BaseType' => '42398',
                                        'Name' => 'std::__cxx11::string const&',
                                        'Size' => '8',
                                        'Type' => 'Ref'
                                      },
-                          '7326' => {
-                                      'BaseType' => '10480',
-                                      'Header' => 'c++config.h',
-                                      'Line' => '231',
-                                      'Name' => 'std::size_t',
-                                      'NameSpace' => 'std',
+                          '66718' => {
+                                       'Header' => 'atomic_base.h',
+                                       'Line' => '238',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'access' => 'private',
+                                                            'name' => '_M_i',
+                                                            'offset' => '0',
+                                                            'type' => '66749'
+                                                          }
+                                                 },
+                                       'Name' => 'struct std::__atomic_base<bool>',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '1',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_IntTp',
+                                                              'type' => '20440'
+                                                            }
+                                                   },
+                                       'Type' => 'Struct'
+                                     },
+                          '66749' => {
+                                       'BaseType' => '20440',
+                                       'Header' => 'atomic_base.h',
+                                       'Line' => '241',
+                                       'Name' => 'std::__atomic_base<bool>::__int_type',
+                                       'NameSpace' => 'std::__atomic_base<bool>',
+                                       'Private' => 1,
+                                       'PrivateABI' => 1,
+                                       'Size' => '1',
+                                       'Type' => 'Typedef'
+                                     },
+                          '67' => {
+                                    'Header' => 'basic_string.h',
+                                    'Line' => '77',
+                                    'Memb' => {
+                                                '0' => {
+                                                         'access' => 'private',
+                                                         'name' => '_M_dataplus',
+                                                         'offset' => '0',
+                                                         'type' => '79'
+                                                       },
+                                                '1' => {
+                                                         'access' => 'private',
+                                                         'name' => '_M_string_length',
+                                                         'offset' => '8',
+                                                         'type' => '267'
+                                                       },
+                                                '2' => {
+                                                         'access' => 'private',
+                                                         'name' => 'unnamed0',
+                                                         'offset' => '16',
+                                                         'type' => '236'
+                                                       }
+                                              },
+                                    'Name' => 'std::__cxx11::basic_string<char>',
+                                    'NameSpace' => 'std::__cxx11',
+                                    'PrivateABI' => 1,
+                                    'Size' => '32',
+                                    'TParam' => {
+                                                  '0' => {
+                                                           'key' => '_CharT',
+                                                           'type' => '20691'
+                                                         }
+                                                },
+                                    'Type' => 'Class'
+                                  },
+                          '6765' => {
+                                      'BaseType' => '67',
+                                      'Header' => 'stringfwd.h',
+                                      'Line' => '74',
+                                      'Name' => 'std::__cxx11::string',
+                                      'NameSpace' => 'std::__cxx11',
                                       'PrivateABI' => 1,
-                                      'Size' => '8',
+                                      'Size' => '32',
                                       'Type' => 'Typedef'
-                                    }
+                                    },
+                          '68789' => {
+                                       'Header' => 'atomic',
+                                       'Line' => '63',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'access' => 'private',
+                                                            'name' => '_M_base',
+                                                            'offset' => '0',
+                                                            'type' => '66718'
+                                                          }
+                                                 },
+                                       'Name' => 'struct std::atomic<bool>',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '1',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'name' => 'bool'
+                                                            }
+                                                   },
+                                       'Type' => 'Struct'
+                                     },
+                          '69787' => {
+                                       'Header' => 'atomic_base.h',
+                                       'Line' => '238',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'access' => 'private',
+                                                            'name' => '_M_i',
+                                                            'offset' => '0',
+                                                            'type' => '69818'
+                                                          }
+                                                 },
+                                       'Name' => 'struct std::__atomic_base<int>',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '4',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_IntTp',
+                                                              'type' => '20393'
+                                                            }
+                                                   },
+                                       'Type' => 'Struct'
+                                     },
+                          '69818' => {
+                                       'BaseType' => '20393',
+                                       'Header' => 'atomic_base.h',
+                                       'Line' => '241',
+                                       'Name' => 'std::__atomic_base<int>::__int_type',
+                                       'NameSpace' => 'std::__atomic_base<int>',
+                                       'Private' => 1,
+                                       'PrivateABI' => 1,
+                                       'Size' => '4',
+                                       'Type' => 'Typedef'
+                                     },
+                          '71858' => {
+                                       'Base' => {
+                                                   '69787' => {
+                                                                'pos' => '0'
+                                                              }
+                                                 },
+                                       'Header' => 'atomic',
+                                       'Line' => '661',
+                                       'Name' => 'struct std::atomic<int>',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '4',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'name' => 'int'
+                                                            }
+                                                   },
+                                       'Type' => 'Struct'
+                                     },
+                          '72207' => {
+                                       'Copied' => 1,
+                                       'Header' => 'chrono',
+                                       'Line' => '812',
+                                       'Name' => 'struct std::chrono::_V2::system_clock',
+                                       'NameSpace' => 'std::chrono::_V2',
+                                       'PrivateABI' => 1,
+                                       'Size' => '1',
+                                       'Type' => 'Struct'
+                                     },
+                          '72232' => {
+                                       'BaseType' => '72932',
+                                       'Header' => 'chrono',
+                                       'Line' => '817',
+                                       'Name' => 'std::chrono::_V2::system_clock::time_point',
+                                       'NameSpace' => 'std::chrono::_V2::system_clock',
+                                       'PrivateABI' => 1,
+                                       'Size' => '8',
+                                       'Type' => 'Typedef'
+                                     },
+                          '72325' => {
+                                       'Header' => 'chrono',
+                                       'Line' => '303',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'access' => 'private',
+                                                            'name' => '__r',
+                                                            'offset' => '0',
+                                                            'type' => '72338'
+                                                          }
+                                                 },
+                                       'Name' => 'struct std::chrono::duration<long, std::ratio<8 byte block:01 00 00 00 00 00 00 00, 8 byte block:00 ca 9a 3b 00 00 00 00> >',
+                                       'NameSpace' => 'std::chrono',
+                                       'PrivateABI' => 1,
+                                       'Size' => '8',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Rep',
+                                                              'type' => '20405'
+                                                            },
+                                                     '1' => {
+                                                              'key' => '_Period',
+                                                              'type' => '73384'
+                                                            }
+                                                   },
+                                       'Type' => 'Struct'
+                                     },
+                          '72338' => {
+                                       'BaseType' => '20405',
+                                       'Header' => 'chrono',
+                                       'Line' => '305',
+                                       'Name' => 'std::chrono::duration<long, std::ratio<8 byte block:01 00 00 00 00 00 00 00, 8 byte block:00 ca 9a 3b 00 00 00 00> >::rep',
+                                       'NameSpace' => 'std::chrono::duration<long, std::ratio<8 byte block:01 00 00 00 00 00 00 00, 8 byte block:00 ca 9a 3b 00 00 00 00> >',
+                                       'PrivateABI' => 1,
+                                       'Size' => '8',
+                                       'Type' => 'Typedef'
+                                     },
+                          '72932' => {
+                                       'Header' => 'chrono',
+                                       'Line' => '610',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'access' => 'private',
+                                                            'name' => '__d',
+                                                            'offset' => '0',
+                                                            'type' => '72945'
+                                                          }
+                                                 },
+                                       'Name' => 'struct std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long, std::ratio<8 byte block:01 00 00 00 00 00 00 00, 8 byte block:00 ca 9a 3b 00 00 00 00> > >',
+                                       'NameSpace' => 'std::chrono',
+                                       'PrivateABI' => 1,
+                                       'Size' => '8',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Clock',
+                                                              'type' => '72207'
+                                                            },
+                                                     '1' => {
+                                                              'key' => '_Dur',
+                                                              'type' => '72325'
+                                                            }
+                                                   },
+                                       'Type' => 'Struct'
+                                     },
+                          '72945' => {
+                                       'BaseType' => '72325',
+                                       'Header' => 'chrono',
+                                       'Line' => '613',
+                                       'Name' => 'std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long, std::ratio<8 byte block:01 00 00 00 00 00 00 00, 8 byte block:00 ca 9a 3b 00 00 00 00> > >::duration',
+                                       'NameSpace' => 'std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long, std::ratio<8 byte block:01 00 00 00 00 00 00 00, 8 byte block:00 ca 9a 3b 00 00 00 00> > >',
+                                       'PrivateABI' => 1,
+                                       'Size' => '8',
+                                       'Type' => 'Typedef'
+                                     },
+                          '73384' => {
+                                       'Header' => 'ratio',
+                                       'Line' => '263',
+                                       'Name' => 'struct std::ratio<8 byte block:01 00 00 00 00 00 00 00, 8 byte block:00 ca 9a 3b 00 00 00 00>',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '1',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Num',
+                                                              'type' => '20405',
+                                                              'val' => '8 byte block: 01 00 00 00 00 00 00 00'
+                                                            },
+                                                     '1' => {
+                                                              'key' => '_Den',
+                                                              'type' => '20405',
+                                                              'val' => '8 byte block: 00 ca 9a 3b 00 00 00 00'
+                                                            }
+                                                   },
+                                       'Type' => 'Struct'
+                                     },
+                          '75473' => {
+                                       'Header' => 'stl_tree.h',
+                                       'Line' => '99',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => '_S_red',
+                                                            'value' => '0'
+                                                          },
+                                                   '1' => {
+                                                            'name' => '_S_black',
+                                                            'value' => '1'
+                                                          }
+                                                 },
+                                       'Name' => 'enum std::_Rb_tree_color',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '4',
+                                       'Type' => 'Enum'
+                                     },
+                          '75503' => {
+                                       'Copied' => 1,
+                                       'Header' => 'stl_tree.h',
+                                       'Line' => '101',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => '_M_color',
+                                                            'offset' => '0',
+                                                            'type' => '75473'
+                                                          },
+                                                   '1' => {
+                                                            'name' => '_M_parent',
+                                                            'offset' => '8',
+                                                            'type' => '75527'
+                                                          },
+                                                   '2' => {
+                                                            'name' => '_M_left',
+                                                            'offset' => '16',
+                                                            'type' => '75527'
+                                                          },
+                                                   '3' => {
+                                                            'name' => '_M_right',
+                                                            'offset' => '24',
+                                                            'type' => '75527'
+                                                          }
+                                                 },
+                                       'Name' => 'struct std::_Rb_tree_node_base',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '32',
+                                       'Type' => 'Struct'
+                                     },
+                          '75527' => {
+                                       'BaseType' => '106757',
+                                       'Header' => 'stl_tree.h',
+                                       'Line' => '103',
+                                       'Name' => 'std::_Rb_tree_node_base::_Base_ptr',
+                                       'NameSpace' => 'std::_Rb_tree_node_base',
+                                       'PrivateABI' => 1,
+                                       'Size' => '8',
+                                       'Type' => 'Typedef'
+                                     },
+                          '75688' => {
+                                       'Header' => 'stl_tree.h',
+                                       'Line' => '168',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => '_M_header',
+                                                            'offset' => '0',
+                                                            'type' => '75503'
+                                                          },
+                                                   '1' => {
+                                                            'name' => '_M_node_count',
+                                                            'offset' => '32',
+                                                            'type' => '14586'
+                                                          }
+                                                 },
+                                       'Name' => 'struct std::_Rb_tree_header',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '40',
+                                       'Type' => 'Struct'
+                                     },
+                          '76304' => {
+                                       'Copied' => 1,
+                                       'Header' => 'shared_ptr_base.h',
+                                       'Line' => '93',
+                                       'Name' => 'std::_Mutex_base<4 byte block:02 00 00 00>',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '1',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Lp',
+                                                              'type' => '96511',
+                                                              'val' => '4 byte block: 02 00 00 00'
+                                                            }
+                                                   },
+                                       'Type' => 'Class'
+                                     },
+                          '76363' => {
+                                       'Header' => 'std_mutex.h',
+                                       'Line' => '60',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'access' => 'protected',
+                                                            'name' => '_M_mutex',
+                                                            'offset' => '0',
+                                                            'type' => '76375'
+                                                          }
+                                                 },
+                                       'Name' => 'std::__mutex_base',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '40',
+                                       'Type' => 'Class'
+                                     },
+                          '76375' => {
+                                       'BaseType' => '102879',
+                                       'Header' => 'std_mutex.h',
+                                       'Line' => '63',
+                                       'Name' => 'std::__mutex_base::__native_type',
+                                       'NameSpace' => 'std::__mutex_base',
+                                       'PrivateABI' => 1,
+                                       'Protected' => 1,
+                                       'Size' => '40',
+                                       'Type' => 'Typedef'
+                                     },
+                          '76498' => {
+                                       'Base' => {
+                                                   '76363' => {
+                                                                'pos' => '0'
+                                                              }
+                                                 },
+                                       'Header' => 'std_mutex.h',
+                                       'Line' => '86',
+                                       'Name' => 'std::mutex',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '40',
+                                       'Type' => 'Class'
+                                     },
+                          '77202' => {
+                                       'Copied' => 1,
+                                       'Name' => 'std::allocator<std::pair<long const, std::shared_ptr<google::cloud::v0::LogBackend> > >',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'type' => '77212'
+                                                            }
+                                                   },
+                                       'Type' => 'Class'
+                                     },
+                          '77212' => {
+                                       'Header' => 'stl_pair.h',
+                                       'Line' => '198',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'first',
+                                                            'offset' => '0',
+                                                            'type' => '48998'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'second',
+                                                            'offset' => '8',
+                                                            'type' => '85102'
+                                                          }
+                                                 },
+                                       'Name' => 'struct std::pair<long const, std::shared_ptr<google::cloud::v0::LogBackend> >',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '24',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_T1',
+                                                              'type' => '48998'
+                                                            },
+                                                     '1' => {
+                                                              'key' => '_T2',
+                                                              'type' => '85102'
+                                                            }
+                                                   },
+                                       'Type' => 'Struct'
+                                     },
+                          '77566' => {
+                                       'Base' => {
+                                                   '96778' => {
+                                                                'pos' => '0'
+                                                              }
+                                                 },
+                                       'Header' => 'allocator.h',
+                                       'Line' => '108',
+                                       'Name' => 'std::allocator<std::_Rb_tree_node<std::pair<long const, std::shared_ptr<google::cloud::v0::LogBackend> > > >',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '1',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'type' => '77790'
+                                                            }
+                                                   },
+                                       'Type' => 'Class'
+                                     },
+                          '77676' => {
+                                       'Header' => 'stl_function.h',
+                                       'Line' => '118',
+                                       'Name' => 'struct std::binary_function<long, long, bool>',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '1',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Arg1',
+                                                              'type' => '20405'
+                                                            },
+                                                     '1' => {
+                                                              'key' => '_Arg2',
+                                                              'type' => '20405'
+                                                            },
+                                                     '2' => {
+                                                              'key' => '_Result',
+                                                              'type' => '20440'
+                                                            }
+                                                   },
+                                       'Type' => 'Struct'
+                                     },
+                          '77716' => {
+                                       'Base' => {
+                                                   '77676' => {
+                                                                'pos' => '0'
+                                                              }
+                                                 },
+                                       'Copied' => 1,
+                                       'Header' => 'stl_function.h',
+                                       'Line' => '381',
+                                       'Name' => 'struct std::less<long>',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '1',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Tp',
+                                                              'type' => '20405'
+                                                            }
+                                                   },
+                                       'Type' => 'Struct'
+                                     },
+                          '77790' => {
+                                       'Base' => {
+                                                   '75503' => {
+                                                                'pos' => '0'
+                                                              }
+                                                 },
+                                       'Copied' => 1,
+                                       'Header' => 'stl_tree.h',
+                                       'Line' => '216',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => '_M_storage',
+                                                            'offset' => '32',
+                                                            'type' => '97475'
+                                                          }
+                                                 },
+                                       'Name' => 'struct std::_Rb_tree_node<std::pair<long const, std::shared_ptr<google::cloud::v0::LogBackend> > >',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '56',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Val',
+                                                              'type' => '77212'
+                                                            }
+                                                   },
+                                       'Type' => 'Struct'
+                                     },
+                          '77896' => {
+                                       'Header' => 'stl_tree.h',
+                                       'Line' => '142',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => '_M_key_compare',
+                                                            'offset' => '0',
+                                                            'type' => '77716'
+                                                          }
+                                                 },
+                                       'Name' => 'struct std::_Rb_tree_key_compare<std::less<long> >',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '1',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Key_compare',
+                                                              'type' => '77716'
+                                                            }
+                                                   },
+                                       'Type' => 'Struct'
+                                     },
+                          '78051' => {
+                                       'Header' => 'stl_tree.h',
+                                       'Line' => '444',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'access' => 'protected',
+                                                            'name' => '_M_impl',
+                                                            'offset' => '0',
+                                                            'type' => '78064'
+                                                          }
+                                                 },
+                                       'Name' => 'std::_Rb_tree<long, std::pair<long const, std::shared_ptr<google::cloud::v0::LogBackend> >, std::_Select1st<std::pair<long const, std::shared_ptr<google::cloud::v0::LogBackend> > >, std::less<long>, std::allocator<std::pair<long const, std::shared_ptr<google::cloud::v0::LogBackend> > > >',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '48',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Key',
+                                                              'type' => '20405'
+                                                            },
+                                                     '1' => {
+                                                              'key' => '_Val',
+                                                              'type' => '77212'
+                                                            },
+                                                     '2' => {
+                                                              'key' => '_KeyOfValue',
+                                                              'type' => '91636'
+                                                            },
+                                                     '3' => {
+                                                              'key' => '_Compare',
+                                                              'type' => '77716'
+                                                            },
+                                                     '4' => {
+                                                              'key' => '_Alloc',
+                                                              'type' => '77202'
+                                                            }
+                                                   },
+                                       'Type' => 'Class'
+                                     },
+                          '78064' => {
+                                       'Base' => {
+                                                   '75688' => {
+                                                                'pos' => '2'
+                                                              },
+                                                   '77566' => {
+                                                                'pos' => '0'
+                                                              },
+                                                   '77896' => {
+                                                                'pos' => '1'
+                                                              }
+                                                 },
+                                       'Header' => 'stl_tree.h',
+                                       'Line' => '677',
+                                       'Name' => 'struct std::_Rb_tree<long, std::pair<long const, std::shared_ptr<google::cloud::v0::LogBackend> >, std::_Select1st<std::pair<long const, std::shared_ptr<google::cloud::v0::LogBackend> > >, std::less<long>, std::allocator<std::pair<long const, std::shared_ptr<google::cloud::v0::LogBackend> > > >::_Rb_tree_impl<std::less<long> >',
+                                       'NameSpace' => 'std::_Rb_tree<long, std::pair<long const, std::shared_ptr<google::cloud::v0::LogBackend> >, std::_Select1st<std::pair<long const, std::shared_ptr<google::cloud::v0::LogBackend> > >, std::less<long>, std::allocator<std::pair<long const, std::shared_ptr<google::cloud::v0::LogBackend> > > >',
+                                       'PrivateABI' => 1,
+                                       'Protected' => 1,
+                                       'Size' => '48',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Key_compare',
+                                                              'type' => '77716'
+                                                            }
+                                                   },
+                                       'Type' => 'Struct'
+                                     },
+                          '79' => {
+                                    'Base' => {
+                                                '15835' => {
+                                                             'pos' => '0'
+                                                           }
+                                              },
+                                    'Header' => 'basic_string.h',
+                                    'Line' => '139',
+                                    'Memb' => {
+                                                '0' => {
+                                                         'name' => '_M_p',
+                                                         'offset' => '0',
+                                                         'type' => '204'
+                                                       }
+                                              },
+                                    'Name' => 'struct std::__cxx11::basic_string<char>::_Alloc_hider',
+                                    'NameSpace' => 'std::__cxx11::basic_string<char>',
+                                    'Private' => 1,
+                                    'PrivateABI' => 1,
+                                    'Size' => '8',
+                                    'Type' => 'Struct'
+                                  },
+                          '82946' => {
+                                       'Header' => 'stl_map.h',
+                                       'Line' => '99',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'access' => 'private',
+                                                            'name' => '_M_t',
+                                                            'offset' => '0',
+                                                            'type' => '82958'
+                                                          }
+                                                 },
+                                       'Name' => 'std::map<long, std::shared_ptr<google::cloud::v0::LogBackend> >',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '48',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Key',
+                                                              'type' => '20405'
+                                                            },
+                                                     '1' => {
+                                                              'key' => '_Tp',
+                                                              'type' => '85102'
+                                                            }
+                                                   },
+                                       'Type' => 'Class'
+                                     },
+                          '82958' => {
+                                       'BaseType' => '78051',
+                                       'Header' => 'stl_map.h',
+                                       'Line' => '142',
+                                       'Name' => 'std::map<long, std::shared_ptr<google::cloud::v0::LogBackend> >::_Rep_type',
+                                       'NameSpace' => 'std::map<long, std::shared_ptr<google::cloud::v0::LogBackend> >',
+                                       'Private' => 1,
+                                       'PrivateABI' => 1,
+                                       'Size' => '48',
+                                       'Type' => 'Typedef'
+                                     },
+                          '85102' => {
+                                       'Base' => {
+                                                   '87654' => {
+                                                                'pos' => '0'
+                                                              }
+                                                 },
+                                       'Header' => 'shared_ptr.h',
+                                       'Line' => '93',
+                                       'Name' => 'std::shared_ptr<google::cloud::v0::LogBackend>',
+                                       'NameSpace' => 'std',
+                                       'Size' => '16',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Tp',
+                                                              'type' => '105657'
+                                                            }
+                                                   },
+                                       'Type' => 'Class'
+                                     },
+                          '85427' => {
+                                       'BaseType' => '85102',
+                                       'Name' => 'std::shared_ptr<google::cloud::v0::LogBackend>const',
+                                       'Size' => '16',
+                                       'Type' => 'Const'
+                                     },
+                          '86010' => {
+                                       'Copied' => 1,
+                                       'Header' => 'shared_ptr_base.h',
+                                       'Line' => '953',
+                                       'Name' => 'std::__shared_ptr_access<google::cloud::v0::LogBackend, 4 byte block:02 00 00 00>',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '1',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Tp',
+                                                              'type' => '105657'
+                                                            },
+                                                     '1' => {
+                                                              'key' => '_Lp',
+                                                              'type' => '96511',
+                                                              'val' => '4 byte block: 02 00 00 00'
+                                                            }
+                                                   },
+                                       'Type' => 'Class'
+                                     },
+                          '86157' => {
+                                       'Header' => 'type_traits',
+                                       'Line' => '1941',
+                                       'Name' => 'struct std::remove_extent<google::cloud::v0::LogBackend>',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '1',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Tp',
+                                                              'type' => '105657'
+                                                            }
+                                                   },
+                                       'Type' => 'Struct'
+                                     },
+                          '86170' => {
+                                       'BaseType' => '105657',
+                                       'Header' => 'type_traits',
+                                       'Line' => '1942',
+                                       'Name' => 'std::remove_extent<google::cloud::v0::LogBackend>::type',
+                                       'NameSpace' => 'std::remove_extent<google::cloud::v0::LogBackend>',
+                                       'PrivateABI' => 1,
+                                       'Size' => '8',
+                                       'Type' => 'Typedef'
+                                     },
+                          '86192' => {
+                                       'Header' => 'shared_ptr_base.h',
+                                       'Line' => '572',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'access' => 'private',
+                                                            'name' => '_M_pi',
+                                                            'offset' => '0',
+                                                            'type' => '107361'
+                                                          }
+                                                 },
+                                       'Name' => 'std::__shared_count<4 byte block:02 00 00 00>',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '8',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Lp',
+                                                              'type' => '96511',
+                                                              'val' => '4 byte block: 02 00 00 00'
+                                                            }
+                                                   },
+                                       'Type' => 'Class'
+                                     },
+                          '86698' => {
+                                       'Base' => {
+                                                   '76304' => {
+                                                                'pos' => '0'
+                                                              }
+                                                 },
+                                       'Header' => 'shared_ptr_base.h',
+                                       'Line' => '112',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => '_vptr',
+                                                            'offset' => '0',
+                                                            'type' => '108318'
+                                                          },
+                                                   '1' => {
+                                                            'access' => 'private',
+                                                            'name' => '_M_use_count',
+                                                            'offset' => '8',
+                                                            'type' => '52720'
+                                                          },
+                                                   '2' => {
+                                                            'access' => 'private',
+                                                            'name' => '_M_weak_count',
+                                                            'offset' => '12',
+                                                            'type' => '52720'
+                                                          }
+                                                 },
+                                       'Name' => 'std::_Sp_counted_base<4 byte block:02 00 00 00>',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '16',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Lp',
+                                                              'type' => '96511',
+                                                              'val' => '4 byte block: 02 00 00 00'
+                                                            }
+                                                   },
+                                       'Type' => 'Class'
+                                     },
+                          '87654' => {
+                                       'Base' => {
+                                                   '86010' => {
+                                                                'pos' => '0'
+                                                              }
+                                                 },
+                                       'Header' => 'shared_ptr_base.h',
+                                       'Line' => '1034',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'access' => 'private',
+                                                            'name' => '_M_ptr',
+                                                            'offset' => '0',
+                                                            'type' => '107412'
+                                                          },
+                                                   '1' => {
+                                                            'access' => 'private',
+                                                            'name' => '_M_refcount',
+                                                            'offset' => '8',
+                                                            'type' => '86192'
+                                                          }
+                                                 },
+                                       'Name' => 'std::__shared_ptr<google::cloud::v0::LogBackend, 4 byte block:02 00 00 00>',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '16',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Tp',
+                                                              'type' => '105657'
+                                                            },
+                                                     '1' => {
+                                                              'key' => '_Lp',
+                                                              'type' => '96511',
+                                                              'val' => '4 byte block: 02 00 00 00'
+                                                            }
+                                                   },
+                                       'Type' => 'Class'
+                                     },
+                          '87674' => {
+                                       'BaseType' => '86170',
+                                       'Header' => 'shared_ptr_base.h',
+                                       'Line' => '1038',
+                                       'Name' => 'std::__shared_ptr<google::cloud::v0::LogBackend, 4 byte block:02 00 00 00>::element_type',
+                                       'NameSpace' => 'std::__shared_ptr<google::cloud::v0::LogBackend, 4 byte block:02 00 00 00>',
+                                       'PrivateABI' => 1,
+                                       'Size' => '8',
+                                       'Type' => 'Typedef'
+                                     },
+                          '91605' => {
+                                       'Header' => 'stl_function.h',
+                                       'Line' => '105',
+                                       'Name' => 'struct std::unary_function<std::pair<long const, std::shared_ptr<google::cloud::v0::LogBackend> >, long const>',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '1',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Arg',
+                                                              'type' => '77212'
+                                                            },
+                                                     '1' => {
+                                                              'key' => '_Result',
+                                                              'type' => '48998'
+                                                            }
+                                                   },
+                                       'Type' => 'Struct'
+                                     },
+                          '91636' => {
+                                       'Base' => {
+                                                   '91605' => {
+                                                                'pos' => '0'
+                                                              }
+                                                 },
+                                       'Copied' => 1,
+                                       'Header' => 'stl_function.h',
+                                       'Line' => '882',
+                                       'Name' => 'struct std::_Select1st<std::pair<long const, std::shared_ptr<google::cloud::v0::LogBackend> > >',
+                                       'NameSpace' => 'std',
+                                       'PrivateABI' => 1,
+                                       'Size' => '1',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Pair',
+                                                              'type' => '77212'
+                                                            }
+                                                   },
+                                       'Type' => 'Struct'
+                                     },
+                          '96511' => {
+                                       'Header' => 'concurrence.h',
+                                       'Line' => '49',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => '_S_single',
+                                                            'value' => '0'
+                                                          },
+                                                   '1' => {
+                                                            'name' => '_S_mutex',
+                                                            'value' => '1'
+                                                          },
+                                                   '2' => {
+                                                            'name' => '_S_atomic',
+                                                            'value' => '2'
+                                                          }
+                                                 },
+                                       'Name' => 'enum __gnu_cxx::_Lock_policy',
+                                       'NameSpace' => '__gnu_cxx',
+                                       'PrivateABI' => 1,
+                                       'Size' => '4',
+                                       'Type' => 'Enum'
+                                     },
+                          '96778' => {
+                                       'Header' => 'new_allocator.h',
+                                       'Line' => '58',
+                                       'Name' => '__gnu_cxx::new_allocator<std::_Rb_tree_node<std::pair<long const, std::shared_ptr<google::cloud::v0::LogBackend> > > >',
+                                       'NameSpace' => '__gnu_cxx',
+                                       'PrivateABI' => 1,
+                                       'Size' => '1',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Tp',
+                                                              'type' => '77790'
+                                                            }
+                                                   },
+                                       'Type' => 'Class'
+                                     },
+                          '97475' => {
+                                       'Header' => 'aligned_buffer.h',
+                                       'Line' => '47',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => '_M_storage',
+                                                            'offset' => '0',
+                                                            'type' => '107856'
+                                                          }
+                                                 },
+                                       'Name' => 'struct __gnu_cxx::__aligned_membuf<std::pair<long const, std::shared_ptr<google::cloud::v0::LogBackend> > >',
+                                       'NameSpace' => '__gnu_cxx',
+                                       'PrivateABI' => 1,
+                                       'Size' => '24',
+                                       'TParam' => {
+                                                     '0' => {
+                                                              'key' => '_Tp',
+                                                              'type' => '77212'
+                                                            }
+                                                   },
+                                       'Type' => 'Struct'
+                                     }
                         },
           'UndefinedSymbols' => {
                                   'libgoogle_cloud_cpp_common.so' => {
@@ -535,6 +2765,10 @@ $VAR1 = {
                                                                        '_ITM_registerTMCloneTable' => 0,
                                                                        '_Unwind_Resume@GCC_3.0' => 0,
                                                                        '_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE5c_strEv@GLIBCXX_3.4.21' => 0,
+                                                                       '_ZNSaIcEC1Ev@GLIBCXX_3.4' => 0,
+                                                                       '_ZNSaIcED1Ev@GLIBCXX_3.4' => 0,
+                                                                       '_ZNSolsEPFRSoS_E@GLIBCXX_3.4' => 0,
+                                                                       '_ZNSolsEi@GLIBCXX_3.4' => 0,
                                                                        '_ZNSt11logic_errorC1EPKc@GLIBCXX_3.4.21' => 0,
                                                                        '_ZNSt11logic_errorD1Ev@GLIBCXX_3.4' => 0,
                                                                        '_ZNSt11range_errorC1EPKc@GLIBCXX_3.4.21' => 0,
@@ -543,20 +2777,50 @@ $VAR1 = {
                                                                        '_ZNSt13runtime_errorD1Ev@GLIBCXX_3.4' => 0,
                                                                        '_ZNSt16invalid_argumentC1EPKc@GLIBCXX_3.4.21' => 0,
                                                                        '_ZNSt16invalid_argumentD1Ev@GLIBCXX_3.4' => 0,
+                                                                       '_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1EOS4_@GLIBCXX_3.4.21' => 0,
+                                                                       '_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1EPKcRKS3_@GLIBCXX_3.4.21' => 0,
+                                                                       '_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev@GLIBCXX_3.4.21' => 0,
                                                                        '_ZNSt8ios_base4InitC1Ev@GLIBCXX_3.4' => 0,
                                                                        '_ZNSt8ios_base4InitD1Ev@GLIBCXX_3.4' => 0,
+                                                                       '_ZSt17__throw_bad_allocv@GLIBCXX_3.4' => 0,
+                                                                       '_ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base@GLIBCXX_3.4' => 0,
+                                                                       '_ZSt18_Rb_tree_incrementPSt18_Rb_tree_node_base@GLIBCXX_3.4' => 0,
+                                                                       '_ZSt20__throw_system_errori@GLIBCXX_3.4.11' => 0,
+                                                                       '_ZSt28_Rb_tree_rebalance_for_erasePSt18_Rb_tree_node_baseRS_@GLIBCXX_3.4' => 0,
+                                                                       '_ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_@GLIBCXX_3.4' => 0,
+                                                                       '_ZSt4clog@GLIBCXX_3.4' => 0,
+                                                                       '_ZSt5flushIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_@GLIBCXX_3.4' => 0,
+                                                                       '_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc@GLIBCXX_3.4' => 0,
+                                                                       '_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_c@GLIBCXX_3.4' => 0,
+                                                                       '_ZStlsIcSt11char_traitsIcESaIcEERSt13basic_ostreamIT_T0_ES7_RKNSt7__cxx1112basic_stringIS4_S5_T1_EE@GLIBCXX_3.4.21' => 0,
                                                                        '_ZTISt11logic_error@GLIBCXX_3.4' => 0,
                                                                        '_ZTISt11range_error@GLIBCXX_3.4' => 0,
                                                                        '_ZTISt13runtime_error@GLIBCXX_3.4' => 0,
                                                                        '_ZTISt16invalid_argument@GLIBCXX_3.4' => 0,
+                                                                       '_ZTVN10__cxxabiv117__class_type_infoE@CXXABI_1.3' => 0,
+                                                                       '_ZTVN10__cxxabiv120__si_class_type_infoE@CXXABI_1.3' => 0,
+                                                                       '_ZdlPv@GLIBCXX_3.4' => 0,
+                                                                       '_Znwm@GLIBCXX_3.4' => 0,
                                                                        '__cxa_allocate_exception@CXXABI_1.3' => 0,
                                                                        '__cxa_atexit@GLIBC_2.2.5' => 0,
+                                                                       '__cxa_begin_catch@CXXABI_1.3' => 0,
+                                                                       '__cxa_end_catch@CXXABI_1.3' => 0,
                                                                        '__cxa_finalize@GLIBC_2.2.5' => 0,
                                                                        '__cxa_free_exception@CXXABI_1.3' => 0,
+                                                                       '__cxa_guard_abort@CXXABI_1.3' => 0,
+                                                                       '__cxa_guard_acquire@CXXABI_1.3' => 0,
+                                                                       '__cxa_guard_release@CXXABI_1.3' => 0,
+                                                                       '__cxa_pure_virtual@CXXABI_1.3' => 0,
+                                                                       '__cxa_rethrow@CXXABI_1.3' => 0,
                                                                        '__cxa_throw@CXXABI_1.3' => 0,
                                                                        '__gmon_start__' => 0,
                                                                        '__gxx_personality_v0@CXXABI_1.3' => 0,
+                                                                       '__pthread_key_create' => 0,
+                                                                       '__stack_chk_fail@GLIBC_2.4' => 0,
+                                                                       'pthread_mutex_lock@GLIBC_2.2.5' => 0,
+                                                                       'pthread_mutex_unlock@GLIBC_2.2.5' => 0,
                                                                        'setenv@GLIBC_2.2.5' => 0,
+                                                                       'strcmp@GLIBC_2.2.5' => 0,
                                                                        'unsetenv@GLIBC_2.2.5' => 0
                                                                      }
                                 },


### PR DESCRIPTION
The google_cloud_cpp_common library ABI has changed, and thus
we need to take a new snapshot of the ABI to receive accurate
reports in the future. I should have taken this snapshot as part
of #703 because I dropped symbols in that PR. In the future, once
the ABI checks start breaking the build this will not happen
anymore.