### PR TITLE
Describe environment variables used in the library.

### DIFF
--- a/google/cloud/bigtable/client_options.h
+++ b/google/cloud/bigtable/client_options.h
@@ -37,11 +37,11 @@ class ClientOptions {
   /**
    * Initialize the client options with the default credentials.
    *
-   * Configure the client to connect to the production instance of Cloud
-   * Bigtable, using the default google credentials for authentication.
+   * Configure the client to connect to the Cloud Bigtable service, using the
+   * default Google credentials for authentication.
    *
    * @par Environment Variables
-   * If the `BIGTABLE_EMULATOR_HOST` environment variable is set the default
+   * If the `BIGTABLE_EMULATOR_HOST` environment variable is set, the default
    * configuration changes in important ways:
    *
    * - The credentials are initialized to `grpc::InsecureCredentials()`.

--- a/google/cloud/bigtable/client_options.h
+++ b/google/cloud/bigtable/client_options.h
@@ -37,15 +37,26 @@ class ClientOptions {
   /**
    * Initialize the client options with the default credentials.
    *
-   * If the `BIGTABLE_EMULATOR_HOST` environment variable is set this
-   * constructor configures the object to connect to the host and port set in
-   * that environment variable. If the environment variable is not set, this
-   * constructor configures the object to connect to the production instance of
-   * Cloud Bigtable using the application default credentials.
+   * Configure the client to connect to the production instance of Cloud
+   * Bigtable, using the default google credentials for authentication.
+   *
+   * @par Environment Variables
+   * If the `BIGTABLE_EMULATOR_HOST` environment variable is set the default
+   * configuration changes in important ways:
+   *
+   * - The credentials are initialized to `grpc::InsecureCredentials()`.
+   * - Any client created with these objects will connect to the endpoint
+   *   (typically just a `host:port` string) set in the environment variable.
+   *
+   * This makes it easy to test applications using the Cloud Bigtable Emulator.
    *
    * @see The Google Cloud Platform introduction to
    * [application default
    * credentials](https://cloud.google.com/docs/authentication/production)
+   * @see `grpc::GoogleDefaultCredentials` in the [grpc
+   * documentation](https://grpc.io/grpc/cpp/namespacegrpc.html)
+   * @see The [documentation](https://cloud.google.com/bigtable/docs/emulator)
+   * for the Cloud Bigtable Emulator.
    */
   ClientOptions();
 

--- a/google/cloud/bigtable/doc/environment-variables.dox
+++ b/google/cloud/bigtable/doc/environment-variables.dox
@@ -1,0 +1,20 @@
+/*!
+@page bigtable-environment-variables Environment Variables Used by the Google Cloud Bigtable C++ Client.
+
+The Cloud Bigtable C++ Client library introduces a single environment variable
+that affects its behavior. If `BIGTABLE_EMULATOR_HOST` is set, it specifies the
+endpoint (typically a `host:port` string) for the [Cloud Bigtable
+Emulator](https://cloud.google.com/bigtable/docs/emulator). And configure the
+library to connect to the emulator by default.
+
+In addition, the library inherits all the [gRPC environment
+variables](https://grpc.io/grpc/cpp/md_doc_environment_variables.html).
+
+@see @link #google::cloud::bigtable::v0::ClientOptions `ClientOptions` @endlink
+    for more details of how `BIGTABLE_EMULATOR_HOST` is used.
+
+@see the [gRPC
+documentation](https://grpc.io/grpc/cpp/md_doc_environment_variables.html) for
+    additional environment variables controlling gRPC.
+
+*/

--- a/google/cloud/bigtable/doc/environment-variables.dox
+++ b/google/cloud/bigtable/doc/environment-variables.dox
@@ -4,7 +4,7 @@
 The Cloud Bigtable C++ Client library introduces a single environment variable
 that affects its behavior. If `BIGTABLE_EMULATOR_HOST` is set, it specifies the
 endpoint (typically a `host:port` string) for the [Cloud Bigtable
-Emulator](https://cloud.google.com/bigtable/docs/emulator). And configure the
+emulator](https://cloud.google.com/bigtable/docs/emulator) and configures the
 library to connect to the emulator by default.
 
 In addition, the library inherits all the [gRPC environment


### PR DESCRIPTION
This fixes #691. There is only one environment variable used by
the client. We also reference the gRPC environment variables
because the application developers may want to use them.