### PR TITLE
Consistently qualify types in RawClient classes.

### DIFF
--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -22,7 +22,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
-using namespace google::cloud::storage::internal::raw_client_wrapper_utils;
+using namespace raw_client_wrapper_utils;
 /**
  * Call a RawClient operation logging both the input and the result.
  *
@@ -37,8 +37,7 @@ template <typename MemberFunction>
 static typename std::enable_if<
     CheckSignature<MemberFunction>::value,
     typename CheckSignature<MemberFunction>::ReturnType>::type
-MakeCall(google::cloud::storage::internal::RawClient& client,
-         MemberFunction function,
+MakeCall(RawClient& client, MemberFunction function,
          typename CheckSignature<MemberFunction>::RequestType const& request,
          char const* context) {
   GCP_LOG(INFO) << context << " << " << request;
@@ -57,28 +56,28 @@ ClientOptions const& LoggingClient::client_options() const {
 }
 
 std::pair<Status, BucketMetadata> LoggingClient::GetBucketMetadata(
-    internal::GetBucketMetadataRequest const& request) {
+    GetBucketMetadataRequest const& request) {
   return MakeCall(*client_, &RawClient::GetBucketMetadata, request, __func__);
 }
 
 std::pair<Status, ObjectMetadata> LoggingClient::InsertObjectMedia(
-    internal::InsertObjectMediaRequest const& request) {
+    InsertObjectMediaRequest const& request) {
   return MakeCall(*client_, &RawClient::InsertObjectMedia, request, __func__);
 }
 
 std::pair<Status, ReadObjectRangeResponse> LoggingClient::ReadObjectRangeMedia(
-    internal::ReadObjectRangeRequest const& request) {
+    ReadObjectRangeRequest const& request) {
   return MakeCall(*client_, &RawClient::ReadObjectRangeMedia, request,
                   __func__);
 }
 
-std::pair<Status, internal::ListObjectsResponse> LoggingClient::ListObjects(
-    internal::ListObjectsRequest const& request) {
+std::pair<Status, ListObjectsResponse> LoggingClient::ListObjects(
+    ListObjectsRequest const& request) {
   return MakeCall(*client_, &RawClient::ListObjects, request, __func__);
 }
 
-std::pair<Status, internal::EmptyResponse> LoggingClient::DeleteObject(
-    google::cloud::storage::internal::DeleteObjectRequest const& request) {
+std::pair<Status, EmptyResponse> LoggingClient::DeleteObject(
+    DeleteObjectRequest const& request) {
   return MakeCall(*client_, &RawClient::DeleteObject, request, __func__);
 }
 

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -33,19 +33,19 @@ class LoggingClient : public RawClient {
   ClientOptions const& client_options() const override;
 
   std::pair<Status, BucketMetadata> GetBucketMetadata(
-      internal::GetBucketMetadataRequest const& request) override;
+      GetBucketMetadataRequest const& request) override;
 
   std::pair<Status, ObjectMetadata> InsertObjectMedia(
-      internal::InsertObjectMediaRequest const& request) override;
+      InsertObjectMediaRequest const& request) override;
 
   std::pair<Status, ReadObjectRangeResponse> ReadObjectRangeMedia(
-      internal::ReadObjectRangeRequest const&) override;
+      ReadObjectRangeRequest const&) override;
 
-  std::pair<Status, internal::ListObjectsResponse> ListObjects(
-      internal::ListObjectsRequest const&) override;
+  std::pair<Status, ListObjectsResponse> ListObjects(
+      ListObjectsRequest const&) override;
 
-  std::pair<Status, internal::EmptyResponse> DeleteObject(
-      internal::DeleteObjectRequest const&) override;
+  std::pair<Status, EmptyResponse> DeleteObject(
+      DeleteObjectRequest const&) override;
 
  private:
   std::shared_ptr<RawClient> client_;

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -50,19 +50,19 @@ class RawClient {
    * TODO(#690) - consider checking that modifiers in a request are compatible.
    */
   virtual std::pair<Status, BucketMetadata> GetBucketMetadata(
-      internal::GetBucketMetadataRequest const& request) = 0;
+      GetBucketMetadataRequest const& request) = 0;
 
   virtual std::pair<Status, ObjectMetadata> InsertObjectMedia(
-      internal::InsertObjectMediaRequest const&) = 0;
+      InsertObjectMediaRequest const&) = 0;
 
-  virtual std::pair<Status, internal::ReadObjectRangeResponse>
-  ReadObjectRangeMedia(internal::ReadObjectRangeRequest const&) = 0;
+  virtual std::pair<Status, ReadObjectRangeResponse> ReadObjectRangeMedia(
+      ReadObjectRangeRequest const&) = 0;
 
-  virtual std::pair<Status, internal::ListObjectsResponse> ListObjects(
-      internal::ListObjectsRequest const&) = 0;
+  virtual std::pair<Status, ListObjectsResponse> ListObjects(
+      ListObjectsRequest const&) = 0;
 
-  virtual std::pair<Status, internal::EmptyResponse> DeleteObject(
-      internal::DeleteObjectRequest const&) = 0;
+  virtual std::pair<Status, EmptyResponse> DeleteObject(
+      DeleteObjectRequest const&) = 0;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -43,7 +43,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
-using namespace google::cloud::storage::internal::raw_client_wrapper_utils;
+using namespace raw_client_wrapper_utils;
 
 /**
  * Call a client operation with retries borrowing the RPC policies.
@@ -64,10 +64,8 @@ template <typename MemberFunction>
 static typename std::enable_if<
     CheckSignature<MemberFunction>::value,
     typename CheckSignature<MemberFunction>::ReturnType>::type
-MakeCall(google::cloud::storage::RetryPolicy& retry_policy,
-         google::cloud::storage::BackoffPolicy& backoff_policy,
-         google::cloud::storage::internal::RawClient& client,
-         MemberFunction function,
+MakeCall(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
+         RawClient& client, MemberFunction function,
          typename CheckSignature<MemberFunction>::RequestType const& request,
          char const* error_message) {
   google::cloud::storage::Status last_status;
@@ -99,19 +97,17 @@ MakeCall(google::cloud::storage::RetryPolicy& retry_policy,
 RetryClient::RetryClient(std::shared_ptr<RawClient> client)
     : RetryClient(
           std::move(client),
-          google::cloud::internal::LimitedTimeRetryPolicy<Status, StatusTraits>(
-              STORAGE_CLIENT_DEFAULT_MAXIMUM_RETRY_PERIOD),
-          google::cloud::internal::ExponentialBackoffPolicy(
-              STORAGE_CLIENT_DEFAULT_INITIAL_BACKOFF_DELAY,
-              STORAGE_CLIENT_DEFAULT_MAXIMUM_BACKOFF_DELAY,
-              STORAGE_CLIENT_DEFAULT_BACKOFF_SCALING)) {}
+          LimitedTimeRetryPolicy(STORAGE_CLIENT_DEFAULT_MAXIMUM_RETRY_PERIOD),
+          ExponentialBackoffPolicy(STORAGE_CLIENT_DEFAULT_INITIAL_BACKOFF_DELAY,
+                                   STORAGE_CLIENT_DEFAULT_MAXIMUM_BACKOFF_DELAY,
+                                   STORAGE_CLIENT_DEFAULT_BACKOFF_SCALING)) {}
 
 ClientOptions const& RetryClient::client_options() const {
   return client_->client_options();
 }
 
 std::pair<Status, BucketMetadata> RetryClient::GetBucketMetadata(
-    internal::GetBucketMetadataRequest const& request) {
+    GetBucketMetadataRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
   return MakeCall(*retry_policy, *backoff_policy, *client_,
@@ -119,7 +115,7 @@ std::pair<Status, BucketMetadata> RetryClient::GetBucketMetadata(
 }
 
 std::pair<Status, ObjectMetadata> RetryClient::InsertObjectMedia(
-    internal::InsertObjectMediaRequest const& request) {
+    InsertObjectMediaRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
   return MakeCall(*retry_policy, *backoff_policy, *client_,
@@ -127,23 +123,23 @@ std::pair<Status, ObjectMetadata> RetryClient::InsertObjectMedia(
 }
 
 std::pair<Status, ReadObjectRangeResponse> RetryClient::ReadObjectRangeMedia(
-    internal::ReadObjectRangeRequest const& request) {
+    ReadObjectRangeRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
   return MakeCall(*retry_policy, *backoff_policy, *client_,
                   &RawClient::ReadObjectRangeMedia, request, __func__);
 }
 
-std::pair<Status, internal::ListObjectsResponse> RetryClient::ListObjects(
-    internal::ListObjectsRequest const& request) {
+std::pair<Status, ListObjectsResponse> RetryClient::ListObjects(
+    ListObjectsRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
   return MakeCall(*retry_policy, *backoff_policy, *client_,
                   &RawClient::ListObjects, request, __func__);
 }
 
-std::pair<Status, internal::EmptyResponse> RetryClient::DeleteObject(
-    internal::DeleteObjectRequest const& request) {
+std::pair<Status, EmptyResponse> RetryClient::DeleteObject(
+    DeleteObjectRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
   return MakeCall(*retry_policy, *backoff_policy, *client_,

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -41,19 +41,19 @@ class RetryClient : public RawClient {
   ClientOptions const& client_options() const override;
 
   std::pair<Status, BucketMetadata> GetBucketMetadata(
-      internal::GetBucketMetadataRequest const& request) override;
+      GetBucketMetadataRequest const& request) override;
 
   std::pair<Status, ObjectMetadata> InsertObjectMedia(
-      internal::InsertObjectMediaRequest const& request) override;
+      InsertObjectMediaRequest const& request) override;
 
   std::pair<Status, ReadObjectRangeResponse> ReadObjectRangeMedia(
-      internal::ReadObjectRangeRequest const&) override;
+      ReadObjectRangeRequest const&) override;
 
-  std::pair<Status, internal::ListObjectsResponse> ListObjects(
-      internal::ListObjectsRequest const&) override;
+  std::pair<Status, ListObjectsResponse> ListObjects(
+      ListObjectsRequest const&) override;
 
-  std::pair<Status, internal::EmptyResponse> DeleteObject(
-      internal::DeleteObjectRequest const&) override;
+  std::pair<Status, EmptyResponse> DeleteObject(
+      DeleteObjectRequest const&) override;
 
  private:
   std::shared_ptr<RawClient> client_;


### PR DESCRIPTION
We were inconsistently qualifying classes in the `internal`
namespace. Sometimes we said `internal::Foo`, sometimes `Foo`,
sometimes `google::cloud::internal::Foo`. Since the RawClient class
and its derived classes live in `google::cloud::internal` I think
we should use just `Foo`.