### PR TITLE
consistent treatment of location id in CreateInstance and CreateCluster

### DIFF
--- a/google/cloud/bigtable/bigtable_strong_types.h
+++ b/google/cloud/bigtable/bigtable_strong_types.h
@@ -27,6 +27,8 @@ using ClusterId = internal::StrongType<std::string, struct ClusterTag>;
 using InstanceId = internal::StrongType<std::string, struct InstanceTag>;
 using SnapshotId = internal::StrongType<std::string, struct SnapshotTag>;
 using TableId = internal::StrongType<std::string, struct TableParam>;
+using ProjectId = internal::StrongType<std::string, struct ProjectTag>;
+using Zone = internal::StrongType<std::string, struct ZoneTag>;
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/google/cloud/bigtable/cluster_config.h
+++ b/google/cloud/bigtable/cluster_config.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_CLUSTER_CONFIG_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_CLUSTER_CONFIG_H_
 
+#include "google/cloud/bigtable/bigtable_strong_types.h"
 #include "google/cloud/bigtable/version.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin.pb.h>
 
@@ -34,9 +35,10 @@ class ClusterConfig {
   ClusterConfig(google::bigtable::admin::v2::Cluster cluster)
       : proto_(std::move(cluster)) {}
 
-  ClusterConfig(std::string location, std::int32_t serve_nodes,
+  ClusterConfig(ProjectId project_id, Zone zone, std::int32_t serve_nodes,
                 StorageType storage) {
-    proto_.set_location(std::move(location));
+    proto_.set_location("projects/" + project_id.get() + "/locations/" +
+                        zone.get());
     proto_.set_serve_nodes(serve_nodes);
     proto_.set_default_storage_type(storage);
   }

--- a/google/cloud/bigtable/cluster_config_test.cc
+++ b/google/cloud/bigtable/cluster_config_test.cc
@@ -18,17 +18,21 @@
 namespace bigtable = google::cloud::bigtable;
 
 TEST(ClusterConfigTest, Constructor) {
-  bigtable::ClusterConfig config("somewhere", 7, bigtable::ClusterConfig::SSD);
+  bigtable::ClusterConfig config(bigtable::ProjectId("some-project"),
+                                 bigtable::Zone("somewhere"), 7,
+                                 bigtable::ClusterConfig::SSD);
   auto proto = config.as_proto();
-  EXPECT_EQ("somewhere", proto.location());
+  EXPECT_EQ("projects/some-project/locations/somewhere", proto.location());
   EXPECT_EQ(7, proto.serve_nodes());
   EXPECT_EQ(bigtable::ClusterConfig::SSD, proto.default_storage_type());
 }
 
 TEST(ClusterConfigTest, Move) {
-  bigtable::ClusterConfig config("somewhere", 7, bigtable::ClusterConfig::HDD);
+  bigtable::ClusterConfig config(bigtable::ProjectId("some-project"),
+                                 bigtable::Zone("somewhere"), 7,
+                                 bigtable::ClusterConfig::HDD);
   auto proto = config.as_proto_move();
-  EXPECT_EQ("somewhere", proto.location());
+  EXPECT_EQ("projects/some-project/locations/somewhere", proto.location());
   EXPECT_EQ(7, proto.serve_nodes());
   EXPECT_EQ(bigtable::ClusterConfig::HDD, proto.default_storage_type());
 }

--- a/google/cloud/bigtable/examples/bigtable_samples_instance_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_samples_instance_admin.cc
@@ -59,7 +59,9 @@ void CreateInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
   google::cloud::bigtable::DisplayName display_name("Put description here");
   std::string cluster_id = instance_id + "-c1";
   auto cluster_config = google::cloud::bigtable::ClusterConfig(
-      zone, 3, google::cloud::bigtable::ClusterConfig::HDD);
+      google::cloud::bigtable::ProjectId(instance_admin.project_id()),
+      google::cloud::bigtable::Zone(zone), 3,
+      google::cloud::bigtable::ClusterConfig::HDD);
   google::cloud::bigtable::InstanceConfig config(
       google::cloud::bigtable::InstanceId(instance_id), display_name,
       {{cluster_id, cluster_config}});
@@ -147,10 +149,10 @@ void CreateCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
 
   google::cloud::bigtable::InstanceId instance_id(ConsumeArg(argc, argv));
   google::cloud::bigtable::ClusterId cluster_id(ConsumeArg(argc, argv));
-  auto location =
-      "projects/" + instance_admin.project_id() + "/locations/us-central1-a";
+  google::cloud::bigtable::Zone zone("us-central1-a");
   auto cluster_config = google::cloud::bigtable::ClusterConfig(
-      location, 3, google::cloud::bigtable::ClusterConfig::HDD);
+      google::cloud::bigtable::ProjectId(instance_admin.project_id()), zone, 3,
+      google::cloud::bigtable::ClusterConfig::HDD);
   auto cluster =
       instance_admin.CreateCluster(cluster_config, instance_id, cluster_id);
   std::cout << "Cluster Created " << cluster.get().name() << std::endl;
@@ -196,8 +198,11 @@ void UpdateCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
   // CreateCluster or GetCluster first and then modify it
   google::cloud::bigtable::InstanceId instance_id(ConsumeArg(argc, argv));
   google::cloud::bigtable::ClusterId cluster_id(ConsumeArg(argc, argv));
+  google::cloud::bigtable::Zone zone("us-central1-a");
+
   auto cluster_config = google::cloud::bigtable::ClusterConfig(
-      "us-central1-f", 0, google::cloud::bigtable::ClusterConfig::HDD);
+      google::cloud::bigtable::ProjectId(instance_admin.project_id()), zone, 0,
+      google::cloud::bigtable::ClusterConfig::HDD);
   auto cluster =
       instance_admin.CreateCluster(cluster_config, instance_id, cluster_id)
           .get();

--- a/google/cloud/bigtable/instance_admin.cc
+++ b/google/cloud/bigtable/instance_admin.cc
@@ -60,10 +60,6 @@ google::bigtable::admin::v2::Instance InstanceAdmin::CreateInstanceImpl(
   // Build the RPC request, try to minimize copying.
   auto request = instance_config.as_proto_move();
   request.set_parent(project_name());
-  for (auto& kv : *request.mutable_clusters()) {
-    kv.second.set_location(project_name() + "/locations/" +
-                           kv.second.location());
-  }
 
   using ClientUtils =
       bigtable::internal::noex::UnaryClientUtils<InstanceAdminClient>;

--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -307,7 +307,9 @@ TEST_F(InstanceAdminTest, CreateInstance) {
 
   auto future = tested.CreateInstance(bigtable::InstanceConfig(
       bigtable::InstanceId("test-instance"), bigtable::DisplayName("foo bar"),
-      {{"c1", {"a-zone", 3, bigtable::ClusterConfig::SSD}}}));
+      {{"c1",
+        {bigtable::ProjectId("my-project"), bigtable::Zone("a-zone"), 3,
+         bigtable::ClusterConfig::SSD}}}));
   auto actual = future.get();
 
   std::string delta;
@@ -351,7 +353,9 @@ TEST_F(InstanceAdminTest, CreateInstanceImmediatelyReady) {
 
   auto future = tested.CreateInstance(bigtable::InstanceConfig(
       bigtable::InstanceId("test-instance"), bigtable::DisplayName("foo bar"),
-      {{"c1", {"a-zone", 3, bigtable::ClusterConfig::SSD}}}));
+      {{"c1",
+        {bigtable::ProjectId("my-project"), bigtable::Zone("a-zone"), 3,
+         bigtable::ClusterConfig::SSD}}}));
   auto actual = future.get();
 
   std::string delta;
@@ -408,7 +412,9 @@ TEST_F(InstanceAdminTest, CreateInstancePollRecoverableFailures) {
 
   auto future = tested.CreateInstance(bigtable::InstanceConfig(
       bigtable::InstanceId("test-instance"), bigtable::DisplayName("foo bar"),
-      {{"c1", {"a-zone", 3, bigtable::ClusterConfig::SSD}}}));
+      {{"c1",
+        {bigtable::ProjectId("my-project"), bigtable::Zone("a-zone"), 3,
+         bigtable::ClusterConfig::SSD}}}));
   auto actual = future.get();
 
   std::string delta;
@@ -429,7 +435,9 @@ TEST_F(InstanceAdminTest, CreateInstanceRequestFailure) {
 
   auto future = tested.CreateInstance(bigtable::InstanceConfig(
       bigtable::InstanceId("test-instance"), bigtable::DisplayName("foo bar"),
-      {{"c1", {"a-zone", 3, bigtable::ClusterConfig::SSD}}}));
+      {{"c1",
+        {bigtable::ProjectId("my-project"), bigtable::Zone("a-zone"), 3,
+         bigtable::ClusterConfig::SSD}}}));
 
   EXPECT_THROW(future.get(), bigtable::GRpcError);
 }
@@ -454,7 +462,9 @@ TEST_F(InstanceAdminTest, CreateInstancePollUnrecoverableFailure) {
 
   auto future = tested.CreateInstance(bigtable::InstanceConfig(
       bigtable::InstanceId("test-instance"), bigtable::DisplayName("foo bar"),
-      {{"c1", {"a-zone", 3, bigtable::ClusterConfig::SSD}}}));
+      {{"c1",
+        {bigtable::ProjectId("my-project"), bigtable::Zone("a-zone"), 3,
+         bigtable::ClusterConfig::SSD}}}));
   EXPECT_THROW(future.get(), bigtable::GRpcError);
 }
 
@@ -500,7 +510,9 @@ TEST_F(InstanceAdminTest, CreateInstancePollReturnsFailure) {
 
   auto future = tested.CreateInstance(bigtable::InstanceConfig(
       bigtable::InstanceId("test-instance"), bigtable::DisplayName("foo bar"),
-      {{"c1", {"a-zone", 3, bigtable::ClusterConfig::SSD}}}));
+      {{"c1",
+        {bigtable::ProjectId("my-project"), bigtable::Zone("a-zone"), 3,
+         bigtable::ClusterConfig::SSD}}}));
   EXPECT_THROW(future.get(), bigtable::GRpcError);
 }
 
@@ -1105,7 +1117,7 @@ TEST_F(InstanceAdminTest, CreateCluster) {
 
   std::string expected_text = R"(
       name: 'projects/my-project/instances/test-instance'
-      location: 'Location1'
+      location: 'projects/my-project/locations/zone1'
       default_storage_type: SSD
   )";
 
@@ -1133,7 +1145,9 @@ TEST_F(InstanceAdminTest, CreateCluster) {
           }));
 
   auto future = tested.CreateCluster(
-      bigtable::ClusterConfig("Location1", 10, bigtable::ClusterConfig::SSD),
+      bigtable::ClusterConfig(bigtable::ProjectId("my-project"),
+                              bigtable::Zone("zone1"), 10,
+                              bigtable::ClusterConfig::SSD),
       bigtable::InstanceId("test-instance"),
       bigtable::ClusterId("other-cluster"));
 
@@ -1153,7 +1167,7 @@ TEST_F(InstanceAdminTest, CreateClusterImmediatelyReady) {
 
   std::string expected_text = R"(
       name: 'projects/my-project/instances/test-instance'
-      location: 'Location1'
+      location: 'projects/my-project/locations/zone1'
       default_storage_type: SSD
   )";
   btproto::Cluster expected;
@@ -1177,7 +1191,9 @@ TEST_F(InstanceAdminTest, CreateClusterImmediatelyReady) {
   EXPECT_CALL(*client_, GetOperation(_, _, _)).Times(0);
 
   auto future = tested.CreateCluster(
-      bigtable::ClusterConfig("Location1", 10, bigtable::ClusterConfig::SSD),
+      bigtable::ClusterConfig(bigtable::ProjectId("my-project"),
+                              bigtable::Zone("zone1"), 10,
+                              bigtable::ClusterConfig::SSD),
       bigtable::InstanceId("test-instance"),
       bigtable::ClusterId("other-cluster"));
   auto actual = future.get();
@@ -1206,7 +1222,7 @@ TEST_F(InstanceAdminTest, CreateClusterPollRecoverableFailures) {
 
   std::string expected_text = R"(
       name: 'projects/my-project/instances/test-instance'
-      location: 'Location1'
+      location: 'projects/my-project/locations/zone1'
       default_storage_type: SSD
   )";
 
@@ -1239,7 +1255,9 @@ TEST_F(InstanceAdminTest, CreateClusterPollRecoverableFailures) {
           }));
 
   auto future = tested.CreateCluster(
-      bigtable::ClusterConfig("Location1", 10, bigtable::ClusterConfig::SSD),
+      bigtable::ClusterConfig(bigtable::ProjectId("my-project"),
+                              bigtable::Zone("zone1"), 10,
+                              bigtable::ClusterConfig::SSD),
       bigtable::InstanceId("test-instance"),
       bigtable::ClusterId("other-cluster"));
   auto actual = future.get();
@@ -1267,7 +1285,7 @@ TEST_F(InstanceAdminTest, UpdateCluster) {
 
   std::string expected_text = R"(
       name: 'projects/my-project/instances/test-instance/clusters/test-cluster'
-      location: 'Location1'
+      location: 'projects/my-project/locations/zone1'
       state: READY
       serve_nodes: 0
       default_storage_type: SSD
@@ -1325,7 +1343,7 @@ TEST_F(InstanceAdminTest, UpdateClusterImmediatelyReady) {
 
   std::string expected_text = R"(
       name: 'projects/my-project/instances/test-instance/clusters/test-cluster'
-      location: 'Location1'
+      location: 'projects/my-project/locations/zone1'
       state: READY
       serve_nodes: 0
       default_storage_type: SSD
@@ -1382,7 +1400,7 @@ TEST_F(InstanceAdminTest, UpdateClusterPollRecoverableFailures) {
 
   std::string expected_text = R"(
       name: 'projects/my-project/instances/test-instance/clusters/test-cluster'
-      location: 'Location1'
+      location: 'projects/my-project/locations/zone1'
       state: READY
       serve_nodes: 0
       default_storage_type: SSD

--- a/google/cloud/bigtable/instance_config_test.cc
+++ b/google/cloud/bigtable/instance_config_test.cc
@@ -20,13 +20,15 @@ namespace bigtable = google::cloud::bigtable;
 TEST(InstanceConfigTest, Constructor) {
   bigtable::InstanceConfig config(
       bigtable::InstanceId("my-instance"), bigtable::DisplayName("pretty name"),
-      {{"my-cluster", {"somewhere", 7, bigtable::ClusterConfig::SSD}}});
+      {{"my-cluster",
+        {bigtable::ProjectId("my-project"), bigtable::Zone("somewhere"), 7,
+         bigtable::ClusterConfig::SSD}}});
   auto proto = config.as_proto();
   EXPECT_EQ("my-instance", proto.instance_id());
   EXPECT_EQ("pretty name", proto.instance().display_name());
   ASSERT_EQ(1, proto.clusters_size());
   auto cluster = proto.clusters().at("my-cluster");
-  EXPECT_EQ("somewhere", cluster.location());
+  EXPECT_EQ("projects/my-project/locations/somewhere", cluster.location());
   EXPECT_EQ(7, cluster.serve_nodes());
   EXPECT_EQ(bigtable::ClusterConfig::SSD, cluster.default_storage_type());
 }
@@ -35,9 +37,15 @@ TEST(InstanceConfigTest, ConstructorManyClusters) {
   bigtable::InstanceConfig config(
       bigtable::InstanceId("my-instance"), bigtable::DisplayName("pretty name"),
       {
-          {"cluster-1", {"somewhere", 7, bigtable::ClusterConfig::SSD}},
-          {"cluster-2", {"elsewhere", 7, bigtable::ClusterConfig::HDD}},
-          {"cluster-3", {"nowhere", 17, bigtable::ClusterConfig::HDD}},
+          {"cluster-1",
+           {bigtable::ProjectId("my-project"), bigtable::Zone("somewhere"), 7,
+            bigtable::ClusterConfig::SSD}},
+          {"cluster-2",
+           {bigtable::ProjectId("my-project"), bigtable::Zone("elsewhere"), 7,
+            bigtable::ClusterConfig::HDD}},
+          {"cluster-3",
+           {bigtable::ProjectId("my-project"), bigtable::Zone("nowhere"), 17,
+            bigtable::ClusterConfig::HDD}},
       });
   auto proto = config.as_proto();
   EXPECT_EQ("my-instance", proto.instance_id());
@@ -45,12 +53,12 @@ TEST(InstanceConfigTest, ConstructorManyClusters) {
   ASSERT_EQ(3, proto.clusters_size());
 
   auto c1 = proto.clusters().at("cluster-1");
-  EXPECT_EQ("somewhere", c1.location());
+  EXPECT_EQ("projects/my-project/locations/somewhere", c1.location());
   EXPECT_EQ(7, c1.serve_nodes());
   EXPECT_EQ(bigtable::ClusterConfig::SSD, c1.default_storage_type());
 
   auto c3 = proto.clusters().at("cluster-3");
-  EXPECT_EQ("nowhere", c3.location());
+  EXPECT_EQ("projects/my-project/locations/nowhere", c3.location());
   EXPECT_EQ(17, c3.serve_nodes());
   EXPECT_EQ(bigtable::ClusterConfig::HDD, c3.default_storage_type());
 }
@@ -59,7 +67,9 @@ TEST(InstanceConfigTest, SetLabels) {
   bigtable::InstanceConfig config(
       bigtable::InstanceId("my-instance"), bigtable::DisplayName("pretty name"),
       {
-          {"cluster-1", {"somewhere", 7, bigtable::ClusterConfig::SSD}},
+          {"cluster-1",
+           {bigtable::ProjectId("my-project"), bigtable::Zone("somewhere"), 7,
+            bigtable::ClusterConfig::SSD}},
       });
 
   config.insert_label("foo", "bar").emplace_label("baz", "qux");

--- a/google/cloud/bigtable/tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_integration_test.cc
@@ -72,14 +72,16 @@ bool IsClusterPresent(std::vector<btadmin::Cluster> const& clusters,
 }
 
 bigtable::InstanceConfig IntegrationTestConfig(
-    std::string const& id, std::string const& zone = "us-central1-f",
+    std::string const& id, std::string const& zone_id = "us-central1-f",
     bigtable::InstanceConfig::InstanceType instance_type =
         bigtable::InstanceConfig::DEVELOPMENT,
     int32_t serve_node = 0) {
+  bigtable::ProjectId project_id(InstanceTestEnvironment::project_id());
   bigtable::InstanceId instance_id(id);
+  bigtable::Zone zone(zone_id);
   bigtable::DisplayName display_name("Integration Tests " + id);
-  auto cluster_config =
-      bigtable::ClusterConfig(zone, serve_node, bigtable::ClusterConfig::HDD);
+  auto cluster_config = bigtable::ClusterConfig(project_id, zone, serve_node,
+                                                bigtable::ClusterConfig::HDD);
   bigtable::InstanceConfig config(instance_id, display_name,
                                   {{id + "-c1", cluster_config}});
   config.set_type(instance_type);
@@ -205,10 +207,11 @@ TEST_F(InstanceAdminIntegrationTest, CreateClusterTest) {
       instance_admin_->CreateInstance(instance_config).get();
   auto clusters_before = instance_admin_->ListClusters(id);
   bigtable::ClusterId cluster_id(id + "-cl2");
-  auto location =
-      "projects/" + instance_admin_->project_id() + "/locations/us-central1-b";
-  auto cluster_config =
-      bigtable::ClusterConfig(location, 3, bigtable::ClusterConfig::HDD);
+  bigtable::ProjectId project_id(instance_admin_->project_id());
+  bigtable::Zone zone("us-central1-b");
+
+  auto cluster_config = bigtable::ClusterConfig(project_id, zone, 3,
+                                                bigtable::ClusterConfig::HDD);
   auto cluster =
       instance_admin_->CreateCluster(cluster_config, instance_id, cluster_id)
           .get();
@@ -283,10 +286,11 @@ TEST_F(InstanceAdminIntegrationTest, UpdateClusterTest) {
   auto clusters_before = instance_admin_->ListClusters(id);
 
   bigtable::ClusterId another_cluster_id(id + "-cl2");
-  auto location =
-      "projects/" + instance_admin_->project_id() + "/locations/us-central1-b";
-  auto cluster_config =
-      bigtable::ClusterConfig(location, 3, bigtable::ClusterConfig::HDD);
+  bigtable::ProjectId project_id(instance_admin_->project_id());
+  bigtable::Zone zone("us-central1-b");
+
+  auto cluster_config = bigtable::ClusterConfig(project_id, zone, 3,
+                                                bigtable::ClusterConfig::HDD);
   auto cluster_before =
       instance_admin_
           ->CreateCluster(cluster_config, instance_id, another_cluster_id)
@@ -322,15 +326,18 @@ TEST_F(InstanceAdminIntegrationTest, GetClusterTest) {
   bigtable::ClusterId cluster_id1(id + "-cl1");
   bigtable::ClusterId cluster_id2(id + "-cl2");
   bigtable::DisplayName display_name(id);
+  bigtable::ProjectId project_id(instance_admin_->project_id());
+  bigtable::Zone zone1("us-central1-f");
+  bigtable::Zone zone2("us-central1-b");
 
   std::vector<std::pair<std::string, bigtable::ClusterConfig>> clusters_config;
   clusters_config.push_back(
       std::make_pair(cluster_id1.get(),
-                     bigtable::ClusterConfig("us-central1-f", 3,
+                     bigtable::ClusterConfig(project_id, zone1, 3,
                                              bigtable::ClusterConfig::HDD)));
   clusters_config.push_back(
       std::make_pair(cluster_id2.get(),
-                     bigtable::ClusterConfig("us-central1-b", 3,
+                     bigtable::ClusterConfig(project_id, zone2, 3,
                                              bigtable::ClusterConfig::HDD)));
   auto instance_config =
       bigtable::InstanceConfig(instance_id, display_name, clusters_config)
@@ -358,15 +365,18 @@ TEST_F(InstanceAdminIntegrationTest, DeleteClustersTest) {
   bigtable::ClusterId cluster_id1(id + "-cl1");
   bigtable::ClusterId cluster_id2(id + "-cl2");
   bigtable::DisplayName display_name(id);
+  bigtable::ProjectId project_id(instance_admin_->project_id());
+  bigtable::Zone zone1("us-central1-f");
+  bigtable::Zone zone2("us-central1-b");
 
   std::vector<std::pair<std::string, bigtable::ClusterConfig>> clusters_config;
   clusters_config.push_back(
       std::make_pair(cluster_id1.get(),
-                     bigtable::ClusterConfig("us-central1-f", 3,
+                     bigtable::ClusterConfig(project_id, zone1, 3,
                                              bigtable::ClusterConfig::HDD)));
   clusters_config.push_back(
       std::make_pair(cluster_id2.get(),
-                     bigtable::ClusterConfig("us-central1-b", 3,
+                     bigtable::ClusterConfig(project_id, zone2, 3,
                                              bigtable::ClusterConfig::HDD)));
   auto instance_config =
       bigtable::InstanceConfig(instance_id, display_name, clusters_config)


### PR DESCRIPTION
added project_id and zone to cluster_config and made it more responsible.