### PR TITLE
Refactor to common GenericObjectRequest<> class.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -129,6 +129,7 @@ add_library(storage_client
             internal/delete_object_request.cc
             internal/empty_response.h
             internal/empty_response.cc
+            internal/generic_object_request.h
             internal/get_bucket_metadata_request.h
             internal/get_bucket_metadata_request.cc
             internal/google_application_default_credentials_file.h

--- a/google/cloud/storage/internal/delete_object_request.h
+++ b/google/cloud/storage/internal/delete_object_request.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_DELETE_OBJECT_REQUEST_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_DELETE_OBJECT_REQUEST_H_
 
-#include "google/cloud/storage/internal/request_parameters.h"
+#include "google/cloud/storage/internal/generic_object_request.h"
 #include "google/cloud/storage/well_known_parameters.h"
 #include <iosfwd>
 
@@ -28,30 +28,12 @@ namespace internal {
  * Delete an object.
  */
 class DeleteObjectRequest
-    : public GenericRequest<DeleteObjectRequest, Generation, IfGenerationMatch,
-                            IfGenerationNotMatch, IfMetaGenerationMatch,
-                            IfMetaGenerationNotMatch, UserProject> {
+    : public GenericObjectRequest<DeleteObjectRequest, Generation,
+                                  IfGenerationMatch, IfGenerationNotMatch,
+                                  IfMetaGenerationMatch,
+                                  IfMetaGenerationNotMatch, UserProject> {
  public:
-  DeleteObjectRequest() = default;
-  explicit DeleteObjectRequest(std::string bucket_name, std::string object_name)
-      : bucket_name_(std::move(bucket_name)),
-        object_name_(std::move(object_name)) {}
-
-  std::string const& bucket_name() const { return bucket_name_; }
-  DeleteObjectRequest& set_bucket_name(std::string bucket_name) {
-    bucket_name_ = std::move(bucket_name);
-    return *this;
-  }
-
-  std::string const& object_name() const { return object_name_; }
-  DeleteObjectRequest& set_object_name(std::string object_name) {
-    object_name_ = std::move(object_name);
-    return *this;
-  }
-
- private:
-  std::string bucket_name_;
-  std::string object_name_;
+  using GenericObjectRequest::GenericObjectRequest;
 };
 
 std::ostream& operator<<(std::ostream& os, DeleteObjectRequest const& r);

--- a/google/cloud/storage/internal/generic_object_request.h
+++ b/google/cloud/storage/internal/generic_object_request.h
@@ -1,0 +1,59 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GENERIC_OBJECT_REQUEST_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GENERIC_OBJECT_REQUEST_H_
+
+#include "google/cloud/storage/internal/request_parameters.h"
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+/// Refactor common attributes for requests about objects.
+template <typename Derived, typename... Parameters>
+class GenericObjectRequest : public GenericRequest<Derived, Parameters...> {
+ public:
+  GenericObjectRequest() = default;
+
+  explicit GenericObjectRequest(std::string bucket_name,
+                                std::string object_name)
+      : bucket_name_(std::move(bucket_name)),
+        object_name_(std::move(object_name)) {}
+
+  std::string const& bucket_name() const { return bucket_name_; }
+  Derived& set_bucket_name(std::string bucket_name) {
+    bucket_name_ = std::move(bucket_name);
+    return *static_cast<Derived*>(this);
+  }
+
+  std::string const& object_name() const { return object_name_; }
+  Derived& set_object_name(std::string object_name) {
+    object_name_ = std::move(object_name);
+    return *static_cast<Derived*>(this);
+  }
+
+ private:
+  std::string bucket_name_;
+  std::string object_name_;
+};
+
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GENERIC_OBJECT_REQUEST_H_

--- a/google/cloud/storage/internal/insert_object_media_request.h
+++ b/google/cloud/storage/internal/insert_object_media_request.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_INSERT_OBJECT_MEDIA_REQUEST_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_INSERT_OBJECT_MEDIA_REQUEST_H_
 
-#include "google/cloud/storage/internal/request_parameters.h"
+#include "google/cloud/storage/internal/generic_object_request.h"
 #include "google/cloud/storage/well_known_parameters.h"
 
 namespace google {
@@ -27,29 +27,19 @@ namespace internal {
  * Request the metadata for a bucket.
  */
 class InsertObjectMediaRequest
-    : public GenericRequest<
+    : public GenericObjectRequest<
           InsertObjectMediaRequest, ContentEncoding, IfGenerationMatch,
           IfGenerationNotMatch, IfMetaGenerationMatch, IfMetaGenerationNotMatch,
           KmsKeyName, PredefinedAcl, Projection, UserProject> {
  public:
-  InsertObjectMediaRequest() = default;
+  InsertObjectMediaRequest() : GenericObjectRequest(), contents_() {}
+
   explicit InsertObjectMediaRequest(std::string bucket_name,
                                     std::string object_name,
                                     std::string contents)
-      : bucket_name_(std::move(bucket_name)),
-        object_name_(std::move(object_name)),
+      : GenericObjectRequest(std::move(bucket_name), std::move(object_name)),
         contents_(std::move(contents)) {}
 
-  std::string const& bucket_name() const { return bucket_name_; }
-  InsertObjectMediaRequest& set_bucket_name(std::string bucket_name) {
-    bucket_name_ = std::move(bucket_name);
-    return *this;
-  }
-  std::string const& object_name() const { return object_name_; }
-  InsertObjectMediaRequest& set_object_name(std::string object_name) {
-    object_name_ = std::move(object_name);
-    return *this;
-  }
   std::string const& contents() const { return contents_; }
   InsertObjectMediaRequest& set_contents(std::string contents) {
     contents_ = std::move(contents);
@@ -57,8 +47,6 @@ class InsertObjectMediaRequest
   }
 
  private:
-  std::string bucket_name_;
-  std::string object_name_;
   std::string contents_;
 };
 

--- a/google/cloud/storage/internal/list_object_acl_request.h
+++ b/google/cloud/storage/internal/list_object_acl_request.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_LIST_OBJECT_ACL_REQUEST_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_LIST_OBJECT_ACL_REQUEST_H_
 
+#include "google/cloud/storage/internal/generic_object_request.h"
 #include "google/cloud/storage/internal/http_response.h"
-#include "google/cloud/storage/internal/request_parameters.h"
 #include "google/cloud/storage/object_access_control.h"
 #include "google/cloud/storage/well_known_parameters.h"
 #include <iosfwd>
@@ -30,29 +30,10 @@ namespace internal {
  * Delete an object.
  */
 class ListObjectAclRequest
-    : public GenericRequest<ListObjectAclRequest, Generation, UserProject> {
+    : public GenericObjectRequest<ListObjectAclRequest, Generation,
+                                  UserProject> {
  public:
-  ListObjectAclRequest() = default;
-  explicit ListObjectAclRequest(std::string bucket_name,
-                                std::string object_name)
-      : bucket_name_(std::move(bucket_name)),
-        object_name_(std::move(object_name)) {}
-
-  std::string const& bucket_name() const { return bucket_name_; }
-  ListObjectAclRequest& set_bucket_name(std::string bucket_name) {
-    bucket_name_ = std::move(bucket_name);
-    return *this;
-  }
-
-  std::string const& object_name() const { return object_name_; }
-  ListObjectAclRequest& set_object_name(std::string object_name) {
-    object_name_ = std::move(object_name);
-    return *this;
-  }
-
- private:
-  std::string bucket_name_;
-  std::string object_name_;
+  using GenericObjectRequest::GenericObjectRequest;
 };
 
 std::ostream& operator<<(std::ostream& os, ListObjectAclRequest const& r);

--- a/google/cloud/storage/internal/read_object_range_request.h
+++ b/google/cloud/storage/internal/read_object_range_request.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_READ_OBJECT_RANGE_REQUEST_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_READ_OBJECT_RANGE_REQUEST_H_
 
+#include "google/cloud/storage/internal/generic_object_request.h"
 #include "google/cloud/storage/internal/http_response.h"
-#include "google/cloud/storage/internal/request_parameters.h"
 #include "google/cloud/storage/well_known_parameters.h"
 
 namespace google {
@@ -28,41 +28,27 @@ namespace internal {
  * Request a range of object data.
  */
 class ReadObjectRangeRequest
-    : public GenericRequest<ReadObjectRangeRequest, Generation,
-                            IfGenerationMatch, IfGenerationNotMatch,
-                            IfMetaGenerationMatch, IfMetaGenerationNotMatch,
-                            UserProject> {
+    : public GenericObjectRequest<ReadObjectRangeRequest, Generation,
+                                  IfGenerationMatch, IfGenerationNotMatch,
+                                  IfMetaGenerationMatch,
+                                  IfMetaGenerationNotMatch, UserProject> {
  public:
-  ReadObjectRangeRequest() = default;
+  ReadObjectRangeRequest() : GenericObjectRequest(), begin_(0), end_(0) {}
 
   // TODO(#724) - consider using StrongType<> for arguments with similar types.
   explicit ReadObjectRangeRequest(std::string bucket_name,
                                   std::string object_name, std::int64_t begin,
                                   std::int64_t end)
-      : bucket_name_(std::move(bucket_name)),
-        object_name_(std::move(object_name)),
+      : GenericObjectRequest(std::move(bucket_name), std::move(object_name)),
         begin_(begin),
         end_(end) {}
 
   // TODO(#724) - consider using StrongType<> for arguments with similar types.
   explicit ReadObjectRangeRequest(std::string bucket_name,
                                   std::string object_name)
-      : bucket_name_(std::move(bucket_name)),
-        object_name_(std::move(object_name)),
+      : GenericObjectRequest(std::move(bucket_name), std::move(object_name)),
         begin_(0),
         end_(0) {}
-
-  std::string const& bucket_name() const { return bucket_name_; }
-  ReadObjectRangeRequest& set_bucket_name(std::string bucket_name) {
-    bucket_name_ = std::move(bucket_name);
-    return *this;
-  }
-
-  std::string const& object_name() const { return object_name_; }
-  ReadObjectRangeRequest& set_object_name(std::string object_name) {
-    object_name_ = std::move(object_name);
-    return *this;
-  }
 
   std::int64_t begin() const { return begin_; }
   ReadObjectRangeRequest& set_begin(std::int64_t v) {
@@ -77,8 +63,6 @@ class ReadObjectRangeRequest
   }
 
  private:
-  std::string bucket_name_;
-  std::string object_name_;
   std::int64_t begin_;
   std::int64_t end_;
 };

--- a/google/cloud/storage/storage_client.bzl
+++ b/google/cloud/storage/storage_client.bzl
@@ -18,6 +18,7 @@ storage_client_HDRS = [
     "internal/curl_client.h",
     "internal/delete_object_request.h",
     "internal/empty_response.h",
+    "internal/generic_object_request.h",
     "internal/get_bucket_metadata_request.h",
     "internal/google_application_default_credentials_file.h",
     "internal/http_response.h",


### PR DESCRIPTION
Several *Request classes had common code that could be refactored.
We need to write a few more of these classes, so saving code now
is nice.