### PR TITLE
Simplify changing retry / backoff policies.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -197,6 +197,7 @@ create_bazel_config(storage_client_testing)
 set(storage_client_unit_tests
     bucket_metadata_test.cc
     bucket_test.cc
+    client_test.cc
     credentials_test.cc
     internal/authorized_user_credentials_test.cc
     internal/binary_data_as_debug_string_test.cc

--- a/google/cloud/storage/bucket_test.cc
+++ b/google/cloud/storage/bucket_test.cc
@@ -24,7 +24,6 @@ namespace storage {
 using namespace testing::canonical_errors;
 namespace {
 using namespace ::testing;
-using ms = std::chrono::milliseconds;
 
 class BucketTest : public ::testing::Test {
  protected:
@@ -68,8 +67,7 @@ TEST_F(BucketTest, GetBucketMetadata) {
             return std::make_pair(Status(), expected);
           }));
   Client client{std::shared_ptr<internal::RawClient>(mock),
-                LimitedErrorCountRetryPolicy(2),
-                ExponentialBackoffPolicy(ms(100), ms(500), 2)};
+                LimitedErrorCountRetryPolicy(2)};
 
   auto actual = client.GetBucketMetadata("foo-bar-baz");
   EXPECT_EQ(expected, actual);
@@ -77,8 +75,7 @@ TEST_F(BucketTest, GetBucketMetadata) {
 
 TEST_F(BucketTest, GetMetadataTooManyFailures) {
   Client client{std::shared_ptr<internal::RawClient>(mock),
-                LimitedErrorCountRetryPolicy(2),
-                ExponentialBackoffPolicy(ms(100), ms(500), 2)};
+                LimitedErrorCountRetryPolicy(2)};
 
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_CALL(*mock, GetBucketMetadata(_))
@@ -145,10 +142,8 @@ TEST_F(BucketTest, InsertObjectMedia) {
 }
 
 TEST_F(BucketTest, InsertObjectMediaTooManyFailures) {
-  using ms = std::chrono::milliseconds;
   Client client{std::shared_ptr<internal::RawClient>(mock),
-                LimitedErrorCountRetryPolicy(2),
-                ExponentialBackoffPolicy(ms(100), ms(500), 2)};
+                LimitedErrorCountRetryPolicy(2)};
 
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_CALL(*mock, InsertObjectMedia(_))

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -29,14 +29,6 @@ static_assert(std::is_copy_constructible<storage::Client>::value,
 static_assert(std::is_copy_assignable<storage::Client>::value,
               "storage::Client must be assignable");
 
-Client::Client(std::shared_ptr<internal::RawClient> client)
-    : raw_client_(std::move(client)) {
-  if (raw_client_->client_options().enable_raw_client_tracing()) {
-    raw_client_.reset(new internal::LoggingClient(std::move(raw_client_)));
-  }
-  raw_client_.reset(new internal::RetryClient(std::move(raw_client_)));
-}
-
 Client::Client(ClientOptions options)
     : Client(std::shared_ptr<internal::RawClient>(
           new internal::DefaultClient<>(std::move(options)))) {}

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -47,16 +47,12 @@ class Client {
   explicit Client(std::shared_ptr<Credentials> credentials)
       : Client(ClientOptions(std::move(credentials))) {}
 
-  /// Build a client with specific retry and backoff policies.
-  template <typename RetryPolicy, typename BackoffPolicy>
-  Client(std::shared_ptr<internal::RawClient> client, RetryPolicy retry_policy,
-         BackoffPolicy backoff_policy)
-      : raw_client_(new internal::RetryClient(std::move(client),
-                                              std::move(retry_policy),
-                                              std::move(backoff_policy))) {}
-
-  /// Build a client with an specific RawClient, with the default retry policy
-  explicit Client(std::shared_ptr<internal::RawClient> client);
+  /// Build a client and maybe override the retry and/or backoff policies.
+  template <typename... Policies>
+  explicit Client(std::shared_ptr<internal::RawClient> client,
+                  Policies&&... policies)
+      : raw_client_(new internal::RetryClient(
+            std::move(client), std::forward<Policies>(policies)...)) {}
 
   /// Build a client with an specific RawClient, without retry policies.
   struct NoRetry {};

--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -1,0 +1,131 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/retry_policy.h"
+#include "google/cloud/storage/testing/canonical_errors.h"
+#include "google/cloud/storage/testing/mock_client.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+using namespace testing::canonical_errors;
+namespace {
+using namespace ::testing;
+
+class ObservableRetryPolicy : public LimitedErrorCountRetryPolicy {
+ public:
+  using LimitedErrorCountRetryPolicy::LimitedErrorCountRetryPolicy;
+
+  std::unique_ptr<RetryPolicy> clone() const override {
+    return std::unique_ptr<RetryPolicy>(new ObservableRetryPolicy(*this));
+  }
+
+  bool IsExhausted() const override {
+    ++is_exhausted_count;
+    return LimitedErrorCountRetryPolicy::IsExhausted();
+  }
+
+  static int is_exhausted_count;
+};
+int ObservableRetryPolicy::is_exhausted_count;
+
+class ObservableBackoffPolicy : public ExponentialBackoffPolicy {
+ public:
+  using ExponentialBackoffPolicy::ExponentialBackoffPolicy;
+
+  std::unique_ptr<BackoffPolicy> clone() const override {
+    return std::unique_ptr<BackoffPolicy>(new ObservableBackoffPolicy(*this));
+  }
+
+  std::chrono::milliseconds OnCompletion() override {
+    ++on_completion_count;
+    return ExponentialBackoffPolicy::OnCompletion();
+  }
+
+  static int on_completion_count;
+};
+
+class ClientTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    mock = std::make_shared<testing::MockClient>();
+    ObservableRetryPolicy::is_exhausted_count = 0;
+    ObservableBackoffPolicy::on_completion_count = 0;
+  }
+  void TearDown() override {
+    ObservableRetryPolicy::is_exhausted_count = 0;
+    ObservableBackoffPolicy::on_completion_count = 0;
+    mock.reset();
+  }
+
+  std::shared_ptr<testing::MockClient> mock;
+};
+
+int ObservableBackoffPolicy::on_completion_count;
+
+TEST_F(ClientTest, OverrideRetryPolicy) {
+  Client client{std::shared_ptr<internal::RawClient>(mock),
+                ObservableRetryPolicy(3)};
+
+  // Reset the counters at the beginning of the test.
+
+  // Call an API (any API) on the client, we do not care about the status, just
+  // that our policy is called.
+  EXPECT_CALL(*mock, GetBucketMetadata(_))
+      .WillOnce(Return(std::make_pair(TransientError(), BucketMetadata{})))
+      .WillOnce(Return(std::make_pair(Status(), BucketMetadata{})));
+  (void)client.GetBucketMetadata("foo-bar-baz");
+  EXPECT_LE(1, ObservableRetryPolicy::is_exhausted_count);
+  EXPECT_EQ(0, ObservableBackoffPolicy::on_completion_count);
+}
+
+TEST_F(ClientTest, OverrideBackoffPolicy) {
+  using ms = std::chrono::milliseconds;
+  Client client{std::shared_ptr<internal::RawClient>(mock),
+                ObservableBackoffPolicy(ms(20), ms(100), 2.0)};
+
+  // Call an API (any API) on the client, we do not care about the status, just
+  // that our policy is called.
+  EXPECT_CALL(*mock, GetBucketMetadata(_))
+      .WillOnce(Return(std::make_pair(TransientError(), BucketMetadata{})))
+      .WillOnce(Return(std::make_pair(Status(), BucketMetadata{})));
+  (void)client.GetBucketMetadata("foo-bar-baz");
+  EXPECT_EQ(0, ObservableRetryPolicy::is_exhausted_count);
+  EXPECT_LE(1, ObservableBackoffPolicy::on_completion_count);
+}
+
+TEST_F(ClientTest, OverrideBothPolicies) {
+  using ms = std::chrono::milliseconds;
+  Client client{std::shared_ptr<internal::RawClient>(mock),
+                ObservableBackoffPolicy(ms(20), ms(100), 2.0),
+                ObservableRetryPolicy(3)};
+
+  // Call an API (any API) on the client, we do not care about the status, just
+  // that our policy is called.
+  EXPECT_CALL(*mock, GetBucketMetadata(_))
+      .WillOnce(Return(std::make_pair(TransientError(), BucketMetadata{})))
+      .WillOnce(Return(std::make_pair(Status(), BucketMetadata{})));
+  (void)client.GetBucketMetadata("foo-bar-baz");
+  EXPECT_LE(1, ObservableRetryPolicy::is_exhausted_count);
+  EXPECT_LE(1, ObservableBackoffPolicy::on_completion_count);
+}
+
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -94,13 +94,18 @@ MakeCall(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
 }
 }  // namespace
 
-RetryClient::RetryClient(std::shared_ptr<RawClient> client)
-    : RetryClient(
-          std::move(client),
-          LimitedTimeRetryPolicy(STORAGE_CLIENT_DEFAULT_MAXIMUM_RETRY_PERIOD),
-          ExponentialBackoffPolicy(STORAGE_CLIENT_DEFAULT_INITIAL_BACKOFF_DELAY,
-                                   STORAGE_CLIENT_DEFAULT_MAXIMUM_BACKOFF_DELAY,
-                                   STORAGE_CLIENT_DEFAULT_BACKOFF_SCALING)) {}
+RetryClient::RetryClient(std::shared_ptr<RawClient> client,
+                         DefaultPolicies unused)
+    : client_(std::move(client)) {
+  retry_policy_ =
+      LimitedTimeRetryPolicy(STORAGE_CLIENT_DEFAULT_MAXIMUM_RETRY_PERIOD)
+          .clone();
+  backoff_policy_ =
+      ExponentialBackoffPolicy(STORAGE_CLIENT_DEFAULT_INITIAL_BACKOFF_DELAY,
+                               STORAGE_CLIENT_DEFAULT_MAXIMUM_BACKOFF_DELAY,
+                               STORAGE_CLIENT_DEFAULT_BACKOFF_SCALING)
+          .clone();
+}
 
 ClientOptions const& RetryClient::client_options() const {
   return client_->client_options();

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -28,14 +28,17 @@ namespace internal {
  */
 class RetryClient : public RawClient {
  public:
-  RetryClient(std::shared_ptr<RawClient> client);
+  struct DefaultPolicies {};
+  explicit RetryClient(std::shared_ptr<RawClient> client,
+                       DefaultPolicies unused);
 
-  template <typename RetryPolicy, typename BackoffPolicy>
-  RetryClient(std::shared_ptr<RawClient> client, RetryPolicy retry_policy,
-              BackoffPolicy backoff_policy)
-      : client_(client),
-        retry_policy_(retry_policy.clone()),
-        backoff_policy_(backoff_policy.clone()) {}
+  template <typename... Policies>
+  explicit RetryClient(std::shared_ptr<RawClient> client,
+                       Policies&&... policies)
+      : RetryClient(std::move(client), DefaultPolicies{}) {
+    ApplyPolicies(std::forward<Policies>(policies)...);
+  }
+
   ~RetryClient() override = default;
 
   ClientOptions const& client_options() const override;
@@ -56,6 +59,18 @@ class RetryClient : public RawClient {
       DeleteObjectRequest const&) override;
 
  private:
+  void Apply(RetryPolicy& policy) { retry_policy_ = policy.clone(); }
+
+  void Apply(BackoffPolicy& policy) { backoff_policy_ = policy.clone(); }
+
+  void ApplyPolicies() {}
+
+  template <typename P, typename... Policies>
+  void ApplyPolicies(P&& head, Policies&&... policies) {
+    Apply(head);
+    ApplyPolicies(std::forward<Policies>(policies)...);
+  }
+
   std::shared_ptr<RawClient> client_;
   std::shared_ptr<RetryPolicy> retry_policy_;
   std::shared_ptr<BackoffPolicy> backoff_policy_;

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -2,6 +2,7 @@
 storage_client_unit_tests = [
     "bucket_metadata_test.cc",
     "bucket_test.cc",
+    "client_test.cc",
     "credentials_test.cc",
     "internal/authorized_user_credentials_test.cc",
     "internal/binary_data_as_debug_string_test.cc",


### PR DESCRIPTION
With this change application developers can change just the
RetryPolicy, just the BackoffPolicy, or both. Before it they
needed to provide both policies in the storage::Client()
constructor, even they may want to just change one of them.

Take advantage of this feature in some of the tests, that makes
the tests simpler and demonstrates that it works. Wrote a unit
test, which is the bulk of the additional code in this change
:confused: 
 