### PR TITLE
Remove using-directives; prefer using-declarations

### DIFF
--- a/google/cloud/storage/bucket_test.cc
+++ b/google/cloud/storage/bucket_test.cc
@@ -22,9 +22,13 @@
 namespace google {
 namespace cloud {
 namespace storage {
-using namespace testing::canonical_errors;
+inline namespace STORAGE_CLIENT_NS {
 namespace {
-using namespace ::testing;
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::ReturnRef;
+using testing::canonical_errors::TransientError;
 
 /**
  * Test the functions in Storage::Client related to 'Buckets: *'.
@@ -96,6 +100,7 @@ TEST_F(BucketTest, GetMetadataPermanentFailure) {
 }
 
 }  // namespace
+}  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/client_object_acl_test.cc
+++ b/google/cloud/storage/client_object_acl_test.cc
@@ -22,10 +22,13 @@
 namespace google {
 namespace cloud {
 namespace storage {
-using namespace testing::canonical_errors;
 namespace {
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::ReturnRef;
 using ms = std::chrono::milliseconds;
-using namespace ::testing;
+using testing::canonical_errors::TransientError;
 
 /**
  * Test the ObjectAccessControls-related functions in storage::Client.

--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -22,9 +22,10 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-using namespace testing::canonical_errors;
 namespace {
-using namespace ::testing;
+using ::testing::_;
+using ::testing::Return;
+using testing::canonical_errors::TransientError;
 
 class ObservableRetryPolicy : public LimitedErrorCountRetryPolicy {
  public:

--- a/google/cloud/storage/internal/authorized_user_credentials_test.cc
+++ b/google/cloud/storage/internal/authorized_user_credentials_test.cc
@@ -20,12 +20,20 @@
 #include <gmock/gmock.h>
 #include <cstring>
 
-namespace storage = google::cloud::storage;
-using storage::internal::AuthorizedUserCredentials;
-using storage::internal::GoogleOAuthRefreshEndpoint;
-using storage::testing::MockHttpRequest;
-using storage::testing::MockHttpRequestBuilder;
-using namespace ::testing;
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+using ::google::cloud::storage::testing::MockHttpRequest;
+using ::google::cloud::storage::testing::MockHttpRequestBuilder;
+using ::testing::_;
+using ::testing::An;
+using ::testing::HasSubstr;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::StrEq;
 
 class AuthorizedUserCredentialsTest : public ::testing::Test {
  protected:
@@ -46,7 +54,7 @@ TEST_F(AuthorizedUserCredentialsTest, Simple) {
 })""";
   auto mock_request = std::make_shared<MockHttpRequest::Impl>();
   EXPECT_CALL(*mock_request, MakeRequest())
-      .WillOnce(Return(storage::internal::HttpResponse{200, response, {}}));
+      .WillOnce(Return(HttpResponse{200, response, {}}));
 
   auto mock_builder = MockHttpRequestBuilder::mock;
   EXPECT_CALL(*mock_builder,
@@ -101,8 +109,8 @@ TEST_F(AuthorizedUserCredentialsTest, Refresh) {
 })""";
   auto mock_request = std::make_shared<MockHttpRequest::Impl>();
   EXPECT_CALL(*mock_request, MakeRequest())
-      .WillOnce(Return(storage::internal::HttpResponse{200, r1, {}}))
-      .WillOnce(Return(storage::internal::HttpResponse{200, r2, {}}));
+      .WillOnce(Return(HttpResponse{200, r1, {}}))
+      .WillOnce(Return(HttpResponse{200, r2, {}}));
 
   // Now setup the builder to return those responses.
   auto mock_builder = MockHttpRequestBuilder::mock;
@@ -136,3 +144,10 @@ TEST_F(AuthorizedUserCredentialsTest, Refresh) {
   EXPECT_EQ("Authorization: Type access-token-r2",
             credentials.AuthorizationHeader());
 }
+
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/google_application_default_credentials_file_test.cc
+++ b/google/cloud/storage/internal/google_application_default_credentials_file_test.cc
@@ -17,8 +17,15 @@
 #include "google/cloud/testing_util/environment_variable_restore.h"
 #include <gmock/gmock.h>
 
-using namespace google::cloud::storage::internal;
-using google::cloud::testing_util::EnvironmentVariableRestore;
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+using ::google::cloud::internal::SetEnv;
+using ::google::cloud::internal::UnsetEnv;
+using ::google::cloud::testing_util::EnvironmentVariableRestore;
 
 class DefaultServiceAccountFileTest : public ::testing::Test {
  public:
@@ -43,17 +50,16 @@ class DefaultServiceAccountFileTest : public ::testing::Test {
 
 /// @test Verify that the application can override the default credentials.
 TEST_F(DefaultServiceAccountFileTest, EnvironmentVariableSet) {
-  google::cloud::internal::SetEnv("GOOGLE_APPLICATION_CREDENTIALS",
-                                  "/foo/bar/baz");
+  SetEnv("GOOGLE_APPLICATION_CREDENTIALS", "/foo/bar/baz");
   auto actual = GoogleApplicationDefaultCredentialsFile();
   EXPECT_EQ("/foo/bar/baz", actual);
 }
 
 /// @test Verify that the file path works as expected when using HOME.
 TEST_F(DefaultServiceAccountFileTest, HomeSet) {
-  google::cloud::internal::UnsetEnv("GOOGLE_APPLICATION_CREDENTIALS");
+  UnsetEnv("GOOGLE_APPLICATION_CREDENTIALS");
   char const* home = GoogleApplicationDefaultCredentialsHomeVariable();
-  google::cloud::internal::SetEnv(home, "/foo/bar/baz");
+  SetEnv(home, "/foo/bar/baz");
   auto actual = GoogleApplicationDefaultCredentialsFile();
   using testing::HasSubstr;
   EXPECT_THAT(actual, HasSubstr("/foo/bar/baz"));
@@ -62,9 +68,9 @@ TEST_F(DefaultServiceAccountFileTest, HomeSet) {
 
 /// @test Verify that the service account file path fails when HOME is not set.
 TEST_F(DefaultServiceAccountFileTest, HomeNotSet) {
-  google::cloud::internal::UnsetEnv("GOOGLE_APPLICATION_CREDENTIALS");
+  UnsetEnv("GOOGLE_APPLICATION_CREDENTIALS");
   char const* home = GoogleApplicationDefaultCredentialsHomeVariable();
-  google::cloud::internal::UnsetEnv(home);
+  UnsetEnv(home);
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_THROW(GoogleApplicationDefaultCredentialsFile(), std::runtime_error);
 #else
@@ -72,3 +78,10 @@ TEST_F(DefaultServiceAccountFileTest, HomeNotSet) {
                             "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
+
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -21,8 +21,9 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
+
 namespace {
-using namespace raw_client_wrapper_utils;
+using raw_client_wrapper_utils::CheckSignature;
 /**
  * Call a RawClient operation logging both the input and the result.
  *

--- a/google/cloud/storage/internal/logging_client_test.cc
+++ b/google/cloud/storage/internal/logging_client_test.cc
@@ -23,7 +23,10 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
-using namespace ::testing;
+using ::testing::_;
+using ::testing::HasSubstr;
+using ::testing::Invoke;
+using ::testing::Return;
 
 class MockLogBackend : public google::cloud::LogBackend {
  public:

--- a/google/cloud/storage/internal/metadata_parser_test.cc
+++ b/google/cloud/storage/internal/metadata_parser_test.cc
@@ -15,7 +15,12 @@
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include <gmock/gmock.h>
 
-using namespace google::cloud::storage::internal;
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
 
 /// @test Verify that we parse RFC-3339 timestamps in JSON objects.
 TEST(MetadataParserTest, ParseTimestampField) {
@@ -170,3 +175,10 @@ TEST(MetadataParserTest, ParseInvalidUnsignedLongFieldType) {
   EXPECT_DEATH_IF_SUPPORTED(ParseUnsignedLongField(json_object, "size"), "");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
+
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/parse_rfc3339_test.cc
+++ b/google/cloud/storage/internal/parse_rfc3339_test.cc
@@ -16,10 +16,19 @@
 #include <gtest/gtest.h>
 #include <ctime>
 
-namespace storage = google::cloud::storage;
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+using ::std::chrono::duration_cast;
+using ::std::chrono::milliseconds;
+using ::std::chrono::nanoseconds;
+using ::std::chrono::seconds;
 
 TEST(ParseRfc3339Test, ParseEpoch) {
-  auto timestamp = storage::internal::ParseRfc3339("1970-01-01T00:00:00Z");
+  auto timestamp = ParseRfc3339("1970-01-01T00:00:00Z");
   // The C++ 11, 14 and 17 standards do not guarantee that the system clock's
   // epoch is actually the same as the Unix Epoch. Luckily, the platforms we
   // support actually have that property, and C++ 20 fixes things. If this test
@@ -36,26 +45,22 @@ TEST(ParseRfc3339Test, ParseEpoch) {
 }
 
 TEST(ParseRfc3339Test, ParseSimpleZulu) {
-  auto timestamp = storage::internal::ParseRfc3339("2018-05-18T14:42:03Z");
+  auto timestamp = ParseRfc3339("2018-05-18T14:42:03Z");
   // Use `date -u +%s --date='2018-05-18T14:42:03'` to get the magic value:
-  using namespace std::chrono;
   EXPECT_EQ(1526654523L,
             duration_cast<seconds>(timestamp.time_since_epoch()).count());
 }
 
 TEST(ParseRfc3339Test, ParseAlternativeSeparators) {
-  auto timestamp = storage::internal::ParseRfc3339("2018-05-18t14:42:03z");
+  auto timestamp = ParseRfc3339("2018-05-18t14:42:03z");
   // Use `date -u +%s --date='2018-05-18T14:42:03'` to get the magic value:
-  using namespace std::chrono;
   EXPECT_EQ(1526654523L,
             duration_cast<seconds>(timestamp.time_since_epoch()).count());
 }
 
 TEST(ParseRfc3339Test, ParseFractional) {
-  auto timestamp =
-      storage::internal::ParseRfc3339("2018-05-18T14:42:03.123456789Z");
+  auto timestamp = ParseRfc3339("2018-05-18T14:42:03.123456789Z");
   // Use `date -u +%s --date='2018-05-18T14:42:03'` to get the magic value:
-  using namespace std::chrono;
   auto actual_seconds = duration_cast<seconds>(timestamp.time_since_epoch());
   EXPECT_EQ(1526654523L, actual_seconds.count());
 
@@ -76,10 +81,8 @@ TEST(ParseRfc3339Test, ParseFractional) {
 }
 
 TEST(ParseRfc3339Test, ParseFractionalMoreThanNanos) {
-  auto timestamp =
-      storage::internal::ParseRfc3339("2018-05-18T14:42:03.1234567890123Z");
+  auto timestamp = ParseRfc3339("2018-05-18T14:42:03.1234567890123Z");
   // Use `date -u +%s --date='2018-05-18T14:42:03'` to get the magic value:
-  using namespace std::chrono;
   auto actual_seconds = duration_cast<seconds>(timestamp.time_since_epoch());
   EXPECT_EQ(1526654523L, actual_seconds.count());
   bool system_clock_has_nanos = std::ratio_greater_equal<
@@ -99,10 +102,8 @@ TEST(ParseRfc3339Test, ParseFractionalMoreThanNanos) {
 }
 
 TEST(ParseRfc3339Test, ParseFractionalLessThanNanos) {
-  auto timestamp =
-      storage::internal::ParseRfc3339("2018-05-18T14:42:03.123456Z");
+  auto timestamp = ParseRfc3339("2018-05-18T14:42:03.123456Z");
   // Use `date -u +%s --date='2018-05-18T14:42:03'` to get the magic value:
-  using namespace std::chrono;
   auto actual_seconds = duration_cast<seconds>(timestamp.time_since_epoch());
   EXPECT_EQ(1526654523L, actual_seconds.count());
   auto actual_nanoseconds =
@@ -111,20 +112,17 @@ TEST(ParseRfc3339Test, ParseFractionalLessThanNanos) {
 }
 
 TEST(ParseRfc3339Test, ParseWithOffset) {
-  auto timestamp = storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:00");
+  auto timestamp = ParseRfc3339("2018-05-18T14:42:03+08:00");
   // Use `date -u +%s --date='2018-05-18T14:42:03+08:00'` to get the magic
   // value.
-  using namespace std::chrono;
   auto actual_seconds = duration_cast<seconds>(timestamp.time_since_epoch());
   EXPECT_EQ(1526625723L, actual_seconds.count());
 }
 
 TEST(ParseRfc3339Test, ParseFull) {
-  auto timestamp =
-      storage::internal::ParseRfc3339("2018-05-18T14:42:03.5-01:05");
+  auto timestamp = ParseRfc3339("2018-05-18T14:42:03.5-01:05");
   // Use `date -u +%s --date='2018-05-18T14:42:03.5-01:05'` to get the magic
   // value.
-  using namespace std::chrono;
   auto actual_seconds = duration_cast<seconds>(timestamp.time_since_epoch());
   EXPECT_EQ(1526658423L, actual_seconds.count());
   auto actual_milliseconds = duration_cast<milliseconds>(
@@ -134,305 +132,260 @@ TEST(ParseRfc3339Test, ParseFull) {
 
 TEST(ParseRfc3339Test, DetectInvalidSeparator) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18x14:42:03Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2018-05-18x14:42:03Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-05-18x14:42:03Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-05-18x14:42:03Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03x"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2018-05-18T14:42:03x"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-05-18T14:42:03x"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-05-18T14:42:03x"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectLongYear) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("52018-05-18T14:42:03Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("52018-05-18T14:42:03Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("52018-05-18T14:42:03Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("52018-05-18T14:42:03Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectShortYear) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("218-05-18T14:42:03Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("218-05-18T14:42:03Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("218-05-18T14:42:03Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("218-05-18T14:42:03Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectLongMonth) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-123-18T14:42:03Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2018-123-18T14:42:03Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-123-18T14:42:03Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-123-18T14:42:03Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectShortMonth) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-1-18T14:42:03Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2018-1-18T14:42:03Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-1-18T14:42:03Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-1-18T14:42:03Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectOutOfRangeMonth) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-33-18T14:42:03Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2018-33-18T14:42:03Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-33-18T14:42:03Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-33-18T14:42:03Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectLongMDay) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-181T14:42:03Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2018-05-181T14:42:03Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-05-181T14:42:03Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-05-181T14:42:03Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectShortMDay) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-1T14:42:03Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2018-05-1T14:42:03Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-05-1T14:42:03Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-05-1T14:42:03Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectOutOfRangeMDay) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-55T14:42:03Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2018-05-55T14:42:03Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-05-55T14:42:03Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-05-55T14:42:03Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectOutOfRangeMDay30) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-06-31T14:42:03Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2018-06-31T14:42:03Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-06-31T14:42:03Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-06-31T14:42:03Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectOutOfRangeMDayFebLeap) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2016-02-30T14:42:03Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2016-02-30T14:42:03Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2016-02-30T14:42:03Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2016-02-30T14:42:03Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectOutOfRangeMDayFebNonLeap) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2017-02-29T14:42:03Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2017-02-29T14:42:03Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2017-02-29T14:42:03Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2017-02-29T14:42:03Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectLongHour) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T144:42:03Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2018-05-18T144:42:03Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-05-18T144:42:03Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-05-18T144:42:03Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectShortHour) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T1:42:03Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2018-05-18T1:42:03Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-05-18T1:42:03Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-05-18T1:42:03Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectOutOfRangeHour) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T24:42:03Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2018-05-18T24:42:03Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-05-18T24:42:03Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-05-18T24:42:03Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectLongMinute) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:442:03Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2018-05-18T14:442:03Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-05-18T14:442:03Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-05-18T14:442:03Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectShortMinute) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:2:03Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2018-05-18T14:2:03Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-05-18T14:2:03Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-05-18T14:2:03Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectOutOfRangeMinute) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T22:60:03Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2018-05-18T22:60:03Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-05-18T22:60:03Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-05-18T22:60:03Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectLongSecond) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:003Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2018-05-18T14:42:003Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-05-18T14:42:003Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-05-18T14:42:003Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectShortSecond) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:3Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2018-05-18T14:42:3Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-05-18T14:42:3Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-05-18T14:42:3Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectOutOfRangeSecond) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T22:42:61Z"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2018-05-18T22:42:61Z"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-05-18T22:42:61Z"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-05-18T22:42:61Z"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectLongOffsetHour) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+008:00"),
+  EXPECT_THROW(ParseRfc3339("2018-05-18T14:42:03+008:00"),
                std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-05-18T14:42:03+008:00"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-05-18T14:42:03+008:00"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectShortOffsetHour) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+8:00"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2018-05-18T14:42:03+8:00"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-05-18T14:42:03+8:00"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-05-18T14:42:03+8:00"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectOutOfRangeOffsetHour) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+24:00"),
+  EXPECT_THROW(ParseRfc3339("2018-05-18T14:42:03+24:00"),
                std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-05-18T14:42:03+24:00"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-05-18T14:42:03+24:00"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectLongOffsetMinute) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:001"),
+  EXPECT_THROW(ParseRfc3339("2018-05-18T14:42:03+08:001"),
                std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:001"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-05-18T14:42:03+08:001"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectShortOffsetMinute) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:1"),
-               std::invalid_argument);
+  EXPECT_THROW(ParseRfc3339("2018-05-18T14:42:03+08:1"), std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:1"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-05-18T14:42:03+08:1"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ParseRfc3339Test, DetectOutOfRangeOffsetMinute) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:60"),
+  EXPECT_THROW(ParseRfc3339("2018-05-18T14:42:03+08:60"),
                std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      storage::internal::ParseRfc3339("2018-05-18T14:42:03+08:60"),
-      "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(ParseRfc3339("2018-05-18T14:42:03+08:60"),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
+
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -43,7 +43,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
-using namespace raw_client_wrapper_utils;
+using raw_client_wrapper_utils::CheckSignature;
 
 /**
  * Call a client operation with retries borrowing the RPC policies.

--- a/google/cloud/storage/object_test.cc
+++ b/google/cloud/storage/object_test.cc
@@ -22,10 +22,14 @@
 namespace google {
 namespace cloud {
 namespace storage {
-using namespace testing::canonical_errors;
+inline namespace STORAGE_CLIENT_NS {
 namespace {
-using namespace ::testing;
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::ReturnRef;
 using ms = std::chrono::milliseconds;
+using testing::canonical_errors::TransientError;
 
 /**
  * Test the functions in Storage::Client related to 'Objects: *'.
@@ -187,6 +191,7 @@ TEST_F(ObjectTest, DeleteObjectPermanentFailure) {
 }
 
 }  // namespace
+}  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/retry_policy_test.cc
+++ b/google/cloud/storage/retry_policy_test.cc
@@ -18,6 +18,7 @@
 namespace google {
 namespace cloud {
 namespace storage {
+inline namespace STORAGE_CLIENT_NS {
 namespace {
 
 TEST(RetryPolicyTest, PermanentFailure) {
@@ -44,6 +45,7 @@ TEST(RetryPolicyTest, PermanentFailure) {
 }
 
 }  // namespace
+}  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google


### PR DESCRIPTION
The GSG prohibits using-directives (using namespace foo), but allows use
of using-declarations (using foo::SpecificSymbol) within .cc files.

This fixes all current occurrences of using-directives under
google/cloud/storage.  Note that while we could add
"google-build-using-namespace" to the list of clang-tidy checks, this would
probably break builds because of all the other using-directives in the rest of
the code (under google/cloud/bigtable).

Occurrences of using-directives were found via these commands:
```
$ cd google/cloud/storage
$ grep -r -- "using namespace [A-Za-z:_]\+;" .
```