### PR TITLE
Fix integration test driver scripts to be usable on macOS.

### DIFF
--- a/google/cloud/bigtable/examples/run_examples_emulator.sh
+++ b/google/cloud/bigtable/examples/run_examples_emulator.sh
@@ -30,8 +30,8 @@ readonly PROJECT_ID="project-$(date +%s)"
 readonly ZONE_ID="fake-zone"
 
 # The examples are noisy,
+log="$(mktemp -t "bigtable_examples.XXXXXX")"
 for example in instance_admin table_admin data; do
-  log=$(mktemp --tmpdir "bigtable_examples_${example}_XXXXXXXXXX.log")
   echo "${COLOR_GREEN}[ RUN      ]${COLOR_RESET} ${example}"
   run_all_${example}_examples "${PROJECT_ID}" "${ZONE_ID}" >${log} 2>&1 </dev/null
   if [ $? = 0 ]; then

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -50,9 +50,8 @@ run_program_examples() {
         " ${program_name} is not compiled"
     return
   fi
-  local object_name="object-$(date +%s)"
+  log="$(mktemp -t "storage_samples.XXXXXX")"
   for example in ${example_list}; do
-    log="$(mktemp --tmpdir "storage_samples.XXXXXXXXXX.log")"
     echo    "${COLOR_GREEN}[ RUN      ]${COLOR_RESET}" \
         "${program_name} ${example} running"
     #
@@ -87,10 +86,8 @@ run_program_examples() {
         echo "================ [end testbench.log ================"
       fi
     fi
-    /bin/rm -f "${log}"
   done
 
-  log="$(mktemp --tmpdir "storage_samples.XXXXXXXXXX.log")"
   echo "${COLOR_GREEN}[ RUN      ]${COLOR_RESET}" \
       "${program_name} (no command) running"
   ${program_path} >"${log}" 2>&1 </dev/null


### PR DESCRIPTION
With these changes the scripts are runnable in macOS without
having to install the full collection of GNU fileutils and
coreutils.

This is not that important, but I was developing on my Laptop this week.