### PR TITLE
Fix EnvironmentVariableRestore helper.

### DIFF
--- a/google/cloud/storage/internal/google_application_default_credentials_file.cc
+++ b/google/cloud/storage/internal/google_application_default_credentials_file.cc
@@ -51,11 +51,12 @@ std::string GoogleApplicationDefaultCredentialsFile() {
   }
   // There are probably more efficient ways to do this, but meh, the strings
   // are typically short, and this does not happen that often.
-  auto root = std::getenv(CREDENTIALS_HOME_VAR);
+  auto root = std::getenv(GoogleApplicationDefaultCredentialsHomeVariable());
   if (root == nullptr) {
     std::ostringstream os;
-    os << "The " << CREDENTIALS_HOME_VAR << " environment variable is not set."
-       << " Cannot determine default path for service account credentials.";
+    os << "The " << GoogleApplicationDefaultCredentialsHomeVariable()
+       << " environment variable is not set. Cannot determine the default"
+       << " path for service account credentials.";
     google::cloud::internal::RaiseRuntimeError(os.str());
   }
   return root + GoogleCredentialsSuffix();

--- a/google/cloud/storage/internal/google_application_default_credentials_file_test.cc
+++ b/google/cloud/storage/internal/google_application_default_credentials_file_test.cc
@@ -51,7 +51,7 @@ TEST_F(DefaultServiceAccountFileTest, EnvironmentVariableSet) {
 
 /// @test Verify that the file path works as expected when using HOME.
 TEST_F(DefaultServiceAccountFileTest, HomeSet) {
-  google::cloud::internal::SetEnv("GOOGLE_APPLICATION_CREDENTIALS", nullptr);
+  google::cloud::internal::UnsetEnv("GOOGLE_APPLICATION_CREDENTIALS");
   char const* home = GoogleApplicationDefaultCredentialsHomeVariable();
   google::cloud::internal::SetEnv(home, "/foo/bar/baz");
   auto actual = GoogleApplicationDefaultCredentialsFile();
@@ -62,7 +62,7 @@ TEST_F(DefaultServiceAccountFileTest, HomeSet) {
 
 /// @test Verify that the service account file path fails when HOME is not set.
 TEST_F(DefaultServiceAccountFileTest, HomeNotSet) {
-  google::cloud::internal::SetEnv("GOOGLE_APPLICATION_CREDENTIALS", nullptr);
+  google::cloud::internal::UnsetEnv("GOOGLE_APPLICATION_CREDENTIALS");
   char const* home = GoogleApplicationDefaultCredentialsHomeVariable();
   google::cloud::internal::UnsetEnv(home);
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS

--- a/google/cloud/testing_util/environment_variable_restore.cc
+++ b/google/cloud/testing_util/environment_variable_restore.cc
@@ -22,11 +22,19 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace testing_util {
 
 void EnvironmentVariableRestore::SetUp() {
-  previous_ = std::getenv(variable_name_.c_str());
+  auto ptr = std::getenv(variable_name_.c_str());
+  was_null_ = (ptr == nullptr);
+  if (not was_null_) {
+    previous_ = std::string(ptr);
+  }
 }
 
 void EnvironmentVariableRestore::TearDown() {
-  google::cloud::internal::SetEnv(variable_name_.c_str(), previous_);
+  if (was_null_) {
+    google::cloud::internal::UnsetEnv(variable_name_.c_str());
+  } else {
+    google::cloud::internal::SetEnv(variable_name_.c_str(), previous_.c_str());
+  }
 }
 
 }  // namespace testing_util

--- a/google/cloud/testing_util/environment_variable_restore.h
+++ b/google/cloud/testing_util/environment_variable_restore.h
@@ -34,15 +34,17 @@ class EnvironmentVariableRestore {
       : EnvironmentVariableRestore(std::string(variable_name)) {}
 
   explicit EnvironmentVariableRestore(std::string variable_name)
-      : variable_name_(std::move(variable_name)),
-        previous_(std::getenv(variable_name_.c_str())) {}
+      : variable_name_(std::move(variable_name)) {
+    SetUp();
+  }
 
   void SetUp();
   void TearDown();
 
  private:
   std::string variable_name_;
-  char const* previous_;
+  bool was_null_;
+  std::string previous_;
 };
 
 }  // namespace testing_util


### PR DESCRIPTION
Change the `previous_` member variable to `std::string` so we copy
the value returned by `std::getenv()`. On Windows the pointer returned
by `std::getenv()` is not guaranteed to remain valid after modifying
*other* environment variables, thus the need for this copy.

This fixes #796.

Also always use GoogleApplicationDefaultCredentailsHomeVariable to
fetch the HOME (vs APPDATA) variable name.  This was a bit
of cleanup I did while trying to figure out what was broken.