### PR TITLE
Enable GCS integration tests in Kokoro.

### DIFF
--- a/ci/kokoro/ubuntu/build.sh
+++ b/ci/kokoro/ubuntu/build.sh
@@ -91,9 +91,6 @@ wget -q https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem
 echo "    Getting cbt tool"
 export GOPATH="${KOKORO_ROOT}/golang"
 go get -u cloud.google.com/go/bigtable/cmd/cbt
-# TODO(#640) - disabled, the GCS library does not support credential files yet.
-# echo "    Getting python modules"
-# sudo python2 -m pip install httpbin
 echo "End of download."
 
 export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/service-account.json"
@@ -116,10 +113,9 @@ echo "Running Google Cloud Bigtable Integration Tests"
 (cd $(bazel info bazel-bin)/google/cloud/bigtable/tests && \
    "${PROJECT_ROOT}/google/cloud/bigtable/examples/run_examples_production.sh")
 
-# TODO(#640) - disabled, the GCS library does not support credential files yet.
-# echo "Running Google Cloud Storage Integration Tests"
-# (cd $(bazel info bazel-bin)/google/cloud/storage/tests && \
-#     "${PROJECT_ROOT}/google/cloud/storage/tests/run_integration_tests_production.sh")
-# echo "Running Google Cloud Storage Examples"
-# (cd $(bazel info bazel-bin)/google/cloud/storage/examples && \
-#     "${PROJECT_ROOT}/google/cloud/storage/examples/run_examples_production.sh")
+echo "Running Google Cloud Storage Integration Tests"
+(cd $(bazel info bazel-bin)/google/cloud/storage/tests && \
+    "${PROJECT_ROOT}/google/cloud/storage/tests/run_integration_tests_production.sh")
+echo "Running Google Cloud Storage Examples"
+(cd $(bazel info bazel-bin)/google/cloud/storage/examples && \
+    "${PROJECT_ROOT}/google/cloud/storage/examples/run_examples_production.sh")

--- a/google/cloud/storage/examples/BUILD
+++ b/google/cloud/storage/examples/BUILD
@@ -20,3 +20,9 @@ cc_binary(
     srcs=["storage_bucket_samples.cc"],
     deps=["//google/cloud/storage:storage_client"],
 )
+
+cc_binary(
+    name="storage_object_samples",
+    srcs=["storage_object_samples.cc"],
+    deps=["//google/cloud/storage:storage_client"],
+)

--- a/google/cloud/storage/internal/default_client.h
+++ b/google/cloud/storage/internal/default_client.h
@@ -126,7 +126,6 @@ class DefaultClient : public RawClient {
           Status{payload.status_code, std::move(payload.payload)},
           internal::ListObjectsResponse{});
     }
-    std::cerr << __func__ << "\n" << payload.payload << std::endl;
     return std::make_pair(
         Status(),
         internal::ListObjectsResponse::FromHttpResponse(std::move(payload)));

--- a/google/cloud/storage/tests/BUILD
+++ b/google/cloud/storage/tests/BUILD
@@ -15,9 +15,12 @@
 package(default_visibility=["//visibility:public"])
 licenses(["notice"])  # Apache 2.0
 
-cc_binary(
-    name="bucket_integration_test",
-    srcs=["bucket_integration_test.cc"],
+load(":storage_client_integration_tests.bzl",
+    "storage_client_integration_tests")
+
+[cc_binary(
+    name=test.replace('/', '_').replace('.cc', ''),
+    srcs=[test],
     deps=[
         "//google/cloud/storage:storage_client",
         "//google/cloud:google_cloud_cpp_common",
@@ -26,4 +29,4 @@ cc_binary(
     ],
     # TODO(#664 / #666) - use the right condition when porting Bazel builds
     linkopts = [ "-lpthread" ],
-)
+) for test in storage_client_integration_tests]

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -30,3 +30,7 @@ foreach (fname ${storage_client_integration_tests})
             nlohmann_json
             storage_common_options)
 endforeach ()
+
+include(CreateBazelConfig)
+export_list_to_bazel("storage_client_integration_tests.bzl"
+    "storage_client_integration_tests")

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -1,0 +1,7 @@
+# DO NOT EDIT -- GENERATED CODE
+storage_client_integration_tests = [
+    "bucket_integration_test.cc",
+    "curl_request_integration_test.cc",
+    "object_integration_test.cc",
+]
+


### PR DESCRIPTION
Had to actually compile some of the integration tests with Bazel,
and cleanup the unnecessary debug output from the library too.
This fixes #640.

@mfschwartz since Matt is OOO, I do need your review on this one.
