### PR TITLE
Add object access control sample.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -206,6 +206,9 @@ class Client {
    * @param object_name the name of the object to be deleted.
    * @param parameters a variadic list of optional parameters. Valid types for
    *   this operation include `Generation`, and `UserProject`.
+   *
+   * @par Example
+   * @snippet storage_object_acl_samples.cc list object acl
    */
   template <typename... Parameters>
   std::vector<ObjectAccessControl> ListObjectAcl(std::string const& bucket_name,

--- a/google/cloud/storage/examples/BUILD
+++ b/google/cloud/storage/examples/BUILD
@@ -27,3 +27,9 @@ cc_binary(
     srcs = ["storage_object_samples.cc"],
     deps = ["//google/cloud/storage:storage_client"],
 )
+
+cc_binary(
+    name = "storage_object_acl_samples",
+    srcs = ["storage_object_acl_samples.cc"],
+    deps = ["//google/cloud/storage:storage_client"],
+)

--- a/google/cloud/storage/examples/CMakeLists.txt
+++ b/google/cloud/storage/examples/CMakeLists.txt
@@ -23,3 +23,6 @@ target_link_libraries(storage_bucket_samples storage_client)
 
 add_executable(storage_object_samples storage_object_samples.cc)
 target_link_libraries(storage_object_samples storage_client)
+
+add_executable(storage_object_acl_samples storage_object_acl_samples.cc)
+target_link_libraries(storage_object_acl_samples storage_client)

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -22,6 +22,92 @@ fi
 source "${PROJECT_ROOT}/ci/colors.sh"
 
 ################################################
+# Run a list of examples in a given program
+# Globals:
+#   COLOR_*: colorize output messages, defined in colors.sh
+# Arguments:
+#   program_name: the name of the program to run.
+#   examples: a string with the list of examples to run, separated by commas
+#   *: the base arguments that all commands need.
+# Returns:
+#   None
+################################################
+run_program_examples() {
+  if [ $# -lt 3 ]; then
+    echo "Usage: run_all_examples <program_name> [example ...]"
+    exit 1
+  fi
+
+  local program_path=$1
+  local example_list=$(echo $2 | tr ',' ' ')
+  shift 2
+  local base_arguments=$*
+
+  local program_name=$(basename ${program_path})
+
+  if [ ! -x ${program_name} ]; then
+    echo "${COLOR_YELLOW}[  SKIPPED ]${COLOR_RESET}" \
+        " ${program_name} is not compiled"
+    return
+  fi
+  local object_name="object-$(date +%s)"
+  for example in ${example_list}; do
+    log="$(mktemp --tmpdir "storage_samples.XXXXXXXXXX.log")"
+    echo    "${COLOR_GREEN}[ RUN      ]${COLOR_RESET}" \
+        "${program_name} ${example} running"
+    #
+    # Magic list of examples that need additional arguments.
+    #
+    case ${example} in
+        insert-object)
+            other_arguments="a-short-string-to-put-in-the-object"
+            ;;
+        *)
+            other_arguments=""
+            ;;
+    esac
+    echo ${program_path} ${example} \
+        ${base_arguments} ${other_arguments} >"${log}"
+    ${program_path} ${example} \
+        ${base_arguments} ${other_arguments} >>"${log}" 2>&1 </dev/null
+    if [ $? = 0 ]; then
+      echo  "${COLOR_GREEN}[       OK ]${COLOR_RESET}" \
+          "${program_name} ${example}"
+      continue
+    else
+      echo    "${COLOR_RED}[    ERROR ]${COLOR_RESET}" \
+          "${program_name} ${example}"
+      echo
+      echo "================ [begin ${log}] ================"
+      cat "${log}"
+      echo "================ [end ${log}] ================"
+      if [ -f "testbench.log" ]; then
+        cat "testbench.log"
+      fi
+    fi
+    /bin/rm -f "${log}"
+  done
+
+  log="$(mktemp --tmpdir "storage_samples.XXXXXXXXXX.log")"
+  echo "${COLOR_GREEN}[ RUN      ]${COLOR_RESET}" \
+      "${program_name} (no command) running"
+  ${program_path} >"${log}" 2>&1 </dev/null
+  # Note the inverted test, this is supposed to exit with 1.
+  if [ $? != 0 ]; then
+    echo "${COLOR_GREEN}[       OK ]${COLOR_RESET}" \
+        "${program_name}" "(no command)"
+  else
+    echo   "${COLOR_RED}[    ERROR ]${COLOR_RESET}" \
+        "${program_name}" "(no command)"
+    echo
+    echo "================ [begin ${log}] ================"
+    cat "${log}"
+    echo "================ [end ${log}] ================"
+  fi
+  /bin/rm -f "${log}"
+}
+
+################################################
 # Run all Bucket examples.
 # Globals:
 #   COLOR_*: colorize output messages, defined in colors.sh
@@ -154,6 +240,45 @@ _EOF_
 }
 
 ################################################
+# Run all Object examples.
+# Globals:
+#   COLOR_*: colorize output messages, defined in colors.sh
+# Arguments:
+#   bucket_name: the name of the bucket to run the examples against.
+# Returns:
+#   None
+################################################
+run_all_object_acl_examples() {
+  local bucket_name=$1
+  shift
+
+  # The list of commands in the storage_bucket_samples program that we will
+  # test. Currently get-metadata assumes that $bucket_name is already created.
+  readonly OBJECT_ACL_COMMANDS=$(tr '\n' ',' <<_EOF_
+list-object-acl
+_EOF_
+)
+
+  # First create an object for the example:
+  local object_name="object-$(date +%s)"
+  if [ ! -x ./storage_object_samples ]; then
+    echo "${COLOR_YELLOW}[  SKIPPED ]${COLOR_RESET}" \
+        " storage_object_samples is not compiled"
+    return
+  fi
+  ./storage_object_samples insert-object \
+      "${bucket_name}" \
+      "${object_name}" \
+      "some-contents-does-not-matter-what"
+
+  EXAMPLE_BASE_ARGUMENTS="${bucket_name} ${object_name}"
+  run_program_examples ./storage_object_acl_samples \
+      "${OBJECT_ACL_COMMANDS}" \
+      "${bucket_name}" \
+      "${object_name}"
+}
+
+################################################
 # Run all the examples.
 # Globals:
 #   BUCKET_NAME: the name of the bucket to use in the examples.
@@ -167,6 +292,7 @@ run_all_storage_examples() {
   echo "${COLOR_GREEN}[ ======== ]${COLOR_RESET}" \
       " Running Google Cloud Storage Examples"
   set +e
+  run_all_object_acl_examples "${BUCKET_NAME}"
   run_all_bucket_examples "${BUCKET_NAME}"
   run_all_object_examples "${BUCKET_NAME}"
   set -e

--- a/google/cloud/storage/examples/storage_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_object_acl_samples.cc
@@ -1,0 +1,112 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include <functional>
+#include <iostream>
+#include <map>
+#include <sstream>
+
+namespace gcs = google::cloud::storage;
+
+namespace {
+struct Usage {
+  std::string msg;
+};
+
+char const* ConsumeArg(int& argc, char* argv[]) {
+  if (argc < 2) {
+    return nullptr;
+  }
+  char const* result = argv[1];
+  std::copy(argv + 2, argv + argc, argv + 1);
+  argc--;
+  return result;
+}
+
+std::string command_usage;
+
+void PrintUsage(int argc, char* argv[], std::string const& msg) {
+  std::string const cmd = argv[0];
+  auto last_slash = std::string(cmd).find_last_of('/');
+  auto program = cmd.substr(last_slash + 1);
+  std::cerr << msg << "\nUsage: " << program << " <command> [arguments]\n\n"
+            << "Commands:\n"
+            << command_usage << std::endl;
+}
+
+void ListObjectAcl(gcs::Client client, int& argc, char* argv[]) {
+  if (argc < 3) {
+    throw Usage{"list-object-acl <bucket-name> <object-name>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  auto object_name = ConsumeArg(argc, argv);
+  //! [list object acl] [START storage_print_file_acl]
+  [](google::cloud::storage::Client client, std::string bucket_name,
+     std::string object_name) {
+    std::cout << "ACLs for object=" << object_name << " in bucket "
+              << bucket_name << std::endl;
+    for (auto&& acl : client.ListObjectAcl(bucket_name, object_name)) {
+      std::cout << acl.role() << ":" << acl.entity() << std::endl;
+    }
+  }
+  //! [list object acl] [END storage_print_file_acl]
+  (std::move(client), bucket_name, object_name);
+}
+
+}  // anonymous namespace
+
+int main(int argc, char* argv[]) try {
+  // Create a client to communicate with Google Cloud Storage.
+  gcs::Client client;
+
+  // Build the list of commands and the usage string from that list.
+  using CommandType = std::function<void(gcs::Client, int&, char* [])>;
+  std::map<std::string, CommandType> commands = {
+      {"list-object-acl", &ListObjectAcl},
+  };
+  for (auto&& kv : commands) {
+    try {
+      int fake_argc = 1;
+      kv.second(client, fake_argc, argv);
+    } catch (Usage const& u) {
+      command_usage += "    ";
+      command_usage += u.msg;
+      command_usage += "\n";
+    }
+  }
+
+  if (argc < 2) {
+    PrintUsage(argc, argv, "Missing command");
+    return 1;
+  }
+
+  std::string const command = ConsumeArg(argc, argv);
+  auto it = commands.find(command);
+  if (commands.end() == it) {
+    PrintUsage(argc, argv, "Unknown command: " + command);
+    return 1;
+  }
+
+  // Call the command with that client.
+  it->second(client, argc, argv);
+
+  return 0;
+} catch (Usage const& ex) {
+  PrintUsage(argc, argv, ex.msg);
+  return 1;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard C++ exception raised: " << ex.what() << std::endl;
+  return 1;
+}

--- a/google/cloud/storage/tests/testbench.py
+++ b/google/cloud/storage/tests/testbench.py
@@ -269,6 +269,20 @@ def objects_delete(bucket_name, object_name):
     return json.dumps({})
 
 
+@gcs.route('/b/<bucket_name>/o/<object_name>/acl')
+def objects_acl_list(bucket_name, object_name):
+    """Implement the 'ObjectAccessControls: list' API.
+
+     List Object Access Controls.
+     """
+    object_path = bucket_name + '/o/' + object_name
+    gcs_object = GCS_OBJECTS.get(object_path,
+                                 GcsObject(bucket_name, object_name))
+    gcs_object.check_preconditions(flask.request)
+    revision = gcs_object.get_revision(flask.request)
+    return json.dumps(revision.metadata.get('acl', []))
+
+
 # Define the WSGI application to handle bucket requests.
 UPLOAD_HANDLER_PATH = '/upload/storage/v1'
 upload = flask.Flask(__name__)


### PR DESCRIPTION
This is part of the fixes for #842. It introduces a new program
to contain all the object access control examples. Runs that
program as part of the CI builds, and fixes the testbench to
support 'ObjectAccessControls: list'.

The driver scripts for the examples were getting too large,
this change stops the bleeding, but I need to go back and
fix the existing drivers (#884).
