### PR TITLE
Skip curl tests for production integration tests.

### DIFF
--- a/google/cloud/storage/tests/run_integration_tests_production.sh
+++ b/google/cloud/storage/tests/run_integration_tests_production.sh
@@ -18,11 +18,6 @@ set -eu
 
 # The CI environment must provide PROJECT_ID and BUCKET_NAME.
 
-
-echo
-echo "Running storage::internal::CurlRequest integration test."
-./curl_request_integration_test
-
 echo
 echo "Running GCS Bucket APIs integration tests."
 ./bucket_integration_test "${PROJECT_ID}" "${BUCKET_NAME}"


### PR DESCRIPTION
This fixes #922. We do not need to run these tests in "production"
because they already run the in the regular testbench tests
against the same code that they would run otherwise (the httpbin
python module).