### PR TITLE
Use ExternalProject_Add() for gRPC.

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -14,3 +14,27 @@
 
 tab_size = 4
 separate_ctrl_name_with_space = True
+
+additional_commands = {
+    "externalproject_add": {
+        "flags": [
+        ],
+        "kwargs": {
+            "BUILD_COMMAND": "+",
+            "COMMAND": "+",
+            "CONFIGURE_COMMAND": "+",
+            "DEPENDS": "+",
+            "DOWNLOAD_COMMAND": "+",
+            "EXCLUDE_FROM_ALL": 1,
+            "INSTALL_COMMAND": "+",
+            "INSTALL_DIR": 1,
+            "LOG_BUILD": 1,
+            "LOG_CONFIGURE": 1,
+            "LOG_DOWNLOAD": 1,
+            "LOG_INSTALL": 1,
+            "PREFIX": 1,
+            "URL": 1,
+            "URL_HASH": 1,
+        }
+    }
+}

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,3 @@
 [submodule "googletest"]
 	path = third_party/googletest
 	url = https://github.com/google/googletest.git
-[submodule "third_party/grpc"]
-	path = third_party/grpc
-	url = https://github.com/grpc/grpc.git
-	branch = v1.10.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,8 @@ matrix:
       # requests because Travis often has long backlogs for macOS.
       os: osx
       compiler: clang
+      env:
+        CMAKE_FLAGS=-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl
       install: ci/install-retry.sh ci/install-macosx.sh
       script: ci/build-macosx.sh
       cache: ccache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,12 @@ if ("${GOOGLE_CLOUD_CPP_ENABLE_CCACHE}")
     find_program(CCACHE_FOUND ccache NAMES /usr/bin/ccache)
     if (CCACHE_FOUND)
         message(STATUS "ccache found: ${CCACHE_FOUND}")
-        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_FOUND}")
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${CCACHE_FOUND}")
+
+        set(GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE
+            "-DCMAKE_CXX_COMPILER_LAUNCHER=${CCACHE_FOUND}"
+            "-DCMAKE_CC_COMPILER_LAUNCHER=${CCACHE_FOUND}")
     endif ()
 endif ()
 

--- a/ci/build-macosx.sh
+++ b/ci/build-macosx.sh
@@ -25,6 +25,6 @@ export PATH="/usr/local/opt/ccache/libexec:$PATH"
 
 cmake -H. -B.build \
   -DCMAKE_BUILD_TYPE="${BUILD_TYPE:-Release}" \
-  -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl
+  ${CMAKE_FLAGS}
 cmake --build .build -- -j "${NCPU:-2}"
 (cd .build && ctest --output-on-failure)

--- a/cmake/ExternalProjectHelper.cmake
+++ b/cmake/ExternalProjectHelper.cmake
@@ -1,0 +1,43 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function (set_library_properties_for_external_project _target _lib)
+    cmake_parse_arguments(F_OPT "ALWAYS_SHARED" "" "" ${ARGN})
+    # This is the main disadvantage of external projects. We cannot use the
+    # project's cmake configuration file because they are not installed until
+    # the project is compiled, and this step
+    if (WIN32)
+        set(_libfullname "${CMAKE_STATIC_LIBRARY_PREFIX}${_lib}${CMAKE_LIB}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    elseif ("${BUILD_SHARED_LIBS}" OR "${F_OPT_ALWAYS_SHARED}")
+        set(_libfullname "${CMAKE_SHARED_LIBRARY_PREFIX}${_lib}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+    else ()
+        set(_libfullname "${CMAKE_STATIC_LIBRARY_PREFIX}${_lib}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    endif ()
+
+    set(_libpath "${PROJECT_BINARY_DIR}/external/lib/${_libfullname}")
+    set(_includepath "${PROJECT_BINARY_DIR}/external/include")
+    message(STATUS "Configuring ${_target} with ${_libpath}")
+    set_property(TARGET ${_target} APPEND PROPERTY
+            INTERFACE_LINK_LIBRARIES "${_libpath}")
+    # Manually create the directory, it will be created as part of the build,
+    # but this runs in the configuration phase, and CMake generates an error if
+    # we add an include directory that does not exist yet.
+    file(MAKE_DIRECTORY "${_includepath}")
+    set_property(TARGET ${_target} APPEND PROPERTY
+            INTERFACE_INCLUDE_DIRECTORIES "${_includepath}")
+endfunction ()
+
+function (set_executable_name_for_external_project VAR _exe)
+    set(${VAR} "${PROJECT_BINARY_DIR}/external/bin/${_exe}${CMAKE_EXECUTABLE_SUFFIX}" PARENT_SCOPE)
+endfunction ()

--- a/cmake/ExternalProjectHelper.cmake
+++ b/cmake/ExternalProjectHelper.cmake
@@ -1,3 +1,4 @@
+# ~~~
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# ~~~
 
 include(GNUInstallDirs)
 
@@ -18,35 +20,50 @@ function (set_library_properties_for_external_project _target _lib)
     cmake_parse_arguments(F_OPT "ALWAYS_SHARED" "" "" ${ARGN})
     # This is the main disadvantage of external projects. The typicaly flow with
     # CMake is:
+    # ~~~
     # 1. Configure: cmake discovers where your libraries and dependencies are,
-    #    and it generates Makefiles (or Ninja files or DevStudio files) to
-    #    compile the code.
-    # 2. Compile: cmake compiles your code.
+    #    and it generates Makefiles (or Ninja files or VisualStudio files) to
+    #    compile the code. The paths and/or flags needed for the dependencies
+    #    are embedded in the generated files.
+    # 2. Compile: make, Ninja or VisualStudio compile your code.
+    # ~~~
     #
     # With external projects the flow is the same, except that step 2 has
     # additional sub-steps:
     #
-    # 1. Configure: as above.
-    # 2. Compile:
-    #    2.1: Download any external projects that your code depends on.
-    #    2.2: Compile those external projects.
-    #    2.3: Install those external projects in the ${CMAKE_BINARY_DIR}/...
-    #    2.4: Compile your code.
+    # ~~~
+    # 1. Configure: as above. But the external projects are not "discovered".
+    # 2. Compile: make, Ninja, or Visual Studio compile your code. But new
+    #    steps are introduced to the compilation:
+    # 2.1: Download any external projects that your code depends on.
+    # 2.2: Compile (and maybe test) those external projects.
+    # 2.3: Install those external projects in the ${CMAKE_BINARY_DIR}/...
+    # 2.4: Compile your code.
+    # ~~~
     #
     # We cannot use an external project's cmake configuration file because they
-    # are created and installed until the project is compiled. However, the
-    # CMake configuration phase (step 1 above) is when these configuration files
-    # are needed.  So we have to manually create "IMPORTED" libraries with the
-    # right paths based on where the external dependencies will install them.
+    # are not created nor installed until after the project is compiled.
+    # However, these files would be needed in step 1 if we want to use them in
+    # CMake.
     #
-    # Generally this is possible because we control how the external projects
-    # are compiled.
+    # The alternative is to manually create "IMPORTED" libraries with the right
+    # paths. Generally this is possible because we control how the external
+    # projects are compiled and installed.
     if (WIN32)
-        set(_libfullname "${CMAKE_STATIC_LIBRARY_PREFIX}${_lib}${CMAKE_LIB}${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    elseif ("${BUILD_SHARED_LIBS}" OR "${F_OPT_ALWAYS_SHARED}")
-        set(_libfullname "${CMAKE_SHARED_LIBRARY_PREFIX}${_lib}${CMAKE_SHARED_LIBRARY_SUFFIX}")
-    else ()
-        set(_libfullname "${CMAKE_STATIC_LIBRARY_PREFIX}${_lib}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+        set(
+            _libfullname
+            "${CMAKE_STATIC_LIBRARY_PREFIX}${_lib}${CMAKE_LIB}${CMAKE_STATIC_LIBRARY_SUFFIX}"
+            )
+    elseif("${BUILD_SHARED_LIBS}" OR "${F_OPT_ALWAYS_SHARED}")
+        set(
+            _libfullname
+            "${CMAKE_SHARED_LIBRARY_PREFIX}${_lib}${CMAKE_SHARED_LIBRARY_SUFFIX}"
+            )
+    else()
+        set(
+            _libfullname
+            "${CMAKE_STATIC_LIBRARY_PREFIX}${_lib}${CMAKE_STATIC_LIBRARY_SUFFIX}"
+            )
     endif ()
 
     # Some libraries always install themselves in the "lib/" directory, while
@@ -60,21 +77,28 @@ function (set_library_properties_for_external_project _target _lib)
 
     if (${_lib} IN_LIST _libs_always_install_in_libdir)
         set(_libpath "${PROJECT_BINARY_DIR}/external/lib/${_libfullname}")
-    else ()
-        set(_libpath "${PROJECT_BINARY_DIR}/external/${CMAKE_INSTALL_LIBDIR}/${_libfullname}")
+    else()
+        set(
+            _libpath
+            "${PROJECT_BINARY_DIR}/external/${CMAKE_INSTALL_LIBDIR}/${_libfullname}"
+            )
     endif ()
     set(_includepath "${PROJECT_BINARY_DIR}/external/include")
     message(STATUS "Configuring ${_target} with ${_libpath}")
-    set_property(TARGET ${_target} APPEND PROPERTY
-            INTERFACE_LINK_LIBRARIES "${_libpath}")
+    set_property(TARGET ${_target}
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES "${_libpath}")
     # Manually create the directory, it will be created as part of the build,
     # but this runs in the configuration phase, and CMake generates an error if
     # we add an include directory that does not exist yet.
     file(MAKE_DIRECTORY "${_includepath}")
-    set_property(TARGET ${_target} APPEND PROPERTY
-            INTERFACE_INCLUDE_DIRECTORIES "${_includepath}")
+    set_property(TARGET ${_target}
+                 APPEND
+                 PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${_includepath}")
 endfunction ()
 
 function (set_executable_name_for_external_project VAR _exe)
-    set(${VAR} "${PROJECT_BINARY_DIR}/external/bin/${_exe}${CMAKE_EXECUTABLE_SUFFIX}" PARENT_SCOPE)
+    set(${VAR}
+        "${PROJECT_BINARY_DIR}/external/bin/${_exe}${CMAKE_EXECUTABLE_SUFFIX}"
+        PARENT_SCOPE)
 endfunction ()

--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -44,6 +44,9 @@ include(EnableCxxExceptions)
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
 
+# Add the gmock library if it does not exist.
+include(IncludeGMock)
+
 if (${CMAKE_VERSION} VERSION_LESS "3.9")
 
     # Old versions of CMake have really poor support for Doxygen generation.

--- a/cmake/IncludeGMock.cmake
+++ b/cmake/IncludeGMock.cmake
@@ -25,10 +25,12 @@ set_property(CACHE GOOGLE_CLOUD_CPP_GMOCK_PROVIDER
                       "vcpkg"
                       "pkg-config")
 
-if ("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "module")
+if (TARGET gmock)
+    # If the gmock target is already defined then skip the rest.
+elseif ("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "module")
 
-    # Compile the googlemock library. This library is rarely installed or pre-
-    # compiled because it should be configured with the same flags as the
+    # Compile the googlemock library.  This library is rarely installed or
+    # pre-compiled because it should be configured with the same flags as the
     # application.
     #
     # TODO(#310) - consider changing the name of this target as it can conflict

--- a/cmake/IncludeGMock.cmake
+++ b/cmake/IncludeGMock.cmake
@@ -27,10 +27,10 @@ set_property(CACHE GOOGLE_CLOUD_CPP_GMOCK_PROVIDER
 
 if (TARGET gmock)
     # If the gmock target is already defined then skip the rest.
-elseif ("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "module")
+elseif("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "module")
 
-    # Compile the googlemock library.  This library is rarely installed or
-    # pre-compiled because it should be configured with the same flags as the
+    # Compile the googlemock library.  This library is rarely installed or pre-
+    # compiled because it should be configured with the same flags as the
     # application.
     #
     # TODO(#310) - consider changing the name of this target as it can conflict

--- a/cmake/IncludeGrpc.cmake
+++ b/cmake/IncludeGrpc.cmake
@@ -19,11 +19,11 @@ find_package(Threads REQUIRED)
 
 # Configure the gRPC dependency, this can be found as a submodule, package, or
 # installed with pkg-config support.
-set(GOOGLE_CLOUD_CPP_GRPC_PROVIDER "module"
+set(GOOGLE_CLOUD_CPP_GRPC_PROVIDER "external"
     CACHE STRING "How to find the gRPC library")
 set_property(CACHE GOOGLE_CLOUD_CPP_GRPC_PROVIDER
              PROPERTY STRINGS
-                      "module"
+                      "external"
                       "package"
                       "vcpkg"
                       "pkg-config")
@@ -50,44 +50,54 @@ set(GOOGLE_CLOUD_CPP_MSVC_COMPILE_OPTIONS
     /wd4838
     /wd4996)
 
-if ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "module")
-    if (NOT GRPC_ROOT_DIR)
-        set(GRPC_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/grpc)
-    endif ()
-    if (NOT EXISTS "${GRPC_ROOT_DIR}/CMakeLists.txt")
-        message(
-            ERROR
-            "GOOGLE_CLOUD_CPP_GRPC_PROVIDER is \"module\" but GRPC_ROOT_DIR is wrong"
-            )
-    endif ()
-    add_subdirectory(${GRPC_ROOT_DIR} third_party/grpc EXCLUDE_FROM_ALL)
-    add_library(gRPC::grpc++ ALIAS grpc++)
-    add_library(gRPC::grpc ALIAS grpc)
-    add_library(protobuf::libprotobuf ALIAS libprotobuf)
+if ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "external")
+    include(external/protobuf)
+    include(external/grpc)
 
-    # The necessary compiler options and definitions are not defined by the
-    # targets, we need to add them.
-    if (WIN32)
-        target_compile_definitions(libprotobuf PUBLIC
-                                   ${GOOGLE_CLOUD_CPP_WIN32_DEFINITIONS})
-    endif (WIN32)
-    if (MSVC)
-        target_compile_options(libprotobuf
-                               PUBLIC ${GOOGLE_CLOUD_CPP_MSVC_COMPILE_OPTIONS})
-    endif (MSVC)
+    include(ExternalProjectHelper)
+    add_library(protobuf::libprotobuf INTERFACE IMPORTED)
+    add_dependencies(protobuf::libprotobuf protobuf_project)
+    set_library_properties_for_external_project(protobuf::libprotobuf protobuf)
+    set_library_properties_for_external_project(protobuf::libprotobuf z)
+    set_property(TARGET protobuf::libprotobuf APPEND PROPERTY
+            INTERFACE_LINK_LIBRARIES protobuf::libprotobuf Threads::Threads)
 
-    # TODO(#286) - workaround build breakage for gRPC v1.10.x on Ubuntu:16.04.
-    include(CheckCXXCompilerFlag)
-    check_cxx_compiler_flag(-Wno-maybe-uninitialized
-                            __cxx_supports_wno_maybe_unitialized)
-    if (__cxx_supports_wno_maybe_unitialized)
-        target_compile_options(ssl PRIVATE -Wno-maybe-uninitialized)
-    endif ()
+    add_library(c-ares::cares INTERFACE IMPORTED)
+    set_library_properties_for_external_project(c-ares::cares cares ALWAYS_SHARED)
+    add_dependencies(c-ares::cares c_ares_project)
 
-    # The binary name is different on some platforms, use CMake magic to get it.
-    set(PROTOBUF_PROTOC_EXECUTABLE $<TARGET_FILE:protoc>)
+    find_package(OpenSSL REQUIRED)
+
+    add_library(gRPC::gpr INTERFACE IMPORTED)
+    set_library_properties_for_external_project(gRPC::gpr gpr)
+    add_dependencies(gRPC::gpr grpc_project)
+    set_property(TARGET gRPC::gpr APPEND PROPERTY
+            INTERFACE_LINK_LIBRARIES c-ares::cares)
+
+    add_library(gRPC::grpc INTERFACE IMPORTED)
+    set_library_properties_for_external_project(gRPC::grpc grpc)
+    add_dependencies(gRPC::grpc grpc_project)
+    set_property(TARGET gRPC::grpc APPEND PROPERTY
+            INTERFACE_LINK_LIBRARIES
+                gRPC::gpr
+                OpenSSL::SSL
+                OpenSSL::Crypto
+                protobuf::libprotobuf)
+
+    add_library(gRPC::grpc++ INTERFACE IMPORTED)
+    set_library_properties_for_external_project(gRPC::grpc++ grpc++)
+    add_dependencies(gRPC::grpc++ grpc_project)
+    set_property(TARGET gRPC::grpc++ APPEND PROPERTY
+            INTERFACE_LINK_LIBRARIES
+                gRPC::grpc
+                c-ares::cares)
+
+    # Discover the protobuf compiler and the gRPC plugin.
+    set_executable_name_for_external_project(
+            PROTOBUF_PROTOC_EXECUTABLE protoc)
     mark_as_advanced(PROTOBUF_PROTOC_EXECUTABLE)
-    set(PROTOC_GRPCPP_PLUGIN_EXECUTABLE $<TARGET_FILE:grpc_cpp_plugin>)
+    set_executable_name_for_external_project(
+            PROTOC_GRPCPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
     mark_as_advanced(PROTOC_GRPCPP_PLUGIN_EXECUTABLE)
 
 elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" MATCHES "^(package|vcpkg)$")

--- a/cmake/IncludeGrpc.cmake
+++ b/cmake/IncludeGrpc.cmake
@@ -59,11 +59,14 @@ if ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "external")
     add_dependencies(protobuf::libprotobuf protobuf_project)
     set_library_properties_for_external_project(protobuf::libprotobuf protobuf)
     set_library_properties_for_external_project(protobuf::libprotobuf z)
-    set_property(TARGET protobuf::libprotobuf APPEND PROPERTY
-            INTERFACE_LINK_LIBRARIES protobuf::libprotobuf Threads::Threads)
+    set_property(TARGET protobuf::libprotobuf
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES protobuf::libprotobuf
+                          Threads::Threads)
 
     add_library(c-ares::cares INTERFACE IMPORTED)
-    set_library_properties_for_external_project(c-ares::cares cares ALWAYS_SHARED)
+    set_library_properties_for_external_project(c-ares::cares cares
+                                                ALWAYS_SHARED)
     add_dependencies(c-ares::cares c_ares_project)
 
     find_package(OpenSSL REQUIRED)
@@ -71,33 +74,33 @@ if ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "external")
     add_library(gRPC::gpr INTERFACE IMPORTED)
     set_library_properties_for_external_project(gRPC::gpr gpr)
     add_dependencies(gRPC::gpr grpc_project)
-    set_property(TARGET gRPC::gpr APPEND PROPERTY
-            INTERFACE_LINK_LIBRARIES c-ares::cares)
+    set_property(TARGET gRPC::gpr
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES c-ares::cares)
 
     add_library(gRPC::grpc INTERFACE IMPORTED)
     set_library_properties_for_external_project(gRPC::grpc grpc)
     add_dependencies(gRPC::grpc grpc_project)
-    set_property(TARGET gRPC::grpc APPEND PROPERTY
-            INTERFACE_LINK_LIBRARIES
-                gRPC::gpr
-                OpenSSL::SSL
-                OpenSSL::Crypto
-                protobuf::libprotobuf)
+    set_property(TARGET gRPC::grpc
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES
+                          gRPC::gpr
+                          OpenSSL::SSL
+                          OpenSSL::Crypto
+                          protobuf::libprotobuf)
 
     add_library(gRPC::grpc++ INTERFACE IMPORTED)
     set_library_properties_for_external_project(gRPC::grpc++ grpc++)
     add_dependencies(gRPC::grpc++ grpc_project)
-    set_property(TARGET gRPC::grpc++ APPEND PROPERTY
-            INTERFACE_LINK_LIBRARIES
-                gRPC::grpc
-                c-ares::cares)
+    set_property(TARGET gRPC::grpc++
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES gRPC::grpc c-ares::cares)
 
     # Discover the protobuf compiler and the gRPC plugin.
-    set_executable_name_for_external_project(
-            PROTOBUF_PROTOC_EXECUTABLE protoc)
+    set_executable_name_for_external_project(PROTOBUF_PROTOC_EXECUTABLE protoc)
     mark_as_advanced(PROTOBUF_PROTOC_EXECUTABLE)
-    set_executable_name_for_external_project(
-            PROTOC_GRPCPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
+    set_executable_name_for_external_project(PROTOC_GRPCPP_PLUGIN_EXECUTABLE
+                                             grpc_cpp_plugin)
     mark_as_advanced(PROTOC_GRPCPP_PLUGIN_EXECUTABLE)
 
 elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" MATCHES "^(package|vcpkg)$")

--- a/cmake/IncludeNlohmannJson.cmake
+++ b/cmake/IncludeNlohmannJson.cmake
@@ -15,33 +15,27 @@
 # ~~~
 
 include(ExternalProject)
-externalproject_add(nlohmann_json_project
-                    PREFIX
-                    "${CMAKE_BINARY_DIR}/external/nlohmann_json"
-                    DOWNLOAD_COMMAND
-                    ${CMAKE_COMMAND}
-                    -DDEST=<INSTALL_DIR>/src
-                    -P
-                    ${PROJECT_SOURCE_DIR}/cmake/DownloadNlohmannJson.cmake
-                    CONFIGURE_COMMAND
-                    "" # This is not great, we abuse the `build` step to create
-                       # the target directory. Unfortunately there is no way to
-                       # specify two commands in the install step.
-                    BUILD_COMMAND
-                    ${CMAKE_COMMAND}
-                    -E
-                    make_directory
-                    <INSTALL_DIR>/include/nlohmann
-                    INSTALL_COMMAND
-                    ${CMAKE_COMMAND}
+externalproject_add(
+    nlohmann_json_project
+    PREFIX "${CMAKE_BINARY_DIR}/external/nlohmann_json"
+    DOWNLOAD_COMMAND ${CMAKE_COMMAND}
+                     -DDEST=<INSTALL_DIR>/src
+                     -P
+                     ${PROJECT_SOURCE_DIR}/cmake/DownloadNlohmannJson.cmake
+    CONFIGURE_COMMAND "" # This is not great, we abuse the `build` step to
+                         # create the target directory. Unfortunately there is
+                         # no way to specify two commands in the install step.
+    BUILD_COMMAND ${CMAKE_COMMAND}
+                  -E
+                  make_directory
+                  <INSTALL_DIR>/include/nlohmann
+    INSTALL_COMMAND ${CMAKE_COMMAND}
                     -E
                     copy
                     <INSTALL_DIR>/src/json.hpp
                     <INSTALL_DIR>/include/nlohmann/json.hpp
-                    LOG_DOWNLOAD
-                    ON
-                    LOG_INSTALL
-                    ON)
+    LOG_DOWNLOAD ON
+    LOG_INSTALL ON)
 
 add_library(nlohmann_json INTERFACE)
 add_dependencies(nlohmann_json nlohmann_json_project)

--- a/cmake/external/c-ares.cmake
+++ b/cmake/external/c-ares.cmake
@@ -1,3 +1,4 @@
+# ~~~
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,35 +12,43 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# ~~~
 
 if (NOT TARGET c_ares_project)
-    if("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles" OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
+    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
+        OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
         include(ProcessorCount)
-        ProcessorCount(NCPU)
+        processorcount(NCPU)
         set(PARALLEL "--" "-j" "${NCPU}")
     else()
         set(PARALLEL "")
-    endif()
+    endif ()
 
     include(ExternalProject)
-    ExternalProject_Add(c_ares_project
+    externalproject_add(
+        c_ares_project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/c-ares"
         INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
         URL https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
-        URL_HASH SHA256=62dd12f0557918f89ad6f5b759f0bf4727174ae9979499f5452c02be38d9d3e8
-        CONFIGURE_COMMAND
-            ${CMAKE_COMMAND}
-            $ENV{CMAKE_FLAGS}
-            ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
-            -DCMAKE_BUILD_TYPE=Release
-            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-            -H<SOURCE_DIR>
-            -B<BINARY_DIR>/Release
-        BUILD_COMMAND
-            ${CMAKE_COMMAND} --build Release ${PARALLEL}
-        INSTALL_COMMAND
-            ${CMAKE_COMMAND} --build Release --target install
+        URL_HASH
+            SHA256=62dd12f0557918f89ad6f5b759f0bf4727174ae9979499f5452c02be38d9d3e8
+        CONFIGURE_COMMAND ${CMAKE_COMMAND}
+                          $ENV{CMAKE_FLAGS}
+                          ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+                          -DCMAKE_BUILD_TYPE=Release
+                          -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                          -H<SOURCE_DIR>
+                          -B<BINARY_DIR>/Release
+        BUILD_COMMAND ${CMAKE_COMMAND}
+                      --build
+                      Release
+                      ${PARALLEL}
+        INSTALL_COMMAND ${CMAKE_COMMAND}
+                        --build
+                        Release
+                        --target
+                        install
         LOG_DOWNLOAD ON
         LOG_CONFIGURE ON
         LOG_BUILD ON

--- a/cmake/external/c-ares.cmake
+++ b/cmake/external/c-ares.cmake
@@ -1,0 +1,47 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if (NOT TARGET c_ares_project)
+    if("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles" OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
+        include(ProcessorCount)
+        ProcessorCount(NCPU)
+        set(PARALLEL "--" "-j" "${NCPU}")
+    else()
+        set(PARALLEL "")
+    endif()
+
+    include(ExternalProject)
+    ExternalProject_Add(c_ares_project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/c-ares"
+        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
+        URL https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
+        URL_HASH SHA256=62dd12f0557918f89ad6f5b759f0bf4727174ae9979499f5452c02be38d9d3e8
+        CONFIGURE_COMMAND
+            ${CMAKE_COMMAND}
+            $ENV{CMAKE_FLAGS}
+            ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+            -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+            -H<SOURCE_DIR>
+            -B<BINARY_DIR>/Release
+        BUILD_COMMAND
+            ${CMAKE_COMMAND} --build Release ${PARALLEL}
+        INSTALL_COMMAND
+            ${CMAKE_COMMAND} --build Release --target install
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+endif ()

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -1,0 +1,57 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(external/c-ares)
+include(external/protobuf)
+
+if (NOT TARGET gprc_project)
+    if("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles" OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
+        include(ProcessorCount)
+        ProcessorCount(NCPU)
+        set(PARALLEL "--" "-j" "${NCPU}")
+    else()
+        set(PARALLEL "")
+    endif()
+
+    include(ExternalProject)
+    ExternalProject_Add(grpc_project
+        DEPENDS c_ares_project protobuf_project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "external/gprc"
+        INSTALL_DIR "external"
+        URL https://github.com/grpc/grpc/archive/v1.10.0.tar.gz
+        URL_HASH SHA256=39a73de6fa2a03bdb9c43c89a4283e09880833b3c1976ef3ce3edf45c8cacf72
+        CONFIGURE_COMMAND
+            ${CMAKE_COMMAND}
+            $ENV{CMAKE_FLAGS}
+            ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+            -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+            -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
+            -DgRPC_BUILD_TESTS=OFF
+            -DgRPC_ZLIB_PROVIDER=package
+            -DgRPC_SSL_PROVIDER=package
+            -DgRPC_CARES_PROVIDER=package
+            -DgRPC_PROTOBUF_PROVIDER=package
+            -H<SOURCE_DIR>
+            -B<BINARY_DIR>/Release
+        BUILD_COMMAND
+            ${CMAKE_COMMAND} --build Release ${PARALLEL}
+        INSTALL_COMMAND
+            ${CMAKE_COMMAND} --build Release --target install
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+endif ()

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -32,7 +32,7 @@ if (NOT TARGET gprc_project)
         grpc_project
         DEPENDS c_ares_project protobuf_project
         EXCLUDE_FROM_ALL ON
-        PREFIX "external/gprc"
+        PREFIX "external/grpc"
         INSTALL_DIR "external"
         URL https://github.com/grpc/grpc/archive/v1.10.0.tar.gz
         URL_HASH

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -1,3 +1,4 @@
+# ~~~
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,45 +12,53 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# ~~~
 
 include(external/c-ares)
 include(external/protobuf)
 
 if (NOT TARGET gprc_project)
-    if("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles" OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
+    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
+        OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
         include(ProcessorCount)
-        ProcessorCount(NCPU)
+        processorcount(NCPU)
         set(PARALLEL "--" "-j" "${NCPU}")
     else()
         set(PARALLEL "")
-    endif()
+    endif ()
 
     include(ExternalProject)
-    ExternalProject_Add(grpc_project
+    externalproject_add(
+        grpc_project
         DEPENDS c_ares_project protobuf_project
         EXCLUDE_FROM_ALL ON
         PREFIX "external/gprc"
         INSTALL_DIR "external"
         URL https://github.com/grpc/grpc/archive/v1.10.0.tar.gz
-        URL_HASH SHA256=39a73de6fa2a03bdb9c43c89a4283e09880833b3c1976ef3ce3edf45c8cacf72
-        CONFIGURE_COMMAND
-            ${CMAKE_COMMAND}
-            $ENV{CMAKE_FLAGS}
-            ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
-            -DCMAKE_BUILD_TYPE=Release
-            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-            -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
-            -DgRPC_BUILD_TESTS=OFF
-            -DgRPC_ZLIB_PROVIDER=package
-            -DgRPC_SSL_PROVIDER=package
-            -DgRPC_CARES_PROVIDER=package
-            -DgRPC_PROTOBUF_PROVIDER=package
-            -H<SOURCE_DIR>
-            -B<BINARY_DIR>/Release
-        BUILD_COMMAND
-            ${CMAKE_COMMAND} --build Release ${PARALLEL}
-        INSTALL_COMMAND
-            ${CMAKE_COMMAND} --build Release --target install
+        URL_HASH
+            SHA256=39a73de6fa2a03bdb9c43c89a4283e09880833b3c1976ef3ce3edf45c8cacf72
+        CONFIGURE_COMMAND ${CMAKE_COMMAND}
+                          $ENV{CMAKE_FLAGS}
+                          ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+                          -DCMAKE_BUILD_TYPE=Release
+                          -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                          -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
+                          -DgRPC_BUILD_TESTS=OFF
+                          -DgRPC_ZLIB_PROVIDER=package
+                          -DgRPC_SSL_PROVIDER=package
+                          -DgRPC_CARES_PROVIDER=package
+                          -DgRPC_PROTOBUF_PROVIDER=package
+                          -H<SOURCE_DIR>
+                          -B<BINARY_DIR>/Release
+        BUILD_COMMAND ${CMAKE_COMMAND}
+                      --build
+                      Release
+                      ${PARALLEL}
+        INSTALL_COMMAND ${CMAKE_COMMAND}
+                        --build
+                        Release
+                        --target
+                        install
         LOG_DOWNLOAD ON
         LOG_CONFIGURE ON
         LOG_BUILD ON

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -1,3 +1,4 @@
+# ~~~
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,54 +12,55 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# ~~~
 
 include(external/zlib)
 
 if (NOT TARGET protobuf_project)
-    if("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles" OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
+    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
+        OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
         include(ProcessorCount)
-        ProcessorCount(NCPU)
+        processorcount(NCPU)
         set(PARALLEL "--" "-j" "${NCPU}")
     else()
         set(PARALLEL "")
-    endif()
+    endif ()
 
     include(ExternalProject)
-    ExternalProject_Add(protobuf_project
+    externalproject_add(
+        protobuf_project
         DEPENDS zlib_project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/protobuf"
         INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
         URL https://github.com/google/protobuf/archive/v3.5.2.tar.gz
-        URL_HASH SHA256=4ffd420f39f226e96aebc3554f9c66a912f6cad6261f39f194f16af8a1f6dab2
-        CONFIGURE_COMMAND
-            ${CMAKE_COMMAND}
-            $ENV{CMAKE_FLAGS}
-            ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
-            -DCMAKE_BUILD_TYPE=Debug
-            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-            -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
-            -Dprotobuf_BUILD_TESTS=OFF
-            -H<SOURCE_DIR>/cmake
-            -B<BINARY_DIR>/Debug
-        COMMAND
-            ${CMAKE_COMMAND}
-            $ENV{CMAKE_FLAGS}
-            ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
-            -DCMAKE_BUILD_TYPE=Release
-            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-            -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
-            -Dprotobuf_BUILD_TESTS=OFF
-            -H<SOURCE_DIR>/cmake
-            -B<BINARY_DIR>/Release
-        BUILD_COMMAND
-            ${CMAKE_COMMAND} --build Debug ${PARALLEL}
-        COMMAND
-            ${CMAKE_COMMAND} --build Release ${PARALLEL}
-        INSTALL_COMMAND
-            ${CMAKE_COMMAND} --build Debug --target install
-        COMMAND
-            ${CMAKE_COMMAND} --build Release --target install
+        URL_HASH
+            SHA256=4ffd420f39f226e96aebc3554f9c66a912f6cad6261f39f194f16af8a1f6dab2
+        CONFIGURE_COMMAND ${CMAKE_COMMAND}
+                          $ENV{CMAKE_FLAGS}
+                          ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+                          -DCMAKE_BUILD_TYPE=Debug
+                          -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                          -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
+                          -Dprotobuf_BUILD_TESTS=OFF
+                          -H<SOURCE_DIR>/cmake
+                          -B<BINARY_DIR>/Debug
+        COMMAND ${CMAKE_COMMAND} $ENV{CMAKE_FLAGS}
+                ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+                -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                -DCMAKE_PREFIX_PATH=<INSTALL_DIR> -Dprotobuf_BUILD_TESTS=OFF
+                -H<SOURCE_DIR>/cmake -B<BINARY_DIR>/Release
+        BUILD_COMMAND ${CMAKE_COMMAND}
+                      --build
+                      Debug
+                      ${PARALLEL}
+        COMMAND ${CMAKE_COMMAND} --build Release ${PARALLEL}
+        INSTALL_COMMAND ${CMAKE_COMMAND}
+                        --build
+                        Debug
+                        --target
+                        install
+        COMMAND ${CMAKE_COMMAND} --build Release --target install
         LOG_DOWNLOAD ON
         LOG_CONFIGURE ON
         LOG_BUILD ON

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -1,0 +1,66 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(external/zlib)
+
+if (NOT TARGET protobuf_project)
+    if("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles" OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
+        include(ProcessorCount)
+        ProcessorCount(NCPU)
+        set(PARALLEL "--" "-j" "${NCPU}")
+    else()
+        set(PARALLEL "")
+    endif()
+
+    include(ExternalProject)
+    ExternalProject_Add(protobuf_project
+        DEPENDS zlib_project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/protobuf"
+        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
+        URL https://github.com/google/protobuf/archive/v3.5.2.tar.gz
+        URL_HASH SHA256=4ffd420f39f226e96aebc3554f9c66a912f6cad6261f39f194f16af8a1f6dab2
+        CONFIGURE_COMMAND
+            ${CMAKE_COMMAND}
+            $ENV{CMAKE_FLAGS}
+            ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+            -DCMAKE_BUILD_TYPE=Debug
+            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+            -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
+            -Dprotobuf_BUILD_TESTS=OFF
+            -H<SOURCE_DIR>/cmake
+            -B<BINARY_DIR>/Debug
+        COMMAND
+            ${CMAKE_COMMAND}
+            $ENV{CMAKE_FLAGS}
+            ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+            -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+            -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
+            -Dprotobuf_BUILD_TESTS=OFF
+            -H<SOURCE_DIR>/cmake
+            -B<BINARY_DIR>/Release
+        BUILD_COMMAND
+            ${CMAKE_COMMAND} --build Debug ${PARALLEL}
+        COMMAND
+            ${CMAKE_COMMAND} --build Release ${PARALLEL}
+        INSTALL_COMMAND
+            ${CMAKE_COMMAND} --build Debug --target install
+        COMMAND
+            ${CMAKE_COMMAND} --build Release --target install
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+endif ()

--- a/cmake/external/zlib.cmake
+++ b/cmake/external/zlib.cmake
@@ -1,3 +1,4 @@
+# ~~~
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,36 +12,44 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# ~~~
 
 if (NOT TARGET zlib_project)
-    if("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles" OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
+    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
+        OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
         include(ProcessorCount)
-        ProcessorCount(NCPU)
+        processorcount(NCPU)
         set(PARALLEL "--" "-j" "${NCPU}")
     else()
         set(PARALLEL "")
-    endif()
+    endif ()
 
     include(ExternalProject)
-    ExternalProject_Add(zlib_project
+    externalproject_add(
+        zlib_project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/zlib"
         INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
         URL https://github.com/madler/zlib/archive/v1.2.11.tar.gz
-        URL_HASH SHA256=629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff
-        CONFIGURE_COMMAND
-            ${CMAKE_COMMAND}
-            $ENV{CMAKE_FLAGS}
-            ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
-            -DCMAKE_BUILD_TYPE=Release
-            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-            -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
-            -H<SOURCE_DIR>
-            -B<BINARY_DIR>/Release
-        BUILD_COMMAND
-            ${CMAKE_COMMAND} --build Release ${PARALLEL}
-        INSTALL_COMMAND
-            ${CMAKE_COMMAND} --build Release --target install
+        URL_HASH
+            SHA256=629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff
+        CONFIGURE_COMMAND ${CMAKE_COMMAND}
+                          $ENV{CMAKE_FLAGS}
+                          ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+                          -DCMAKE_BUILD_TYPE=Release
+                          -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                          -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
+                          -H<SOURCE_DIR>
+                          -B<BINARY_DIR>/Release
+        BUILD_COMMAND ${CMAKE_COMMAND}
+                      --build
+                      Release
+                      ${PARALLEL}
+        INSTALL_COMMAND ${CMAKE_COMMAND}
+                        --build
+                        Release
+                        --target
+                        install
         LOG_DOWNLOAD ON
         LOG_CONFIGURE ON
         LOG_BUILD ON

--- a/cmake/external/zlib.cmake
+++ b/cmake/external/zlib.cmake
@@ -1,0 +1,48 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if (NOT TARGET zlib_project)
+    if("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles" OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
+        include(ProcessorCount)
+        ProcessorCount(NCPU)
+        set(PARALLEL "--" "-j" "${NCPU}")
+    else()
+        set(PARALLEL "")
+    endif()
+
+    include(ExternalProject)
+    ExternalProject_Add(zlib_project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/zlib"
+        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
+        URL https://github.com/madler/zlib/archive/v1.2.11.tar.gz
+        URL_HASH SHA256=629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff
+        CONFIGURE_COMMAND
+            ${CMAKE_COMMAND}
+            $ENV{CMAKE_FLAGS}
+            ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+            -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+            -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
+            -H<SOURCE_DIR>
+            -B<BINARY_DIR>/Release
+        BUILD_COMMAND
+            ${CMAKE_COMMAND} --build Release ${PARALLEL}
+        INSTALL_COMMAND
+            ${CMAKE_COMMAND} --build Release --target install
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+endif ()

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -111,8 +111,6 @@ add_library(bigtable::protos ALIAS bigtable_protos)
 # Enable unit tests
 enable_testing()
 
-include(IncludeGMock)
-
 add_dependencies(skip-scanbuild-targets gmock bigtable_protos)
 
 # Generate the version information from the CMake values.


### PR DESCRIPTION
This is part of #518. It makes the management of the gRPC
dependency homogenous between Bazel and CMake build, both
will download the same version, as opposed to using a submodule
in CMake and downloads in Bazel. It also should speed up the build
by a few seconds, because the download of a single version is
faster than downloading the full history.

It also cleans up our namespace for targets in CMake, we no longer
get random targets (such as gtest) introduced by the gRPC
submodule.
