### PR TITLE
storage::Client to storage::internal::RawClient.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -93,8 +93,6 @@ add_library(storage_client
     bucket.cc
     bucket_metadata.h
     bucket_metadata.cc
-    client.h
-    client.cc
     client_options.h
     client_options.cc
     credentials.h
@@ -117,6 +115,8 @@ add_library(storage_client
     internal/nljson.h
     internal/parse_rfc3339.h
     internal/parse_rfc3339.cc
+    internal/raw_client.h
+    internal/raw_client.cc
     internal/read_object_range_request.h
     internal/read_object_range_request.cc
     internal/request_parameters.h

--- a/google/cloud/storage/bucket.h
+++ b/google/cloud/storage/bucket.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BUCKET_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BUCKET_H_
 
-#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/internal/raw_client.h"
 
 namespace google {
 namespace cloud {
@@ -29,7 +29,7 @@ inline namespace STORAGE_CLIENT_NS {
 class Bucket {
  public:
   /// Create an object to access @p bucket_name.
-  Bucket(std::shared_ptr<Client> client, std::string bucket_name)
+  Bucket(std::shared_ptr<internal::RawClient> client, std::string bucket_name)
       : client_(std::move(client)), bucket_name_(std::move(bucket_name)) {
     ValidateBucketName(bucket_name_);
   }
@@ -90,7 +90,7 @@ class Bucket {
       internal::InsertObjectMediaRequest const& request);
 
  private:
-  std::shared_ptr<Client> client_;
+  std::shared_ptr<internal::RawClient> client_;
   std::string bucket_name_;
 };
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/internal/default_client.h
+++ b/google/cloud/storage/internal/default_client.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_DEFAULT_CLIENT_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_DEFAULT_CLIENT_H_
 
-#include "google/cloud/storage/client.h"
 #include "google/cloud/storage/internal/curl_request.h"
+#include "google/cloud/storage/internal/raw_client.h"
 
 namespace google {
 namespace cloud {
@@ -32,7 +32,7 @@ namespace internal {
  * TODO(#717) - document the CurlRequest interface as a concept.
  */
 template <typename HttpRequest = CurlRequest>
-class DefaultClient : public Client {
+class DefaultClient : public RawClient {
  public:
   explicit DefaultClient(std::shared_ptr<Credentials> credentials)
       : DefaultClient(ClientOptions(std::move(credentials))) {}

--- a/google/cloud/storage/internal/raw_client.cc
+++ b/google/cloud/storage/internal/raw_client.cc
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/storage/internal/default_client.h"
 
 namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-std::shared_ptr<Client> CreateDefaultClient(ClientOptions options) {
+std::shared_ptr<internal::RawClient> CreateDefaultClient(
+    ClientOptions options) {
   return std::make_shared<storage::internal::DefaultClient<>>(
       std::move(options));
 }

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_CLIENT_H_
-#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_CLIENT_H_
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_RAW_CLIENT_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_RAW_CLIENT_H_
 
 #include "google/cloud/storage/bucket_metadata.h"
 #include "google/cloud/storage/client_options.h"
@@ -29,30 +29,16 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
-// Forward declare RetryClient so we can make it a friend.  Cannot include
-// the file because that would create a loop.
-class RetryClient;
-}  // namespace internal
-
 /**
  * Define the interface used to communicate with Google Cloud Storage.
  *
  * This is a dependency injection point so higher-level abstractions (like
  * `storage::Bucket` or `storage::Object`) can be effectively tested.
  */
-class Client {
+class RawClient {
  public:
-  virtual ~Client() = default;
+  virtual ~RawClient() = default;
 
-  // The member functions of this class are not intended for general use by
-  // application developers (they are simply a dependency injection point). Make
-  // them protected, so the mock classes can override them, and then make the
-  // classes that do use them friends.
- protected:
-  friend class internal::RetryClient;
-  friend class Bucket;
-  friend class Object;
-  friend class ObjectReadStreamBuf;
   /**
    * Execute a request to fetch bucket metadata.
    *
@@ -68,22 +54,24 @@ class Client {
   ReadObjectRangeMedia(internal::ReadObjectRangeRequest const&) = 0;
 };
 
+}  // namespace internal
+
 /**
  * Create the default client type given the options.
  */
-std::shared_ptr<Client> CreateDefaultClient(ClientOptions options);
+std::shared_ptr<internal::RawClient> CreateDefaultClient(ClientOptions options);
 
 /**
  * Create the default client type with the default configuration.
  */
-inline std::shared_ptr<Client> CreateDefaultClient() {
+inline std::shared_ptr<internal::RawClient> CreateDefaultClient() {
   return CreateDefaultClient(ClientOptions());
 }
 
 /**
  * Create the default client type given the credentials.
  */
-inline std::shared_ptr<Client> CreateDefaultClient(
+inline std::shared_ptr<internal::RawClient> CreateDefaultClient(
     std::shared_ptr<Credentials> credentials) {
   return CreateDefaultClient(ClientOptions(std::move(credentials)));
 }
@@ -93,4 +81,4 @@ inline std::shared_ptr<Client> CreateDefaultClient(
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_CLIENT_H_
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_RAW_CLIENT_H_

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -43,7 +43,7 @@ struct RetryUtils {
    */
   template <typename Request, typename Response>
   using DesiredSignature = std::pair<google::cloud::storage::Status, Response> (
-      google::cloud::storage::Client::*)(Request const&);
+      google::cloud::storage::internal::RawClient::*)(Request const&);
 
   /**
    * Determine if @p T is a pointer to member function with the expected
@@ -103,7 +103,8 @@ struct RetryUtils {
       typename CheckSignature<MemberFunction>::ReturnType>::type
   MakeCall(google::cloud::storage::RetryPolicy& retry_policy,
            google::cloud::storage::BackoffPolicy& backoff_policy,
-           google::cloud::storage::Client& client, MemberFunction function,
+           google::cloud::storage::internal::RawClient& client,
+           MemberFunction function,
            typename CheckSignature<MemberFunction>::RequestType const& request,
            char const* error_message) {
     google::cloud::storage::Status last_status;
@@ -133,7 +134,7 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
-RetryClient::RetryClient(std::shared_ptr<Client> client)
+RetryClient::RetryClient(std::shared_ptr<RawClient> client)
     : RetryClient(
           std::move(client),
           google::cloud::internal::LimitedTimeRetryPolicy<Status, StatusTraits>(
@@ -148,7 +149,7 @@ std::pair<Status, BucketMetadata> RetryClient::GetBucketMetadata(
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
   return RetryUtils::MakeCall(*retry_policy, *backoff_policy, *client_,
-                              &Client::GetBucketMetadata, request, __func__);
+                              &RawClient::GetBucketMetadata, request, __func__);
 }
 
 std::pair<Status, ObjectMetadata> RetryClient::InsertObjectMedia(
@@ -156,7 +157,7 @@ std::pair<Status, ObjectMetadata> RetryClient::InsertObjectMedia(
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
   return RetryUtils::MakeCall(*retry_policy, *backoff_policy, *client_,
-                              &Client::InsertObjectMedia, request, __func__);
+                              &RawClient::InsertObjectMedia, request, __func__);
 }
 
 std::pair<Status, ReadObjectRangeResponse> RetryClient::ReadObjectRangeMedia(
@@ -164,7 +165,8 @@ std::pair<Status, ReadObjectRangeResponse> RetryClient::ReadObjectRangeMedia(
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
   return RetryUtils::MakeCall(*retry_policy, *backoff_policy, *client_,
-                              &Client::ReadObjectRangeMedia, request, __func__);
+                              &RawClient::ReadObjectRangeMedia, request,
+                              __func__);
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_RETRY_CLIENT_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_RETRY_CLIENT_H_
 
-#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/storage/retry_policy.h"
 
 namespace google {
@@ -26,19 +26,18 @@ namespace internal {
 /**
  * A decorator for `storage::Client` that retries operations using policies.
  */
-class RetryClient : public Client {
+class RetryClient : public RawClient {
  public:
-  RetryClient(std::shared_ptr<Client> client);
+  RetryClient(std::shared_ptr<RawClient> client);
 
   template <typename RetryPolicy, typename BackoffPolicy>
-  RetryClient(std::shared_ptr<Client> client, RetryPolicy retry_policy,
+  RetryClient(std::shared_ptr<RawClient> client, RetryPolicy retry_policy,
               BackoffPolicy backoff_policy)
       : client_(client),
         retry_policy_(retry_policy.clone()),
         backoff_policy_(backoff_policy.clone()) {}
   ~RetryClient() override = default;
 
- protected:
   std::pair<Status, BucketMetadata> GetBucketMetadata(
       internal::GetBucketMetadataRequest const& request) override;
 
@@ -49,7 +48,7 @@ class RetryClient : public Client {
       internal::ReadObjectRangeRequest const&) override;
 
  private:
-  std::shared_ptr<Client> client_;
+  std::shared_ptr<RawClient> client_;
   std::shared_ptr<RetryPolicy> retry_policy_;
   std::shared_ptr<BackoffPolicy> backoff_policy_;
 };

--- a/google/cloud/storage/object.h
+++ b/google/cloud/storage/object.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OBJECT_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OBJECT_H_
 
-#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/internal/raw_client.h"
 #include <string>
 
 namespace google {
@@ -30,7 +30,7 @@ inline namespace STORAGE_CLIENT_NS {
 class Object {
  public:
   /// Create an object to access @p bucket_name.
-  Object(std::shared_ptr<Client> client, std::string bucket_name,
+  Object(std::shared_ptr<internal::RawClient> client, std::string bucket_name,
          std::string object_name)
       : client_(std::move(client)),
         bucket_name_(std::move(bucket_name)),
@@ -43,7 +43,7 @@ class Object {
   std::string const& object_name() const { return object_name_; }
 
  private:
-  std::shared_ptr<Client> client_;
+  std::shared_ptr<internal::RawClient> client_;
   std::string bucket_name_;
   std::string object_name_;
 };

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OBJECT_STREAM_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OBJECT_STREAM_H_
 
-#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/internal/raw_client.h"
 #include <iostream>
 #include <string>
 
@@ -32,7 +32,7 @@ class ObjectReadStreamBuf : public std::basic_streambuf<char> {
     RepositionInputSequence();
   }
 
-  explicit ObjectReadStreamBuf(std::shared_ptr<Client> client,
+  explicit ObjectReadStreamBuf(std::shared_ptr<internal::RawClient> client,
                                internal::ReadObjectRangeRequest request)
       : std::basic_streambuf<char>(),
         client_(std::move(client)),
@@ -76,7 +76,7 @@ class ObjectReadStreamBuf : public std::basic_streambuf<char> {
   int_type RepositionInputSequence();
 
  private:
-  std::shared_ptr<Client> client_;
+  std::shared_ptr<internal::RawClient> client_;
   internal::ReadObjectRangeRequest request_;
   internal::ReadObjectRangeResponse response_;
 };
@@ -103,7 +103,7 @@ class ObjectReadStream : public std::basic_istream<char> {
    * @param request an initialized request to read data. If no range is
    *     specified in this request then this reads the full object.
    */
-  ObjectReadStream(std::shared_ptr<Client> client,
+  ObjectReadStream(std::shared_ptr<internal::RawClient> client,
                    internal::ReadObjectRangeRequest request)
       : std::basic_istream<char>(&buf_),
         buf_(std::move(client), std::move(request)) {}

--- a/google/cloud/storage/storage_client.bzl
+++ b/google/cloud/storage/storage_client.bzl
@@ -2,7 +2,6 @@
 storage_client_HDRS = [
     "bucket.h",
     "bucket_metadata.h",
-    "client.h",
     "client_options.h",
     "credentials.h",
     "internal/authorized_user_credentials.h",
@@ -17,6 +16,7 @@ storage_client_HDRS = [
     "internal/metadata_parser.h",
     "internal/nljson.h",
     "internal/parse_rfc3339.h",
+    "internal/raw_client.h",
     "internal/read_object_range_request.h",
     "internal/request_parameters.h",
     "internal/retry_client.h",
@@ -32,7 +32,6 @@ storage_client_HDRS = [
 storage_client_SRCS = [
     "bucket.cc",
     "bucket_metadata.cc",
-    "client.cc",
     "client_options.cc",
     "credentials.cc",
     "internal/common_metadata.cc",
@@ -41,6 +40,7 @@ storage_client_SRCS = [
     "internal/google_application_default_credentials_file.cc",
     "internal/metadata_parser.cc",
     "internal/parse_rfc3339.cc",
+    "internal/raw_client.cc",
     "internal/read_object_range_request.cc",
     "internal/retry_client.cc",
     "object.cc",

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_MOCK_CLIENT_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_MOCK_CLIENT_H_
 
-#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/internal/raw_client.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -23,13 +23,13 @@ namespace cloud {
 namespace storage {
 namespace testing {
 
-class MockClient : public storage::Client {
+class MockClient : public google::cloud::storage::internal::RawClient {
  public:
   // The MOCK_* macros get confused if the return type is a compound template
   // with a comma, that is because Foo<T,R> looks like two arguments to the
   // preprocessor, but Foo<R> will look like a single argument.
   template <typename R>
-  using ResponseWrapper = std::pair<storage::Status, R>;
+  using ResponseWrapper = std::pair<google::cloud::storage::Status, R>;
 
   MOCK_METHOD1(GetBucketMetadata,
                ResponseWrapper<storage::BucketMetadata>(


### PR DESCRIPTION
This is part of the work for #759. Note that because
RawClient is in the `internal` namespace we can
remove a lot of the `friend ...` declarations.

