### PR TITLE
Implement InstanceAdmin::UpdateAppProfile()

### DIFF
--- a/google/cloud/bigtable/app_profile_config.cc
+++ b/google/cloud/bigtable/app_profile_config.cc
@@ -39,6 +39,24 @@ AppProfileConfig AppProfileConfig::SingleClusterRouting(
   return tmp;
 }
 
+void AppProfileUpdateConfig::AddPathIfNotPresent(std::string field_name) {
+  auto const& paths = proto_.update_mask().paths();
+  auto is_present =
+      paths.end() != std::find(paths.begin(), paths.end(), field_name);
+  if (not is_present) {
+    proto_.mutable_update_mask()->add_paths(std::move(field_name));
+  }
+}
+
+void AppProfileUpdateConfig::RemoveIfPresent(std::string const& field_name) {
+  auto& paths = *proto_.mutable_update_mask()->mutable_paths();
+  auto i = std::find(paths.begin(), paths.end(), field_name);
+  if (paths.end() == i) {
+    return;
+  }
+  paths.erase(i);
+}
+
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/app_profile_config.h
+++ b/google/cloud/bigtable/app_profile_config.h
@@ -67,6 +67,61 @@ class AppProfileConfig {
   google::bigtable::admin::v2::CreateAppProfileRequest proto_;
 };
 
+/// Build a proto to update an Application Profile configuration.
+class AppProfileUpdateConfig {
+ public:
+  AppProfileUpdateConfig() : proto_() {}
+
+  AppProfileUpdateConfig& set_ignore_warnings(bool value) {
+    proto_.set_ignore_warnings(value);
+    return *this;
+  }
+  AppProfileUpdateConfig& set_description(std::string description) {
+    proto_.mutable_app_profile()->set_description(std::move(description));
+    AddPathIfNotPresent("description");
+    return *this;
+  }
+  AppProfileUpdateConfig& set_etag(std::string etag) {
+    proto_.mutable_app_profile()->set_etag(std::move(etag));
+    AddPathIfNotPresent("etag");
+    return *this;
+  }
+  AppProfileUpdateConfig& set_multi_cluster_use_any() {
+    *proto_.mutable_app_profile()->mutable_multi_cluster_routing_use_any() = {};
+    RemoveIfPresent("single_cluster_routing");
+    AddPathIfNotPresent("multi_cluster_routing_use_any");
+    return *this;
+  }
+  AppProfileUpdateConfig& set_single_cluster_routing(
+      ClusterId const& cluster_id, bool allow_transactional_writes = false) {
+    proto_.mutable_app_profile()
+        ->mutable_single_cluster_routing()
+        ->set_cluster_id(cluster_id.get());
+    proto_.mutable_app_profile()
+        ->mutable_single_cluster_routing()
+        ->set_allow_transactional_writes(allow_transactional_writes);
+    RemoveIfPresent("multi_cluster_routing_use_any");
+    AddPathIfNotPresent("single_cluster_routing");
+    return *this;
+  }
+
+  // NOLINT: accessors can (and should) be snake_case.
+  google::bigtable::admin::v2::UpdateAppProfileRequest const& as_proto() const {
+    return proto_;
+  }
+
+  // NOLINT: accessors can (and should) be snake_case.
+  google::bigtable::admin::v2::UpdateAppProfileRequest as_proto_move() {
+    return std::move(proto_);
+  }
+
+ private:
+  void AddPathIfNotPresent(std::string field_name);
+  void RemoveIfPresent(std::string const& field_name);
+
+  google::bigtable::admin::v2::UpdateAppProfileRequest proto_;
+};
+
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/examples/bigtable_samples_instance_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_samples_instance_admin.cc
@@ -291,6 +291,76 @@ void GetAppProfile(google::cloud::bigtable::InstanceAdmin instance_admin,
 }
 //! [get app profile]
 
+//! [update app profile description]
+void UpdateAppProfileDescription(
+    google::cloud::bigtable::InstanceAdmin instance_admin, int argc,
+    char* argv[]) {
+  if (argc != 4) {
+    throw Usage{
+        "update-app-profile-description: <project-id> <instance-id>"
+        " <profile-id> <cluster-id>"};
+  }
+  google::cloud::bigtable::InstanceId instance_id(ConsumeArg(argc, argv));
+  google::cloud::bigtable::AppProfileId profile_id(ConsumeArg(argc, argv));
+  std::string description = ConsumeArg(argc, argv);
+  auto profile_future = instance_admin.UpdateAppProfile(
+      instance_id, profile_id,
+      google::cloud::bigtable::AppProfileUpdateConfig().set_description(
+          description));
+  auto profile = profile_future.get();
+  std::string detail;
+  google::protobuf::TextFormat::PrintToString(profile, &detail);
+  std::cout << "Application Profile details=" << detail << std::endl;
+}
+//! [update app profile description]
+
+//! [update app profile routing any]
+void UpdateAppProfileRoutingAny(
+    google::cloud::bigtable::InstanceAdmin instance_admin, int argc,
+    char* argv[]) {
+  if (argc != 3) {
+    throw Usage{
+        "update-app-profile-routing-any: <project-id> <instance-id>"
+        " <profile-id>"};
+  }
+  google::cloud::bigtable::InstanceId instance_id(ConsumeArg(argc, argv));
+  google::cloud::bigtable::AppProfileId profile_id(ConsumeArg(argc, argv));
+  auto profile_future = instance_admin.UpdateAppProfile(
+      instance_id, profile_id,
+      google::cloud::bigtable::AppProfileUpdateConfig()
+          .set_multi_cluster_use_any()
+          .set_ignore_warnings(true));
+  auto profile = profile_future.get();
+  std::string detail;
+  google::protobuf::TextFormat::PrintToString(profile, &detail);
+  std::cout << "Application Profile details=" << detail << std::endl;
+}
+//! [update app profile routing any]
+
+//! [update app profile routing]
+void UpdateAppProfileRoutingSingleCluster(
+    google::cloud::bigtable::InstanceAdmin instance_admin, int argc,
+    char* argv[]) {
+  if (argc != 4) {
+    throw Usage{
+        "update-app-profile-routing: <project-id> <instance-id> <profile-id>"
+        " <cluster-id>"};
+  }
+  google::cloud::bigtable::InstanceId instance_id(ConsumeArg(argc, argv));
+  google::cloud::bigtable::AppProfileId profile_id(ConsumeArg(argc, argv));
+  google::cloud::bigtable::ClusterId cluster_id(ConsumeArg(argc, argv));
+  auto profile_future = instance_admin.UpdateAppProfile(
+      instance_id, profile_id,
+      google::cloud::bigtable::AppProfileUpdateConfig()
+          .set_single_cluster_routing(cluster_id)
+          .set_ignore_warnings(true));
+  auto profile = profile_future.get();
+  std::string detail;
+  google::protobuf::TextFormat::PrintToString(profile, &detail);
+  std::cout << "Application Profile details=" << detail << std::endl;
+}
+//! [update app profile routing]
+
 //! [list app profiles]
 void ListAppProfiles(google::cloud::bigtable::InstanceAdmin instance_admin,
                      int argc, char* argv[]) {
@@ -361,6 +431,9 @@ int main(int argc, char* argv[]) try {
       {"create-app-profile", &CreateAppProfile},
       {"create-app-profile-cluster", &CreateAppProfileCluster},
       {"get-app-profile", &GetAppProfile},
+      {"update-app-profile-description", &UpdateAppProfileDescription},
+      {"update-app-profile-routing-any", &UpdateAppProfileRoutingAny},
+      {"update-app-profile-routing", &UpdateAppProfileRoutingSingleCluster},
       {"list-app-profiles", &ListAppProfiles},
       {"delete-app-profile", &DeleteAppProfile},
   };

--- a/google/cloud/bigtable/examples/run_examples_emulator.sh
+++ b/google/cloud/bigtable/examples/run_examples_emulator.sh
@@ -39,9 +39,9 @@ for example in instance_admin table_admin data; do
   else
     echo   "${COLOR_RED}[    ERROR ]${COLOR_RESET} ${example} examples"
     echo
-    echo "================ ${LOG} ================"
+    echo "================ ${log} ================"
     cat ${log}
-    echo "================ ${LOG} ================"
+    echo "================ ${log} ================"
   fi
   /bin/rm "${log}"
 done

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -66,26 +66,6 @@ class InstanceAdmin {
                          Policies&&... policies)
       : impl_(std::move(client), std::forward<Policies>(policies)...) {}
 
-  /**
-   * Create a new InstanceAdmin using explicit policies to handle RPC errors.
-   *
-   * @tparam RPCRetryPolicy control which operations to retry and for how long.
-   * @tparam RPCBackoffPolicy control how does the client backs off after an RPC
-   *     error.
-   * @tparam PollingPolicy controls polling of long running operations
-   * @param client the interface to create grpc stubs, report errors, etc.
-   * @param retry_policy the policy to handle RPC errors.
-   * @param backoff_policy the policy to control backoff after an error.
-   * @param polling_policy the PollingPolicy instance.
-   */
-  template <typename RPCRetryPolicy, typename RPCBackoffPolicy,
-            typename PollingPolicy>
-  InstanceAdmin(std::shared_ptr<InstanceAdminClient> client,
-                RPCRetryPolicy retry_policy, RPCBackoffPolicy backoff_policy,
-                PollingPolicy polling_policy)
-      : impl_(std::move(client), std::move(retry_policy),
-              std::move(backoff_policy), std::move(polling_policy)) {}
-
   /// The full name (`projects/<project_id>`) of the project.
   std::string const& project_name() const { return impl_.project_name(); }
   /// The project id, i.e., `project_name()` without the `projects/` prefix.

--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -1606,6 +1606,7 @@ TEST_F(InstanceAdminTest, UpdateAppProfileRecoverableFailures) {
   EXPECT_TRUE(differencer.Compare(expected_copy, actual)) << delta;
 }
 
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 /// @test Verify that `bigtable::InstanceAdmin::UpdateAppProfile` works.
 TEST_F(InstanceAdminTest, UpdateAppProfileTooManyRecoverableFailures) {
   using ::testing::_;
@@ -1626,18 +1627,12 @@ TEST_F(InstanceAdminTest, UpdateAppProfileTooManyRecoverableFailures) {
           .set_description("Test Profile")
           .set_multi_cluster_use_any());
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_THROW(try { future.get(); } catch (std::runtime_error const& ex) {
     EXPECT_THAT(ex.what(), HasSubstr("try-again"));
     EXPECT_THAT(ex.what(), HasSubstr("UpdateAppProfile"));
     throw;
   },
                std::runtime_error);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(
-      tested.UpdateAppProfile(future.get(),
-      "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 /// @test Verify that `bigtable::InstanceAdmin::UpdateAppProfile` works.
@@ -1648,7 +1643,6 @@ TEST_F(InstanceAdminTest, UpdateAppProfilePermanentFailure) {
   using ::testing::Return;
   bigtable::InstanceAdmin tested(client_);
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_CALL(*client_, UpdateAppProfile(_, _, _))
       .WillOnce(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
@@ -1666,20 +1660,8 @@ TEST_F(InstanceAdminTest, UpdateAppProfilePermanentFailure) {
     throw;
   },
                std::runtime_error);
-#else
-  EXPECT_CALL(*client_, UpdateAppProfile(_, _, _))
-      .WillRepeatedly(
-          Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
-
-  auto future = tested.UpdateAppProfile(
-      google::cloud::bigtable::InstanceId("test-instance"),
-      google::cloud::bigtable::AppProfileId("my-profile"),
-      google::cloud::bigtable::AppProfileUpdateConfig()
-          .set_description("Test Profile")
-          .set_multi_cluster_use_any());
-  EXPECT_DEATH_IF_SUPPORTED(future.get(), "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 
 /// @test Failures while polling in `bigtable::InstanceAdmin::UpdateAppProfile`.
 TEST_F(InstanceAdminTest, UpdateAppProfilePollRecoverableFailures) {

--- a/google/cloud/bigtable/internal/instance_admin.cc
+++ b/google/cloud/bigtable/internal/instance_admin.cc
@@ -175,6 +175,20 @@ btproto::AppProfile InstanceAdmin::GetAppProfile(
       "InstanceAdmin::GetAppProfile", status, true);
 }
 
+::google::longrunning::Operation InstanceAdmin::UpdateAppProfile(
+    bigtable::InstanceId instance_id, bigtable::AppProfileId profile_id,
+    AppProfileUpdateConfig config, grpc::Status& status) {
+  auto request = config.as_proto_move();
+  request.mutable_app_profile()->set_name(
+      InstanceName(instance_id.get() + "/appProfiles/" + profile_id.get()));
+
+  // This API is not idempotent, call it without retry.
+  return ClientUtils::MakeNonIdemponentCall(
+      *client_, rpc_retry_policy_->clone(), metadata_update_policy_,
+      &InstanceAdminClient::UpdateAppProfile, request,
+      "InstanceAdmin::UpdateAppProfile", status);
+}
+
 std::vector<btproto::AppProfile> InstanceAdmin::ListAppProfiles(
     std::string const& instance_id, grpc::Status& status) {
   // Copy the policies in effect for the operation.

--- a/google/cloud/bigtable/internal/instance_admin.cc
+++ b/google/cloud/bigtable/internal/instance_admin.cc
@@ -183,10 +183,10 @@ btproto::AppProfile InstanceAdmin::GetAppProfile(
       InstanceName(instance_id.get() + "/appProfiles/" + profile_id.get()));
 
   // This API is not idempotent, call it without retry.
-  return ClientUtils::MakeNonIdemponentCall(
-      *client_, rpc_retry_policy_->clone(), metadata_update_policy_,
-      &InstanceAdminClient::UpdateAppProfile, request,
-      "InstanceAdmin::UpdateAppProfile", status);
+  return ClientUtils::MakeCall(
+      *client_, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
+      metadata_update_policy_, &InstanceAdminClient::UpdateAppProfile, request,
+      "InstanceAdmin::UpdateAppProfile", status, true);
 }
 
 std::vector<btproto::AppProfile> InstanceAdmin::ListAppProfiles(

--- a/google/cloud/bigtable/internal/instance_admin.h
+++ b/google/cloud/bigtable/internal/instance_admin.h
@@ -124,6 +124,10 @@ class InstanceAdmin {
       bigtable::InstanceId const& instance_id,
       bigtable::ClusterId const& cluster_id, grpc::Status& status);
 
+  ::google::longrunning::Operation UpdateAppProfile(
+      bigtable::InstanceId instance_id, bigtable::AppProfileId profile_id,
+      AppProfileUpdateConfig config, grpc::Status& status);
+
   ::google::bigtable::admin::v2::AppProfile CreateAppProfile(
       bigtable::InstanceId const& instance_id, AppProfileConfig config,
       grpc::Status& status);

--- a/google/cloud/bigtable/tests/instance_admin_emulator.cc
+++ b/google/cloud/bigtable/tests/instance_admin_emulator.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/bigtable/internal/make_unique.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h>
 #include <google/longrunning/operations.grpc.pb.h>
+#include <google/protobuf/text_format.h>
 #include <grpcpp/grpcpp.h>
 
 namespace btadmin = google::bigtable::admin::v2;
@@ -36,6 +37,10 @@ class InstanceAdminEmulator final
       grpc::ServerContext* context,
       btadmin::CreateInstanceRequest const* request,
       google::longrunning::Operation* response) override {
+    std::string request_text;
+    google::protobuf::TextFormat::PrintToString(*request, &request_text);
+    std::cout << __func__ << "request=" << request_text << std::endl;
+
     std::string name =
         request->parent() + "/instances/" + request->instance_id();
     auto ins = instances_.emplace(name, request->instance());
@@ -65,6 +70,10 @@ class InstanceAdminEmulator final
   grpc::Status GetInstance(grpc::ServerContext* context,
                            btadmin::GetInstanceRequest const* request,
                            btadmin::Instance* response) override {
+    std::string request_text;
+    google::protobuf::TextFormat::PrintToString(*request, &request_text);
+    std::cout << __func__ << "request=" << request_text << std::endl;
+
     auto i = instances_.find(request->name());
     if (i == instances_.end()) {
       return grpc::Status(grpc::StatusCode::NOT_FOUND, "instance missing");
@@ -77,6 +86,10 @@ class InstanceAdminEmulator final
       grpc::ServerContext* context,
       btadmin::ListInstancesRequest const* request,
       btadmin::ListInstancesResponse* response) override {
+    std::string request_text;
+    google::protobuf::TextFormat::PrintToString(*request, &request_text);
+    std::cout << __func__ << "request=" << request_text << std::endl;
+
     std::string prefix = request->parent() + "/instances/";
     for (auto const& kv : instances_) {
       if (0 == kv.first.find(prefix)) {
@@ -89,6 +102,10 @@ class InstanceAdminEmulator final
   grpc::Status UpdateInstance(grpc::ServerContext* context,
                               btadmin::Instance const* request,
                               btadmin::Instance* response) override {
+    std::string request_text;
+    google::protobuf::TextFormat::PrintToString(*request, &request_text);
+    std::cout << __func__ << "request=" << request_text << std::endl;
+
     return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
   }
 
@@ -96,6 +113,10 @@ class InstanceAdminEmulator final
       grpc::ServerContext* context,
       btadmin::PartialUpdateInstanceRequest const* request,
       google::longrunning::Operation* response) override {
+    std::string request_text;
+    google::protobuf::TextFormat::PrintToString(*request, &request_text);
+    std::cout << __func__ << "request=" << request_text << std::endl;
+
     std::string name = request->instance().name();
     auto it = instances_.find(name);
     if (it == instances_.end()) {
@@ -141,6 +162,10 @@ class InstanceAdminEmulator final
   grpc::Status DeleteInstance(grpc::ServerContext* context,
                               btadmin::DeleteInstanceRequest const* request,
                               google::protobuf::Empty* response) override {
+    std::string request_text;
+    google::protobuf::TextFormat::PrintToString(*request, &request_text);
+    std::cout << __func__ << "request=" << request_text << std::endl;
+
     auto i = instances_.find(request->name());
     if (i == instances_.end()) {
       return grpc::Status(grpc::StatusCode::NOT_FOUND, "instance missing");
@@ -160,6 +185,10 @@ class InstanceAdminEmulator final
       grpc::ServerContext* context,
       btadmin::CreateClusterRequest const* request,
       google::longrunning::Operation* response) override {
+    std::string request_text;
+    google::protobuf::TextFormat::PrintToString(*request, &request_text);
+    std::cout << __func__ << "request=" << request_text << std::endl;
+
     std::string name = request->parent() + "/clusters/" + request->cluster_id();
     auto ins = clusters_.emplace(name, request->cluster());
     if (ins.second) {
@@ -179,6 +208,10 @@ class InstanceAdminEmulator final
   grpc::Status GetCluster(grpc::ServerContext* context,
                           btadmin::GetClusterRequest const* request,
                           btadmin::Cluster* response) override {
+    std::string request_text;
+    google::protobuf::TextFormat::PrintToString(*request, &request_text);
+    std::cout << __func__ << "request=" << request_text << std::endl;
+
     auto i = clusters_.find(request->name());
     if (i == clusters_.end()) {
       return grpc::Status(grpc::StatusCode::NOT_FOUND, "cluster missing");
@@ -190,6 +223,10 @@ class InstanceAdminEmulator final
   grpc::Status ListClusters(grpc::ServerContext* context,
                             btadmin::ListClustersRequest const* request,
                             btadmin::ListClustersResponse* response) override {
+    std::string request_text;
+    google::protobuf::TextFormat::PrintToString(*request, &request_text);
+    std::cout << __func__ << "request=" << request_text << std::endl;
+
     // magical instance name "-" must return all clusters in the project
     auto project_path =
         request->parent().substr(0, request->parent().find("/instances"));
@@ -219,6 +256,10 @@ class InstanceAdminEmulator final
   grpc::Status UpdateCluster(
       grpc::ServerContext* context, btadmin::Cluster const* request,
       google::longrunning::Operation* response) override {
+    std::string request_text;
+    google::protobuf::TextFormat::PrintToString(*request, &request_text);
+    std::cout << __func__ << "request=" << request_text << std::endl;
+
     std::string name = request->name();
     auto it = clusters_.find(name);
     if (it == clusters_.end()) {
@@ -237,6 +278,10 @@ class InstanceAdminEmulator final
   grpc::Status DeleteCluster(grpc::ServerContext* context,
                              btadmin::DeleteClusterRequest const* request,
                              google::protobuf::Empty* response) override {
+    std::string request_text;
+    google::protobuf::TextFormat::PrintToString(*request, &request_text);
+    std::cout << __func__ << "request=" << request_text << std::endl;
+
     auto i = clusters_.find(request->name());
     if (i == clusters_.end()) {
       return grpc::Status(grpc::StatusCode::NOT_FOUND, "instance missing");
@@ -248,6 +293,10 @@ class InstanceAdminEmulator final
   grpc::Status CreateAppProfile(grpc::ServerContext* context,
                                 btadmin::CreateAppProfileRequest const* request,
                                 btadmin::AppProfile* response) override {
+    std::string request_text;
+    google::protobuf::TextFormat::PrintToString(*request, &request_text);
+    std::cout << __func__ << "request=" << request_text << std::endl;
+
     auto name = request->parent() + "/appProfiles/" + request->app_profile_id();
     auto ins = app_profiles_.emplace(name, request->app_profile());
     if (ins.second) {
@@ -264,6 +313,10 @@ class InstanceAdminEmulator final
   grpc::Status GetAppProfile(grpc::ServerContext* context,
                              btadmin::GetAppProfileRequest const* request,
                              btadmin::AppProfile* response) override {
+    std::string request_text;
+    google::protobuf::TextFormat::PrintToString(*request, &request_text);
+    std::cout << __func__ << "request=" << request_text << std::endl;
+
     auto i = app_profiles_.find(request->name());
     if (i == app_profiles_.end()) {
       return grpc::Status(grpc::StatusCode::NOT_FOUND, "app profile not found");
@@ -276,6 +329,10 @@ class InstanceAdminEmulator final
       grpc::ServerContext* context,
       btadmin::ListAppProfilesRequest const* request,
       btadmin::ListAppProfilesResponse* response) override {
+    std::string request_text;
+    google::protobuf::TextFormat::PrintToString(*request, &request_text);
+    std::cout << __func__ << "request=" << request_text << std::endl;
+
     auto const& parent = request->parent();
     for (auto const& kv : app_profiles_) {
       if (0 == kv.first.find(parent)) {
@@ -290,13 +347,17 @@ class InstanceAdminEmulator final
       grpc::ServerContext* context,
       btadmin::UpdateAppProfileRequest const* request,
       google::longrunning::Operation* response) override {
+    std::string request_text;
+    google::protobuf::TextFormat::PrintToString(*request, &request_text);
+    std::cout << __func__ << "request=" << request_text << std::endl;
+
     std::string name = request->app_profile().name();
     auto it = app_profiles_.find(name);
     if (it == app_profiles_.end()) {
       return grpc::Status(grpc::StatusCode::NOT_FOUND, "app profile not found");
     }
 
-    auto& stored_app_profile = it->second;
+    btadmin::AppProfile& stored_app_profile = it->second;
 
     for (int index = 0; index != request->update_mask().paths_size(); ++index) {
       if ("description" == request->update_mask().paths(index)) {
@@ -324,6 +385,10 @@ class InstanceAdminEmulator final
   grpc::Status DeleteAppProfile(grpc::ServerContext* context,
                                 btadmin::DeleteAppProfileRequest const* request,
                                 google::protobuf::Empty* response) override {
+    std::string request_text;
+    google::protobuf::TextFormat::PrintToString(*request, &request_text);
+    std::cout << __func__ << "request=" << request_text << std::endl;
+
     auto i = app_profiles_.find(request->name());
     if (i == app_profiles_.end()) {
       return grpc::Status(grpc::StatusCode::NOT_FOUND, "app profile not found");
@@ -335,12 +400,20 @@ class InstanceAdminEmulator final
   grpc::Status GetIamPolicy(grpc::ServerContext* context,
                             google::iam::v1::GetIamPolicyRequest const* request,
                             google::iam::v1::Policy* response) override {
+    std::string request_text;
+    google::protobuf::TextFormat::PrintToString(*request, &request_text);
+    std::cout << __func__ << "request=" << request_text << std::endl;
+
     return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
   }
 
   grpc::Status SetIamPolicy(grpc::ServerContext* context,
                             google::iam::v1::SetIamPolicyRequest const* request,
                             google::iam::v1::Policy* response) override {
+    std::string request_text;
+    google::protobuf::TextFormat::PrintToString(*request, &request_text);
+    std::cout << __func__ << "request=" << request_text << std::endl;
+
     return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
   }
 
@@ -348,6 +421,10 @@ class InstanceAdminEmulator final
       grpc::ServerContext* context,
       google::iam::v1::TestIamPermissionsRequest const* request,
       google::iam::v1::TestIamPermissionsResponse* response) override {
+    std::string request_text;
+    google::protobuf::TextFormat::PrintToString(*request, &request_text);
+    std::cout << __func__ << "request=" << request_text << std::endl;
+
     return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
   }
 

--- a/google/cloud/bigtable/tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_integration_test.cc
@@ -443,6 +443,22 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteAppProfile) {
   EXPECT_THAT(detail_1.name(), HasSubstr(instance_id));
   EXPECT_THAT(detail_1.name(), HasSubstr(id1));
 
+  auto detail_2 = instance_admin_->GetAppProfile(
+      bigtable::InstanceId(instance_id), bigtable::AppProfileId(id2));
+  EXPECT_EQ(detail_2.name(), profile_2.name());
+  EXPECT_THAT(detail_2.name(), HasSubstr(instance_id));
+  EXPECT_THAT(detail_2.name(), HasSubstr(id2));
+
+  auto profile_updated_future = instance_admin_->UpdateAppProfile(
+      bigtable::InstanceId(instance_id), bigtable::AppProfileId(id2),
+      bigtable::AppProfileUpdateConfig().set_description("new description"));
+
+  auto update_2 = profile_updated_future.get();
+  auto detail_2_after_update = instance_admin_->GetAppProfile(
+      bigtable::InstanceId(instance_id), bigtable::AppProfileId(id2));
+  EXPECT_EQ("new description", update_2.description());
+  EXPECT_EQ("new description", detail_2_after_update.description());
+
   instance_admin_->DeleteAppProfile(bigtable::InstanceId(instance_id),
                                     bigtable::AppProfileId(id1), true);
   current_profiles = instance_admin_->ListAppProfiles(instance_id);


### PR DESCRIPTION
This finally fixes #780. This change implements the API, adds
the integration tests, unit tests, and code samples.

I needed some debugging messages in the instance emulator.
I decided to leave them there because I think it may be useful in the
future.  I can move to a separate PR if you prefer.

