### PR TITLE
Use custom initializer for GoogleMock/GoogleTest.

### DIFF
--- a/ci/build-windows.ps1
+++ b/ci/build-windows.ps1
@@ -56,7 +56,7 @@ if ($LastExitCode) {
 }
 
 # Compile inside the build directory. Pass /m flag to msbuild to use all cores.
-cmake --build build-output -- /m
+cmake --build build-output --config $env:CONFIG -- /m
 if ($LastExitCode) {
     throw "cmake build failed with exit code $LastExitCode"
 }

--- a/cmake/IncludeGMock.cmake
+++ b/cmake/IncludeGMock.cmake
@@ -25,7 +25,6 @@ if ("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "module")
     # application.
     # TODO(#310) - the name of this target can easily conflict, consider changing it.
     add_library(gmock
-            ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest/src/gtest_main.cc
             ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest/src/gtest-all.cc
             ${PROJECT_THIRD_PARTY_DIR}/googletest/googlemock/src/gmock-all.cc)
     target_include_directories(gmock
@@ -62,7 +61,7 @@ elseif ("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "vcpkg")
     __gtest_import_library(GMock::GMock GMOCK_LIBRARY "DEBUG")
     # TODO(#310) - the name of this target can easily conflict, consider changing it.
     add_library(gmock INTERFACE)
-    target_link_libraries(gmock INTERFACE GMock::GMock GTest::Main)
+    target_link_libraries(gmock INTERFACE GMock::GMock)
 
 elseif ("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "package")
     find_package(Threads REQUIRED)

--- a/cmake/IncludeGTest.cmake
+++ b/cmake/IncludeGTest.cmake
@@ -25,13 +25,3 @@ add_library(gtest
 target_include_directories(gtest
         PUBLIC ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest/include
         PUBLIC ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest)
-
-# Compile the gtest_main library.  This library is rarely installed or
-# pre-compiled because it should be configured with the same flags as the
-# application.
-add_library(gtest_main
-        ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest/src/gtest_main.cc)
-target_include_directories(gtest_main
-        PUBLIC ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest/include
-        PUBLIC ${PROJECT_THIRD_PARTY_DIR}/googletest/googletest)
-add_dependencies(gtest_main gtest)

--- a/google/cloud/BUILD
+++ b/google/cloud/BUILD
@@ -55,6 +55,5 @@ cc_library(
     deps = [
       ":google_cloud_cpp_common",
       "@com_google_googletest//:gtest",
-      "@com_google_googletest//:gtest_main",
     ],
 )

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -93,7 +93,10 @@ google_cloud_cpp_add_clang_tidy(google_cloud_cpp_common)
 add_library(google_cloud_cpp_testing
     testing_util/check_predicate_becomes_false.h
     testing_util/environment_variable_restore.h
-    testing_util/environment_variable_restore.cc)
+    testing_util/environment_variable_restore.cc
+    testing_util/custom_google_mock_main.cc
+    testing_util/init_google_mock.h
+    testing_util/init_google_mock.cc)
 target_link_libraries(google_cloud_cpp_testing PUBLIC
     google_cloud_cpp_common gmock)
 
@@ -116,7 +119,10 @@ foreach (fname ${google_cloud_cpp_common_unit_tests})
     string(REPLACE ".cc" "" target ${target})
     add_executable(${target} ${fname})
     target_link_libraries(${target} PRIVATE
-        google_cloud_cpp_common gmock google_cloud_cpp_common_options)
+            google_cloud_cpp_testing
+            google_cloud_cpp_common
+            gmock
+            google_cloud_cpp_common_options)
     add_test(NAME ${target} COMMAND ${target})
 endforeach ()
 

--- a/google/cloud/bigtable/BUILD
+++ b/google/cloud/bigtable/BUILD
@@ -44,10 +44,10 @@ cc_library(
     hdrs = bigtable_client_testing_HDRS,
     deps = [
       ":bigtable_client",
+      "//google/cloud:google_cloud_cpp_testing",
       "//google/cloud:google_cloud_cpp_common",
       "@com_github_googleapis_googleapis//:bigtable_protos",
       "@com_google_googletest//:gtest",
-      "@com_google_googletest//:gtest_main",
     ]
 )
 
@@ -59,8 +59,8 @@ load(":bigtable_client_unit_tests.bzl", "bigtable_client_unit_tests")
       ":bigtable_client_testing",
       ":bigtable_client",
       "//google/cloud:google_cloud_cpp_testing",
+      "//google/cloud:google_cloud_cpp_common",
       "@com_google_googletest//:gtest",
-      "@com_google_googletest//:gtest_main",
     ],
 ) for test in bigtable_client_unit_tests]
 
@@ -73,8 +73,8 @@ cc_test(
     deps = [
         ":bigtable_client_testing",
         ":bigtable_client",
+        "//google/cloud:google_cloud_cpp_testing",
         "//google/cloud:google_cloud_cpp_common",
         "@com_google_googletest//:gtest",
-        "@com_google_googletest//:gtest_main",
     ],
 )

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -276,7 +276,11 @@ foreach (fname ${bigtable_client_unit_tests})
     string(REPLACE ".cc" "" target ${target})
     add_executable(${target} ${fname})
     target_link_libraries(${target} PRIVATE
-            bigtable_client_testing bigtable_client bigtable_protos
+            bigtable_client_testing
+            bigtable_client
+            bigtable_protos
+            google_cloud_cpp_testing
+            google_cloud_cpp_common
             gmock gRPC::grpc++ gRPC::grpc protobuf::libprotobuf
             bigtable_common_options)
     add_test(NAME ${target} COMMAND ${target})

--- a/google/cloud/bigtable/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigtable/benchmarks/CMakeLists.txt
@@ -37,9 +37,16 @@ foreach (fname ${bigtable_benchmarks_unit_tests})
     string(REPLACE ".cc" "" target ${target})
     add_executable(${target} ${fname})
     target_link_libraries(${target} PRIVATE
-            bigtable_benchmark_common bigtable_client
-            bigtable_protos bigtable_common_options
-            gmock gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
+            bigtable_benchmark_common
+            bigtable_client
+            bigtable_protos
+            bigtable_common_options
+            google_cloud_cpp_testing
+            google_cloud_cpp_common
+            gmock
+            gRPC::grpc++
+            gRPC::grpc
+            protobuf::libprotobuf)
     add_test(NAME ${target} COMMAND ${target})
 endforeach ()
 

--- a/google/cloud/bigtable/tests/BUILD
+++ b/google/cloud/bigtable/tests/BUILD
@@ -24,8 +24,9 @@ load(":bigtable_client_integration_tests.bzl",
     deps=[
       "//google/cloud/bigtable:bigtable_client_testing",
       "//google/cloud/bigtable:bigtable_client",
-      "@com_google_googletest//:gtest",
-      "@com_google_googletest//:gtest_main",
+      "//google/cloud:google_cloud_cpp_testing",
+      "//google/cloud:google_cloud_cpp_common",
+      "@com_google_googletest//:gtest"
     ],
 ) for test in bigtable_client_integration_tests]
 

--- a/google/cloud/bigtable/tests/CMakeLists.txt
+++ b/google/cloud/bigtable/tests/CMakeLists.txt
@@ -30,9 +30,16 @@ foreach (fname ${bigtable_client_integration_tests})
     string(REPLACE ".cc" "" target ${target})
     add_executable(${target} ${fname})
     target_link_libraries(${target} PRIVATE
-        bigtable_client_testing bigtable_client bigtable_protos
-        gmock gRPC::grpc++ gRPC::grpc protobuf::libprotobuf
-        bigtable_common_options)
+            bigtable_client_testing
+            bigtable_client
+            bigtable_protos
+            google_cloud_cpp_testing
+            google_cloud_cpp_common
+            gmock
+            gRPC::grpc++
+            gRPC::grpc
+            protobuf::libprotobuf
+            bigtable_common_options)
 endforeach ()
 
 add_executable(instance_admin_emulator instance_admin_emulator.cc)

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/bigtable/internal/make_unique.h"
 #include "google/cloud/bigtable/testing/table_integration_test.h"
 #include "google/cloud/internal/random.h"
+#include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>
 #include <string>
 #include <vector>
@@ -258,7 +259,7 @@ TEST_F(AdminIntegrationTest, DropAllRowsTest) {
 // Test Cases Finished
 
 int main(int argc, char* argv[]) {
-  ::testing::InitGoogleTest(&argc, argv);
+  google::cloud::testing_util::InitGoogleMock(argc, argv);
 
   // Check for arguments validity
   if (argc != 3) {

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/bigtable/internal/endian.h"
 #include "google/cloud/bigtable/testing/chrono_literals.h"
 #include "google/cloud/bigtable/testing/table_integration_test.h"
+#include "google/cloud/testing_util/init_google_mock.h"
 
 namespace {
 namespace admin_proto = google::bigtable::admin::v2;
@@ -49,7 +50,7 @@ bool UsingCloudBigtableEmulator() {
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) {
-  ::testing::InitGoogleTest(&argc, argv);
+  google::cloud::testing_util::InitGoogleMock(argc, argv);
 
   // Make sure the arguments are valid.
   if (argc != 3) {

--- a/google/cloud/bigtable/tests/filters_integration_test.cc
+++ b/google/cloud/bigtable/tests/filters_integration_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigtable/testing/chrono_literals.h"
 #include "google/cloud/bigtable/testing/table_integration_test.h"
+#include "google/cloud/testing_util/init_google_mock.h"
 
 namespace {
 namespace btproto = google::bigtable::v2;
@@ -69,7 +70,7 @@ bool UsingCloudBigtableEmulator();
 }  // namespace
 
 int main(int argc, char* argv[]) {
-  ::testing::InitGoogleTest(&argc, argv);
+  google::cloud::testing_util::InitGoogleMock(argc, argv);
 
   // Make sure the arguments are valid.
   if (argc != 3) {

--- a/google/cloud/bigtable/tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_integration_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/bigtable/instance_admin.h"
 #include "google/cloud/bigtable/internal/make_unique.h"
 #include "google/cloud/internal/random.h"
+#include "google/cloud/testing_util/init_google_mock.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 
@@ -390,7 +391,7 @@ TEST_F(InstanceAdminIntegrationTest, DeleteClustersTest) {
 }
 
 int main(int argc, char* argv[]) {
-  ::testing::InitGoogleTest(&argc, argv);
+  google::cloud::testing_util::InitGoogleMock(argc, argv);
 
   if (argc != 2) {
     std::string const cmd = argv[0];

--- a/google/cloud/bigtable/tests/mutations_integration_test.cc
+++ b/google/cloud/bigtable/tests/mutations_integration_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/bigtable/internal/endian.h"
 #include "google/cloud/bigtable/testing/chrono_literals.h"
 #include "google/cloud/bigtable/testing/table_integration_test.h"
+#include "google/cloud/testing_util/init_google_mock.h"
 
 namespace {
 
@@ -490,7 +491,7 @@ TEST_F(MutationIntegrationTest, DeleteFromRowTest) {
 // Test Cases Finished
 
 int main(int argc, char* argv[]) {
-  ::testing::InitGoogleTest(&argc, argv);
+  google::cloud::testing_util::InitGoogleMock(argc, argv);
 
   // Make sure the arguments are valid.
   if (argc != 3) {

--- a/google/cloud/firestore/BUILD
+++ b/google/cloud/firestore/BUILD
@@ -42,9 +42,9 @@ load(":firestore_client_unit_tests.bzl", "firestore_client_unit_tests")
     srcs = [test],
     deps = [
         ":firestore_client",
+        "//google/cloud:google_cloud_cpp_testing",
         "//google/cloud:google_cloud_cpp_common",
         "@com_google_googletest//:gtest",
-        "@com_google_googletest//:gtest_main",
     ],
     # TODO(#664 / #666) - use the right condition when porting Bazel builds
     linkopts = [ "-lpthread" ],

--- a/google/cloud/firestore/CMakeLists.txt
+++ b/google/cloud/firestore/CMakeLists.txt
@@ -80,7 +80,10 @@ foreach (fname ${firestore_client_unit_tests})
     string(REPLACE ".cc" "" target ${target})
     add_executable(${target} ${fname})
     target_link_libraries(${target} PRIVATE
-        firestore_client gmock firestore_common_options)
+            firestore_client
+            google_cloud_cpp_testing
+            google_cloud_cpp_common
+            gmock firestore_common_options)
     add_test(NAME ${target} COMMAND ${target})
 endforeach ()
 

--- a/google/cloud/firestore/field_path_test.cc
+++ b/google/cloud/firestore/field_path_test.cc
@@ -17,11 +17,6 @@
 
 namespace firestore = google::cloud::firestore;
 
-int main(int argc, char* argv[]) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-
 TEST(FieldPath, EmptyStringInConstructor) {
   const std::vector<std::string> parts = {"a", "", "b"};
   ASSERT_FALSE(firestore::FieldPath(parts).valid());

--- a/google/cloud/google_cloud_cpp_testing.bzl
+++ b/google/cloud/google_cloud_cpp_testing.bzl
@@ -2,9 +2,12 @@
 google_cloud_cpp_testing_HDRS = [
     "testing_util/check_predicate_becomes_false.h",
     "testing_util/environment_variable_restore.h",
+    "testing_util/init_google_mock.h",
 ]
 
 google_cloud_cpp_testing_SRCS = [
     "testing_util/environment_variable_restore.cc",
+    "testing_util/custom_google_mock_main.cc",
+    "testing_util/init_google_mock.cc",
 ]
 

--- a/google/cloud/storage/BUILD
+++ b/google/cloud/storage/BUILD
@@ -96,9 +96,9 @@ cc_library(
         ":libcurl",
         ":nlohmann_json",
         ":storage_client",
+        "//google/cloud:google_cloud_cpp_testing",
         "//google/cloud:google_cloud_cpp_common",
         "@com_google_googletest//:gtest",
-        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/google/cloud/storage/tests/BUILD
+++ b/google/cloud/storage/tests/BUILD
@@ -23,9 +23,9 @@ load(":storage_client_integration_tests.bzl",
     srcs=[test],
     deps=[
         "//google/cloud/storage:storage_client",
+        "//google/cloud:google_cloud_cpp_testing",
         "//google/cloud:google_cloud_cpp_common",
         "@com_google_googletest//:gtest",
-        "@com_google_googletest//:gtest_main",
     ],
     # TODO(#664 / #666) - use the right condition when porting Bazel builds
     linkopts = [ "-lpthread" ],

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -24,6 +24,8 @@ foreach (fname ${storage_client_integration_tests})
     target_link_libraries(${target}
         PRIVATE
             storage_client
+            google_cloud_cpp_testing
+            google_cloud_cpp_common
             gmock
             CURL::CURL
             Threads::Threads

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/list_objects_reader.h"
+#include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>
 
 namespace storage = google::cloud::storage;
@@ -187,7 +188,7 @@ TEST_F(BucketIntegrationTest, ListObjects) {
 }
 
 int main(int argc, char* argv[]) {
-  ::testing::InitGoogleTest(&argc, argv);
+  google::cloud::testing_util::InitGoogleMock(argc, argv);
 
   // Make sure the arguments are valid.
   if (argc != 3) {

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/internal/random.h"
 #include "google/cloud/storage/client.h"
+#include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>
 
 namespace gcs = google::cloud::storage;
@@ -81,7 +82,7 @@ non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 }
 
 int main(int argc, char* argv[]) {
-  ::testing::InitGoogleTest(&argc, argv);
+  google::cloud::testing_util::InitGoogleMock(argc, argv);
 
   // Make sure the arguments are valid.
   if (argc != 3) {

--- a/google/cloud/testing_util/custom_google_mock_main.cc
+++ b/google/cloud/testing_util/custom_google_mock_main.cc
@@ -1,0 +1,21 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/testing_util/init_google_mock.h"
+#include <gmock/gmock.h>
+
+int main(int argc, char* argv[]) {
+  google::cloud::testing_util::InitGoogleMock(argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/google/cloud/testing_util/init_google_mock.cc
+++ b/google/cloud/testing_util/init_google_mock.cc
@@ -1,0 +1,48 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/testing_util/init_google_mock.h"
+#include <gmock/gmock.h>
+
+#ifdef _WIN32
+#include <crtdbg.h>
+#endif  // _WIN32
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace testing_util {
+void InitGoogleMock(int& argc, char* argv[]) {
+  ::testing::InitGoogleMock(&argc, argv);
+  // On Windows, with MSVC, when compiling in Debug mode, the runtime creates a
+  // popup dialog if an assertion fails. That is very convenient when doing
+  // interactive debugging, but a real problem when running the unit tests in
+  // batch mode. It is particularly bad when running the tests in a CI
+  // environment because then the CI build hangs (until some time out), without
+  // any errors in the log to debug the assertion failure.
+#if defined(_WIN32) && defined(_MSC_VER)
+  ::_set_error_mode(_OUT_TO_STDERR);
+  _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+  _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
+  _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+  _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+  _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+  _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+#endif  // defined(_WIN32) && defined(_MSC_VER)
+}
+
+}  // namespace testing_util
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/testing_util/init_google_mock.h
+++ b/google/cloud/testing_util/init_google_mock.h
@@ -1,0 +1,37 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_INIT_GOOGLE_MOCK_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_INIT_GOOGLE_MOCK_H_
+
+#include "google/cloud/version.h"
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace testing_util {
+/**
+ * Initialize the GoogleTest framework including some custom settings for
+ * google-cloud-cpp
+ *
+ * @param argc the number of elements in @p argv
+ * @param argv the command-line parameters for the program.
+ */
+void InitGoogleMock(int& argc, char* argv[]);
+}  // namespace testing_util
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_INIT_GOOGLE_MOCK_H_


### PR DESCRIPTION
This fixes #789.  On Windows, with MSVC, when compiling in Debug
mode, the runtime creates a popup dialog if an assertion fails.
That can block a CI build on AppVeyor until it times out, and
because the details of the error are in the dialog, no useful
information is left in the log. With this change the main()
function for our tests sets up the runtime to print assertion
errors to stderr instead.