### PR TITLE
Refactor retry policy to google/cloud/internal.

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library(google_cloud_cpp_common
     internal/port_platform.h
     internal/random.h
     internal/random.cc
+    internal/retry_policy.h
     internal/setenv.h
     internal/setenv.cc
     internal/throw_delegate.h
@@ -90,6 +91,7 @@ google_cloud_cpp_add_clang_tidy(google_cloud_cpp_common)
 set(google_cloud_cpp_common_unit_tests
     internal/optional_test.cc
     internal/random_test.cc
+    internal/retry_policy_test.cc
     internal/throw_delegate_test.cc
     log_test.cc)
 

--- a/google/cloud/bigtable/internal/bulk_mutator.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator.cc
@@ -101,7 +101,7 @@ void BulkMutator::ProcessResponse(
     }
     auto& original = *mutations_.mutable_entries(index);
     // Failed responses are handled according to the current policies.
-    if (IsRetryableStatusCode(code) and annotation.is_idempotent) {
+    if (SafeGrpcRetry::IsTransientFailure(code) and annotation.is_idempotent) {
       // Retryable requests are saved in the pending mutations, along with the
       // mapping from their index in pending_mutations_ to the original
       // vector and other miscellanea.

--- a/google/cloud/bigtable/polling_policy.h
+++ b/google/cloud/bigtable/polling_policy.h
@@ -81,7 +81,7 @@ class GenericPollingPolicy : public PollingPolicy {
   }
 
   bool IsPermanentError(grpc::Status const& status) override {
-    return not rpc_retry_policy_.can_retry(status.error_code());
+    return RPCRetryPolicy::IsPermanentFailure(status);
   }
 
   bool OnFailure(grpc::Status const& status) override {

--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -115,8 +115,6 @@ class RetryPolicyMock : public bigtable::RPCRetryPolicy {
   bool on_failure(grpc::Status const& status) override {
     return on_failure_impl(status);
   }
-
-  bool can_retry(grpc::StatusCode code) const override { return true; }
 };
 
 class BackoffPolicyMock : public bigtable::RPCBackoffPolicy {

--- a/google/cloud/bigtable/rpc_retry_policy.cc
+++ b/google/cloud/bigtable/rpc_retry_policy.cc
@@ -35,10 +35,6 @@ std::unique_ptr<RPCRetryPolicy> DefaultRPCRetryPolicy() {
   return std::unique_ptr<RPCRetryPolicy>(new LimitedTimeRetryPolicy);
 }
 
-LimitedTimeRetryPolicy::LimitedTimeRetryPolicy()
-    : maximum_duration_(MAXIMUM_RETRY_PERIOD),
-      deadline_(std::chrono::system_clock::now() + maximum_duration_) {}
-
 std::unique_ptr<RPCRetryPolicy> LimitedErrorCountRetryPolicy::clone() const {
   return std::unique_ptr<RPCRetryPolicy>(
       new LimitedErrorCountRetryPolicy(*this));
@@ -48,38 +44,24 @@ void LimitedErrorCountRetryPolicy::setup(
     grpc::ClientContext& /*unused*/) const {}
 
 bool LimitedErrorCountRetryPolicy::on_failure(grpc::Status const& status) {
-  using namespace std::chrono;
-  if (not can_retry(status.error_code())) {
-    return false;
-  }
-  return ++failure_count_ <= maximum_failures_;
+  return impl_.OnFailure(status);
 }
 
-bool LimitedErrorCountRetryPolicy::can_retry(grpc::StatusCode code) const {
-  return IsRetryableStatusCode(code);
-}
+LimitedTimeRetryPolicy::LimitedTimeRetryPolicy()
+    : impl_(MAXIMUM_RETRY_PERIOD) {}
 
 std::unique_ptr<RPCRetryPolicy> LimitedTimeRetryPolicy::clone() const {
-  return std::unique_ptr<RPCRetryPolicy>(
-      new LimitedTimeRetryPolicy(maximum_duration_));
+  return std::unique_ptr<RPCRetryPolicy>(new LimitedTimeRetryPolicy(*this));
 }
 
 void LimitedTimeRetryPolicy::setup(grpc::ClientContext& context) const {
-  if (context.deadline() >= deadline_) {
-    context.set_deadline(deadline_);
+  if (context.deadline() >= impl_.deadline()) {
+    context.set_deadline(impl_.deadline());
   }
 }
 
 bool LimitedTimeRetryPolicy::on_failure(grpc::Status const& status) {
-  using namespace std::chrono;
-  if (not can_retry(status.error_code())) {
-    return false;
-  }
-  return std::chrono::system_clock::now() < deadline_;
-}
-
-bool LimitedTimeRetryPolicy::can_retry(grpc::StatusCode code) const {
-  return IsRetryableStatusCode(code);
+  return impl_.OnFailure(status);
 }
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/google/cloud/bigtable/rpc_retry_policy.h
+++ b/google/cloud/bigtable/rpc_retry_policy.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_RPC_RETRY_POLICY_H_
 
 #include "google/cloud/bigtable/version.h"
+#include "google/cloud/internal/retry_policy.h"
 #include <grpcpp/grpcpp.h>
 #include <chrono>
 #include <memory>
@@ -24,6 +25,25 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+/// An adapter to use `grpc::Status` with the `google::cloud::*Policies`.
+struct SafeGrpcRetry {
+  // Sometimes we need to use google::protobuf::rpc::Status, in which case this
+  // is a easier function
+  static inline bool IsTransientFailure(grpc::StatusCode code) {
+    return code == grpc::StatusCode::OK or code == grpc::StatusCode::ABORTED or
+           code == grpc::StatusCode::UNAVAILABLE or
+           code == grpc::StatusCode::DEADLINE_EXCEEDED;
+  }
+
+  static inline bool IsOkay(grpc::Status const& status) { return status.ok(); }
+  static inline bool IsTransientFailure(grpc::Status const& status) {
+    return IsTransientFailure(status.error_code());
+  }
+  static inline bool IsPermanentFailure(grpc::Status const& status) {
+    return not IsTransientFailure(status);
+  }
+};
+
 /**
  * Define the interface for controlling how the Bigtable client
  * retries RPC operations.
@@ -66,8 +86,9 @@ class RPCRetryPolicy {
    */
   virtual bool on_failure(grpc::Status const& status) = 0;
 
-  /// Return true if the status code is retryable.
-  virtual bool can_retry(grpc::StatusCode code) const = 0;
+  static bool IsPermanentFailure(grpc::Status const& status) {
+    return SafeGrpcRetry::IsPermanentFailure(status);
+  }
 };
 
 /// Return an instance of the default RPCRetryPolicy.
@@ -79,16 +100,17 @@ std::unique_ptr<RPCRetryPolicy> DefaultRPCRetryPolicy();
 class LimitedErrorCountRetryPolicy : public RPCRetryPolicy {
  public:
   explicit LimitedErrorCountRetryPolicy(int maximum_failures)
-      : failure_count_(0), maximum_failures_(maximum_failures) {}
+      : impl_(maximum_failures) {}
 
   std::unique_ptr<RPCRetryPolicy> clone() const override;
   void setup(grpc::ClientContext& context) const override;
   bool on_failure(grpc::Status const& status) override;
-  bool can_retry(grpc::StatusCode code) const override;
 
  private:
-  int failure_count_;
-  int maximum_failures_;
+  using Impl =
+      google::cloud::internal::LimitedErrorCountRetryPolicy<grpc::Status,
+                                                            SafeGrpcRetry>;
+  Impl impl_;
 };
 
 /**
@@ -99,27 +121,17 @@ class LimitedTimeRetryPolicy : public RPCRetryPolicy {
   LimitedTimeRetryPolicy();
   template <typename duration_t>
   explicit LimitedTimeRetryPolicy(duration_t maximum_duration)
-      : maximum_duration_(std::chrono::duration_cast<std::chrono::milliseconds>(
-            maximum_duration)),
-        deadline_(std::chrono::system_clock::now() + maximum_duration_) {}
+      : impl_(maximum_duration) {}
 
   std::unique_ptr<RPCRetryPolicy> clone() const override;
   void setup(grpc::ClientContext& context) const override;
   bool on_failure(grpc::Status const& status) override;
-  bool can_retry(grpc::StatusCode code) const override;
 
  private:
-  std::chrono::milliseconds maximum_duration_;
-  std::chrono::system_clock::time_point deadline_;
+  using Impl = google::cloud::internal::LimitedTimeRetryPolicy<grpc::Status,
+                                                               SafeGrpcRetry>;
+  Impl impl_;
 };
-
-/// The most common retryable codes, refactored because it is used in several
-/// places.
-constexpr bool IsRetryableStatusCode(grpc::StatusCode code) {
-  return code == grpc::StatusCode::OK or code == grpc::StatusCode::ABORTED or
-         code == grpc::StatusCode::UNAVAILABLE or
-         code == grpc::StatusCode::DEADLINE_EXCEEDED;
-}
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/google/cloud/bigtable/rpc_retry_policy.h
+++ b/google/cloud/bigtable/rpc_retry_policy.h
@@ -35,7 +35,7 @@ struct SafeGrpcRetry {
            code == grpc::StatusCode::DEADLINE_EXCEEDED;
   }
 
-  static inline bool IsOkay(grpc::Status const& status) { return status.ok(); }
+  static inline bool IsOk(grpc::Status const& status) { return status.ok(); }
   static inline bool IsTransientFailure(grpc::Status const& status) {
     return IsTransientFailure(status.error_code());
   }
@@ -59,6 +59,7 @@ struct SafeGrpcRetry {
  * prototype to create new RPCRetryPolicy objects of the same
  * (dynamic) type and with the same initial state.
  *
+ * TODO(#740) - fix the snake_case member function names.
  */
 class RPCRetryPolicy {
  public:

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -4,6 +4,7 @@ google_cloud_cpp_common_HDRS = [
     "internal/optional.h",
     "internal/port_platform.h",
     "internal/random.h",
+    "internal/retry_policy.h",
     "internal/setenv.h",
     "internal/throw_delegate.h",
     "log.h",

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -2,6 +2,7 @@
 google_cloud_cpp_common_unit_tests = [
     "internal/optional_test.cc",
     "internal/random_test.cc",
+    "internal/retry_policy_test.cc",
     "internal/throw_delegate_test.cc",
     "log_test.cc",
 ]

--- a/google/cloud/internal/retry_policy.h
+++ b/google/cloud/internal/retry_policy.h
@@ -1,0 +1,151 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_RETRY_POLICY_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_RETRY_POLICY_H_
+
+#include "google/cloud/version.h"
+#include <chrono>
+#include <memory>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+/**
+ * Define the interface for retry policies.
+ *
+ * @tparam StatusTypeParam the type used to represent success/failures.
+ * @tparam RetryablePolicyParam the policy to decide if status is retryable.
+ */
+template <typename StatusTypeParam, typename RetryablePolicyParam>
+class RetryPolicy {
+ public:
+  using StatusType = StatusTypeParam;
+  using RetryablePolicy = RetryablePolicyParam;
+
+  virtual ~RetryPolicy() = default;
+
+  virtual std::unique_ptr<RetryPolicy> clone() const = 0;
+
+  bool OnFailure(StatusType const& status) {
+    if (RetryablePolicy::IsPermanentFailure(status)) {
+      return false;
+    }
+    OnFailureImpl();
+    return not Exhausted();
+  }
+  virtual bool Exhausted() const = 0;
+
+ protected:
+  virtual void OnFailureImpl() = 0;
+};
+
+/**
+ * Implement a simple "count errors and then stop" retry policy.
+ */
+template <typename StatusTypeParam, typename RetryablePolicyParam>
+class LimitedErrorCountRetryPolicy
+    : public RetryPolicy<StatusTypeParam, RetryablePolicyParam> {
+ public:
+  using BaseType = RetryPolicy<StatusTypeParam, RetryablePolicyParam>;
+  using typename BaseType::RetryablePolicy;
+  using typename BaseType::StatusType;
+
+  explicit LimitedErrorCountRetryPolicy(int maximum_failures)
+      : failure_count_(0), maximum_failures_(maximum_failures) {}
+
+  LimitedErrorCountRetryPolicy(LimitedErrorCountRetryPolicy&& rhs) noexcept
+      : LimitedErrorCountRetryPolicy(rhs.maximum_failures_) {}
+  LimitedErrorCountRetryPolicy(LimitedErrorCountRetryPolicy const& rhs) noexcept
+      : LimitedErrorCountRetryPolicy(rhs.maximum_failures_) {}
+
+  std::unique_ptr<BaseType> clone() const override {
+    return std::unique_ptr<BaseType>(
+        new LimitedErrorCountRetryPolicy(maximum_failures_));
+  }
+  bool Exhausted() const override { return failure_count_ > maximum_failures_; }
+
+ protected:
+  void OnFailureImpl() override { ++failure_count_; }
+
+ private:
+  int failure_count_;
+  int maximum_failures_;
+};
+
+/**
+ * Implement a simple "keep trying for this time" retry policy.
+ */
+template <typename StatusTypeParam, typename RetryablePolicyParam>
+class LimitedTimeRetryPolicy
+    : public RetryPolicy<StatusTypeParam, RetryablePolicyParam> {
+ public:
+  using BaseType = RetryPolicy<StatusTypeParam, RetryablePolicyParam>;
+  using typename BaseType::RetryablePolicy;
+  using typename BaseType::StatusType;
+
+  /**
+   * Constructor given a `std::chrono::duration<>` object.
+   *
+   * @tparam DurationRep a placeholder to match the `Rep` tparam for @p
+   *     duration's type. The semantics of this template parameter are
+   *     documented in `std::chrono::duration<>` (in brief, the underlying
+   *     arithmetic type used to store the number of ticks), for our purposes it
+   *     is simply a formal parameter.
+   * @tparam DurationPeriod a placeholder to match the `Period` tparam for @p
+   *     duration's type. The semantics of this template parameter are
+   *     documented in `std::chrono::duration<>` (in brief, the length of the
+   *     tick in seconds, expressed as a `std::ratio<>`), for our purposes it is
+   *     simply a formal parameter.
+   * @param maximum_duration the maximum time allowed before the policy expires,
+   *     while the application can express this time in any units they desire,
+   *     the class truncates to milliseconds.
+   */
+  template <typename DurationRep, typename DurationPeriod>
+  explicit LimitedTimeRetryPolicy(
+      std::chrono::duration<DurationRep, DurationPeriod> maximum_duration)
+      : maximum_duration_(std::chrono::duration_cast<std::chrono::milliseconds>(
+            maximum_duration)),
+        deadline_(std::chrono::system_clock::now() + maximum_duration_) {}
+
+  LimitedTimeRetryPolicy(LimitedTimeRetryPolicy&& rhs) noexcept
+      : LimitedTimeRetryPolicy(rhs.maximum_duration_) {}
+  LimitedTimeRetryPolicy(LimitedTimeRetryPolicy const& rhs)
+      : LimitedTimeRetryPolicy(rhs.maximum_duration_) {}
+
+  std::unique_ptr<BaseType> clone() const override {
+    return std::unique_ptr<BaseType>(
+        new LimitedTimeRetryPolicy(maximum_duration_));
+  }
+  bool Exhausted() const override {
+    return std::chrono::system_clock::now() >= deadline_;
+  }
+
+  std::chrono::system_clock::time_point deadline() const { return deadline_; }
+
+ protected:
+  void OnFailureImpl() override {}
+
+ private:
+  std::chrono::milliseconds maximum_duration_;
+  std::chrono::system_clock::time_point deadline_;
+};
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_RETRY_POLICY_H_

--- a/google/cloud/internal/retry_policy.h
+++ b/google/cloud/internal/retry_policy.h
@@ -33,7 +33,6 @@ namespace internal {
 template <typename StatusType, typename RetryablePolicy>
 class RetryPolicy {
  public:
-
   virtual ~RetryPolicy() = default;
 
   virtual std::unique_ptr<RetryPolicy> clone() const = 0;
@@ -96,8 +95,7 @@ class LimitedErrorCountRetryPolicy
  *     permanent failure.
  */
 template <typename StatusType, typename RetryablePolicy>
-class LimitedTimeRetryPolicy
-    : public RetryPolicy<StatusType, RetryablePolicy> {
+class LimitedTimeRetryPolicy : public RetryPolicy<StatusType, RetryablePolicy> {
  public:
   using BaseType = RetryPolicy<StatusType, RetryablePolicy>;
 

--- a/google/cloud/internal/retry_policy_test.cc
+++ b/google/cloud/internal/retry_policy_test.cc
@@ -1,0 +1,126 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/retry_policy.h"
+#include <gmock/gmock.h>
+#include <thread>
+
+namespace {
+struct Status {
+  bool is_retryable;
+  bool is_ok;
+};
+struct IsRetryablePolicy {
+  static bool IsPermanentFailure(Status const& s) {
+    return s.is_ok or not s.is_retryable;
+  }
+};
+
+Status CreateTransientError() { return Status{true, false}; }
+Status CreatePermanentError() { return Status{false, false}; }
+
+using RetryPolicyForTest =
+    google::cloud::internal::RetryPolicy<Status, IsRetryablePolicy>;
+using LimitedTimeRetryPolicyForTest =
+    google::cloud::internal::LimitedTimeRetryPolicy<Status, IsRetryablePolicy>;
+using LimitedErrorCountRetryPolicyForTest =
+    google::cloud::internal::LimitedErrorCountRetryPolicy<Status,
+                                                          IsRetryablePolicy>;
+
+auto const kLimitedTimeTestPeriod = std::chrono::milliseconds(50);
+auto const kLimitedTimeTolerance = std::chrono::milliseconds(10);
+
+/**
+ * @test Verify that a retry policy configured to run for 50ms works correctly.
+ *
+ * This eliminates some amount of code duplication in the following tests.
+ */
+void CheckLimitedTime(RetryPolicyForTest& tested) {
+  auto start = std::chrono::system_clock::now();
+  // This is one of those tests that can get annoyingly flaky, it is based on
+  // time.  Basically we want to know that the policy will accept failures
+  // until around its prescribed deadline (50ms in this test).  Instead of
+  // measuring for *exactly* 50ms, we pass the test if:
+  //   - All calls to OnFailure() in the first 50ms - 10ms pass.
+  //   - Calls to OnFailure() after 50ms + 10ms are rejected.
+  //   - We do not care about the results from 40ms to 60ms.
+  // I know 10ms feels like a long time, but it is not on a loaded VM running
+  // the tests inside some container.
+  auto must_be_true_before =
+      start + kLimitedTimeTestPeriod - kLimitedTimeTolerance;
+  auto must_be_false_after =
+      start + kLimitedTimeTestPeriod + kLimitedTimeTolerance;
+  for (int i = 0; i != 100; ++i) {
+    auto actual = tested.OnFailure(CreateTransientError());
+    auto now = std::chrono::system_clock::now();
+    if (now < must_be_true_before) {
+      EXPECT_TRUE(actual);
+    } else if (must_be_false_after < now) {
+      EXPECT_FALSE(actual);
+      if (not actual) {
+        // Terminate the loop early if we can.
+        break;
+      }
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+}
+
+}  // anonymous namespace
+
+/// @test A simple test for the LimitedTimeRetryPolicy.
+TEST(LimitedTimeRetryPolicy, Simple) {
+  LimitedTimeRetryPolicyForTest tested(kLimitedTimeTestPeriod);
+  CheckLimitedTime(tested);
+}
+
+/// @test Test cloning for LimitedTimeRetryPolicy.
+TEST(LimitedTimeRetryPolicy, Clone) {
+  LimitedTimeRetryPolicyForTest original(kLimitedTimeTestPeriod);
+  auto cloned = original.clone();
+  CheckLimitedTime(*cloned);
+}
+
+/// @test Verify that non-retryable errors cause an immediate failure.
+TEST(LimitedTimeRetryPolicy, OnNonRetryable) {
+  LimitedTimeRetryPolicyForTest tested(std::chrono::milliseconds(10));
+  EXPECT_FALSE(tested.OnFailure(CreatePermanentError()));
+}
+
+/// @test A simple test for the LimitedErrorCountRetryPolicy.
+TEST(LimitedErrorCountRetryPolicy, Simple) {
+  LimitedErrorCountRetryPolicyForTest tested(3);
+  EXPECT_TRUE(tested.OnFailure(CreateTransientError()));
+  EXPECT_TRUE(tested.OnFailure(CreateTransientError()));
+  EXPECT_TRUE(tested.OnFailure(CreateTransientError()));
+  EXPECT_FALSE(tested.OnFailure(CreateTransientError()));
+  EXPECT_FALSE(tested.OnFailure(CreateTransientError()));
+}
+
+/// @test Test cloning for LimitedErrorCountRetryPolicy.
+TEST(LimitedErrorCountRetryPolicy, Clone) {
+  LimitedErrorCountRetryPolicyForTest original(3);
+  auto tested = original.clone();
+  EXPECT_TRUE(tested->OnFailure(CreateTransientError()));
+  EXPECT_TRUE(tested->OnFailure(CreateTransientError()));
+  EXPECT_TRUE(tested->OnFailure(CreateTransientError()));
+  EXPECT_FALSE(tested->OnFailure(CreateTransientError()));
+  EXPECT_FALSE(tested->OnFailure(CreateTransientError()));
+}
+
+/// @test Verify that non-retryable errors cause an immediate failure.
+TEST(LimitedErrorCountRetryPolicy, OnNonRetryable) {
+  LimitedErrorCountRetryPolicyForTest tested(3);
+  EXPECT_FALSE(tested.OnFailure(CreatePermanentError()));
+}


### PR DESCRIPTION
This is part of the fixes for #552. I think in a future change
I will also replace the retry policy interfaces in bigtable
(the new one is simpler), but I wanted a smaller change that
just showed the code moving to a central place.

I also kept the original tests in bigtable, though they are
now redundant, because I wanted to make sure this did
not break any of them.
