### PR TITLE
CreateCluster now takes only location id instread of full path

### DIFF
--- a/google/cloud/bigtable/examples/bigtable_samples_instance_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_samples_instance_admin.cc
@@ -147,8 +147,7 @@ void CreateCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
 
   google::cloud::bigtable::InstanceId instance_id(ConsumeArg(argc, argv));
   google::cloud::bigtable::ClusterId cluster_id(ConsumeArg(argc, argv));
-  auto location =
-      "projects/" + instance_admin.project_id() + "/locations/us-central1-a";
+  auto location = "us-central1-a";
   auto cluster_config = google::cloud::bigtable::ClusterConfig(
       location, 3, google::cloud::bigtable::ClusterConfig::HDD);
   auto cluster =

--- a/google/cloud/bigtable/instance_admin.cc
+++ b/google/cloud/bigtable/instance_admin.cc
@@ -314,6 +314,8 @@ google::bigtable::admin::v2::Cluster InstanceAdmin::CreateClusterImpl(
 
   // Build the RPC request, try to minimize copying.
   auto cluster = cluster_config.as_proto_move();
+  cluster.set_location(project_name() + "/locations/" + cluster.location());
+
   btproto::CreateClusterRequest request;
   request.mutable_cluster()->Swap(&cluster);
   request.set_parent(project_name() + "/instances/" + instance_id.get());

--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -1105,7 +1105,7 @@ TEST_F(InstanceAdminTest, CreateCluster) {
 
   std::string expected_text = R"(
       name: 'projects/my-project/instances/test-instance'
-      location: 'Location1'
+      location: 'projects/my-project/locations/fake-zone'
       default_storage_type: SSD
   )";
 
@@ -1133,7 +1133,7 @@ TEST_F(InstanceAdminTest, CreateCluster) {
           }));
 
   auto future = tested.CreateCluster(
-      bigtable::ClusterConfig("Location1", 10, bigtable::ClusterConfig::SSD),
+      bigtable::ClusterConfig("fake-zone", 10, bigtable::ClusterConfig::SSD),
       bigtable::InstanceId("test-instance"),
       bigtable::ClusterId("other-cluster"));
 
@@ -1153,7 +1153,7 @@ TEST_F(InstanceAdminTest, CreateClusterImmediatelyReady) {
 
   std::string expected_text = R"(
       name: 'projects/my-project/instances/test-instance'
-      location: 'Location1'
+      location: 'projects/my-project/locations/fake-zone'
       default_storage_type: SSD
   )";
   btproto::Cluster expected;
@@ -1177,7 +1177,7 @@ TEST_F(InstanceAdminTest, CreateClusterImmediatelyReady) {
   EXPECT_CALL(*client_, GetOperation(_, _, _)).Times(0);
 
   auto future = tested.CreateCluster(
-      bigtable::ClusterConfig("Location1", 10, bigtable::ClusterConfig::SSD),
+      bigtable::ClusterConfig("fake-zone", 10, bigtable::ClusterConfig::SSD),
       bigtable::InstanceId("test-instance"),
       bigtable::ClusterId("other-cluster"));
   auto actual = future.get();
@@ -1206,7 +1206,7 @@ TEST_F(InstanceAdminTest, CreateClusterPollRecoverableFailures) {
 
   std::string expected_text = R"(
       name: 'projects/my-project/instances/test-instance'
-      location: 'Location1'
+      location: 'projects/my-project/locations/fake-zone'
       default_storage_type: SSD
   )";
 
@@ -1239,7 +1239,7 @@ TEST_F(InstanceAdminTest, CreateClusterPollRecoverableFailures) {
           }));
 
   auto future = tested.CreateCluster(
-      bigtable::ClusterConfig("Location1", 10, bigtable::ClusterConfig::SSD),
+      bigtable::ClusterConfig("fake-zone", 10, bigtable::ClusterConfig::SSD),
       bigtable::InstanceId("test-instance"),
       bigtable::ClusterId("other-cluster"));
   auto actual = future.get();

--- a/google/cloud/bigtable/tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_integration_test.cc
@@ -205,8 +205,7 @@ TEST_F(InstanceAdminIntegrationTest, CreateClusterTest) {
       instance_admin_->CreateInstance(instance_config).get();
   auto clusters_before = instance_admin_->ListClusters(id);
   bigtable::ClusterId cluster_id(id + "-cl2");
-  auto location =
-      "projects/" + instance_admin_->project_id() + "/locations/us-central1-b";
+  auto location = "us-central1-b";
   auto cluster_config =
       bigtable::ClusterConfig(location, 3, bigtable::ClusterConfig::HDD);
   auto cluster =
@@ -283,8 +282,7 @@ TEST_F(InstanceAdminIntegrationTest, UpdateClusterTest) {
   auto clusters_before = instance_admin_->ListClusters(id);
 
   bigtable::ClusterId another_cluster_id(id + "-cl2");
-  auto location =
-      "projects/" + instance_admin_->project_id() + "/locations/us-central1-b";
+  auto location = "us-central1-b";
   auto cluster_config =
       bigtable::ClusterConfig(location, 3, bigtable::ClusterConfig::HDD);
   auto cluster_before =


### PR DESCRIPTION
modified `InstanceAdmin::CreateCluster` to build the appropriate location path before grpc call.  