### PR TITLE
Implement Client::GetObjectAcl.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -286,6 +286,28 @@ class Client {
     raw_client_->DeleteObjectAcl(request);
   }
 
+  /**
+   * Get the value of an existing object ACL.
+   *
+   * @param bucket_name the name of the bucket that contains the object.
+   * @param object_name the name of the object.
+   * @param entity the name of the entity added to the ACL.
+   * @param parameters a variadic list of optional parameters. Valid types for
+   *   this operation include `Generation`, and `UserProject`.
+   *
+   * @par Example
+   * @snippet storage_object_acl_samples.cc get object acl
+   */
+  template <typename... Parameters>
+  ObjectAccessControl GetObjectAcl(std::string const& bucket_name,
+                                   std::string const& object_name,
+                                   std::string const& entity,
+                                   Parameters&&... parameters) {
+    internal::ObjectAclRequest request(bucket_name, object_name, entity);
+    request.set_multiple_parameters(std::forward<Parameters>(parameters)...);
+    return raw_client_->GetObjectAcl(request).second;
+  }
+
  private:
   BucketMetadata GetBucketMetadataImpl(
       internal::GetBucketMetadataRequest const& request);

--- a/google/cloud/storage/client_object_acl_test.cc
+++ b/google/cloud/storage/client_object_acl_test.cc
@@ -187,6 +187,50 @@ TEST_F(ObjectAccessControlsTest, DeleteObjectAclPermanentFailure) {
       "DeleteObjectAcl");
 }
 
+TEST_F(ObjectAccessControlsTest, GetObjectAcl) {
+  auto expected = ObjectAccessControl::ParseFromString(R"""({
+          "bucket": "test-bucket",
+          "object": "test-object",
+          "entity": "user-test-user-1",
+          "role": "READER"
+      })""");
+
+  EXPECT_CALL(*mock, GetObjectAcl(_))
+      .WillOnce(Return(std::make_pair(TransientError(), ObjectAccessControl{})))
+      .WillOnce(Invoke([&expected](internal::ObjectAclRequest const& r) {
+        EXPECT_EQ("test-bucket", r.bucket_name());
+        EXPECT_EQ("test-object", r.object_name());
+        EXPECT_EQ("user-test-user-1", r.entity());
+
+        return std::make_pair(Status(), expected);
+      }));
+  Client client{std::shared_ptr<internal::RawClient>(mock)};
+
+  ObjectAccessControl actual =
+      client.GetObjectAcl("test-bucket", "test-object", "user-test-user-1");
+  EXPECT_EQ(expected, actual);
+}
+
+TEST_F(ObjectAccessControlsTest, GetObjectAclTooManyFailures) {
+  testing::TooManyFailuresTest<ObjectAccessControl>(
+      mock, EXPECT_CALL(*mock, GetObjectAcl(_)),
+      [](Client& client) {
+        client.GetObjectAcl("test-bucket-name", "test-object-name",
+                            "user-test-user-1");
+      },
+      "GetObjectAcl");
+}
+
+TEST_F(ObjectAccessControlsTest, GetObjectAclPermanentFailure) {
+  testing::PermanentFailureTest<ObjectAccessControl>(
+      *client, EXPECT_CALL(*mock, GetObjectAcl(_)),
+      [](Client& client) {
+        client.GetObjectAcl("test-bucket-name", "test-object-name",
+                            "user-test-user");
+      },
+      "GetObjectAcl");
+}
+
 }  // namespace
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -202,6 +202,7 @@ run_all_object_acl_examples() {
   readonly OBJECT_ACL_COMMANDS=$(tr '\n' ',' <<_EOF_
 list-object-acl
 create-object-acl
+get-object-acl
 _EOF_
 )
 

--- a/google/cloud/storage/examples/storage_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_object_acl_samples.cc
@@ -105,6 +105,25 @@ void DeleteObjectAcl(gcs::Client client, int& argc, char* argv[]) {
   (std::move(client), bucket_name, object_name, entity);
 }
 
+void GetObjectAcl(gcs::Client client, int& argc, char* argv[]) {
+  if (argc < 4) {
+    throw Usage{"get-object-acl <bucket-name> <object-name> <entity>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  auto object_name = ConsumeArg(argc, argv);
+  auto entity = ConsumeArg(argc, argv);
+  //! [get object acl] [START storage_get_file_acl]
+  [](google::cloud::storage::Client client, std::string bucket_name,
+     std::string object_name, std::string entity) {
+    google::cloud::storage::ObjectAccessControl acl =
+        client.GetObjectAcl(bucket_name, object_name, entity);
+    std::cout << "ACL entry for " << entity << " in object " << object_name
+              << " in bucket " << bucket_name << " is " << acl << std::endl;
+  }
+  //! [get object acl] [END storage_get_file_acl]
+  (std::move(client), bucket_name, object_name, entity);
+}
+
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) try {
@@ -117,6 +136,7 @@ int main(int argc, char* argv[]) try {
       {"list-object-acl", &ListObjectAcl},
       {"create-object-acl", &CreateObjectAcl},
       {"delete-object-acl", &DeleteObjectAcl},
+      {"get-object-acl", &GetObjectAcl},
   };
   for (auto&& kv : commands) {
     try {

--- a/google/cloud/storage/examples/storage_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_object_acl_samples.cc
@@ -132,7 +132,7 @@ int main(int argc, char* argv[]) try {
   gcs::Client client;
 
   // Build the list of commands and the usage string from that list.
-  using CommandType = std::function<void(gcs::Client, int&, char*[])>;
+  using CommandType = std::function<void(gcs::Client, int&, char* [])>;
   std::map<std::string, CommandType> commands = {
       {"list-object-acl", &ListObjectAcl},
       {"create-object-acl", &CreateObjectAcl},

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -217,6 +217,24 @@ std::pair<Status, EmptyResponse> CurlClient::DeleteObjectAcl(
   return std::make_pair(Status(), internal::EmptyResponse{});
 }
 
+std::pair<Status, ObjectAccessControl> CurlClient::GetObjectAcl(
+    ObjectAclRequest const& request) {
+  CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
+                             "/o/" + request.object_name() + "/acl/" +
+                             request.entity());
+  builder.SetDebugLogging(options_.enable_http_tracing());
+  builder.AddHeader(options_.credentials()->AuthorizationHeader());
+  request.AddParametersToHttpRequest(builder);
+  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  if (payload.status_code >= 300) {
+    return std::make_pair(
+        Status{payload.status_code, std::move(payload.payload)},
+        ObjectAccessControl{});
+  }
+  return std::make_pair(Status(),
+                        ObjectAccessControl::ParseFromString(payload.payload));
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -57,11 +57,12 @@ class CurlClient : public RawClient {
 
   std::pair<Status, ListObjectAclResponse> ListObjectAcl(
       ListObjectAclRequest const& request) override;
-  std::pair<Status, EmptyResponse> DeleteObjectAcl(
-      ObjectAclRequest const&) override;
-
   std::pair<Status, ObjectAccessControl> CreateObjectAcl(
       CreateObjectAclRequest const&) override;
+  std::pair<Status, EmptyResponse> DeleteObjectAcl(
+      ObjectAclRequest const&) override;
+  std::pair<Status, ObjectAccessControl> GetObjectAcl(
+      ObjectAclRequest const&) override;
 
  private:
   ClientOptions options_;

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -106,6 +106,11 @@ std::pair<Status, EmptyResponse> LoggingClient::DeleteObjectAcl(
   return MakeCall(*client_, &RawClient::DeleteObjectAcl, request, __func__);
 }
 
+std::pair<Status, ObjectAccessControl> LoggingClient::GetObjectAcl(
+    ObjectAclRequest const& request) {
+  return MakeCall(*client_, &RawClient::GetObjectAcl, request, __func__);
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -59,6 +59,8 @@ class LoggingClient : public RawClient {
       CreateObjectAclRequest const&) override;
   std::pair<Status, EmptyResponse> DeleteObjectAcl(
       ObjectAclRequest const&) override;
+  std::pair<Status, ObjectAccessControl> GetObjectAcl(
+      ObjectAclRequest const&) override;
 
  private:
   std::shared_ptr<RawClient> client_;

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -80,6 +80,8 @@ class RawClient {
       CreateObjectAclRequest const&) = 0;
   virtual std::pair<Status, EmptyResponse> DeleteObjectAcl(
       ObjectAclRequest const&) = 0;
+  virtual std::pair<Status, ObjectAccessControl> GetObjectAcl(
+      ObjectAclRequest const&) = 0;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -191,6 +191,14 @@ std::pair<Status, EmptyResponse> RetryClient::DeleteObjectAcl(
                   &RawClient::DeleteObjectAcl, request, __func__);
 }
 
+std::pair<Status, ObjectAccessControl> RetryClient::GetObjectAcl(
+    ObjectAclRequest const& request) {
+  auto retry_policy = retry_policy_->clone();
+  auto backoff_policy = backoff_policy_->clone();
+  return MakeCall(*retry_policy, *backoff_policy, *client_,
+                  &RawClient::GetObjectAcl, request, __func__);
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -70,6 +70,8 @@ class RetryClient : public RawClient {
       CreateObjectAclRequest const&) override;
   std::pair<Status, EmptyResponse> DeleteObjectAcl(
       ObjectAclRequest const&) override;
+  std::pair<Status, ObjectAccessControl> GetObjectAcl(
+      ObjectAclRequest const&) override;
 
  private:
   void Apply(RetryPolicy& policy) { retry_policy_ = policy.clone(); }

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -57,6 +57,8 @@ class MockClient : public google::cloud::storage::internal::RawClient {
                                     internal::CreateObjectAclRequest const&));
   MOCK_METHOD1(DeleteObjectAcl, ResponseWrapper<internal::EmptyResponse>(
                                     internal::ObjectAclRequest const&));
+  MOCK_METHOD1(GetObjectAcl, ResponseWrapper<ObjectAccessControl>(
+                                 internal::ObjectAclRequest const&));
 };
 }  // namespace testing
 }  // namespace storage

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -160,11 +160,15 @@ TEST_F(ObjectIntegrationTest, AccessControlCRUD) {
 
   ObjectAccessControl result =
       client.CreateObjectAcl(bucket_name, object_name, entity_name, "OWNER");
+  EXPECT_EQ("OWNER", result.role());
   auto current_acl = client.ListObjectAcl(bucket_name, object_name);
   // Search using the entity name returned by the request, because we use
   // 'project-editors-<project_id>' this different than the original entity
   // name, the server "translates" the project id to a project number.
   EXPECT_EQ(1, name_counter(result.entity(), current_acl));
+
+  auto get_result = client.GetObjectAcl(bucket_name, object_name, entity_name);
+  EXPECT_EQ(get_result, result);
 
   // Remove an entity and verify it is no longer in the ACL.
   client.DeleteObjectAcl(bucket_name, object_name, entity_name);

--- a/google/cloud/storage/tests/testbench.py
+++ b/google/cloud/storage/tests/testbench.py
@@ -103,9 +103,12 @@ class GcsObjectVersion(object):
             'storageClass': 'STANDARD',
             'etag': 'XYZ='
         }
-        self.insert_acl('project-owners-123456789', 'OWNER')
-        self.insert_acl('project-editors-123456789', 'OWNER')
-        self.insert_acl('project-viewers-123456789', 'READER')
+        self.insert_acl(
+            self.canonical_entity_name('project-owners-123456789'), 'OWNER')
+        self.insert_acl(
+            self.canonical_entity_name('project-editors-123456789'), 'OWNER')
+        self.insert_acl(
+            self.canonical_entity_name('project-viewers-123456789'), 'READER')
 
     def canonical_entity_name(self, entity):
         """
@@ -118,12 +121,12 @@ class GcsObjectVersion(object):
         :return:str the name in canonical form.
         """
         if entity.startswith('project-owners-'):
-            return 'project-owners-123456789'
+            entity = 'project-owners-123456789'
         if entity.startswith('project-editors-'):
-            return 'project-editors-123456789'
+            entity = 'project-editors-123456789'
         if entity.startswith('project-viewers-'):
-            return 'project-viewers-123456789'
-        return entity
+            entity = 'project-viewers-123456789'
+        return entity.lower()
 
     def insert_acl(self, entity, role):
         """

--- a/google/cloud/storage/tests/testbench.py
+++ b/google/cloud/storage/tests/testbench.py
@@ -143,7 +143,7 @@ class GcsObjectVersion(object):
             email = entity
         # Replace or insert the entry
         indexed = {
-            entry.get('entity'): entry
+            entry.get('entity').lower(): entry
             for entry in self.metadata.get('acl', [])
         }
         indexed[entity] = {
@@ -170,7 +170,7 @@ class GcsObjectVersion(object):
         """
         entity = self.canonical_entity_name(entity)
         indexed = {
-            acl.get('entity'): acl
+            acl.get('entity').lower(): acl
             for acl in self.metadata.get('acl', [])
         }
         indexed.pop(entity)
@@ -185,7 +185,7 @@ class GcsObjectVersion(object):
         """
         entity = self.canonical_entity_name(entity)
         for acl in self.metadata.get('acl', []):
-            if acl.get('entity', '') == entity:
+            if acl.get('entity', '').lower() == entity:
                 return acl
         raise ErrorResponse(
             'Entity %s not found in object %s' % (entity, self.name))


### PR DESCRIPTION
This fixes #840. It implements the API, the unit tests
the integration tests, and the sample snippet.