### PR TITLE
Implement class to build patch requests.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -163,6 +163,7 @@ add_library(storage_client
             internal/object_streambuf.cc
             internal/parse_rfc3339.h
             internal/parse_rfc3339.cc
+            internal/patch_builder.h
             internal/raw_client.h
             internal/read_object_range_request.h
             internal/read_object_range_request.cc
@@ -249,6 +250,7 @@ set(storage_client_unit_tests
     internal/nljson_test.cc
     internal/object_acl_requests_test.cc
     internal/parse_rfc3339_test.cc
+    internal/patch_builder_test.cc
     internal/retry_client_test.cc
     internal/read_object_range_request_test.cc
     internal/service_account_credentials_test.cc

--- a/google/cloud/storage/internal/patch_builder.h
+++ b/google/cloud/storage/internal/patch_builder.h
@@ -184,7 +184,7 @@ class PatchBuilder {
     return *this;
   }
 
-  template<typename T>
+  template <typename T>
   PatchBuilder& SetArrayField(char const* field_name, std::vector<T> const& v) {
     patch_[field_name] = v;
     return *this;

--- a/google/cloud/storage/internal/patch_builder.h
+++ b/google/cloud/storage/internal/patch_builder.h
@@ -28,7 +28,8 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 /**
- * Prepare a patch for the '*: patch' APIs in google cloud storage.
+ * Prepare a patch for the '<Resource Type>: patch' APIs in Google Cloud
+ * Storage.
  *
  * There are multiple APIs in Google Cloud Storage that receive patches. The
  * format for these patches is described in:
@@ -65,7 +66,7 @@ class PatchBuilder {
    * Add a boolean field to the patch.
    *
    * There is no `bool` value used to represent `null`, if you want to delete
-   * boolean fields using the `optional<bool>` overload.
+   * boolean fields use the `optional<bool>` overload.
    */
   PatchBuilder& AddBoolField(char const* field_name, bool lhs, bool rhs) {
     if (lhs == rhs) return *this;

--- a/google/cloud/storage/internal/patch_builder.h
+++ b/google/cloud/storage/internal/patch_builder.h
@@ -1,0 +1,177 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_PATCH_BUILDER_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_PATCH_BUILDER_H_
+
+#include "google/cloud/internal/optional.h"
+#include "google/cloud/storage/internal/nljson.h"
+#include <string>
+#include <vector>
+
+#include <iostream>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+/**
+ * Prepare a patch for the '*: patch' APIs in google cloud storage.
+ *
+ * There are multiple APIs in Google Cloud Storage that receive patches. The
+ * format for these patches is described in:
+ *
+ * https://cloud.google.com/storage/docs/json_api/v1/how-tos/performance#patch
+ *
+ * At a high level: fields present in the patch are set to their new values,
+ * unless the field has value `null`, in which case the field is removed.
+ */
+class PatchBuilder {
+ public:
+  PatchBuilder() = default;
+
+  /// Add a string field, treat empty strings as `null`.
+  PatchBuilder& AddStringField(char const* field_name, std::string const& lhs,
+                               std::string const& rhs) {
+    if (lhs == rhs) return *this;
+    if (rhs.empty()) {
+      patch_[field_name] = nullptr;
+      return *this;
+    }
+    patch_[field_name] = rhs;
+    return *this;
+  }
+
+  /**
+   * Add a boolean field to the patch.
+   *
+   * There is no `bool` value used to represent `null`, if you want to delete
+   * boolean fields using the `optional<bool>` overload.
+   */
+  PatchBuilder& AddBoolField(char const* field_name, bool lhs, bool rhs) {
+    if (lhs == rhs) return *this;
+    patch_[field_name] = rhs;
+    return *this;
+  }
+
+  //@{
+  /**
+   * @name Add patches for integral fields.
+   */
+  PatchBuilder& AddIntField(char const* field_name, std::int32_t lhs,
+                            std::int32_t rhs, std::int32_t null_value = 0) {
+    return AddIntegerField(field_name, lhs, rhs, null_value);
+  }
+  PatchBuilder& AddIntField(char const* field_name, std::uint32_t lhs,
+                            std::uint32_t rhs, std::uint32_t null_value = 0) {
+    return AddIntegerField(field_name, lhs, rhs, null_value);
+  }
+  PatchBuilder& AddIntField(char const* field_name, std::int64_t lhs,
+                            std::int64_t rhs, std::int64_t null_value = 0) {
+    return AddIntegerField(field_name, lhs, rhs, null_value);
+  }
+  PatchBuilder& AddIntField(char const* field_name, std::uint64_t lhs,
+                            std::uint64_t rhs, std::uint64_t null_value = 0) {
+    return AddIntegerField(field_name, lhs, rhs, null_value);
+  }
+  //@}
+
+  /**
+   * Add a patch for a field of type @p T represented by C++ optionals.
+   *
+   * @tparam T the type of the field, typically `std::string`, `bool`, or some
+   *     integral type.
+   * @param field_name the name of the field.
+   * @param lhs the previous value of the field.
+   * @param rhs the new value for the field. If both @p lhs and @p rhs are empty
+   *     the patch leaves the value untouched, if @p rhs is empty, create a
+   *     patch that removes the previous value.
+   */
+  template <typename T>
+  PatchBuilder& AddOptionalField(
+      char const* field_name, google::cloud::internal::optional<T> const& lhs,
+      google::cloud::internal::optional<T> const& rhs) {
+    if (lhs == rhs) return *this;
+    if (not rhs.has_value()) {
+      patch_[field_name] = nullptr;
+      return *this;
+    }
+    patch_[field_name] = *rhs;
+    return *this;
+  }
+
+  /**
+   * Add a patch for a array fields.
+   *
+   * @tparam T the type of the field, typically `std::string`, `bool`, or
+   *     some integral type.
+   *
+   * @param field_name the name of the field.
+   * @param lhs the previous value of the field.
+   * @param rhs the new value for the field. If both @p lhs and @p rhs are empty
+   *     the patch leaves the value untouched, if @p rhs is empty, create a
+   *     patch that removes the previous value.
+   */
+  template <typename T>
+  PatchBuilder& AddArrayField(char const* field_name, std::vector<T> const& lhs,
+                              std::vector<T> const& rhs) {
+    if (lhs == rhs) return *this;
+    if (rhs.empty()) {
+      patch_[field_name] = nullptr;
+      return *this;
+    }
+    patch_[field_name] = rhs;
+    return *this;
+  }
+
+  /// Add a patch for @p field_name.
+  PatchBuilder& AddSubPatch(char const* field_name,
+                            PatchBuilder const& builder) {
+    patch_[field_name] = builder.patch_;
+    return *this;
+  }
+
+  /// Create a patch that removes @p field_name
+  PatchBuilder& RemoveField(char const* field_name) {
+    patch_[field_name] = nullptr;
+    return *this;
+  }
+
+  /// Return the patch as a string.
+  std::string ToString() const { return patch_.dump(); }
+
+ private:
+  /// Refactor the patch fields.
+  template <typename Integer>
+  PatchBuilder& AddIntegerField(char const* field_name, Integer lhs,
+                                Integer rhs, Integer null_value) {
+    if (lhs == rhs) return *this;
+    if (rhs == null_value) {
+      patch_[field_name] = nullptr;
+      return *this;
+    }
+    patch_[field_name] = rhs;
+    return *this;
+  }
+
+  nl::json patch_;
+};
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_PATCH_BUILDER_H_

--- a/google/cloud/storage/internal/patch_builder.h
+++ b/google/cloud/storage/internal/patch_builder.h
@@ -42,6 +42,13 @@ class PatchBuilder {
  public:
   PatchBuilder() = default;
 
+  /// Return the patch as a string.
+  std::string ToString() const { return patch_.dump(); }
+
+  //@{
+  /// @name Calculate the delta between the original (`lhs`) and the new (`rhs`)
+  /// values and set the patch instructions accordingly.
+
   /// Add a string field, treat empty strings as `null`.
   PatchBuilder& AddStringField(char const* field_name, std::string const& lhs,
                                std::string const& rhs) {
@@ -66,10 +73,6 @@ class PatchBuilder {
     return *this;
   }
 
-  //@{
-  /**
-   * @name Add patches for integral fields.
-   */
   PatchBuilder& AddIntField(char const* field_name, std::int32_t lhs,
                             std::int32_t rhs, std::int32_t null_value = 0) {
     return AddIntegerField(field_name, lhs, rhs, null_value);
@@ -86,7 +89,6 @@ class PatchBuilder {
                             std::uint64_t rhs, std::uint64_t null_value = 0) {
     return AddIntegerField(field_name, lhs, rhs, null_value);
   }
-  //@}
 
   /**
    * Add a patch for a field of type @p T represented by C++ optionals.
@@ -135,6 +137,7 @@ class PatchBuilder {
     patch_[field_name] = rhs;
     return *this;
   }
+  //@}
 
   /// Add a patch for @p field_name.
   PatchBuilder& AddSubPatch(char const* field_name,
@@ -149,8 +152,44 @@ class PatchBuilder {
     return *this;
   }
 
-  /// Return the patch as a string.
-  std::string ToString() const { return patch_.dump(); }
+  //@{
+  /// @name Create a patch that sets fields to the given value.
+  PatchBuilder& SetStringField(char const* field_name, std::string const& v) {
+    patch_[field_name] = v;
+    return *this;
+  }
+
+  PatchBuilder& SetBoolField(char const* field_name, bool v) {
+    patch_[field_name] = v;
+    return *this;
+  }
+
+  PatchBuilder& SetIntField(char const* field_name, std::int32_t v) {
+    patch_[field_name] = v;
+    return *this;
+  }
+
+  PatchBuilder& SetIntField(char const* field_name, std::uint32_t v) {
+    patch_[field_name] = v;
+    return *this;
+  }
+
+  PatchBuilder& SetIntField(char const* field_name, std::int64_t v) {
+    patch_[field_name] = v;
+    return *this;
+  }
+
+  PatchBuilder& SetIntField(char const* field_name, std::uint64_t v) {
+    patch_[field_name] = v;
+    return *this;
+  }
+
+  template<typename T>
+  PatchBuilder& SetArrayField(char const* field_name, std::vector<T> const& v) {
+    patch_[field_name] = v;
+    return *this;
+  }
+  //@}
 
  private:
   /// Refactor the patch fields.

--- a/google/cloud/storage/internal/patch_builder_test.cc
+++ b/google/cloud/storage/internal/patch_builder_test.cc
@@ -1,0 +1,137 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/patch_builder.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+TEST(PatchBuilderTest, String) {
+  PatchBuilder builder;
+  builder.AddStringField("set-value", "", "new-value");
+  builder.AddStringField("unset-value", "old-value", "");
+  builder.AddStringField("untouched-value", "same-value", "same-value");
+  nl::json expected{
+      {"set-value", "new-value"},
+      {"unset-value", nullptr},
+  };
+  nl::json actual = nl::json::parse(builder.ToString());
+  EXPECT_EQ(expected, actual) << builder.ToString();
+}
+
+TEST(PatchBuilderTest, Bool) {
+  PatchBuilder builder;
+  builder.AddBoolField("set-value", true, false);
+  builder.AddBoolField("untouched-value", false, false);
+  nl::json expected{
+      {"set-value", false},
+  };
+  nl::json actual = nl::json::parse(builder.ToString());
+  EXPECT_EQ(expected, actual) << builder.ToString();
+}
+
+TEST(PatchBuilderTest, Int) {
+  PatchBuilder builder;
+  builder.AddIntField("set-value", std::int32_t(0), std::int32_t(42));
+  builder.AddIntField("unset-value", std::int32_t(42), std::int32_t(0));
+  builder.AddIntField("untouched-value", std::int32_t(7), std::int32_t(7));
+  nl::json expected{
+      {"set-value", 42},
+      {"unset-value", nullptr},
+  };
+  nl::json actual = nl::json::parse(builder.ToString());
+  EXPECT_EQ(expected, actual) << builder.ToString();
+}
+
+TEST(PatchBuilderTest, OptionalBool) {
+  PatchBuilder builder;
+  using bopt = google::cloud::internal::optional<bool>;
+  builder.AddOptionalField("set-value", bopt(false), bopt(true));
+  builder.AddOptionalField("unset-value", bopt(false), bopt());
+  builder.AddOptionalField("untouched-value", bopt(true), bopt(true));
+  nl::json expected{
+      {"set-value", true},
+      {"unset-value", nullptr},
+  };
+  nl::json actual = nl::json::parse(builder.ToString());
+  EXPECT_EQ(expected, actual) << builder.ToString();
+}
+
+TEST(PatchBuilderTest, OptionalInt) {
+  PatchBuilder builder;
+  using opt = google::cloud::internal::optional<std::int64_t>;
+  builder.AddOptionalField("set-value", opt(0), opt(42));
+  builder.AddOptionalField("unset-value", opt(42), opt());
+  builder.AddOptionalField("untouched-value", opt(7), opt(7));
+  builder.AddOptionalField("set-to-zero", opt(1), opt(0));
+  nl::json expected{
+      {"set-value", 42},
+      {"unset-value", nullptr},
+      {"set-to-zero", 0},
+  };
+  nl::json actual = nl::json::parse(builder.ToString());
+  EXPECT_EQ(expected, actual) << builder.ToString();
+}
+
+TEST(PatchBuilderTest, ArrayField) {
+  PatchBuilder builder;
+  using vec = std::vector<int>;
+  builder.AddArrayField("set-value", vec{1, 2, 3}, vec{4, 2});
+  builder.AddArrayField("unset-value", vec{4, 2}, vec{});
+  builder.AddArrayField("untouched-value", vec{7, 6, 5}, vec{7, 6, 5});
+  nl::json expected{
+      {"set-value", {4, 2}},
+      {"unset-value", nullptr},
+  };
+  nl::json actual = nl::json::parse(builder.ToString());
+  EXPECT_EQ(expected, actual) << builder.ToString();
+}
+
+TEST(PatchBuilderTest, SubPatch) {
+  PatchBuilder builder;
+  builder.AddStringField("some-field", "", "new-value");
+  PatchBuilder subpatch;
+  subpatch.AddStringField("set-value", "", "new-value");
+  subpatch.AddStringField("unset-value", "old-value", "");
+  subpatch.AddStringField("untouched-value", "same-value", "same-value");
+  builder.AddSubPatch("the-field", subpatch);
+  nl::json expected{
+      {"some-field", "new-value"},
+      {"the-field", {{"set-value", "new-value"}, {"unset-value", nullptr}}},
+  };
+  nl::json actual = nl::json::parse(builder.ToString());
+  EXPECT_EQ(expected, actual) << builder.ToString();
+}
+
+TEST(PatchBuilderTest, RemoveField) {
+  PatchBuilder builder;
+  builder.AddStringField("some-field", "", "new-value");
+  builder.RemoveField("the-field");
+  nl::json expected{
+      {"some-field", "new-value"},
+      {"the-field", nullptr},
+  };
+  nl::json actual = nl::json::parse(builder.ToString());
+  EXPECT_EQ(expected, actual) << builder.ToString();
+}
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/patch_builder_test.cc
+++ b/google/cloud/storage/internal/patch_builder_test.cc
@@ -129,6 +129,66 @@ TEST(PatchBuilderTest, RemoveField) {
   nl::json actual = nl::json::parse(builder.ToString());
   EXPECT_EQ(expected, actual) << builder.ToString();
 }
+
+TEST(PatchBuilderTest, SetStringField) {
+  PatchBuilder builder;
+  builder.SetStringField("some-field", "new-value");
+  builder.SetStringField("empty-field", "");
+  nl::json expected{
+      {"some-field", "new-value"},
+      {"empty-field", ""},
+  };
+  nl::json actual = nl::json::parse(builder.ToString());
+  EXPECT_EQ(expected, actual) << builder.ToString();
+}
+
+TEST(PatchBuilderTest, SetBoolField) {
+  PatchBuilder builder;
+  builder.SetBoolField("true-field", true);
+  builder.SetBoolField("false-field", false);
+  nl::json expected{
+      {"true-field", true},
+      {"false-field", false},
+  };
+  nl::json actual = nl::json::parse(builder.ToString());
+  EXPECT_EQ(expected, actual) << builder.ToString();
+}
+
+TEST(PatchBuilderTest, SetIntField) {
+  PatchBuilder builder;
+  builder.SetIntField("field-32-7", std::int32_t(7));
+  builder.SetIntField("field-32-0", std::int32_t(0));
+  builder.SetIntField("field-u32-7", std::uint32_t(7));
+  builder.SetIntField("field-u32-0", std::uint32_t(0));
+  builder.SetIntField("field-64-7", std::int64_t(7));
+  builder.SetIntField("field-64-0", std::int64_t(0));
+  builder.SetIntField("field-u64-7", std::uint64_t(7));
+  builder.SetIntField("field-u64-0", std::uint64_t(0));
+  nl::json expected{
+      {"field-32-7", std::int32_t(7)},   {"field-32-0", std::int32_t(0)},
+      {"field-u32-7", std::uint32_t(7)}, {"field-u32-0", std::uint32_t(0)},
+      {"field-64-7", std::int64_t(7)},   {"field-64-0", std::int64_t(0)},
+      {"field-u64-7", std::uint64_t(7)}, {"field-u64-0", std::uint64_t(0)},
+  };
+  nl::json actual = nl::json::parse(builder.ToString());
+  EXPECT_EQ(expected, actual) << builder.ToString();
+}
+
+TEST(PatchBuilderTest, SetArrayField) {
+  PatchBuilder builder;
+  builder.SetArrayField("field-a", std::vector<std::string>{});
+  builder.SetArrayField("field-b", std::vector<std::string>{"foo", "bar"});
+  builder.SetArrayField("field-c", std::vector<std::int32_t>{2, 3, 5, 7});
+  builder.SetArrayField("field-d", std::vector<bool>{false, true, true});
+  nl::json expected{
+      {"field-a", std::vector<std::string>{}},
+      {"field-b", std::vector<std::string>{"foo", "bar"}},
+      {"field-c", std::vector<int>{2, 3, 5, 7}},
+      {"field-d", std::vector<bool>{false, true, true}},
+  };
+  nl::json actual = nl::json::parse(builder.ToString());
+  EXPECT_EQ(expected, actual) << builder.ToString();
+}
 }  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/storage_client.bzl
+++ b/google/cloud/storage/storage_client.bzl
@@ -38,6 +38,7 @@ storage_client_HDRS = [
     "internal/object_acl_requests.h",
     "internal/object_streambuf.h",
     "internal/parse_rfc3339.h",
+    "internal/patch_builder.h",
     "internal/raw_client.h",
     "internal/read_object_range_request.h",
     "internal/retry_client.h",

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -23,6 +23,7 @@ storage_client_unit_tests = [
     "internal/nljson_test.cc",
     "internal/object_acl_requests_test.cc",
     "internal/parse_rfc3339_test.cc",
+    "internal/patch_builder_test.cc",
     "internal/retry_client_test.cc",
     "internal/read_object_range_request_test.cc",
     "internal/service_account_credentials_test.cc",


### PR DESCRIPTION
In the JSON API we need to send patch requests that remove fields
by setting them to null, and both insert and set fields by giving
their new values. This change introduces a class to make it eaiser
to create these patch messages. Part of the changes for #843.