### PR TITLE
Workaround gcc-4.8 bug for TensorFlow.

### DIFF
--- a/google/cloud/bigtable/internal/rowreaderiterator.h
+++ b/google/cloud/bigtable/internal/rowreaderiterator.h
@@ -54,7 +54,6 @@ class RowReaderIterator : public std::iterator<std::input_iterator_tag, Row> {
 
   Row const& operator*() const& { return *row_; }
   Row& operator*() & { return *row_; }
-  Row const&& operator*() const&& { return *std::move(row_); }
   Row&& operator*() && { return *std::move(row_); }
 
   bool operator==(RowReaderIterator const& that) const {

--- a/google/cloud/bigtable/internal/rowreaderiterator.h
+++ b/google/cloud/bigtable/internal/rowreaderiterator.h
@@ -54,8 +54,13 @@ class RowReaderIterator : public std::iterator<std::input_iterator_tag, Row> {
 
   Row const& operator*() const& { return *row_; }
   Row& operator*() & { return *row_; }
+#if !defined(__GNUC__) || __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 8)
+  // Exclude this function for gcc-4.8. While we do not support gcc-4.8, we have
+  // made an exception here because the TensorFlow folks need it.
+  Row const&& operator*() const&& { return *std::move(row_); }
+#endif  // !defined(__GNUC__) || __GNUC__ > 4 || (__GNUC__ == 4 &&
+        // __GNUC_MINOR__ > 8)
   Row&& operator*() && { return *std::move(row_); }
-
   bool operator==(RowReaderIterator const& that) const {
     // All non-end iterators are equal.
     return owner_ == that.owner_ and row_.has_value() == that.row_.has_value();


### PR DESCRIPTION
While we do not support gcc-4.8, TensorFlow does, and it was easy
to workaround the compiler bugs this time.  We may have to revisit
the decision to drop gcc-4.8 support altogether.  For now, just
make the code work for the TensorFlow folks.