### PR TITLE
Improve README steps to build the system [skip ci].

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ against the latest version of the SDK on each commit and PR.
 
 #### CentOS
 
-The default compiler on CentOS has poor support for C++11. We need to upgrade
-the compiler and other development tools. In this instructions, we use g++-7 via
-[Software Collections](https://www.softwarecollections.org/).
+The default compiler on CentOS doesn't fully support C++11. We need to upgrade
+the compiler and other development tools. In this instructions, we use `g++-7`
+via [Software Collections](https://www.softwarecollections.org/).
 
 ```bash
 # Extra Packages for Enterprise Linux used to install cmake3
@@ -136,7 +136,7 @@ sudo zypper install -y cmake gcc gcc-c++ git libcurl-devel make
 #### OpenSuSE (Leap)
 
 The stock compiler on OpenSuSE (Leap) has poor support for C++11, we recommend
-updating to GCC-5 using:
+updating to `g++-5` using:
 
 ```bash
 sudo zypper refresh
@@ -162,11 +162,11 @@ sudo apt install -y build-essential cmake git gcc g++ cmake libcurl4-openssl-dev
 
 #### Ubuntu (Trusty Tahr)
 
-The default compiler on Ubuntu-14.04 (Trusty Tahr) has poor support for C++11.
+The default compiler on Ubuntu-14.04 (Trusty Tahr) doesn't fully support C++11.
 In addition, gRPC requires a newer version of OpenSSL than the one included
 in the system.
 
-It is possible to work around these limitations on a *fresh* installation of
+It is possible to work around these limitations on a *new* installation of
 Ubuntu-14.04, but there are [known issues][issue-913] working on a system where
 these libraries are already installed.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ against the latest version of the SDK on each commit and PR.
 #### CentOS
 
 The default compiler on CentOS has poor support for C++11. We need to upgrade
-the compiler and other development tools. In this instructions we use g++-7 via
+the compiler and other development tools. In this instructions, we use g++-7 via
 [Software Collections](https://www.softwarecollections.org/).
 
 ```bash
@@ -166,8 +166,8 @@ The default compiler on Ubuntu-14.04 (Trusty Tahr) has poor support for C++11.
 In addition, gRPC requires a newer version of OpenSSL than the one included
 in the system.
 
-It is possible to workaround these limitations on a *fresh* installation of
-Ubuntu-14.04, but there are known [issues][issue-913] working on a system where
+It is possible to work around these limitations on a *fresh* installation of
+Ubuntu-14.04, but there are [known issues][issue-913] working on a system where
 these libraries are already installed.
 
 [issue-913]: https://github.com/GoogleCloudPlatform/google-cloud-cpp/issues/913

--- a/README.md
+++ b/README.md
@@ -36,8 +36,12 @@ APIs.
   - [Tests](#tests)
 - [Install Dependencies](#install-dependencies)
   - [CentOS](#centos)
+  - [Debian (Stretch)](#debian-stretch)
   - [Fedora](#fedora)
+  - [OpenSuSE (Tumbleweed)](#opensuse-tumbleweed)
+  - [OpenSuSE (Leap)](#opensuse-leap)
   - [Ubuntu (Bionic Beaver)](#ubuntu-bionic-beaver)
+  - [Ubuntu (Xenial Xerus)](#ubuntu-xenial-xerus)
   - [Ubuntu (Trusty)](#ubuntu-trusty)
   - [macOS (using brew)](#macos-using-brew)
   - [Windows](#windows)
@@ -90,6 +94,10 @@ against the latest version of the SDK on each commit and PR.
 
 #### CentOS
 
+The default compiler on CentOS has poor support for C++11. We need to upgrade
+the compiler and other development tools. In this instructions we use g++-7 via
+[Software Collections](https://www.softwarecollections.org/).
+
 ```bash
 # Extra Packages for Enterprise Linux used to install cmake3
 rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
@@ -98,49 +106,97 @@ yum install centos-release-scl
 yum-config-manager --enable rhel-server-rhscl-7-rpms
 
 yum makecache
-yum install -y devtoolset-7 c-ares-devel ccache cmake3 curl curl-devel git golang graphviz openssl-devel pkgconfig python python-pip python-gunicorn shtool unzip wget which zlib-devel
-
-pip install httpbin
+yum install -y devtoolset-7 cmake3 curl-devel git openssl-devel
 
 # Install cmake3 & ctest3 as cmake & ctest respectively.
 ln -sf /usr/bin/cmake3 /usr/bin/cmake && ln -sf /usr/bin/ctest3 /usr/bin/ctest
+```
+
+#### Debian (Stretch)
+
+```bash
+sudo apt update
+sudo apt install -y build-essential cmake git gcc g++ cmake libcurl4-openssl-dev libssl-dev make zlib1g-dev
 ```
 
 #### Fedora
 
 ```bash
 sudo dnf makecache
-sudo dnf install autoconf automake c-ares-devel ccache clang clang-tools-extra cmake curl dia doxygen gcc-c++ git golang graphviz  lcov libcurl-devel libtool make ncurses-term openssl-devel pkgconfig python python-gunicorn python-httpbin shtool unzip wget  which zlib-devel
+sudo dnf install -y clang cmake gcc-c++ git libcurl-devel make openssl-devel
+```
+
+#### OpenSuSE (Tumbleweed)
+
+```bash
+sudo zypper refresh
+sudo zypper install -y cmake gcc gcc-c++ git libcurl-devel make
+```
+
+#### OpenSuSE (Leap)
+
+The stock compiler on OpenSuSE (Leap) has poor support for C++11, we recommend
+updating to GCC-5 using:
+
+```bash
+sudo zypper refresh
+sudo zypper install -y cmake gcc gcc-c++ git libcurl-devel make
+sudo zypper install gcc5 gcc5-c++
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 100
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 100
 ```
 
 #### Ubuntu (Bionic Beaver)
 
 ```bash
 sudo apt update
-sudo apt install abi-compliance-checker abi-dumper automake build-essential ccache clang clang-format cmake curl doxygen  gawk git gcc g++ golang cmake libcurl4-openssl-dev libssl-dev libtool lsb-release make python-gunicorn python-httpbin tar wget zlib1g-dev
-
-# By default, Ubuntu 18.04 does not install the alternatives for clang-format
-# so we need to manually install those.
-sudo apt update
-sudo apt install -y clang-tidy clang-format clang-tools       
-sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-6.0 100
-sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-6.0 100
-sudo update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-6.0 100
-/usr/bin/env GOPATH=/usr go get github.com/bazelbuild/buildtools/buildifier
+sudo apt install -y build-essential cmake git gcc g++ cmake libcurl4-openssl-dev libssl-dev make zlib1g-dev
 ```
 
-#### Ubuntu (Trusty)
+#### Ubuntu (Xenial Xerus)
+
+```bash
+sudo apt update
+sudo apt install -y build-essential cmake git gcc g++ cmake libcurl4-openssl-dev libssl-dev make zlib1g-dev
+```
+
+#### Ubuntu (Trusty Tahr)
+
+The default compiler on Ubuntu-14.04 (Trusty Tahr) has poor support for C++11.
+In addition, gRPC requires a newer version of OpenSSL than the one included
+in the system.
+
+It is possible to workaround these limitations on a *fresh* installation of
+Ubuntu-14.04, but there are known [issues][issue-913] working on a system where
+these libraries are already installed.
+
+[issue-913]: https://github.com/GoogleCloudPlatform/google-cloud-cpp/issues/913
+
+Nevertheless, the following steps are known to work:
 
 ```bash
 sudo apt update
 sudo apt install -y software-properties-common
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo apt update
-sudo apt install abi-compliance-checker abi-dumper automake build-essential ccache clang clang-format cmake curl doxygen  gawk git gcc g++ golang cmake libcurl4-openssl-dev libssl-dev libtool lsb-release make python-gunicorn python-httpbin tar wget zlib1g-dev
-sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.8 100
-sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.8 100
+sudo apt install -y cmake3 git gcc-4.9 g++-4.9 make wget zlib1g-dev
 sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 100
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 100
+cd /var/tmp/
+sudo wget -q https://www.openssl.org/source/openssl-1.0.2n.tar.gz
+sudo tar xf openssl-1.0.2n.tar.gz
+cd /var/tmp/openssl-1.0.2n
+sudo ./Configure --prefix=/usr/local --openssldir=/usr/local linux-x86_64 shared
+sudo make -j $(nproc)
+sudo make install
+
+cd /var/tmp/
+sudo wget -q https://curl.haxx.se/download/curl-7.61.0.tar.gz
+sudo tar xf curl-7.61.0.tar.gz
+cd /var/tmp/curl-7.61.0
+sudo ./configure
+sudo make -j $(nproc)
+sudo make install
 ```
 
 #### macOS (using brew)
@@ -188,8 +244,8 @@ cd build-output
 ctest --output-on-failure
 ```
 
-You will find compiled binaries in `build-output\` respective to their source directories.
-
+You will find compiled binaries in `build-output\` respective to their
+source directories.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ APIs.
   - [OpenSuSE (Leap)](#opensuse-leap)
   - [Ubuntu (Bionic Beaver)](#ubuntu-bionic-beaver)
   - [Ubuntu (Xenial Xerus)](#ubuntu-xenial-xerus)
-  - [Ubuntu (Trusty)](#ubuntu-trusty)
+  - [Ubuntu (Trusty)](#ubuntu-trusty-tahr)
   - [macOS (using brew)](#macos-using-brew)
-  - [Windows](#windows)
+  - [Windows](#windows-using-vcpkg)
 - [Build](#build)
   - [Linux and macOS](#linux-and-macos)
   - [Windows](#windows-1)
@@ -95,7 +95,7 @@ against the latest version of the SDK on each commit and PR.
 #### CentOS
 
 The default compiler on CentOS doesn't fully support C++11. We need to upgrade
-the compiler and other development tools. In this instructions, we use `g++-7`
+the compiler and other development tools. In these instructions, we use `g++-7`
 via [Software Collections](https://www.softwarecollections.org/).
 
 ```bash
@@ -205,7 +205,7 @@ sudo make install
 brew install curl cmake
 ```
 
-#### Windows
+#### Windows (using vcpkg)
 
 ```bash
 set PROVIDER=vcpkg

--- a/ci/test-readme/Dockerfile.centos
+++ b/ci/test-readme/Dockerfile.centos
@@ -1,0 +1,43 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=7
+FROM centos:${DISTRO_VERSION}
+MAINTAINER "Carlos O'Ryan <coryan@google.com>"
+
+# Please keep the formatting in these commands, it is optimized to cut & paste
+# into the README.md file.
+
+# We need the "Extra Packages for Enterprise Linux" for cmake3
+RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum install -y centos-release-scl
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
+RUN yum makecache
+RUN yum install -y devtoolset-7 cmake3 curl-devel git openssl-devel
+
+# Install cmake3 + ctest3 as cmake + ctest.
+RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake
+RUN ln -sf /usr/bin/ctest3 /usr/bin/ctest
+
+ARG CXX=g++
+ARG CC=gcc
+
+WORKDIR /var/tmp/
+RUN git clone https://github.com/GoogleCloudPlatform/google-cloud-cpp.git
+WORKDIR /var/tmp/google-cloud-cpp
+RUN git submodule update --init
+RUN scl enable devtoolset-7 -- cmake -H. -Bbuild-output
+RUN scl enable devtoolset-7 -- cmake --build build-output -- -j $(nproc)
+WORKDIR /var/tmp/google-cloud-cpp/build-output
+RUN scl enable devtoolset-7 -- ctest --output-on-failure

--- a/ci/test-readme/Dockerfile.debian
+++ b/ci/test-readme/Dockerfile.debian
@@ -1,0 +1,34 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=stretch
+FROM debian:${DISTRO_VERSION}
+MAINTAINER "Carlos O'Ryan <coryan@google.com>"
+
+# Please keep the formatting in these commands, it is optimized to cut & paste
+# into the README.md file.
+RUN apt update
+RUN apt install -y build-essential cmake git gcc g++ cmake libcurl4-openssl-dev libssl-dev make zlib1g-dev
+
+ARG CXX=g++
+ARG CC=gcc
+
+WORKDIR /var/tmp/
+RUN git clone https://github.com/GoogleCloudPlatform/google-cloud-cpp.git
+WORKDIR /var/tmp/google-cloud-cpp
+RUN git submodule update --init
+RUN cmake -H. -Bbuild-output
+RUN cmake --build build-output -- -j $(nproc)
+WORKDIR /var/tmp/google-cloud-cpp/build-output
+RUN ctest --output-on-failure

--- a/ci/test-readme/Dockerfile.fedora
+++ b/ci/test-readme/Dockerfile.fedora
@@ -1,0 +1,34 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=28
+FROM fedora:${DISTRO_VERSION}
+MAINTAINER "Carlos O'Ryan <coryan@google.com>"
+
+# Please keep the formatting in these commands, it is optimized to cut & paste
+# into the README.md file.
+RUN dnf makecache
+RUN dnf install -y clang cmake gcc-c++ git libcurl-devel make openssl-devel
+
+ARG CXX=g++
+ARG CC=gcc
+
+WORKDIR /var/tmp/
+RUN git clone https://github.com/GoogleCloudPlatform/google-cloud-cpp.git
+WORKDIR /var/tmp/google-cloud-cpp
+RUN git submodule update --init
+RUN cmake -H. -Bbuild-output
+RUN cmake --build build-output -- -j $(nproc)
+WORKDIR /var/tmp/google-cloud-cpp/build-output
+RUN ctest --output-on-failure

--- a/ci/test-readme/Dockerfile.opensuse
+++ b/ci/test-readme/Dockerfile.opensuse
@@ -1,0 +1,40 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=tumbleweed
+FROM opensuse:${DISTRO_VERSION}
+MAINTAINER "Carlos O'Ryan <coryan@google.com>"
+
+# Please keep the formatting in these commands, it is optimized to cut & paste
+# into the README.md file.
+RUN zypper refresh
+RUN zypper install -y cmake gcc gcc-c++ git libcurl-devel libopenssl-devel make
+
+RUN source /etc/os-release ; if [ "${NAME}" = "openSUSE Leap" ]; then \
+    zypper refresh && zypper install -y gcc5 gcc5-c++; \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 100; \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 100; \
+  fi
+
+ARG CXX=g++
+ARG CC=gcc
+
+WORKDIR /var/tmp/
+RUN git clone https://github.com/GoogleCloudPlatform/google-cloud-cpp.git
+WORKDIR /var/tmp/google-cloud-cpp
+RUN git submodule update --init
+RUN cmake -H. -Bbuild-output
+RUN cmake --build build-output -- -j $(nproc)
+WORKDIR /var/tmp/google-cloud-cpp/build-output
+RUN ctest --output-on-failure

--- a/ci/test-readme/Dockerfile.ubuntu
+++ b/ci/test-readme/Dockerfile.ubuntu
@@ -1,0 +1,34 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=bionic
+FROM ubuntu:${DISTRO_VERSION}
+MAINTAINER "Carlos O'Ryan <coryan@google.com>"
+
+# Please keep the formatting in these commands, it is optimized to cut & paste
+# into the README.md file.
+RUN apt update
+RUN apt install -y build-essential cmake git gcc g++ cmake libcurl4-openssl-dev libssl-dev make zlib1g-dev
+
+ARG CXX=g++
+ARG CC=gcc
+
+WORKDIR /var/tmp/
+RUN git clone https://github.com/GoogleCloudPlatform/google-cloud-cpp.git
+WORKDIR /var/tmp/google-cloud-cpp
+RUN git submodule update --init
+RUN cmake -H. -Bbuild-output
+RUN cmake --build build-output -- -j $(nproc)
+WORKDIR /var/tmp/google-cloud-cpp/build-output
+RUN ctest --output-on-failure

--- a/ci/test-readme/Dockerfile.ubuntu-trusty
+++ b/ci/test-readme/Dockerfile.ubuntu-trusty
@@ -1,0 +1,55 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=trusty
+FROM ubuntu:${DISTRO_VERSION}
+MAINTAINER "Carlos O'Ryan <coryan@google.com>"
+
+# Please keep the formatting in these commands, it is optimized to cut & paste
+# into the README.md file.
+RUN apt update
+RUN apt install -y software-properties-common
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y
+RUN apt update
+RUN apt install -y cmake3 git gcc-4.9 g++-4.9 make wget zlib1g-dev
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 100
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 100
+WORKDIR /var/tmp/
+RUN wget -q https://www.openssl.org/source/openssl-1.0.2n.tar.gz
+RUN tar xf openssl-1.0.2n.tar.gz
+WORKDIR /var/tmp/openssl-1.0.2n
+RUN ./Configure --prefix=/usr/local --openssldir=/usr/local linux-x86_64 shared
+RUN make -j $(nproc)
+RUN make install
+
+#RUN export CMAKE_FLAGS=-DOPENSSL_ROOT_DIR=/usr/local
+WORKDIR /var/tmp/
+RUN wget -q https://curl.haxx.se/download/curl-7.61.0.tar.gz
+RUN tar xf curl-7.61.0.tar.gz
+WORKDIR /var/tmp/curl-7.61.0
+RUN ./configure
+RUN make -j $(nproc)
+RUN make install
+
+ARG CXX=g++
+ARG CC=gcc
+
+WORKDIR /var/tmp/
+RUN git clone https://github.com/GoogleCloudPlatform/google-cloud-cpp.git
+WORKDIR /var/tmp/google-cloud-cpp
+RUN git submodule update --init
+RUN cmake -H. -Bbuild-output
+RUN cmake --build build-output -- -j $(nproc)
+WORKDIR /var/tmp/google-cloud-cpp/build-output
+RUN ctest --output-on-failure

--- a/ci/test-readme/README.md
+++ b/ci/test-readme/README.md
@@ -1,0 +1,8 @@
+# Verification Scripts for the Build Instructions
+
+The Dockerfiles in this directory serve as verification scripts for the
+installation instructions in the top-level [README](../../README.md) file.
+
+The CI scripts and Dockerfiles are more complex than what most users care about,
+they install development tools, such as code formatters, drivers for the
+integration tests, and programs to verify the install targets.


### PR DESCRIPTION
Reduce the number of dependencies to install.

Add documentation for OpenSuSE, clarify that the
steps for Ubuntu Bionic also work for Ubuntu Xenial. Sadly the
steps for Ubuntu Trusty are quite convoluted, created #913 to
improve that. Add the steps for Debian Stretch.

I created a bunch of Dockerfiles to test these instructions.
