### PR TITLE
Fix memory corruption in instance emulator.

### DIFF
--- a/google/cloud/bigtable/tests/instance_admin_emulator.cc
+++ b/google/cloud/bigtable/tests/instance_admin_emulator.cc
@@ -172,10 +172,12 @@ class InstanceAdminEmulator final
     }
     instances_.erase(i->first);
 
-    for (auto it : clusters_) {
-      if (it.first.find(request->name()) != std::string::npos) {
-        clusters_.erase(it.first);
+    for (auto it = clusters_.begin(); it != clusters_.end();) {
+      if (std::string::npos == it->first.find(request->name())) {
+        ++it;
+        continue;
       }
+      clusters_.erase(it++);
     }
 
     return grpc::Status::OK;


### PR DESCRIPTION
Some of the integration tests were getting flaky, and one of them
showed the instance emulator crashing. Running with valgrind(1)
found memory corruption immediately. Calling std::map::erase()
while an iterator is not valid, the iterator is invalidated.