### PR TITLE
Simplify configuration of policies.

### DIFF
--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -56,7 +56,7 @@ class InstanceAdmin {
    *     - `PollingPolicy` for how long will the class wait for
    *       `google.longrunning.Operation` to complete. This class combines both
    *       the backoff policy for checking long running operations and the
-   *       retry policy
+   *       retry policy.
    *
    * @see GenericPollingPolicy, ExponentialBackoffPolicy,
    *     LimitedErrorCountRetryPolicy, LimitedTimeRetryPolicy.

--- a/google/cloud/bigtable/internal/instance_admin.h
+++ b/google/cloud/bigtable/internal/instance_admin.h
@@ -67,7 +67,7 @@ class InstanceAdmin {
    *     - `PollingPolicy` for how long will the class wait for
    *       `google.longrunning.Operation` to complete. This class combines both
    *       the backoff policy for checking long running operations and the
-   *       retry policy
+   *       retry policy.
    *
    * @see GenericPollingPolicy, ExponentialBackoffPolicy,
    *     LimitedErrorCountRetryPolicy, LimitedTimeRetryPolicy.

--- a/google/cloud/bigtable/internal/table_admin.h
+++ b/google/cloud/bigtable/internal/table_admin.h
@@ -76,7 +76,7 @@ class TableAdmin {
    *     - `PollingPolicy` for how long will the class wait for
    *       `google.longrunning.Operation` to complete. This class combines both
    *       the backoff policy for checking long running operations and the
-   *       retry policy
+   *       retry policy.
    *
    * @see GenericPollingPolicy, ExponentialBackoffPolicy,
    *     LimitedErrorCountRetryPolicy, LimitedTimeRetryPolicy.

--- a/google/cloud/bigtable/internal/table_test.cc
+++ b/google/cloud/bigtable/internal/table_test.cc
@@ -67,6 +67,19 @@ struct MockRpcFactory {
 
 }  // anonymous namespace
 
+TEST_F(NoexTableTest, ChangeOnePolicy) {
+  bigtable::noex::Table table(client_, "some-table",
+                              bigtable::AlwaysRetryMutationPolicy());
+  EXPECT_THAT(table.table_name(), ::testing::HasSubstr("some-table"));
+}
+
+TEST_F(NoexTableTest, ChangePolicies) {
+  bigtable::noex::Table table(client_, "some-table",
+                              bigtable::AlwaysRetryMutationPolicy(),
+                              bigtable::LimitedErrorCountRetryPolicy(42));
+  EXPECT_THAT(table.table_name(), ::testing::HasSubstr("some-table"));
+}
+
 TEST_F(NoexTableTest, ClientProjectId) {
   EXPECT_EQ(kProjectId, client_->project_id());
 }
@@ -706,9 +719,7 @@ TEST_F(NoexTableTest, BulkApplyTooManyFailures) {
       // Configure the Table to stop at 3 failures.
       bt::LimitedErrorCountRetryPolicy(2),
       // Use much shorter backoff than the default to test faster.
-      bt::ExponentialBackoffPolicy(10_us, 40_us),
-      // TODO(#66) - it is annoying to set a policy we do not care about.
-      bt::SafeIdempotentMutationPolicy());
+      bt::ExponentialBackoffPolicy(10_us, 40_us));
 
   // Setup the mocks to fail more than 3 times.
   auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -64,7 +64,7 @@ class TableAdmin {
    *     - `PollingPolicy` for how long will the class wait for
    *       `google.longrunning.Operation` to complete. This class combines both
    *       the backoff policy for checking long running operations and the
-   *       retry policy
+   *       retry policy.
    *
    * @see GenericPollingPolicy, ExponentialBackoffPolicy,
    *     LimitedErrorCountRetryPolicy, LimitedTimeRetryPolicy.

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -46,46 +46,34 @@ class TableAdmin {
   /**
    * Create a new TableAdmin using explicit policies to handle RPC errors.
    *
-   * @tparam RPCRetryPolicy control which operations to retry and for how long.
-   * @tparam RPCBackoffPolicy control how does the client backs off after an RPC
-   *     error.
    * @param client the interface to create grpc stubs, report errors, etc.
    * @param instance_id the id of the instance, e.g., "my-instance", the full
    *   name (e.g. '/projects/my-project/instances/my-instance') is built using
    *   the project id in the @p client parameter.
-   * @param retry_policy the policy to handle RPC errors.
-   * @param backoff_policy the policy to control backoff after an error.
-   */
-  template <typename RPCRetryPolicy, typename RPCBackoffPolicy>
-  TableAdmin(std::shared_ptr<AdminClient> client, std::string instance_id,
-             RPCRetryPolicy retry_policy, RPCBackoffPolicy backoff_policy)
-      : impl_(std::move(client), std::move(instance_id),
-              std::move(retry_policy), std::move(backoff_policy)) {}
-
-  /**
-   * Create a new TableAdmin using explicit policies to handle RPC errors.
+   * @param policies the set of policy overrides for this object.
+   * @tparam Policies the types of the policies to override, the types must
+   *     derive from one of the following types:
+   *     - `RPCBackoffPolicy` how to backoff from a failed RPC. Currently only
+   *       `ExponentialBackoffPolicy` is implemented. You can also create your
+   *       own policies that backoff using a different algorithm.
+   *     - `RPCRetryPolicy` for how long to retry failed RPCs. Use
+   *       `LimitedErrorCountRetryPolicy` to limit the number of failures
+   *       allowed. Use `LimitedTimeRetryPolicy` to bound the time for any
+   *       request. You can also create your own policies that combine time and
+   *       error counts.
+   *     - `PollingPolicy` for how long will the class wait for
+   *       `google.longrunning.Operation` to complete. This class combines both
+   *       the backoff policy for checking long running operations and the
+   *       retry policy
    *
-   * @tparam RPCRetryPolicy control which operations to retry and for how long.
-   * @tparam RPCBackoffPolicy control how does the client backs off after an RPC
-   *     error.
-   * @tparam PollingPolicy provides parameters for asynchronous calls.
-   * @param client the interface to create grpc stubs, report errors, etc.
-   * @param instance_id the id of the instance, e.g., "my-instance", the full
-   *   name (e.g. '/projects/my-project/instances/my-instance') is built using
-   *   the project id in the @p client parameter.
-   * @param retry_policy the policy to handle RPC errors.
-   * @param backoff_policy the policy to control backoff after an error.
-   * @param polling_policy the policy to control the asynchronous call
-   * parameters
+   * @see GenericPollingPolicy, ExponentialBackoffPolicy,
+   *     LimitedErrorCountRetryPolicy, LimitedTimeRetryPolicy.
    */
-  template <typename RPCRetryPolicy, typename RPCBackoffPolicy,
-            typename PollingPolicy>
+  template <typename... Policies>
   TableAdmin(std::shared_ptr<AdminClient> client, std::string instance_id,
-             RPCRetryPolicy retry_policy, RPCBackoffPolicy backoff_policy,
-             PollingPolicy polling_policy)
+             Policies&&... policies)
       : impl_(std::move(client), std::move(instance_id),
-              std::move(retry_policy), std::move(backoff_policy),
-              std::move(polling_policy)) {}
+              std::forward<Policies>(policies)...) {}
 
   TableAdmin(TableAdmin const& table_admin) = default;
   TableAdmin& operator=(TableAdmin const& table_admin) = default;

--- a/google/cloud/bigtable/table_bulk_apply_test.cc
+++ b/google/cloud/bigtable/table_bulk_apply_test.cc
@@ -189,9 +189,7 @@ TEST_F(TableBulkApplyTest, TooManyFailures) {
       // Configure the Table to stop at 3 failures.
       bt::LimitedErrorCountRetryPolicy(2),
       // Use much shorter backoff than the default to test faster.
-      bt::ExponentialBackoffPolicy(10_us, 40_us),
-      // TODO(#66) - it is annoying to set a policy we do not care about.
-      bt::SafeIdempotentMutationPolicy());
+      bt::ExponentialBackoffPolicy(10_us, 40_us));
 
   // Setup the mocks to fail more than 3 times.
   auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -81,3 +81,16 @@ TEST_F(TableTest, MoveAssignment) {
   dest = std::move(source);
   EXPECT_EQ(expected, dest.table_name());
 }
+
+TEST_F(TableTest, ChangeOnePolicy) {
+  bigtable::Table table(client_, "some-table",
+                        bigtable::AlwaysRetryMutationPolicy());
+  EXPECT_THAT(table.table_name(), ::testing::HasSubstr("some-table"));
+}
+
+TEST_F(TableTest, ChangePolicies) {
+  bigtable::Table table(client_, "some-table",
+                        bigtable::AlwaysRetryMutationPolicy(),
+                        bigtable::LimitedErrorCountRetryPolicy(42));
+  EXPECT_THAT(table.table_name(), ::testing::HasSubstr("some-table"));
+}


### PR DESCRIPTION
This fixes #66. Until now, if you wanted to change one of the
policies in a Table, TableAdmin, or InstanceAdmin object you had
to pass *all* of them in the constructor. With this change you can
just pass the ones that you want to override. That makes life
easier for our users.