### PR TITLE
Update docs links in README [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ C++ Idiomatic Clients for [Google Cloud Platform][cloud-platform] services.
 [![Travis CI status][travis-shield]][travis-link]
 [![AppVeyor CI status][appveyor-shield]][appveyor-link]
 [![Codecov Coverage status][codecov-shield]][codecov-link]
-[![Documentation][doxygen-shield]][doxygen-link]
 
 - [Google Cloud Platform Documentation][cloud-platform-docs]
+- [Client Library Documentation][client-library-docs]
 
 [travis-shield]: https://travis-ci.org/GoogleCloudPlatform/google-cloud-cpp.svg?branch=master
 [travis-link]: https://travis-ci.org/GoogleCloudPlatform/google-cloud-cpp/builds
@@ -15,15 +15,14 @@ C++ Idiomatic Clients for [Google Cloud Platform][cloud-platform] services.
 [appveyor-link]: https://ci.appveyor.com/project/coryan/google-cloud-cpp/branch/master
 [codecov-shield]: https://codecov.io/gh/GoogleCloudPlatform/google-cloud-cpp/branch/master/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/GoogleCloudPlatform/google-cloud-cpp
-[doxygen-shield]: https://img.shields.io/badge/documentation-master-brightgreen.svg
-[doxygen-link]: http://GoogleCloudPlatform.github.io/google-cloud-cpp/
 [cloud-platform]: https://cloud.google.com/
 [cloud-platform-docs]: https://cloud.google.com/docs/
+[client-library-docs]: http://GoogleCloudPlatform.github.io/google-cloud-cpp/
 
 This library supports the following Google Cloud Platform services with clients
 at an [Alpha](#versioning) quality level:
 
-- [Google Cloud Bigtable](bigtable)
+- [Google Cloud Bigtable](google/cloud/bigtable)
 
 The libraries in this code base likely do not (yet) cover all the available
 APIs. See the [`googleapis` repo](https://github.com/googleapis/googleapis)


### PR DESCRIPTION
* Remove the documentation badge: it's confusing because it's not
  actually a build status page, but links to docs; I couldn't find it in
  the README at first because I mentally ignored the list of badges;
  only realized it points to the docs when I read the source. Other
  client library pages don't use a badge for documentation, but
  explicitly link to GCP docs and client library docs via text.

* Fix link to the Cloud Bigtable source code, which was moved when the
  namespace changed.

Fixes #744 and also adds visibility to the link to the published docs.

> Note: some of these fixes are also present in 2 other PRs (#745 and #754) but they also contain many other changes which are still being discussed, while these links are either broken or hard to discover on our main README, so I want to make sure we can fix them ASAP, and it should merge cleanly with other in-progress PRs.