### PR TITLE
Switch Kokoro configuration to Bazel.

### DIFF
--- a/ci/kokoro/ubuntu/build.sh
+++ b/ci/kokoro/ubuntu/build.sh
@@ -82,6 +82,18 @@ bazel --bazelrc=/dev/null build \
 echo
 echo "================================================================"
 echo "================================================================"
+
+echo "DEBUG DEBUG DEBUG DO NOT MERGE"
+echo "================================================================"
+echo "================================================================"
+bazel info
+echo "================================================================"
+echo "================================================================"
+bazel info output_base
+ls -l "$(bazel info output_base)
+ls -l "$(bazel info output_base)/external
+ls -l "$(bazel info output_base)/external/com_github_grpc_grpc/
+echo "DEBUG DEBUG DEBUG DO NOT MERGE"
 export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$(bazel info output_base)/external/com_github_grpc_grpc/etc/roots.pem"
 # If this file does not exist gRPC blocks trying to connect, so it is better
 # to break the build early (the ls command breaks and the build stops) if that

--- a/ci/kokoro/ubuntu/build.sh
+++ b/ci/kokoro/ubuntu/build.sh
@@ -72,8 +72,7 @@ echo "================================================================"
 # integration tests. We have not figured out how to run the integration test
 # scripts with the more advanced bazelrc file (the artifacts go missing), so
 # build with very simple settings instead.
-bazel build \
-    --bazelrc=/dev/null \
+bazel --bazelrc=/dev/null build \
     --test_output=errors \
     --verbose_failures=true \
     --keep_going \

--- a/ci/kokoro/ubuntu/build.sh
+++ b/ci/kokoro/ubuntu/build.sh
@@ -83,28 +83,11 @@ echo
 echo "================================================================"
 echo "================================================================"
 
-echo "DEBUG DEBUG DEBUG DO NOT MERGE"
-echo "================================================================"
-echo "================================================================"
-bazel info
-echo "================================================================"
-echo "================================================================"
-bazel info output_base
-ls -l "$(bazel info output_base)
-ls -l "$(bazel info output_base)/external
-ls -l "$(bazel info output_base)/external/com_github_grpc_grpc/
-echo "DEBUG DEBUG DEBUG DO NOT MERGE"
-export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$(bazel info output_base)/external/com_github_grpc_grpc/etc/roots.pem"
-# If this file does not exist gRPC blocks trying to connect, so it is better
-# to break the build early (the ls command breaks and the build stops) if that
-# is the case.
-echo "GRPC_DEFAULT_SSL_ROOTS_FILE_PATH = ${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}"
-ls -l "$(dirname "${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}")"
-ls -l "${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}"
-
-export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/service-account.json"
-
 echo "Download dependencies for integration tests."
+# Download the gRPC roots.pem file, somewhere inside the bowels of Bazel this
+# file might exist, but my attempts and using it fail.
+echo "    Getting roots.pem for gRPC."
+wget -q https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem
 echo "    Getting cbt tool"
 export GOPATH="${KOKORO_ROOT}/golang"
 go get -u cloud.google.com/go/bigtable/cmd/cbt
@@ -112,6 +95,16 @@ go get -u cloud.google.com/go/bigtable/cmd/cbt
 # echo "    Getting python modules"
 # sudo python2 -m pip install httpbin
 echo "End of download."
+
+export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/service-account.json"
+export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$PWD/roots.pem"
+
+# If this file does not exist gRPC blocks trying to connect, so it is better
+# to break the build early (the ls command breaks and the build stops) if that
+# is the case.
+echo "GRPC_DEFAULT_SSL_ROOTS_FILE_PATH = ${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}"
+ls -l "$(dirname "${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}")"
+ls -l "${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}"
 
 echo
 echo "================================================================"

--- a/ci/kokoro/ubuntu/build.sh
+++ b/ci/kokoro/ubuntu/build.sh
@@ -39,7 +39,7 @@ build:results-local --experimental_remote_spawn_cache
 _EOF_
 
 # First build and run the unit tests.
-INVOCATION_ID="$(python -c 'import uuid; print uuid.uuid4()')"
+readonly INVOCATION_ID="$(python -c 'import uuid; print uuid.uuid4()')"
 echo "Configure and start Bazel: " ${INVOCATION_ID}
 echo "================================================================"
 echo "https://source.cloud.google.com/results/invocations/${INVOCATION_ID}"
@@ -84,8 +84,8 @@ echo "================================================================"
 echo "================================================================"
 
 echo "Download dependencies for integration tests."
-# Download the gRPC roots.pem file, somewhere inside the bowels of Bazel this
-# file might exist, but my attempts and using it fail.
+# Download the gRPC `roots.pem` file. Somewhere inside the bowels of Bazel, this
+# file might exist, but my attempts at using it have failed.
 echo "    Getting roots.pem for gRPC."
 wget -q https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem
 echo "    Getting cbt tool"

--- a/ci/kokoro/ubuntu/build.sh
+++ b/ci/kokoro/ubuntu/build.sh
@@ -71,8 +71,8 @@ echo "================================================================"
 # go last (and in a separate invocation) so Bazel state is preserved to run the
 # integration tests. We have not figured out how to run the integration test
 # scripts with the more advanced bazelrc file (the artifacts go missing), so
-# build with very simple settings instead.
-bazel --bazelrc=/dev/null build \
+# build with the default settings (whatever is in .bazelrc) instead.
+bazel build \
     --test_output=errors \
     --verbose_failures=true \
     --keep_going \

--- a/ci/kokoro/ubuntu/build.sh
+++ b/ci/kokoro/ubuntu/build.sh
@@ -16,36 +16,100 @@
 
 set -eu
 
-export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/service-account.json"
+echo "Reading CI secret configuration parameters."
 source "${KOKORO_GFILE_DIR}/test-configuration.sh"
-
-echo "Getting cbt tool"
-export GOPATH="${KOKORO_ROOT}/golang"
-go get -u cloud.google.com/go/bigtable/cmd/cbt
-
-echo "Getting python dependencies"
-sudo python2 -m pip install gunicorn httpbin
 
 echo "Running build and tests"
 cd "$(dirname $0)/../../.."
 readonly PROJECT_ROOT="${PWD}"
 
-git submodule update --init --recursive
-cmake -DCMAKE_BUILD_TYPE=Release -H. -Bbuild-output
-cmake --build build-output -- -j $(nproc)
 
-cd build-output
-ctest --output-on-failure
+cat >>kokoro-bazelrc <<_EOF_
+# Set flags for uploading to BES without Remote Build Execution.
+startup --host_jvm_args=-Dbazel.DigestFunction=SHA256
+build:results-local --remote_cache=remotebuildexecution.googleapis.com
+build:results-local --spawn_strategy=local
+build:results-local --remote_timeout=3600
+build:results-local --bes_backend="buildeventservice.googleapis.com"
+build:results-local --bes_best_effort=false
+build:results-local --bes_timeout=10m
+build:results-local --tls_enabled=true
+build:results-local --auth_enabled=true
+build:results-local --auth_scope=https://www.googleapis.com/auth/cloud-source-tools
+build:results-local --experimental_remote_spawn_cache
+_EOF_
 
-# The integration tests
-export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="${PROJECT_ROOT}/third_party/grpc/etc/roots.pem"
+# First build and run the unit tests.
+INVOCATION_ID="$(python -c 'import uuid; print uuid.uuid4()')"
+echo "Configure and start Bazel: " ${INVOCATION_ID}
+echo "================================================================"
+echo "    https://source.cloud.google.com/results/invocations/${INVOCATION_ID}"
+echo "================================================================"
+echo ${INVOCATION_ID} >> "${KOKORO_ARTIFACTS_DIR}/bazel_invocation_ids"
 
+bazel --bazelrc=kokoro-bazelrc test \
+    --test_output=errors \
+    --verbose_failures=true \
+    --keep_going \
+    --project_id=${KOKORO_PROJECT_ID} \
+    --auth_credentials="${KOKORO_GFILE_DIR}/build-results-service-account.json" \
+    --remote_instance_name="projects/${KOKORO_PROJECT_ID}" \
+    --invocation_id="${INVOCATION_ID}" \
+    --config=results-local \
+    -- //google/cloud/...:all
+
+echo
+echo "================================================================"
+echo "================================================================"
+echo "Copying artifacts"
+cp "$(bazel info output_base)/java.log" "${KOKORO_ARTIFACTS_DIR}/" || echo "java log copy failed."
+echo "End of copying."
+
+echo
+echo "================================================================"
+echo "================================================================"
+# Then build everything else (integration tests, examples, etc). This needs to
+# go last (and in a separate invocation) so Bazel state is preserved to run the
+# integration tests.
+bazel build \
+    --test_output=errors \
+    --verbose_failures=true \
+    --keep_going \
+    -- //google/cloud/...:all
+
+# The integration tests need further configuration and tools.
+echo
+echo "================================================================"
+echo "================================================================"
+export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$(bazel info output_base)/external/com_github_grpc_grpc/etc/roots.pem"
+export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/service-account.json"
+
+echo "Download dependencies for integration tests."
+echo "    Getting cbt tool"
+export GOPATH="${KOKORO_ROOT}/golang"
+go get -u cloud.google.com/go/bigtable/cmd/cbt
+# echo "    Getting python modules"
+# sudo python2 -m pip install httpbin
+echo "End of download."
+
+echo ROOTS PATH = ${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}
+
+ls -l ${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH} || echo "no roots file"
+ls -l $(dirname ${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}) || echo "no roots file dir"
+
+echo
+echo "================================================================"
+echo "================================================================"
 echo "Running Google Cloud Bigtable Integration Tests"
-(cd google/cloud/bigtable/tests && \
-    "${PROJECT_ROOT}/google/cloud/bigtable/tests/run_integration_tests_production.sh")
+(cd $(bazel info bazel-bin)/google/cloud/bigtable/tests && \
+   "${PROJECT_ROOT}/google/cloud/bigtable/tests/run_integration_tests_production.sh")
+(cd $(bazel info bazel-bin)/google/cloud/bigtable/tests && \
+   "${PROJECT_ROOT}/google/cloud/bigtable/examples/run_examples_production.sh")
 
 # TODO(#640) - disabled until we can get the credentials to work with key files.
 # echo "Running Google Cloud Storage Integration Tests"
-# (cd google/cloud/storage/tests && "${PROJECT_ROOT}/google/cloud/storage/tests/run_integration_tests_production.sh")
+# (cd $(bazel info bazel-bin)/google/cloud/storage/tests && \
+#     "${PROJECT_ROOT}/google/cloud/storage/tests/run_integration_tests_production.sh")
 # echo "Running Google Cloud Storage Examples"
-# (cd google/cloud/storage/examples && "${PROJECT_ROOT}/google/cloud/storage/examples/run_examples_production.sh")
+# (cd $(bazel info bazel-bin)/google/cloud/storage/examples && \
+#     "${PROJECT_ROOT}/google/cloud/storage/examples/run_examples_production.sh")

--- a/ci/kokoro/ubuntu/continuous.cfg
+++ b/ci/kokoro/ubuntu/continuous.cfg
@@ -18,3 +18,12 @@ timeout_mins: 20
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.sh"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"
+
+action {
+  define_artifacts {
+    regex: "**/test.xml"
+    regex: "**/*.log"
+    regex: "bazel_invocation_ids"
+  }
+}

--- a/ci/kokoro/ubuntu/presubmit.cfg
+++ b/ci/kokoro/ubuntu/presubmit.cfg
@@ -18,3 +18,12 @@ timeout_mins: 20
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.sh"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"
+
+action {
+  define_artifacts {
+    regex: "**/test.xml"
+    regex: "**/*.log"
+    regex: "bazel_invocation_ids"
+  }
+}


### PR DESCRIPTION
This fixes #642 (well this and a number of configuration changes).
We can grant access to the Kokoro logs to particular users (and 
eventually to all of the Internet).

This also free up a slot in the Travis build for more things we
cannot do in Kokoro, and also means we can upload the test results
to the ResultStore.

It also unblocks external projects (#518) for complicated reasons.

In summary, nothing major, but improves the CI a bit.
