### PR TITLE
Install flask + httpbin using pip.

### DIFF
--- a/ci/travis/Dockerfile.centos
+++ b/ci/travis/Dockerfile.centos
@@ -37,14 +37,13 @@ RUN yum makecache && yum install -y \
     pkgconfig \
     python \
     python-pip \
-    python-gunicorn \
     shtool \
     unzip \
     wget \
     which \
     zlib-devel
 
-RUN pip install httpbin
+RUN pip install httpbin flask
 
 # Install cmake3 + ctest3 as cmake + ctest.
 RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && \

--- a/ci/travis/Dockerfile.fedora
+++ b/ci/travis/Dockerfile.fedora
@@ -39,13 +39,13 @@ RUN dnf makecache && dnf install -y \
     openssl-devel \
     pkgconfig \
     python \
-    python-gunicorn \
-    python-httpbin \
     shtool \
     unzip \
     wget \
     which \
     zlib-devel
+
+RUN pip install httpbin flask
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.

--- a/ci/travis/Dockerfile.ubuntu
+++ b/ci/travis/Dockerfile.ubuntu
@@ -39,8 +39,6 @@ RUN apt update && \
         libtool \
         lsb-release \
         make \
-        python-gunicorn \
-        python-httpbin \
         python-pip \
         tar \
         wget \
@@ -63,6 +61,10 @@ RUN if grep -q 18.04 /etc/lsb-release; then \
 # "latest" version is updated, and we do not want the builds to break just
 # because some third party changed something.
 RUN pip install numpy cmake_format==0.4.0
+
+# Install Python packages used in the integration tests.
+RUN apt update && apt install -y apache2-dev
+RUN pip install flask httpbin mod_wsgi
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.

--- a/ci/travis/Dockerfile.ubuntu-trusty
+++ b/ci/travis/Dockerfile.ubuntu-trusty
@@ -39,8 +39,6 @@ RUN apt update && apt install -y software-properties-common && \
         libtool \
         lsb-release \
         make \
-        python-dev \
-        python-pip \
         tar \
         wget \
         zlib1g-dev \
@@ -50,7 +48,9 @@ RUN apt update && apt install -y software-properties-common && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 100 && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 100
 
-RUN pip install gunicorn httpbin
+# Install Python packages used in the integration tests.
+RUN apt update && apt install -y apache2-dev python-dev python-pip
+RUN pip install flask httpbin
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.


### PR DESCRIPTION
The packages (such as python-httpbin) are often too old, and do
not support chunked transfer encoding, which we will need shortly.
