### PR TITLE
Add support to enable per-call tracing.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -193,6 +193,7 @@ create_bazel_config(storage_client_testing)
 set(storage_client_unit_tests
     bucket_metadata_test.cc
     bucket_test.cc
+    storage_client_options_test.cc
     internal/authorized_user_credentials_test.cc
     internal/binary_data_as_debug_string_test.cc
     internal/default_client_test.cc
@@ -221,6 +222,7 @@ foreach (fname ${storage_client_unit_tests})
             storage_client_testing
             google_cloud_cpp_testing
             storage_client
+            google_cloud_cpp_testing
             gmock
             CURL::CURL
             storage_common_options

--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -40,7 +40,8 @@ ClientOptions::ClientOptions(std::shared_ptr<Credentials> credentials)
     : credentials_(std::move(credentials)),
       endpoint_("https://www.googleapis.com"),
       version_("v1"),
-      enable_http_tracing_(false) {
+      enable_http_tracing_(false),
+      enable_raw_client_tracing_(false) {
   char const* emulator = std::getenv("CLOUD_STORAGE_TESTBENCH_ENDPOINT");
   if (emulator != nullptr) {
     endpoint_ = emulator;
@@ -68,6 +69,10 @@ void ClientOptions::SetupFromEnvironment() {
     if (enabled.end() != enabled.find("http")) {
       GCP_LOG(INFO) << "Enabling logging for http";
       set_enable_http_tracing(true);
+    }
+    if (enabled.end() != enabled.find("raw-client")) {
+      GCP_LOG(INFO) << "Enabling logging for RawClient functions";
+      set_enable_raw_client_tracing(true);
     }
   }
 }

--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -65,6 +65,12 @@ class ClientOptions {
     return *this;
   }
 
+  bool enable_raw_client_tracing() const { return enable_raw_client_tracing_; }
+  ClientOptions& set_enable_raw_client_tracing(bool enable) {
+    enable_raw_client_tracing_ = enable;
+    return *this;
+  }
+
  private:
   void SetupFromEnvironment();
 
@@ -73,6 +79,7 @@ class ClientOptions {
   std::string endpoint_;
   std::string version_;
   bool enable_http_tracing_;
+  bool enable_raw_client_tracing_;
 };
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/storage_client_options_test.cc
+++ b/google/cloud/storage/storage_client_options_test.cc
@@ -1,0 +1,99 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/setenv.h"
+#include "google/cloud/storage/client_options.h"
+#include "google/cloud/testing_util/environment_variable_restore.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+class ClientOptionsTest : public ::testing::Test {
+ public:
+  ClientOptionsTest()
+      : enable_tracing_("CLOUD_STORAGE_ENABLE_TRACING"),
+        endpoint_("CLOUD_STORAGE_TESTBENCH_ENDPOINT") {}
+
+ protected:
+  void SetUp() override { enable_tracing_.SetUp(); }
+  void TearDown() override { enable_tracing_.TearDown(); }
+
+ protected:
+  testing_util::EnvironmentVariableRestore enable_tracing_;
+  testing_util::EnvironmentVariableRestore endpoint_;
+};
+
+TEST_F(ClientOptionsTest, Default) {
+  google::cloud::internal::SetEnv("CLOUD_STORAGE_ENABLE_TRACING", nullptr);
+  // Create the options with the insecure credentials because the default
+  // credentials may result in an error in the CI environment.
+  auto creds = CreateInsecureCredentials();
+  ClientOptions options(creds);
+  EXPECT_FALSE(options.enable_http_tracing());
+  EXPECT_FALSE(options.enable_raw_client_tracing());
+  EXPECT_TRUE(creds.get() == options.credentials().get());
+  EXPECT_EQ("https://www.googleapis.com", options.endpoint());
+  EXPECT_EQ("v1", options.version());
+}
+
+TEST_F(ClientOptionsTest, EnableRpc) {
+  google::cloud::internal::SetEnv("CLOUD_STORAGE_ENABLE_TRACING",
+                                  "foo,raw-client,bar");
+  ClientOptions options(CreateInsecureCredentials());
+  EXPECT_TRUE(options.enable_raw_client_tracing());
+}
+
+TEST_F(ClientOptionsTest, EnableHttp) {
+  google::cloud::internal::SetEnv("CLOUD_STORAGE_ENABLE_TRACING",
+                                  "foo,http,bar");
+  ClientOptions options(CreateInsecureCredentials());
+  EXPECT_TRUE(options.enable_http_tracing());
+}
+
+TEST_F(ClientOptionsTest, EndpointFromEnvironment) {
+  google::cloud::internal::SetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT",
+                                  "http://localhost:1234");
+  ClientOptions options(CreateInsecureCredentials());
+  EXPECT_EQ("http://localhost:1234", options.endpoint());
+}
+
+TEST_F(ClientOptionsTest, SetVersion) {
+  ClientOptions options(CreateInsecureCredentials());
+  options.set_version("vTest");
+  EXPECT_EQ("vTest", options.version());
+}
+
+TEST_F(ClientOptionsTest, SetEndpoint) {
+  ClientOptions options(CreateInsecureCredentials());
+  options.set_endpoint("http://localhost:2345");
+  EXPECT_EQ("http://localhost:2345", options.endpoint());
+}
+
+TEST_F(ClientOptionsTest, SetCredentials) {
+  auto creds = CreateInsecureCredentials();
+  ClientOptions options(creds);
+  auto other = CreateInsecureCredentials();
+  options.set_credentials(other);
+  EXPECT_TRUE(other.get() == options.credentials().get());
+  EXPECT_FALSE(creds.get() == other.get());
+}
+
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/storage_client_options_test.cc
+++ b/google/cloud/storage/storage_client_options_test.cc
@@ -40,7 +40,8 @@ class ClientOptionsTest : public ::testing::Test {
 TEST_F(ClientOptionsTest, Default) {
   google::cloud::internal::SetEnv("CLOUD_STORAGE_ENABLE_TRACING", nullptr);
   // Create the options with the insecure credentials because the default
-  // credentials may result in an error in the CI environment.
+  // credentials try to load the application default credentials, and those do
+  // not exist in the CI environment, which results in errors or warnings.
   auto creds = CreateInsecureCredentials();
   ClientOptions options(creds);
   EXPECT_FALSE(options.enable_http_tracing());

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -2,6 +2,7 @@
 storage_client_unit_tests = [
     "bucket_metadata_test.cc",
     "bucket_test.cc",
+    "storage_client_options_test.cc",
     "internal/authorized_user_credentials_test.cc",
     "internal/binary_data_as_debug_string_test.cc",
     "internal/default_client_test.cc",


### PR DESCRIPTION
Part of the fixes for #570. Refactor the code to configure tracing
of each RawClient member function call, in this PR just tweak the
ClientOptions class and create a test for it.

Since I needed to write a unit test for `ClientOptions` I added some
missing tests for that class.
