### PR TITLE
Simplify definition of *Request classes.

### DIFF
--- a/google/cloud/storage/internal/delete_object_request.h
+++ b/google/cloud/storage/internal/delete_object_request.h
@@ -28,9 +28,9 @@ namespace internal {
  * Delete an object.
  */
 class DeleteObjectRequest
-    : private RequestParameters<Generation, IfGenerationMatch,
-                                IfGenerationNotMatch, IfMetaGenerationMatch,
-                                IfMetaGenerationNotMatch, UserProject> {
+    : public GenericRequest<DeleteObjectRequest, Generation, IfGenerationMatch,
+                            IfGenerationNotMatch, IfMetaGenerationMatch,
+                            IfMetaGenerationNotMatch, UserProject> {
  public:
   DeleteObjectRequest() = default;
   explicit DeleteObjectRequest(std::string bucket_name, std::string object_name)
@@ -48,48 +48,6 @@ class DeleteObjectRequest
     object_name_ = std::move(object_name);
     return *this;
   }
-  /**
-   * Set a single optional parameter.
-   *
-   * @tparam Parameter the type of the parameter.
-   * @param p the parameter value.
-   * @return a reference to this object for chaining.
-   */
-  template <typename Parameter>
-  DeleteObjectRequest& set_parameter(Parameter&& p) {
-    RequestParameters::set_parameter(std::forward<Parameter>(p));
-    return *this;
-  }
-
-  /**
-   * Change one or more parameters for the request.
-   *
-   * This is a shorthand to replace:
-   *
-   * @code
-   * request.set_parameter(m1).set_parameter(m2).set_parameter(m3)
-   * @endcode
-   *
-   * with:
-   *
-   * @code
-   * request.set_multiple_parameters(m1, m2, m3)
-   * @endcode
-
-   * @tparam Parameters the type of the parameters
-   * @param p the parameter values
-   * @return The object after all the parameters have been changed.
-   */
-  template <typename... Parameters>
-  DeleteObjectRequest& set_multiple_parameters(Parameters&&... p) {
-    RequestParameters::set_multiple_parameters(std::forward<Parameters>(p)...);
-    return *this;
-  }
-
-  using RequestParameters::AddParametersToHttpRequest;
-
-  /// Dump parameter values to a std::ostream
-  using RequestParameters::DumpParameters;
 
  private:
   std::string bucket_name_;

--- a/google/cloud/storage/internal/get_bucket_metadata_request.h
+++ b/google/cloud/storage/internal/get_bucket_metadata_request.h
@@ -28,8 +28,8 @@ namespace internal {
  * Request the metadata for a bucket.
  */
 class GetBucketMetadataRequest
-    : private RequestParameters<IfMetaGenerationMatch, IfMetaGenerationNotMatch,
-                                Projection, UserProject> {
+    : public GenericRequest<GetBucketMetadataRequest, IfMetaGenerationMatch,
+                            IfMetaGenerationNotMatch, Projection, UserProject> {
  public:
   GetBucketMetadataRequest() = default;
   explicit GetBucketMetadataRequest(std::string bucket_name)
@@ -40,49 +40,6 @@ class GetBucketMetadataRequest
     bucket_name_ = std::move(bucket_name);
     return *this;
   }
-
-  /**
-   * Set a single optional parameter.
-   *
-   * @tparam Parameter the type of the parameter.
-   * @param p the parameter value.
-   * @return a reference to this object for chaining.
-   */
-  template <typename Parameter>
-  GetBucketMetadataRequest& set_parameter(Parameter&& p) {
-    RequestParameters::set_parameter(std::forward<Parameter>(p));
-    return *this;
-  }
-
-  /**
-   * Change one or more parameters for the request.
-   *
-   * This is a shorthand to replace:
-   *
-   * @code
-   * request.set_parameter(m1).set_parameter(m2).set_parameter(m3)
-   * @endcode
-   *
-   * with:
-   *
-   * @code
-   * request.set_multiple_parameters(m1, m2, m3)
-   * @endcode
-
-   * @tparam Parameters the type of the parameters
-   * @param p the parameter values
-   * @return The object after all the parameters have been changed.
-   */
-  template <typename... Parameters>
-  GetBucketMetadataRequest& set_multiple_parameters(Parameters&&... p) {
-    RequestParameters::set_multiple_parameters(std::forward<Parameters>(p)...);
-    return *this;
-  }
-
-  using RequestParameters::AddParametersToHttpRequest;
-
-  /// Dump parameter values to a std::ostream
-  using RequestParameters::DumpParameters;
 
  private:
   std::string bucket_name_;

--- a/google/cloud/storage/internal/insert_object_media_request.h
+++ b/google/cloud/storage/internal/insert_object_media_request.h
@@ -29,10 +29,10 @@ namespace internal {
  * TODO(#710) - add missing request parameters.
  */
 class InsertObjectMediaRequest
-    : private RequestParameters<Generation, IfGenerationMatch,
-                                IfGenerationNotMatch, IfMetaGenerationMatch,
-                                IfMetaGenerationNotMatch, Projection,
-                                UserProject> {
+    : public GenericRequest<InsertObjectMediaRequest, Generation,
+                            IfGenerationMatch, IfGenerationNotMatch,
+                            IfMetaGenerationMatch, IfMetaGenerationNotMatch,
+                            Projection, UserProject> {
  public:
   InsertObjectMediaRequest() = default;
   explicit InsertObjectMediaRequest(std::string bucket_name,
@@ -57,50 +57,6 @@ class InsertObjectMediaRequest
     contents_ = std::move(contents);
     return *this;
   }
-
-  /**
-   * Set a single optional parameter.
-   *
-   * @tparam Parameter the type of the parameter.
-   * @param p the parameter value.
-   * @return a reference to this object for chaining.
-   */
-  template <typename Parameter>
-  InsertObjectMediaRequest& set_parameter(Parameter&& p) {
-    RequestParameters::set_parameter(std::forward<Parameter>(p));
-    return *this;
-  }
-
-  /**
-   * Change one or more parameters for the request.
-   *
-   * This is a shorthand to replace:
-   *
-   * @code
-   * request.set_parameter(m1).set_parameter(m2).set_parameter(m3)
-   * @endcode
-   *
-   * with:
-   *
-   * @code
-   * request.set_multiple_parameters(m1, m2, m3)
-   * @endcode
-
-   * @tparam Parameters the type of the parameters
-   * @param p the parameter values
-   * @return The object after all the parameters have been changed.
-   */
-  template <typename... Parameters>
-  InsertObjectMediaRequest& set_multiple_parameters(Parameters&&... p) {
-    RequestParameters::set_multiple_parameters(std::forward<Parameters>(p)...);
-    return *this;
-  }
-
-  /// Set any parameters in a HttpRequest object.
-  using RequestParameters::AddParametersToHttpRequest;
-
-  /// Dump parameter values to a std::ostream
-  using RequestParameters::DumpParameters;
 
  private:
   std::string bucket_name_;

--- a/google/cloud/storage/internal/list_objects_request.h
+++ b/google/cloud/storage/internal/list_objects_request.h
@@ -29,7 +29,8 @@ namespace internal {
  * Request the metadata for a bucket.
  */
 class ListObjectsRequest
-    : private RequestParameters<MaxResults, Prefix, Projection, UserProject> {
+    : public GenericRequest<ListObjectsRequest, MaxResults, Prefix, Projection,
+                            UserProject> {
  public:
   ListObjectsRequest() = default;
   explicit ListObjectsRequest(std::string bucket_name)
@@ -46,49 +47,6 @@ class ListObjectsRequest
     page_token_ = std::move(page_token);
     return *this;
   }
-
-  /**
-   * Set a single optional parameter.
-   *
-   * @tparam Parameter the type of the parameter.
-   * @param p the parameter value.
-   * @return a reference to this object for chaining.
-   */
-  template <typename Parameter>
-  ListObjectsRequest& set_parameter(Parameter&& p) {
-    RequestParameters::set_parameter(std::forward<Parameter>(p));
-    return *this;
-  }
-
-  /**
-   * Change one or more parameters for the request.
-   *
-   * This is a shorthand to replace:
-   *
-   * @code
-   * request.set_parameter(m1).set_parameter(m2).set_parameter(m3)
-   * @endcode
-   *
-   * with:
-   *
-   * @code
-   * request.set_multiple_parameters(m1, m2, m3)
-   * @endcode
-
-   * @tparam Parameters the type of the parameters
-   * @param p the parameter values
-   * @return The object after all the parameters have been changed.
-   */
-  template <typename... Parameters>
-  ListObjectsRequest& set_multiple_parameters(Parameters&&... p) {
-    RequestParameters::set_multiple_parameters(std::forward<Parameters>(p)...);
-    return *this;
-  }
-
-  using RequestParameters::AddParametersToHttpRequest;
-
-  /// Dump parameter values to a std::ostream
-  using RequestParameters::DumpParameters;
 
  private:
   std::string bucket_name_;

--- a/google/cloud/storage/internal/read_object_range_request.h
+++ b/google/cloud/storage/internal/read_object_range_request.h
@@ -28,9 +28,10 @@ namespace internal {
  * Request a range of object data.
  */
 class ReadObjectRangeRequest
-    : private RequestParameters<Generation, IfGenerationMatch,
-                                IfGenerationNotMatch, IfMetaGenerationMatch,
-                                IfMetaGenerationNotMatch, UserProject> {
+    : public GenericRequest<ReadObjectRangeRequest, Generation,
+                            IfGenerationMatch, IfGenerationNotMatch,
+                            IfMetaGenerationMatch, IfMetaGenerationNotMatch,
+                            UserProject> {
  public:
   ReadObjectRangeRequest() = default;
 
@@ -74,23 +75,6 @@ class ReadObjectRangeRequest
     end_ = v;
     return *this;
   }
-
-  template <typename Parameter>
-  ReadObjectRangeRequest& set_parameter(Parameter&& p) {
-    RequestParameters::set_parameter(std::forward<Parameter>(p));
-    return *this;
-  }
-
-  template <typename... Parameters>
-  ReadObjectRangeRequest& set_multiple_parameters(Parameters&&... p) {
-    RequestParameters::set_multiple_parameters(std::forward<Parameters>(p)...);
-    return *this;
-  }
-
-  using RequestParameters::AddParametersToHttpRequest;
-
-  /// Dump parameter values to a std::ostream
-  using RequestParameters::DumpParameters;
 
  private:
   std::string bucket_name_;


### PR DESCRIPTION
Use the CRTP [[1]] to simplify the definition of *Request classes.
Considering that we have about 35 of these classes to write, the
easier it is to write them the better.

[1]: https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern