### PR TITLE
Add unit test for GoogleDefaultCredentials.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -193,7 +193,6 @@ create_bazel_config(storage_client_testing)
 set(storage_client_unit_tests
     bucket_metadata_test.cc
     bucket_test.cc
-    storage_client_options_test.cc
     internal/authorized_user_credentials_test.cc
     internal/binary_data_as_debug_string_test.cc
     internal/default_client_test.cc
@@ -211,6 +210,7 @@ set(storage_client_unit_tests
     object_metadata_test.cc
     object_stream_test.cc
     retry_policy_test.cc
+    storage_client_options_test.cc
     link_test.cc)
 
 foreach (fname ${storage_client_unit_tests})

--- a/google/cloud/storage/credentials_test.cc
+++ b/google/cloud/storage/credentials_test.cc
@@ -1,0 +1,95 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/credentials.h"
+#include "google/cloud/internal/setenv.h"
+#include "google/cloud/storage/internal/authorized_user_credentials.h"
+#include "google/cloud/storage/internal/service_account_credentials.h"
+#include "google/cloud/testing_util/environment_variable_restore.h"
+#include <gmock/gmock.h>
+#include <fstream>
+#include <typeinfo>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+
+char const VAR_NAME[] = "GOOGLE_APPLICATION_CREDENTIALS";
+
+class CredentialsTest : public ::testing::Test {
+ protected:
+  void SetUp() override { env_.SetUp(); }
+  void TearDown() override { env_.TearDown(); }
+
+ private:
+  testing_util::EnvironmentVariableRestore env_ =
+      testing_util::EnvironmentVariableRestore(VAR_NAME);
+};
+
+TEST_F(CredentialsTest, Insecure) {
+  InsecureCredentials credentials;
+  EXPECT_EQ("", credentials.AuthorizationHeader());
+}
+
+TEST_F(CredentialsTest, LoadAuthorizedUser) {
+  char const filename[] = "authorized-user.json";
+  std::ofstream os(filename);
+  os << R"""({
+  "client_id": "test-invalid-test-invalid.apps.googleusercontent.com",
+  "client_secret": "invalid-invalid-invalid",
+  "refresh_token": "1/test-test-test",
+  "type": "authorized_user"
+})""";
+  os.close();
+  google::cloud::internal::SetEnv(VAR_NAME, filename);
+
+  // Need to create a temporary for the pointer because clang-tidy warns about
+  // using expressions with (potential) side-effects inside typeid().
+  auto credentials = GoogleDefaultCredentials();
+  auto ptr = credentials.get();
+  EXPECT_EQ(typeid(*ptr), typeid(internal::AuthorizedUserCredentials<>));
+}
+
+TEST_F(CredentialsTest, LoadServiceAccount) {
+  char const filename[] = "service-account.json";
+  std::ofstream os(filename);
+  os << R"""({
+    "type": "service_account",
+    "project_id": "foo-project",
+    "private_key_id": "a1a111aa1111a11a11a11aa111a111a1a1111111",
+    "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCltiF2oP3KJJ+S\ntTc1McylY+TuAi3AdohX7mmqIjd8a3eBYDHs7FlnUrFC4CRijCr0rUqYfg2pmk4a\n6TaKbQRAhWDJ7XD931g7EBvCtd8+JQBNWVKnP9ByJUaO0hWVniM50KTsWtyX3up/\nfS0W2R8Cyx4yvasE8QHH8gnNGtr94iiORDC7De2BwHi/iU8FxMVJAIyDLNfyk0hN\neheYKfIDBgJV2v6VaCOGWaZyEuD0FJ6wFeLybFBwibrLIBE5Y/StCrZoVZ5LocFP\nT4o8kT7bU6yonudSCyNMedYmqHj/iF8B2UN1WrYx8zvoDqZk0nxIglmEYKn/6U7U\ngyETGcW9AgMBAAECggEAC231vmkpwA7JG9UYbviVmSW79UecsLzsOAZnbtbn1VLT\nPg7sup7tprD/LXHoyIxK7S/jqINvPU65iuUhgCg3Rhz8+UiBhd0pCH/arlIdiPuD\n2xHpX8RIxAq6pGCsoPJ0kwkHSw8UTnxPV8ZCPSRyHV71oQHQgSl/WjNhRi6PQroB\nSqc/pS1m09cTwyKQIopBBVayRzmI2BtBxyhQp9I8t5b7PYkEZDQlbdq0j5Xipoov\n9EW0+Zvkh1FGNig8IJ9Wp+SZi3rd7KLpkyKPY7BK/g0nXBkDxn019cET0SdJOHQG\nDiHiv4yTRsDCHZhtEbAMKZEpku4WxtQ+JjR31l8ueQKBgQDkO2oC8gi6vQDcx/CX\nZ23x2ZUyar6i0BQ8eJFAEN+IiUapEeCVazuxJSt4RjYfwSa/p117jdZGEWD0GxMC\n+iAXlc5LlrrWs4MWUc0AHTgXna28/vii3ltcsI0AjWMqaybhBTTNbMFa2/fV2OX2\nUimuFyBWbzVc3Zb9KAG4Y7OmJQKBgQC5324IjXPq5oH8UWZTdJPuO2cgRsvKmR/r\n9zl4loRjkS7FiOMfzAgUiXfH9XCnvwXMqJpuMw2PEUjUT+OyWjJONEK4qGFJkbN5\n3ykc7p5V7iPPc7Zxj4mFvJ1xjkcj+i5LY8Me+gL5mGIrJ2j8hbuv7f+PWIauyjnp\nNx/0GVFRuQKBgGNT4D1L7LSokPmFIpYh811wHliE0Fa3TDdNGZnSPhaD9/aYyy78\nLkxYKuT7WY7UVvLN+gdNoVV5NsLGDa4cAV+CWPfYr5PFKGXMT/Wewcy1WOmJ5des\nAgMC6zq0TdYmMBN6WpKUpEnQtbmh3eMnuvADLJWxbH3wCkg+4xDGg2bpAoGAYRNk\nMGtQQzqoYNNSkfus1xuHPMA8508Z8O9pwKU795R3zQs1NAInpjI1sOVrNPD7Ymwc\nW7mmNzZbxycCUL/yzg1VW4P1a6sBBYGbw1SMtWxun4ZbnuvMc2CTCh+43/1l+FHe\nMmt46kq/2rH2jwx5feTbOE6P6PINVNRJh/9BDWECgYEAsCWcH9D3cI/QDeLG1ao7\nrE2NcknP8N783edM07Z/zxWsIsXhBPY3gjHVz2LDl+QHgPWhGML62M0ja/6SsJW3\nYvLLIc82V7eqcVJTZtaFkuht68qu/Jn1ezbzJMJ4YXDYo1+KFi+2CAGR06QILb+I\nlUtj+/nH3HDQjM4ltYfTPUg=\n-----END PRIVATE KEY-----\n",
+    "client_email": "foo-email@foo-project.iam.gserviceaccount.com",
+    "client_id": "100000000000000000001",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://accounts.google.com/o/oauth2/token",
+    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/foo-email%40foo-project.iam.gserviceaccount.com"
+})""";
+  os.close();
+  google::cloud::internal::SetEnv(VAR_NAME, filename);
+
+  // Need to create a temporary for the pointer because clang-tidy warns about
+  // using expressions with (potential) side-effects inside typeid().
+  auto credentials = GoogleDefaultCredentials();
+  auto ptr = credentials.get();
+  EXPECT_EQ(typeid(*ptr), typeid(internal::ServiceAccountCredentials<>));
+}
+
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/credentials_test.cc
+++ b/google/cloud/storage/credentials_test.cc
@@ -39,12 +39,23 @@ class CredentialsTest : public ::testing::Test {
       testing_util::EnvironmentVariableRestore(VAR_NAME);
 };
 
+/// @test Verify `InsecureCredentials` works as expected.
 TEST_F(CredentialsTest, Insecure) {
   InsecureCredentials credentials;
   EXPECT_EQ("", credentials.AuthorizationHeader());
 }
 
-TEST_F(CredentialsTest, LoadAuthorizedUser) {
+/**
+ * @test Verify `GoogleDefaultCredentials()` loads authorized user credentials.
+ *
+ * This test only verifies the right type of object is created, the unit tests
+ * for `AuthorizedUserCredentials` already check that once loaded the class
+ * works correctly. Testing here would be redundant. Furthermore, calling
+ * `AuthorizationHeader()` initiates the key verification workflow, that
+ * requires valid keys and contacting Google's production servers, and would
+ * make this an integration test.
+ */
+TEST_F(CredentialsTest, LoadValidAuthorizedUserCredentials) {
   char const filename[] = "authorized-user.json";
   std::ofstream os(filename);
   os << R"""({
@@ -63,7 +74,17 @@ TEST_F(CredentialsTest, LoadAuthorizedUser) {
   EXPECT_EQ(typeid(*ptr), typeid(internal::AuthorizedUserCredentials<>));
 }
 
-TEST_F(CredentialsTest, LoadServiceAccount) {
+/**
+ * @test Verify `GoogleDefaultCredentials()` loads service account credentials.
+ *
+ * This test only verifies the right type of object is created, the unit tests
+ * for `ServiceAccountCredentials` already check that once loaded the class
+ * works correctly. Testing here would be redundant. Furthermore, calling
+ * `AuthorizationHeader()` initiates the key verification workflow, that
+ * requires valid keys and contacting Google's production servers, and would
+ * make this an integration test.
+ */
+TEST_F(CredentialsTest, LoadValdServiceAccountCredentials) {
   char const filename[] = "service-account.json";
   std::ofstream os(filename);
   os << R"""({

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -2,7 +2,6 @@
 storage_client_unit_tests = [
     "bucket_metadata_test.cc",
     "bucket_test.cc",
-    "storage_client_options_test.cc",
     "internal/authorized_user_credentials_test.cc",
     "internal/binary_data_as_debug_string_test.cc",
     "internal/default_client_test.cc",
@@ -20,6 +19,7 @@ storage_client_unit_tests = [
     "object_metadata_test.cc",
     "object_stream_test.cc",
     "retry_policy_test.cc",
+    "storage_client_options_test.cc",
     "link_test.cc",
 ]
 


### PR DESCRIPTION
Basically improve coverage by checking that the right type
of credential is loaded.  The unit tests for each credential type
already check functionality for these classes. The code coverage
has dropped below 95% and I am picking up low handing fruit.