### PR TITLE
Do not reuse cluster names in the example script.

### DIFF
--- a/google/cloud/bigtable/examples/run_examples_utils.sh
+++ b/google/cloud/bigtable/examples/run_examples_utils.sh
@@ -83,9 +83,6 @@ function run_all_instance_admin_examples {
   # Create a (very likely unique) instance name.
   local -r INSTANCE="in-$(date +%s)"
 
-  #Create a cluster name.
-  local -r CLUSTER="cluster2"
-
   echo
   echo "Run create-instance example."
   ${setenv} ../examples/bigtable_samples_instance_admin create-instance "${project_id}" "${INSTANCE}" "${zone_id}"
@@ -109,7 +106,8 @@ function run_all_instance_admin_examples {
 
   echo
   echo "Run create cluster example."
-  ${setenv} ../examples/bigtable_samples_instance_admin create-cluster "${project_id}" "${INSTANCE}" "${CLUSTER}"
+  ${setenv} ../examples/bigtable_samples_instance_admin create-cluster \
+      "${project_id}" "${INSTANCE}" "${INSTANCE}-c2"
 
   reset_trap
   echo


### PR DESCRIPTION
Reusing cluster names results in this error:

Cannot re-create cluster 'cluster2' in a different instance [6=ALREADY_EXISTS] -

Note that even changing the instance does not work, the cluster
name must be unique *even after it is deleted*.  This fixes that
problem and unblocks commits to the code.