### PR TITLE
Add (some) missing functionality in BucketMetadata.

### DIFF
--- a/google/cloud/internal/optional_test.cc
+++ b/google/cloud/internal/optional_test.cc
@@ -191,6 +191,23 @@ TEST(OptionalTest, MoveAssignment_NoValue_Value) {
   EXPECT_EQ(0, Observable::copy_constructor);
 }
 
+TEST(OptionalTest, MoveAssignment_NoValue_T) {
+  Observable other("foo");
+  OptionalObservable assigned;
+  EXPECT_FALSE(assigned.has_value());
+
+  Observable::reset_counters();
+  assigned = std::move(other);
+  EXPECT_TRUE(assigned.has_value());
+  EXPECT_EQ("foo", assigned->str());
+  EXPECT_EQ("moved-out", other.str());
+  EXPECT_EQ(0, Observable::destructor);
+  EXPECT_EQ(0, Observable::move_assignment);
+  EXPECT_EQ(0, Observable::copy_assignment);
+  EXPECT_EQ(1, Observable::move_constructor);
+  EXPECT_EQ(0, Observable::copy_constructor);
+}
+
 TEST(OptionalTest, MoveAssignment_Value_NoValue) {
   OptionalObservable other;
   OptionalObservable assigned(Observable("bar"));
@@ -227,6 +244,23 @@ TEST(OptionalTest, MoveAssignment_Value_Value) {
   EXPECT_EQ("moved-out", other->str());
 }
 
+TEST(OptionalTest, MoveAssignment_Value_T) {
+  Observable other("foo");
+  OptionalObservable assigned(Observable("bar"));
+  EXPECT_TRUE(assigned.has_value());
+
+  Observable::reset_counters();
+  assigned = std::move(other);
+  EXPECT_TRUE(assigned.has_value());
+  EXPECT_EQ(0, Observable::destructor);
+  EXPECT_EQ(1, Observable::move_assignment);
+  EXPECT_EQ(0, Observable::copy_assignment);
+  EXPECT_EQ(0, Observable::move_constructor);
+  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ("foo", assigned->str());
+  EXPECT_EQ("moved-out", other.str());
+}
+
 TEST(OptionalTest, CopyAssignment_NoValue_NoValue) {
   OptionalObservable other;
   OptionalObservable assigned;
@@ -256,6 +290,23 @@ TEST(OptionalTest, CopyAssignment_NoValue_Value) {
   EXPECT_TRUE(assigned.has_value());
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("foo", other->str());
+  EXPECT_EQ(0, Observable::destructor);
+  EXPECT_EQ(0, Observable::move_assignment);
+  EXPECT_EQ(0, Observable::copy_assignment);
+  EXPECT_EQ(0, Observable::move_constructor);
+  EXPECT_EQ(1, Observable::copy_constructor);
+}
+
+TEST(OptionalTest, CopyAssignment_NoValue_T) {
+  Observable other("foo");
+  OptionalObservable assigned;
+  EXPECT_FALSE(assigned.has_value());
+
+  Observable::reset_counters();
+  assigned = other;
+  EXPECT_TRUE(assigned.has_value());
+  EXPECT_EQ("foo", assigned->str());
+  EXPECT_EQ("foo", other.str());
   EXPECT_EQ(0, Observable::destructor);
   EXPECT_EQ(0, Observable::move_assignment);
   EXPECT_EQ(0, Observable::copy_assignment);
@@ -297,6 +348,23 @@ TEST(OptionalTest, CopyAssignment_Value_Value) {
   EXPECT_EQ(0, Observable::copy_constructor);
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("foo", other->str());
+}
+
+TEST(OptionalTest, CopyAssignment_Value_T) {
+  Observable other("foo");
+  OptionalObservable assigned(Observable("bar"));
+  EXPECT_TRUE(assigned.has_value());
+
+  Observable::reset_counters();
+  assigned = other;
+  EXPECT_TRUE(assigned.has_value());
+  EXPECT_EQ(0, Observable::destructor);
+  EXPECT_EQ(0, Observable::move_assignment);
+  EXPECT_EQ(1, Observable::copy_assignment);
+  EXPECT_EQ(0, Observable::move_constructor);
+  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ("foo", assigned->str());
+  EXPECT_EQ("foo", other.str());
 }
 
 TEST(OptionalTest, MoveValue) {

--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -49,6 +49,7 @@ bool BucketMetadata::operator==(BucketMetadata const& rhs) const {
   return static_cast<internal::CommonMetadata<BucketMetadata> const&>(*this) ==
              rhs and
          acl_ == rhs.acl_ and
+         billing_.requester_pays == rhs.billing_.requester_pays and
          project_number_ == rhs.project_number_ and
          location_ == rhs.location_ and labels_ == rhs.labels_;
 }
@@ -61,8 +62,12 @@ std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs) {
     os << sep << acl;
     sep = ", ";
   }
-  os << "], etag=" << rhs.etag()
-     << ", id=" << rhs.id() << ", kind=" << rhs.kind();
+  auto prev = os.flags();
+  os << "], billing.requesterPays=" << std::boolalpha
+     << rhs.billing().requester_pays;
+  os.flags(prev);
+  os << ", etag=" << rhs.etag() << ", id=" << rhs.id()
+     << ", kind=" << rhs.kind();
   for (auto const& kv : rhs.labels_) {
     os << ", labels." << kv.first << "=" << kv.second;
   }

--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -25,7 +25,7 @@ CorsEntry ParseCors(internal::nl::json const& json) {
   auto parse_string_list = [](internal::nl::json const& json,
                               char const* field_name) {
     std::vector<std::string> list;
-    if (json.count(field_name)) {
+    if (json.count(field_name) != 0) {
       for (auto const& kv : json[field_name].items()) {
         list.emplace_back(kv.value().get<std::string>());
       }
@@ -44,7 +44,9 @@ CorsEntry ParseCors(internal::nl::json const& json) {
 
 std::ostream& operator<<(std::ostream& os, CorsEntry const& rhs) {
   auto join = [](char const* sep, std::vector<std::string> const& list) {
-    if (list.empty()) return std::string{};
+    if (list.empty()) {
+      return std::string{};
+    }
     return std::accumulate(++list.begin(), list.end(), list.front(),
                            [sep](std::string a, std::string const& b) {
                              a += sep;
@@ -68,17 +70,17 @@ BucketMetadata BucketMetadata::ParseFromJson(internal::nl::json const& json) {
       result.acl_.emplace_back(BucketAccessControl::ParseFromJson(kv.value()));
     }
   }
-  if (json.count("billing")) {
+  if (json.count("billing") != 0) {
     auto billing = json["billing"];
     result.billing_.requester_pays =
         internal::ParseBoolField(billing, "requesterPays");
   }
-  if (json.count("cors")) {
+  if (json.count("cors") != 0) {
     for (auto const& kv : json["cors"].items()) {
       result.cors_.emplace_back(ParseCors(kv.value()));
     }
   }
-  if (json.count("defaultObjectAcl")) {
+  if (json.count("defaultObjectAcl") != 0) {
     for (auto const& kv : json["defaultObjectAcl"].items()) {
       result.default_acl_.emplace_back(
           ObjectAccessControl::ParseFromJson(kv.value()));

--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -33,7 +33,9 @@ CorsEntry ParseCors(internal::nl::json const& json) {
     return list;
   };
   CorsEntry result;
-  result.max_age_seconds = internal::ParseLongField(json, "maxAgeSeconds");
+  if (json.count("maxAgeSeconds") != 0) {
+    result.max_age_seconds = internal::ParseLongField(json, "maxAgeSeconds");
+  }
   result.method = parse_string_list(json, "method");
   result.origin = parse_string_list(json, "origin");
   result.response_header = parse_string_list(json, "responseHeader");
@@ -54,10 +56,15 @@ std::ostream& operator<<(std::ostream& os, CorsEntry const& rhs) {
                              return a;
                            });
   };
-  return os << "CorsEntry={" << rhs.max_age_seconds << ", method=["
-            << join(", ", rhs.method) << "], origin=[" << join(", ", rhs.origin)
-            << "], response_header=[" << join(", ", rhs.response_header)
-            << "]}";
+  os << "CorsEntry={";
+  char const* sep = "";
+  if (rhs.max_age_seconds.has_value()) {
+    os << "max_age_seconds=" << *rhs.max_age_seconds;
+    sep = ", ";
+  }
+  return os << sep << "method=[" << join(", ", rhs.method) << "], origin=["
+            << join(", ", rhs.origin) << "], response_header=["
+            << join(", ", rhs.response_header) << "]}";
 }
 
 BucketMetadata BucketMetadata::ParseFromJson(internal::nl::json const& json) {

--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -120,33 +120,44 @@ bool BucketMetadata::operator==(BucketMetadata const& rhs) const {
 
 std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs) {
   // TODO(#536) - convert back to JSON for a nicer format.
-  os << "BucketMetadata={name=" << rhs.name() << ", acl=[";
+  os << "BucketMetadata={name=" << rhs.name();
+
+  os << ", acl=[";
   char const* sep = "";
   for (auto const& acl : rhs.acl()) {
     os << sep << acl;
     sep = ", ";
   }
+  os << "]";
+
   auto prev = os.flags();
-  os << "], billing.requesterPays=" << std::boolalpha
+  os << ", billing.requesterPays=" << std::boolalpha
      << rhs.billing().requester_pays;
   os.flags(prev);
+
   os << ", cors=[";
   sep = "";
   for (auto const& cors : rhs.cors()) {
     os << sep << cors;
     sep = ", ";
   }
-  os << "], default_acl=[";
+  os << "]";
+
+  os << ", default_acl=[";
   sep = "";
   for (auto const& acl : rhs.default_acl()) {
     os << sep << acl;
     sep = ", ";
   }
-  os << "], etag=" << rhs.etag() << ", id=" << rhs.id()
+  os << "]";
+
+  os << ", etag=" << rhs.etag() << ", id=" << rhs.id()
      << ", kind=" << rhs.kind();
+
   for (auto const& kv : rhs.labels_) {
     os << ", labels." << kv.first << "=" << kv.second;
   }
+
   os << ", location=" << rhs.location()
      << ", metageneration=" << rhs.metageneration() << ", name=" << rhs.name()
      << ", self_link=" << rhs.self_link()

--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -78,6 +78,12 @@ BucketMetadata BucketMetadata::ParseFromJson(internal::nl::json const& json) {
       result.cors_.emplace_back(ParseCors(kv.value()));
     }
   }
+  if (json.count("defaultObjectAcl")) {
+    for (auto const& kv : json["defaultObjectAcl"].items()) {
+      result.default_acl_.emplace_back(
+          ObjectAccessControl::ParseFromJson(kv.value()));
+    }
+  }
   result.location_ = json.value("location", "");
   result.project_number_ = internal::ParseLongField(json, "projectNumber");
   if (json.count("labels") > 0) {
@@ -98,7 +104,8 @@ bool BucketMetadata::operator==(BucketMetadata const& rhs) const {
              rhs and
          acl_ == rhs.acl_ and
          billing_.requester_pays == rhs.billing_.requester_pays and
-         cors_ == rhs.cors_ and project_number_ == rhs.project_number_ and
+         cors_ == rhs.cors_ and default_acl_ == rhs.default_acl_ and
+         project_number_ == rhs.project_number_ and
          location_ == rhs.location_ and labels_ == rhs.labels_;
 }
 
@@ -118,6 +125,12 @@ std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs) {
   sep = "";
   for (auto const& cors : rhs.cors()) {
     os << sep << cors;
+    sep = ", ";
+  }
+  os << "], default_acl=[";
+  sep = "";
+  for (auto const& acl : rhs.default_acl()) {
+    os << sep << acl;
     sep = ", ";
   }
   os << "], etag=" << rhs.etag() << ", id=" << rhs.id()

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BUCKET_METADATA_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BUCKET_METADATA_H_
 
+#include "google/cloud/internal/optional.h"
 #include "google/cloud/storage/bucket_access_control.h"
 #include "google/cloud/storage/internal/common_metadata.h"
 #include "google/cloud/storage/internal/nljson.h"
@@ -34,6 +35,8 @@ inline namespace STORAGE_CLIENT_NS {
  *     information on "Requester Pays" billing.
  */
 struct BucketBilling {
+  BucketBilling() : requester_pays(false) {}
+
   bool requester_pays;
 };
 
@@ -55,7 +58,7 @@ struct BucketBilling {
  *     on how to set and troubleshoot CORS settings.
  */
 struct CorsEntry {
-  std::int64_t max_age_seconds;
+  google::cloud::internal::optional<std::int64_t> max_age_seconds;
   std::vector<std::string> method;
   std::vector<std::string> origin;
   std::vector<std::string> response_header;
@@ -91,7 +94,7 @@ std::ostream& operator<<(std::ostream& os, CorsEntry const& rhs);
  */
 class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
  public:
-  BucketMetadata() : billing_(BucketBilling{false}), project_number_(0) {}
+  BucketMetadata() : project_number_(0) {}
 
   static BucketMetadata ParseFromJson(internal::nl::json const& json);
   static BucketMetadata ParseFromString(std::string const& payload);

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -21,6 +21,7 @@
 #include "google/cloud/storage/object_access_control.h"
 #include <map>
 #include <tuple>
+#include <utility>
 
 namespace google {
 namespace cloud {
@@ -69,27 +70,11 @@ inline bool operator==(CorsEntry const& lhs, CorsEntry const& rhs) {
                                                    rhs.response_header);
 }
 
-inline bool operator!=(CorsEntry const& lhs, CorsEntry const& rhs) {
-  return not(lhs == rhs);
-}
-
 inline bool operator<(CorsEntry const& lhs, CorsEntry const& rhs) {
   return std::tie(lhs.max_age_seconds, lhs.method, lhs.origin,
                   lhs.response_header) < std::tie(rhs.max_age_seconds,
                                                   rhs.method, rhs.origin,
                                                   rhs.response_header);
-}
-
-inline bool operator>=(CorsEntry const& lhs, CorsEntry const& rhs) {
-  return not(lhs < rhs);
-}
-
-inline bool operator>(CorsEntry const& lhs, CorsEntry const& rhs) {
-  return rhs < lhs;
-}
-
-inline bool operator<=(CorsEntry const& lhs, CorsEntry const& rhs) {
-  return rhs >= lhs;
 }
 //@}
 

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -106,7 +106,7 @@ std::ostream& operator<<(std::ostream& os, CorsEntry const& rhs);
  */
 class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
  public:
-  BucketMetadata() : project_number_(0) {}
+  BucketMetadata() : billing_(BucketBilling{false}), project_number_(0) {}
 
   static BucketMetadata ParseFromJson(internal::nl::json const& json);
   static BucketMetadata ParseFromString(std::string const& payload);

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -24,6 +24,10 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
+struct BucketBilling {
+  bool requester_pays;
+};
+
 /**
  * Represents a Google Cloud Storage Bucket Metadata object.
  *
@@ -42,12 +46,32 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
 
   // Please keep these in alphabetical order, that make it easier to verify we
   // have actually implemented all of them.
+  //@{
+  /**
+   * @name Get and set Bucket Access Control Lists.
+   *
+   * @see https://cloud.google.com/storage/docs/access-control/lists
+   */
   std::vector<BucketAccessControl> const& acl() const { return acl_; }
   std::vector<BucketAccessControl>& mutable_acl() { return acl_; }
   BucketMetadata& set_acl(std::vector<BucketAccessControl> acl) {
     acl_ = std::move(acl);
     return *this;
   }
+  //@}
+
+  //@{
+  /**
+   * @name Get and set billing configuration for the Bucket.
+   *
+   * @see https://cloud.google.com/storage/docs/requester-pays
+   */
+  BucketBilling const& billing() const { return billing_; }
+  BucketMetadata& set_billing(BucketBilling const& v) {
+    billing_ = v;
+    return *this;
+  }
+  //@}
 
   using CommonMetadata::etag;
   using CommonMetadata::id;
@@ -86,6 +110,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   friend std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs);
   // Keep the fields in alphabetical order.
   std::vector<BucketAccessControl> acl_;
+  BucketBilling billing_;
   std::map<std::string, std::string> labels_;
   std::string location_;
   std::int64_t project_number_;

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BUCKET_METADATA_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BUCKET_METADATA_H_
 
+#include "google/cloud/storage/bucket_access_control.h"
 #include "google/cloud/storage/internal/common_metadata.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include <map>
@@ -39,6 +40,15 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   static BucketMetadata ParseFromJson(internal::nl::json const& json);
   static BucketMetadata ParseFromString(std::string const& payload);
 
+  // Please keep these in alphabetical order, that make it easier to verify we
+  // have actually implemented all of them.
+  std::vector<BucketAccessControl> const& acl() const { return acl_; }
+  std::vector<BucketAccessControl>& mutable_acl() { return acl_; }
+  BucketMetadata& set_acl(std::vector<BucketAccessControl> acl) {
+    acl_ = std::move(acl);
+    return *this;
+  }
+
   using CommonMetadata::etag;
   using CommonMetadata::id;
   using CommonMetadata::kind;
@@ -62,7 +72,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   using CommonMetadata::updated;
 
   bool operator==(BucketMetadata const& rhs) const;
-  bool operator!=(BucketMetadata const& rhs) { return not(*this == rhs); }
+  bool operator!=(BucketMetadata const& rhs) const { return not(*this == rhs); }
 
   constexpr static char STORAGE_CLASS_STANDARD[] = "STANDARD";
   constexpr static char STORAGE_CLASS_MULTI_REGIONAL[] = "MULTI_REGIONAL";
@@ -75,6 +85,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
  private:
   friend std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs);
   // Keep the fields in alphabetical order.
+  std::vector<BucketAccessControl> acl_;
   std::map<std::string, std::string> labels_;
   std::string location_;
   std::int64_t project_number_;

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/bucket_access_control.h"
 #include "google/cloud/storage/internal/common_metadata.h"
 #include "google/cloud/storage/internal/nljson.h"
+#include "google/cloud/storage/object_access_control.h"
 #include <map>
 #include <tuple>
 
@@ -160,6 +161,29 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   }
   //@}
 
+  //@{
+  /**
+   * @name Get and set the Default Object Access Control Lists.
+   *
+   * @see https://cloud.google.com/storage/docs/access-control/lists#default for
+   *     general information of default ACLs.
+   *
+   * @see
+   * https://cloud.google.com/storage/docs/access-control/create-manage-lists#defaultobjects
+   *     for information on how to set the default ACLs.
+   */
+  std::vector<ObjectAccessControl> const& default_acl() const {
+    return default_acl_;
+  }
+  std::vector<ObjectAccessControl>& mutable_default_acl() {
+    return default_acl_;
+  }
+  BucketMetadata& set_default_acl(std::vector<ObjectAccessControl> acl) {
+    default_acl_ = std::move(acl);
+    return *this;
+  }
+  //@}
+
   using CommonMetadata::etag;
   using CommonMetadata::id;
   using CommonMetadata::kind;
@@ -199,6 +223,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   std::vector<BucketAccessControl> acl_;
   BucketBilling billing_;
   std::vector<CorsEntry> cors_;
+  std::vector<ObjectAccessControl> default_acl_;
   std::map<std::string, std::string> labels_;
   std::string location_;
   std::int64_t project_number_;

--- a/google/cloud/storage/bucket_metadata_test.cc
+++ b/google/cloud/storage/bucket_metadata_test.cc
@@ -113,13 +113,11 @@ TEST(BucketMetadataTest, Parse) {
   EXPECT_EQ("acl-id-1", actual.acl().at(1).id());
   EXPECT_TRUE(actual.billing().requester_pays);
   EXPECT_EQ(2U, actual.cors().size());
-  auto expected_cors_0 = CorsEntry{
-    3600, {"GET", "HEAD"}, {"cross-origin-example.com"}, {}
-  };
+  auto expected_cors_0 =
+      CorsEntry{3600, {"GET", "HEAD"}, {"cross-origin-example.com"}, {}};
   EXPECT_EQ(expected_cors_0, actual.cors().at(0));
   auto expected_cors_1 = CorsEntry{
-      7200, {"GET", "HEAD"}, {"another-example.com"}, {"Content-Type"}
-  };
+      7200, {"GET", "HEAD"}, {"another-example.com"}, {"Content-Type"}};
   EXPECT_EQ(expected_cors_1, actual.cors().at(1));
   EXPECT_EQ(1U, actual.default_acl().size());
   EXPECT_EQ("user-test-user-3", actual.default_acl().at(0).entity());
@@ -149,12 +147,11 @@ TEST(BucketMetadataTest, Parse) {
   auto magic_timestamp = 1526758274L;
   using std::chrono::duration_cast;
   EXPECT_EQ(magic_timestamp, duration_cast<std::chrono::seconds>(
-                             actual.time_created().time_since_epoch())
-                             .count());
+                                 actual.time_created().time_since_epoch())
+                                 .count());
   EXPECT_EQ(magic_timestamp + 10, duration_cast<std::chrono::seconds>(
-                             actual.updated().time_since_epoch())
-                             .count());
-
+                                      actual.updated().time_since_epoch())
+                                      .count());
 }
 
 /// @test Verify that the IOStream operator works as expected.

--- a/google/cloud/storage/bucket_metadata_test.cc
+++ b/google/cloud/storage/bucket_metadata_test.cc
@@ -57,6 +57,9 @@ BucketMetadata CreateBucketMetadataForTest() {
         "etag": "AYX="
       }
       ],
+      "billing": {
+        "requesterPays": false
+      },
       "etag": "XYZ=",
       "id": "test-bucket",
       "kind": "storage#bucket",
@@ -155,6 +158,16 @@ TEST(BucketMetadataTest, SetAcl) {
   copy.set_acl(std::move(acl));
   EXPECT_NE(expected, copy);
   EXPECT_EQ("READER", copy.acl().at(0).role());
+}
+
+/// @test Verify we can change the billing configuration in BucketMetadata.
+TEST(BucketMetadataTest, SetBilling) {
+  auto expected = CreateBucketMetadataForTest();
+  auto copy = expected;
+  auto billing = copy.billing();
+  billing.requester_pays = not billing.requester_pays;
+  copy.set_billing(billing);
+  EXPECT_NE(expected, copy);
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/metadata_parser.h
+++ b/google/cloud/storage/internal/metadata_parser.h
@@ -26,6 +26,9 @@ namespace internal {
 /**
  * Parse a boolean field, even if it is represented by a string type in the JSON
  * object.
+ *
+ * @return the value of @p field_name in @p json, or `false` if the field is not
+ * present.
  */
 bool ParseBoolField(nl::json const& json, char const* field_name);
 
@@ -45,18 +48,27 @@ std::uint32_t ParseUnsignedIntField(nl::json const& json,
 /**
  * Parse a long integer field, even if it is represented by a string type in
  * the JSON object.
+ *
+ * @return the value of @p field_name in @p json, or `0` if the field is not
+ * present.
  */
 std::int64_t ParseLongField(nl::json const& json, char const* field_name);
 
 /**
  * Parse an unsigned long integer field, even if it is represented by a string
  * type in the JSON object.
+ *
+ * @return the value of @p field_name in @p json, or `0` if the field is not
+ * present.
  */
 std::uint64_t ParseUnsignedLongField(nl::json const& json,
                                      char const* field_name);
 
 /**
  * Parse a RFC 3339 timestamp.
+ *
+ * @return the value of @p field_name in @p json, or the epoch if the field is
+ * not present.
  */
 std::chrono::system_clock::time_point ParseTimestampField(
     nl::json const& json, char const* field_name);

--- a/google/cloud/storage/internal/metadata_parser_test.cc
+++ b/google/cloud/storage/internal/metadata_parser_test.cc
@@ -21,6 +21,65 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+/// @test Verify that we parse boolean values in JSON objects.
+TEST(MetadataParserTest, ParseBoolField) {
+  std::string text = R"""({
+      "flag1": true,
+      "flag2": false
+})""";
+  auto json_object = nl::json::parse(text);
+  EXPECT_TRUE(ParseBoolField(json_object, "flag1"));
+  EXPECT_FALSE(ParseBoolField(json_object, "flag2"));
+}
+
+/// @test Verify that we parse boolean values in JSON objects.
+TEST(MetadataParserTest, ParseBoolFieldFromString) {
+  std::string text = R"""({
+      "flag1": "true",
+      "flag2": "false"
+})""";
+  auto json_object = nl::json::parse(text);
+  EXPECT_TRUE(ParseBoolField(json_object, "flag1"));
+  EXPECT_FALSE(ParseBoolField(json_object, "flag2"));
+}
+
+/// @test Verify that we parse missing boolean values in JSON objects.
+TEST(MetadataParserTest, ParseMissingBoolField) {
+  std::string text = R"""({
+      "flag": true
+})""";
+  auto json_object = nl::json::parse(text);
+  auto actual = ParseBoolField(json_object, "some-other-flag");
+  EXPECT_FALSE(actual);
+}
+
+/// @test Verify that we raise an exception with invalid boolean fields.
+TEST(MetadataParserTest, ParseInvalidBoolFieldValue) {
+  std::string text = R"""({
+      "flag": "not-a-boolean"
+})""";
+  auto json_object = nl::json::parse(text);
+
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(ParseBoolField(json_object, "flag"), std::invalid_argument);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(ParseBoolField(json_object, "flag"), "");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+/// @test Verify that we raise an exception with invalid boolean fields.
+TEST(MetadataParserTest, ParseInvalidBoolFieldType) {
+  std::string text = R"""({
+      "flag": [0, 1, 2]
+})""";
+  auto json_object = nl::json::parse(text);
+
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(ParseBoolField(json_object, "flag"), std::invalid_argument);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(ParseBoolField(json_object, "flag"), "");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
 
 /// @test Verify that we parse RFC-3339 timestamps in JSON objects.
 TEST(MetadataParserTest, ParseTimestampField) {

--- a/google/cloud/storage/object_metadata.cc
+++ b/google/cloud/storage/object_metadata.cc
@@ -96,7 +96,7 @@ std::ostream& operator<<(std::ostream& os, ObjectMetadata const& rhs) {
     os << sep << acl;
     sep = ", ";
   }
-  os << ", bucket=" << rhs.bucket() << ", cache_control=" << rhs.cache_control()
+  os << "], bucket=" << rhs.bucket() << ", cache_control=" << rhs.cache_control()
      << ", component_count=" << rhs.component_count()
      << ", content_disposition=" << rhs.content_disposition()
      << ", content_encoding=" << rhs.content_encoding()

--- a/google/cloud/storage/object_metadata.cc
+++ b/google/cloud/storage/object_metadata.cc
@@ -96,7 +96,8 @@ std::ostream& operator<<(std::ostream& os, ObjectMetadata const& rhs) {
     os << sep << acl;
     sep = ", ";
   }
-  os << "], bucket=" << rhs.bucket() << ", cache_control=" << rhs.cache_control()
+  os << "], bucket=" << rhs.bucket()
+     << ", cache_control=" << rhs.cache_control()
      << ", component_count=" << rhs.component_count()
      << ", content_disposition=" << rhs.content_disposition()
      << ", content_encoding=" << rhs.content_encoding()


### PR DESCRIPTION
This is the first in a series of PRs working towards fixing #537.  In this PR we introduced Bucket ACLs, Default Object ACLs, billing configuration, and CORS configuration.

