### PR TITLE
Implement storage::Client::ListObjectAcl.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -212,6 +212,7 @@ set(storage_client_unit_tests
     bucket_access_control_test.cc
     bucket_metadata_test.cc
     bucket_test.cc
+    client_object_acl_test.cc
     client_test.cc
     credentials_test.cc
     internal/access_control_common_test.cc

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -173,6 +173,23 @@ class Client {
     raw_client_->DeleteObject(request);
   }
 
+  /**
+   * Retrieve the list of ObjectAccessControls for an object.
+   *
+   * @param bucket_name the name of the bucket that contains the object.
+   * @param object_name the name of the object to be deleted.
+   * @param parameters a variadic list of optional parameters. Valid types for
+   *   this operation include `Generation`, and `UserProject`.
+   */
+  template <typename... Parameters>
+  std::vector<ObjectAccessControl> ListObjectAcl(std::string const& bucket_name,
+                                                 std::string const& object_name,
+                                                 Parameters&&... parameters) {
+    internal::ListObjectAclRequest request(bucket_name, object_name);
+    request.set_multiple_parameters(std::forward<Parameters>(parameters)...);
+    return raw_client_->ListObjectAcl(request).second.items;
+  }
+
  private:
   BucketMetadata GetBucketMetadataImpl(
       internal::GetBucketMetadataRequest const& request);

--- a/google/cloud/storage/client_object_acl_test.cc
+++ b/google/cloud/storage/client_object_acl_test.cc
@@ -1,0 +1,144 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/retry_policy.h"
+#include "google/cloud/storage/testing/canonical_errors.h"
+#include "google/cloud/storage/testing/mock_client.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+using namespace testing::canonical_errors;
+namespace {
+using ms = std::chrono::milliseconds;
+using namespace ::testing;
+
+/**
+ * Test the ObjectAccessControls-related functions in storage::Client.
+ */
+class ObjectAccessControlsTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    mock = std::make_shared<testing::MockClient>();
+    EXPECT_CALL(*mock, client_options())
+        .WillRepeatedly(ReturnRef(client_options));
+    client.reset(new Client{std::shared_ptr<internal::RawClient>(mock)});
+  }
+  void TearDown() override {
+    client.reset();
+    mock.reset();
+  }
+
+  std::shared_ptr<testing::MockClient> mock;
+  std::unique_ptr<Client> client;
+  ClientOptions client_options = ClientOptions(CreateInsecureCredentials());
+};
+
+TEST_F(ObjectAccessControlsTest, ListObjectAcl) {
+  std::vector<ObjectAccessControl> expected{
+      ObjectAccessControl::ParseFromString(R"""({
+          "bucket": "test-bucket",
+          "object": "test-object",
+          "entity": "user-test-user-1",
+          "role": "OWNER"
+      })"""),
+      ObjectAccessControl::ParseFromString(R"""({
+          "bucket": "test-bucket",
+          "object": "test-object",
+          "entity": "user-test-user-2",
+          "role": "READER"
+      })"""),
+  };
+
+  EXPECT_CALL(*mock, ListObjectAcl(_))
+      .WillOnce(Return(
+          std::make_pair(TransientError(), internal::ListObjectAclResponse{})))
+      .WillOnce(Invoke([&expected](internal::ListObjectAclRequest const& r) {
+        EXPECT_EQ("test-bucket", r.bucket_name());
+        EXPECT_EQ("test-object", r.object_name());
+
+        return std::make_pair(Status(),
+                              internal::ListObjectAclResponse{expected});
+      }));
+  Client client{std::shared_ptr<internal::RawClient>(mock)};
+
+  std::vector<ObjectAccessControl> actual =
+      client.ListObjectAcl("test-bucket", "test-object");
+  EXPECT_EQ(expected, actual);
+}
+
+TEST_F(ObjectAccessControlsTest, ListObjectAclTooManyFailures) {
+  Client client{std::shared_ptr<internal::RawClient>(mock),
+                LimitedErrorCountRetryPolicy(2),
+                ExponentialBackoffPolicy(ms(100), ms(500), 2)};
+
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_CALL(*mock, ListObjectAcl(_))
+      .WillOnce(Return(
+          std::make_pair(TransientError(), internal::ListObjectAclResponse{})))
+      .WillOnce(Return(
+          std::make_pair(TransientError(), internal::ListObjectAclResponse{})))
+      .WillOnce(Return(
+          std::make_pair(TransientError(), internal::ListObjectAclResponse{})));
+  EXPECT_THROW(
+      try {
+        client.ListObjectAcl("test-bucket", "test-object");
+      } catch (std::runtime_error const& ex) {
+        EXPECT_THAT(ex.what(), HasSubstr("Retry policy exhausted"));
+        EXPECT_THAT(ex.what(), HasSubstr("ListObjectAcl"));
+        throw;
+      },
+      std::runtime_error);
+#else
+  // With EXPECT_DEATH*() the mocking framework cannot detect how many times the
+  // operation is called.
+  EXPECT_CALL(*mock, ListObjectAcl(_))
+      .WillRepeatedly(Return(
+          std::make_pair(TransientError(), internal::ListObjectAclResponse{})));
+  EXPECT_DEATH_IF_SUPPORTED(client.ListObjectAcl("test-bucket", "test-object"),
+                            "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST_F(ObjectAccessControlsTest, ListObjectAclPermanentFailure) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_CALL(*mock, ListObjectAcl(_))
+      .WillOnce(Return(
+          std::make_pair(PermanentError(), internal::ListObjectAclResponse{})));
+  EXPECT_THROW(
+      try {
+        client->ListObjectAcl("test-bucket", "test-object");
+      } catch (std::runtime_error const& ex) {
+        EXPECT_THAT(ex.what(), HasSubstr("Permanent error"));
+        EXPECT_THAT(ex.what(), HasSubstr("ListObjectAcl"));
+        throw;
+      },
+      std::runtime_error);
+#else
+  // With EXPECT_DEATH*() the mocking framework cannot detect how many times the
+  // operation is called.
+  EXPECT_CALL(*mock, ListObjectAcl(_))
+      .WillRepeatedly(Return(
+          std::make_pair(PermanentError(), internal::ListObjectAclResponse{})));
+  EXPECT_DEATH_IF_SUPPORTED(client->ListObjectAcl("test-bucket", "test-object"),
+                            "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+}  // namespace
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -60,9 +60,8 @@ std::pair<Status, ObjectMetadata> CurlClient::InsertObjectMedia(
                         ObjectMetadata::ParseFromJson(payload.payload));
 }
 
-std::pair<Status, internal::ReadObjectRangeResponse>
-CurlClient::ReadObjectRangeMedia(
-    internal::ReadObjectRangeRequest const& request) {
+std::pair<Status, ReadObjectRangeResponse> CurlClient::ReadObjectRangeMedia(
+    ReadObjectRangeRequest const& request) {
   // Assume the bucket name is validated by the caller.
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
                              "/o/" + request.object_name());
@@ -88,8 +87,8 @@ CurlClient::ReadObjectRangeMedia(
       internal::ReadObjectRangeResponse::FromHttpResponse(std::move(payload)));
 }
 
-std::pair<Status, internal::ListObjectsResponse> CurlClient::ListObjects(
-    internal::ListObjectsRequest const& request) {
+std::pair<Status, ListObjectsResponse> CurlClient::ListObjects(
+    ListObjectsRequest const& request) {
   // Assume the bucket name is validated by the caller.
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
                              "/o");
@@ -108,8 +107,8 @@ std::pair<Status, internal::ListObjectsResponse> CurlClient::ListObjects(
       internal::ListObjectsResponse::FromHttpResponse(std::move(payload)));
 }
 
-std::pair<Status, internal::EmptyResponse> CurlClient::DeleteObject(
-    internal::DeleteObjectRequest const& request) {
+std::pair<Status, EmptyResponse> CurlClient::DeleteObject(
+    DeleteObjectRequest const& request) {
   // Assume the bucket name is validated by the caller.
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
                              "/o/" + request.object_name());
@@ -124,6 +123,24 @@ std::pair<Status, internal::EmptyResponse> CurlClient::DeleteObject(
         internal::EmptyResponse{});
   }
   return std::make_pair(Status(), internal::EmptyResponse{});
+}
+
+std::pair<Status, ListObjectAclResponse> CurlClient::ListObjectAcl(
+    ListObjectAclRequest const& request) {
+  // Assume the bucket name is validated by the caller.
+  CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
+                             "/o/" + request.object_name() + "/acl");
+  builder.SetDebugLogging(options_.enable_http_tracing());
+  builder.AddHeader(options_.credentials()->AuthorizationHeader());
+  request.AddParametersToHttpRequest(builder);
+  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  if (payload.status_code >= 300) {
+    return std::make_pair(
+        Status(),
+        internal::ListObjectAclResponse::FromHttpResponse(std::move(payload)));
+  }
+  return std::make_pair(Status{payload.status_code, std::move(payload.payload)},
+                        internal::ListObjectAclResponse{});
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -50,6 +50,8 @@ class CurlClient : public RawClient {
       ListObjectsRequest const& request) override;
   std::pair<Status, EmptyResponse> DeleteObject(
       DeleteObjectRequest const& request) override;
+  std::pair<Status, ListObjectAclResponse> ListObjectAcl(
+      ListObjectAclRequest const& request) override;
 
  private:
   ClientOptions options_;

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -81,6 +81,11 @@ std::pair<Status, EmptyResponse> LoggingClient::DeleteObject(
   return MakeCall(*client_, &RawClient::DeleteObject, request, __func__);
 }
 
+std::pair<Status, ListObjectAclResponse> LoggingClient::ListObjectAcl(
+    ListObjectAclRequest const& request) {
+  return MakeCall(*client_, &RawClient::ListObjectAcl, request, __func__);
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -47,6 +47,9 @@ class LoggingClient : public RawClient {
   std::pair<Status, EmptyResponse> DeleteObject(
       DeleteObjectRequest const&) override;
 
+  std::pair<Status, ListObjectAclResponse> ListObjectAcl(
+      ListObjectAclRequest const& request) override;
+
  private:
   std::shared_ptr<RawClient> client_;
 };

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -22,6 +22,7 @@
 #include "google/cloud/storage/internal/empty_response.h"
 #include "google/cloud/storage/internal/get_bucket_metadata_request.h"
 #include "google/cloud/storage/internal/insert_object_media_request.h"
+#include "google/cloud/storage/internal/list_object_acl_request.h"
 #include "google/cloud/storage/internal/list_objects_request.h"
 #include "google/cloud/storage/internal/read_object_range_request.h"
 #include "google/cloud/storage/object_metadata.h"
@@ -63,6 +64,9 @@ class RawClient {
 
   virtual std::pair<Status, EmptyResponse> DeleteObject(
       DeleteObjectRequest const&) = 0;
+
+  virtual std::pair<Status, ListObjectAclResponse> ListObjectAcl(
+      ListObjectAclRequest const&) = 0;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -151,6 +151,14 @@ std::pair<Status, EmptyResponse> RetryClient::DeleteObject(
                   &RawClient::DeleteObject, request, __func__);
 }
 
+std::pair<Status, ListObjectAclResponse> RetryClient::ListObjectAcl(
+    ListObjectAclRequest const& request) {
+  auto retry_policy = retry_policy_->clone();
+  auto backoff_policy = backoff_policy_->clone();
+  return MakeCall(*retry_policy, *backoff_policy, *client_,
+                  &RawClient::ListObjectAcl, request, __func__);
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -58,6 +58,9 @@ class RetryClient : public RawClient {
   std::pair<Status, EmptyResponse> DeleteObject(
       DeleteObjectRequest const&) override;
 
+  std::pair<Status, ListObjectAclResponse> ListObjectAcl(
+      ListObjectAclRequest const& request) override;
+
  private:
   void Apply(RetryPolicy& policy) { retry_policy_ = policy.clone(); }
 

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -3,6 +3,7 @@ storage_client_unit_tests = [
     "bucket_access_control_test.cc",
     "bucket_metadata_test.cc",
     "bucket_test.cc",
+    "client_object_acl_test.cc",
     "client_test.cc",
     "credentials_test.cc",
     "internal/access_control_common_test.cc",

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -45,6 +45,8 @@ class MockClient : public google::cloud::storage::internal::RawClient {
                                 internal::ListObjectsRequest const&));
   MOCK_METHOD1(DeleteObject, ResponseWrapper<internal::EmptyResponse>(
                                  internal::DeleteObjectRequest const&));
+  MOCK_METHOD1(ListObjectAcl, ResponseWrapper<internal::ListObjectAclResponse>(
+                                  internal::ListObjectAclRequest const&));
 };
 }  // namespace testing
 }  // namespace storage


### PR DESCRIPTION
This is part of the work for #842. This change introduces the
API and the unit tests. The integration tests and examples will
be introduced later.