### PR TITLE
Implement Client::WriteObject().

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -229,6 +229,7 @@ set(storage_client_unit_tests
     bucket_test.cc
     client_object_acl_test.cc
     client_test.cc
+    client_write_object_test.cc
     credentials_test.cc
     internal/access_control_common_test.cc
     internal/authorized_user_credentials_test.cc

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -198,6 +198,25 @@ class Client {
   }
 
   /**
+   * Write contents into an object.
+   *
+   * @param bucket_name the name of the bucket that contains the object.
+   * @param object_name the name of the object to be read.
+   * @param parameters a variadic list of optional parameters. Valid types for
+   *   this operation include
+   *   `IfGenerationMatch`/`IfGenerationNotMatch`, `IfMetagenerationMatch`/
+   *   `IfMetagenerationNotMatch`, `Generation`, and `UserProject`.
+   */
+  template <typename... Parameters>
+  ObjectWriteStream WriteObject(std::string const& bucket_name,
+                                std::string const& object_name,
+                                Parameters&&... parameters) {
+    internal::InsertObjectStreamingRequest request(bucket_name, object_name);
+    request.set_multiple_parameters(std::forward<Parameters>(parameters)...);
+    return ObjectWriteStream(raw_client_->WriteObject(request).second);
+  }
+
+  /**
    * Delete an object.
    *
    * @param bucket_name the name of the bucket that contains the object.
@@ -338,6 +357,7 @@ class Client {
  private:
   BucketMetadata GetBucketMetadataImpl(
       internal::GetBucketMetadataRequest const& request);
+
   ObjectMetadata InsertObjectMediaImpl(
       internal::InsertObjectMediaRequest const& request);
 

--- a/google/cloud/storage/client_write_object_test.cc
+++ b/google/cloud/storage/client_write_object_test.cc
@@ -1,0 +1,150 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/retry_policy.h"
+#include "google/cloud/storage/testing/canonical_errors.h"
+#include "google/cloud/storage/testing/mock_client.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+using ::testing::_;
+using ::testing::HasSubstr;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::ReturnRef;
+using testing::canonical_errors::PermanentError;
+using testing::canonical_errors::TransientError;
+using ms = std::chrono::milliseconds;
+
+/**
+ * Test the functions in Storage::Client related to writing objects.'Objects:
+ * *'.
+ */
+class WriteObjectTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    mock = std::make_shared<testing::MockClient>();
+    EXPECT_CALL(*mock, client_options())
+        .WillRepeatedly(ReturnRef(client_options));
+    client.reset(new Client{std::shared_ptr<internal::RawClient>(mock)});
+  }
+  void TearDown() override {
+    client.reset();
+    mock.reset();
+  }
+
+  std::shared_ptr<testing::MockClient> mock;
+  std::unique_ptr<Client> client;
+  ClientOptions client_options = ClientOptions(CreateInsecureCredentials());
+};
+
+class MockStreambuf : public internal::ObjectWriteStreambuf {
+ public:
+  MOCK_CONST_METHOD0(IsOpen, bool());
+  MOCK_METHOD0(DoClose, internal::HttpResponse());
+};
+
+TEST_F(WriteObjectTest, WriteObject) {
+  std::string text = R"""({
+      "name": "test-bucket-name/test-object-name/1"
+})""";
+  auto expected = ObjectMetadata::ParseFromString(text);
+
+  EXPECT_CALL(*mock, WriteObject(_))
+      .WillOnce(Invoke(
+          [&text](internal::InsertObjectStreamingRequest const& request) {
+            EXPECT_EQ("test-bucket-name", request.bucket_name());
+            EXPECT_EQ("test-object-name", request.object_name());
+            auto* mock_result = new MockStreambuf;
+            EXPECT_CALL(*mock_result, DoClose())
+                .WillRepeatedly(Return(internal::HttpResponse{200, text, {}}));
+            EXPECT_CALL(*mock_result, IsOpen()).WillRepeatedly(Return(true));
+            std::unique_ptr<internal::ObjectWriteStreambuf> result(mock_result);
+            return std::make_pair(storage::Status(), std::move(result));
+          }));
+
+  auto stream = client->WriteObject("test-bucket-name", "test-object-name");
+  stream << "Hello World!";
+  ObjectMetadata actual = stream.Close();
+  EXPECT_EQ(expected, actual);
+}
+
+TEST_F(WriteObjectTest, WriteObjectTooManyFailures) {
+  Client client{std::shared_ptr<internal::RawClient>(mock),
+                LimitedErrorCountRetryPolicy(2)};
+
+  auto returner = [](internal::InsertObjectStreamingRequest const&) {
+    return std::make_pair(TransientError(),
+                          std::unique_ptr<internal::ObjectWriteStreambuf>{});
+  };
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_CALL(*mock, WriteObject(_))
+      .WillOnce(Invoke(returner))
+      .WillOnce(Invoke(returner))
+      .WillOnce(Invoke(returner));
+  EXPECT_THROW(
+      try {
+        client.WriteObject("test-bucket-name", "test-object-name").Close();
+      } catch (std::runtime_error const& ex) {
+        EXPECT_THAT(ex.what(), HasSubstr("Retry policy exhausted"));
+        EXPECT_THAT(ex.what(), HasSubstr("WriteObject"));
+        throw;
+      },
+      std::runtime_error);
+#else
+  // With EXPECT_DEATH*() the mocking framework cannot detect how many times the
+  // operation is called.
+  EXPECT_CALL(*mock, WriteObject(_)).WillRepeatedly(Invoke(returner));
+  EXPECT_DEATH_IF_SUPPORTED(
+      client.WriteObject("test-bucket-name", "test-object-name").Close(),
+      "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST_F(WriteObjectTest, WriteObjectPermanentFailure) {
+  auto returner = [](internal::InsertObjectStreamingRequest const&) {
+    return std::make_pair(PermanentError(),
+                          std::unique_ptr<internal::ObjectWriteStreambuf>{});
+  };
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_CALL(*mock, WriteObject(_)).WillOnce(Invoke(returner));
+  EXPECT_THROW(
+      try {
+        client->WriteObject("test-bucket-name", "test-object-name").Close();
+      } catch (std::runtime_error const& ex) {
+        EXPECT_THAT(ex.what(), HasSubstr("Permanent error"));
+        EXPECT_THAT(ex.what(), HasSubstr("WriteObject"));
+        throw;
+      },
+      std::runtime_error);
+#else
+  // With EXPECT_DEATH*() the mocking framework cannot detect how many times the
+  // operation is called.
+  EXPECT_CALL(*mock, WriteObject(_)).WillRepeatedly(Invoke(returner));
+  EXPECT_DEATH_IF_SUPPORTED(
+      client->WriteObject("test-bucket-name", "test-object-name").Close(),
+      "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -68,6 +68,9 @@ run_program_examples() {
         insert-object)
             arguments="${base_arguments} a-short-string-to-put-in-the-object"
             ;;
+        write-object)
+            arguments="${base_arguments} 100000"
+            ;;
         create-object-acl)
             arguments="${base_arguments} allAuthenticatedUsers READER"
             ;;
@@ -177,6 +180,7 @@ run_all_object_examples() {
 insert-object
 get-object-metadata
 read-object
+write-object
 delete-object
 _EOF_
 )

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -112,6 +112,35 @@ void DeleteObject(gcs::Client client, int& argc, char* argv[]) {
 }
 //! [delete object]
 
+void WriteObject(gcs::Client client, int& argc, char* argv[]) {
+  if (argc < 3) {
+    throw Usage{
+        "write-object <bucket-name> <object-name> <target-object-size>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  auto object_name = ConsumeArg(argc, argv);
+  auto desired_size = std::stol(ConsumeArg(argc, argv));
+
+  //! [write object]
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string bucket_name, std::string object_name,
+     long desired_size) {
+    std::string const text = "Lorem ipsum dolor sit amet";
+    auto stream = client.WriteObject(bucket_name, object_name);
+
+    auto approximate_size = 0;
+    int lineno = 0;
+    while (approximate_size < desired_size) {
+      stream << ++lineno << ": " << text << "\n";
+      approximate_size += text.size();
+    }
+    gcs::ObjectMetadata meta = stream.Close();
+    std::cout << "The actual object size is: " << meta.size() << std::endl;
+  }
+  //! [write object]
+  (std::move(client), bucket_name, object_name, desired_size);
+}
+
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) try {
@@ -121,6 +150,7 @@ int main(int argc, char* argv[]) try {
       {"insert-object", &InsertObject},
       {"get-object-metadata", &GetObjectMetadata},
       {"delete-object", &DeleteObject},
+      {"write-object", &WriteObject},
   };
 
   if (argc < 2) {

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -115,30 +115,30 @@ void DeleteObject(gcs::Client client, int& argc, char* argv[]) {
 void WriteObject(gcs::Client client, int& argc, char* argv[]) {
   if (argc < 3) {
     throw Usage{
-        "write-object <bucket-name> <object-name> <target-object-size>"};
+        "write-object <bucket-name> <object-name> <target-object-line-count>"};
   }
   auto bucket_name = ConsumeArg(argc, argv);
   auto object_name = ConsumeArg(argc, argv);
-  auto desired_size = std::stol(ConsumeArg(argc, argv));
+  auto desired_line_count = std::stol(ConsumeArg(argc, argv));
 
   //! [write object]
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
-     long desired_size) {
+     long desired_line_count) {
     std::string const text = "Lorem ipsum dolor sit amet";
     auto stream = client.WriteObject(bucket_name, object_name);
 
-    auto approximate_size = 0;
-    int lineno = 0;
-    while (approximate_size < desired_size) {
-      stream << ++lineno << ": " << text << "\n";
-      approximate_size += text.size();
+    for (int lineno = 0; lineno != desired_line_count; ++lineno) {
+      // Add 1 to the counter, because it is conventional to number lines
+      // starting at 1.
+      stream << (lineno + 1) << ": " << text << "\n";
     }
+
     gcs::ObjectMetadata meta = stream.Close();
-    std::cout << "The actual object size is: " << meta.size() << std::endl;
+    std::cout << "The resulting object size is: " << meta.size() << std::endl;
   }
   //! [write object]
-  (std::move(client), bucket_name, object_name, desired_size);
+  (std::move(client), bucket_name, object_name, desired_line_count);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/internal/curl_client.h"
 #include "google/cloud/storage/internal/curl_request_builder.h"
+#include "google/cloud/storage/internal/curl_streambuf.h"
 
 namespace google {
 namespace cloud {
@@ -119,6 +120,23 @@ std::pair<Status, ReadObjectRangeResponse> CurlClient::ReadObjectRangeMedia(
   return std::make_pair(
       Status(),
       internal::ReadObjectRangeResponse::FromHttpResponse(std::move(payload)));
+}
+
+std::pair<Status, std::unique_ptr<ObjectWriteStreambuf>>
+CurlClient::WriteObject(InsertObjectStreamingRequest const& request) {
+  auto url = upload_endpoint_ + "/b/" + request.bucket_name() + "/o";
+  CurlRequestBuilder builder(url);
+  builder.SetDebugLogging(options_.enable_http_tracing());
+  builder.AddHeader(options_.credentials()->AuthorizationHeader());
+  request.AddParametersToHttpRequest(builder);
+  builder.AddQueryParameter("uploadType", "media");
+  builder.AddQueryParameter("name", request.object_name());
+  builder.AddHeader("Content-Type: application/octet-stream");
+  std::unique_ptr<internal::CurlStreambuf> buf(
+      new internal::CurlStreambuf(builder.BuildUpload(), 128 * 1024));
+  return std::make_pair(
+      Status(),
+      std::unique_ptr<internal::ObjectWriteStreambuf>(std::move(buf)));
 }
 
 std::pair<Status, ListObjectsResponse> CurlClient::ListObjects(

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -50,6 +50,8 @@ class CurlClient : public RawClient {
       GetObjectMetadataRequest const& request) override;
   std::pair<Status, ReadObjectRangeResponse> ReadObjectRangeMedia(
       ReadObjectRangeRequest const& request) override;
+  std::pair<Status, std::unique_ptr<ObjectWriteStreambuf>> WriteObject(
+      InsertObjectStreamingRequest const&) override;
   std::pair<Status, ListObjectsResponse> ListObjects(
       ListObjectsRequest const& request) override;
   std::pair<Status, EmptyResponse> DeleteObject(

--- a/google/cloud/storage/internal/insert_object_media_request.cc
+++ b/google/cloud/storage/internal/insert_object_media_request.cc
@@ -28,6 +28,14 @@ std::ostream& operator<<(std::ostream& os, InsertObjectMediaRequest const& r) {
      << BinaryDataAsDebugString(r.contents().data(), r.contents().size());
   return os << "}";
 }
+
+std::ostream& operator<<(std::ostream& os,
+                         InsertObjectStreamingRequest const& r) {
+  os << "InsertObjectStreamingRequest={bucket_name=" << r.bucket_name()
+     << ", object_name=" << r.object_name();
+  r.DumpParameters(os, ", ");
+  return os << "}";
+}
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/insert_object_media_request.h
+++ b/google/cloud/storage/internal/insert_object_media_request.h
@@ -24,7 +24,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 /**
- * Request the metadata for a bucket.
+ * Insert an object with a simple std::string for its media.
  */
 class InsertObjectMediaRequest
     : public GenericObjectRequest<
@@ -51,6 +51,21 @@ class InsertObjectMediaRequest
 };
 
 std::ostream& operator<<(std::ostream& os, InsertObjectMediaRequest const& r);
+
+/**
+ * Insert an object with streaming media.
+ */
+class InsertObjectStreamingRequest
+    : public GenericObjectRequest<
+          InsertObjectStreamingRequest, ContentEncoding, IfGenerationMatch,
+          IfGenerationNotMatch, IfMetaGenerationMatch, IfMetaGenerationNotMatch,
+          KmsKeyName, PredefinedAcl, Projection, UserProject> {
+ public:
+  using GenericObjectRequest::GenericObjectRequest;
+};
+
+std::ostream& operator<<(std::ostream& os,
+                         InsertObjectStreamingRequest const& r);
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/insert_object_media_request_test.cc
+++ b/google/cloud/storage/internal/insert_object_media_request_test.cc
@@ -23,28 +23,41 @@ namespace internal {
 namespace {
 using ::testing::HasSubstr;
 
-TEST(InsertObjectMediaRequestTest, OStreamBasic) {
-  InsertObjectMediaRequest request("my-bucket", "my-object", "object contents");
-  std::ostringstream os;
-  os << request;
-  EXPECT_THAT(os.str(), HasSubstr("my-bucket"));
-  EXPECT_THAT(os.str(), HasSubstr("my-object"));
-}
-
-TEST(InsertObjectMediaRequestTest, OStreamParameter) {
+TEST(InsertObjectMediaRequestTest, OStream) {
   InsertObjectMediaRequest request("my-bucket", "my-object", "object contents");
   request.set_multiple_parameters(
       IfGenerationMatch(0), Projection("full"), ContentEncoding("media"),
       KmsKeyName("random-key"), PredefinedAcl("authenticatedRead"));
   std::ostringstream os;
   os << request;
-  EXPECT_THAT(os.str(), HasSubstr("ifGenerationMatch=0"));
-  EXPECT_THAT(os.str(), HasSubstr("projection=full"));
-  EXPECT_THAT(os.str(), HasSubstr("kmsKeyName=random-key"));
-  EXPECT_THAT(os.str(), HasSubstr("contentEncoding=media"));
-  EXPECT_THAT(os.str(), HasSubstr("predefinedAcl=authenticatedRead"));
+  auto str = os.str();
+  EXPECT_THAT(str, HasSubstr("InsertObjectMediaRequest"));
+  EXPECT_THAT(str, HasSubstr("my-bucket"));
+  EXPECT_THAT(str, HasSubstr("my-object"));
+  EXPECT_THAT(str, HasSubstr("ifGenerationMatch=0"));
+  EXPECT_THAT(str, HasSubstr("projection=full"));
+  EXPECT_THAT(str, HasSubstr("kmsKeyName=random-key"));
+  EXPECT_THAT(str, HasSubstr("contentEncoding=media"));
+  EXPECT_THAT(str, HasSubstr("predefinedAcl=authenticatedRead"));
 }
 
+TEST(InsertObjectStreamingRequestTest, OStream) {
+  InsertObjectStreamingRequest request("my-bucket", "my-object");
+  request.set_multiple_parameters(
+      IfGenerationMatch(0), Projection("full"), ContentEncoding("media"),
+      KmsKeyName("random-key"), PredefinedAcl("authenticatedRead"));
+  std::ostringstream os;
+  os << request;
+  auto str = os.str();
+  EXPECT_THAT(str, HasSubstr("InsertObjectStreamingRequest"));
+  EXPECT_THAT(str, HasSubstr("my-bucket"));
+  EXPECT_THAT(str, HasSubstr("my-object"));
+  EXPECT_THAT(str, HasSubstr("ifGenerationMatch=0"));
+  EXPECT_THAT(str, HasSubstr("projection=full"));
+  EXPECT_THAT(str, HasSubstr("kmsKeyName=random-key"));
+  EXPECT_THAT(str, HasSubstr("contentEncoding=media"));
+  EXPECT_THAT(str, HasSubstr("predefinedAcl=authenticatedRead"));
+}
 }  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -47,6 +47,9 @@ class LoggingClient : public RawClient {
   std::pair<Status, ReadObjectRangeResponse> ReadObjectRangeMedia(
       ReadObjectRangeRequest const&) override;
 
+  std::pair<Status, std::unique_ptr<ObjectWriteStreambuf>> WriteObject(
+      InsertObjectStreamingRequest const&) override;
+
   std::pair<Status, ListObjectsResponse> ListObjects(
       ListObjectsRequest const&) override;
 

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -27,6 +27,7 @@
 #include "google/cloud/storage/internal/list_object_acl_request.h"
 #include "google/cloud/storage/internal/list_objects_request.h"
 #include "google/cloud/storage/internal/object_acl_requests.h"
+#include "google/cloud/storage/internal/object_streambuf.h"
 #include "google/cloud/storage/internal/read_object_range_request.h"
 #include "google/cloud/storage/object_metadata.h"
 #include "google/cloud/storage/status.h"
@@ -67,6 +68,9 @@ class RawClient {
   virtual std::pair<Status, ReadObjectRangeResponse> ReadObjectRangeMedia(
       ReadObjectRangeRequest const&) = 0;
 
+  virtual std::pair<Status, std::unique_ptr<ObjectWriteStreambuf>> WriteObject(
+      InsertObjectStreamingRequest const&) = 0;
+
   virtual std::pair<Status, ListObjectsResponse> ListObjects(
       ListObjectsRequest const&) = 0;
 
@@ -86,7 +90,6 @@ class RawClient {
 };
 
 }  // namespace internal
-
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -151,6 +151,15 @@ std::pair<Status, ReadObjectRangeResponse> RetryClient::ReadObjectRangeMedia(
                   &RawClient::ReadObjectRangeMedia, request, __func__);
 }
 
+std::pair<Status, std::unique_ptr<ObjectWriteStreambuf>>
+RetryClient::WriteObject(
+    internal::InsertObjectStreamingRequest const& request) {
+  auto retry_policy = retry_policy_->clone();
+  auto backoff_policy = backoff_policy_->clone();
+  return MakeCall(*retry_policy, *backoff_policy, *client_,
+                  &RawClient::WriteObject, request, __func__);
+}
+
 std::pair<Status, ListObjectsResponse> RetryClient::ListObjects(
     ListObjectsRequest const& request) {
   auto retry_policy = retry_policy_->clone();

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -58,6 +58,9 @@ class RetryClient : public RawClient {
   std::pair<Status, ReadObjectRangeResponse> ReadObjectRangeMedia(
       ReadObjectRangeRequest const&) override;
 
+  std::pair<Status, std::unique_ptr<ObjectWriteStreambuf>> WriteObject(
+      InsertObjectStreamingRequest const&) override;
+
   std::pair<Status, ListObjectsResponse> ListObjects(
       ListObjectsRequest const&) override;
 

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -144,7 +144,7 @@ class ObjectWriteStream : public std::basic_ostream<char> {
    * Reading from the stream will result in http requests to get more data
    * from the GCS object.
    *
-   * @param buf an initialized ObjectWriteStreamBuf to upload the data.
+   * @param buf an initialized ObjectWriteStreambuf to upload the data.
    */
   explicit ObjectWriteStream(
       std::unique_ptr<internal::ObjectWriteStreambuf> buf)

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -5,6 +5,7 @@ storage_client_unit_tests = [
     "bucket_test.cc",
     "client_object_acl_test.cc",
     "client_test.cc",
+    "client_write_object_test.cc",
     "credentials_test.cc",
     "internal/access_control_common_test.cc",
     "internal/authorized_user_credentials_test.cc",

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -46,6 +46,9 @@ class MockClient : public google::cloud::storage::internal::RawClient {
   MOCK_METHOD1(ReadObjectRangeMedia,
                ResponseWrapper<internal::ReadObjectRangeResponse>(
                    internal::ReadObjectRangeRequest const&));
+  MOCK_METHOD1(WriteObject,
+               ResponseWrapper<std::unique_ptr<internal::ObjectWriteStreambuf>>(
+                   internal::InsertObjectStreamingRequest const&));
   MOCK_METHOD1(ListObjects, ResponseWrapper<internal::ListObjectsResponse>(
                                 internal::ListObjectsRequest const&));
   MOCK_METHOD1(DeleteObject, ResponseWrapper<internal::EmptyResponse>(

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -133,6 +133,67 @@ TEST_F(ObjectIntegrationTest, BasicReadWrite) {
   client.DeleteObject(bucket_name, object_name);
 }
 
+TEST_F(ObjectIntegrationTest, StreamingWrite) {
+  Client client;
+  auto bucket_name = ObjectTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+
+  // We will construct the expected response while streaming the data up.
+  std::string expected;
+
+  auto generate_random_line = [this] {
+    std::string const characters =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz"
+        "0123456789"
+        ".,/;:'[{]}=+-_}]`~!@#$%^&*()\t\n\r\v";
+    return google::cloud::internal::Sample(generator_, 200, characters);
+  };
+
+  // Create the object, but only if it does not exist already.
+  auto os = client.WriteObject(bucket_name, object_name, IfGenerationMatch(0));
+  for (int line = 0; line != 1000; ++line) {
+    std::string random = generate_random_line();
+    os << random;
+    expected += random;
+  }
+  ObjectMetadata meta = os.Close();
+  EXPECT_EQ(object_name, meta.name());
+  EXPECT_EQ(bucket_name, meta.bucket());
+  ASSERT_EQ(expected.size(), meta.size());
+
+  // Create a iostream to read the object back.
+  auto stream = client.Read(bucket_name, object_name);
+  std::string actual(std::istreambuf_iterator<char>{stream}, {});
+  ASSERT_FALSE(actual.empty());
+  EXPECT_EQ(expected, actual);
+
+  client.DeleteObject(bucket_name, object_name);
+}
+
+TEST_F(ObjectIntegrationTest, StreamingWriteAutoClose) {
+  Client client;
+  auto bucket_name = ObjectTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+
+  // We will construct the expected response while streaming the data up.
+  std::string expected = "A short string to test\n";
+
+  {
+    // Create the object, but only if it does not exist already.
+    auto os =
+        client.WriteObject(bucket_name, object_name, IfGenerationMatch(0));
+    os << expected;
+  }
+  // Create a iostream to read the object back.
+  auto stream = client.Read(bucket_name, object_name);
+  std::string actual(std::istreambuf_iterator<char>{stream}, {});
+  ASSERT_FALSE(actual.empty());
+  EXPECT_EQ(expected, actual);
+
+  client.DeleteObject(bucket_name, object_name);
+}
+
 TEST_F(ObjectIntegrationTest, AccessControlCRUD) {
   Client client;
   auto bucket_name = ObjectTestEnvironment::bucket_name();

--- a/google/cloud/storage/tests/testbench.py
+++ b/google/cloud/storage/tests/testbench.py
@@ -88,7 +88,7 @@ class GcsObjectVersion(object):
         now = time.gmtime(time.time())
         timestamp = time.strftime('%Y-%m-%dT%H:%M:%SZ', now)
         if request.environ.get('HTTP_TRANSFER_ENCODING', '') == 'chunked':
-            self.media = ''.join(request.environ.get('wsgi.input').readlines())
+            self.media = request.environ.get('wsgi.input').read()
         else:
             self.media = request.data
         self.metadata = {


### PR DESCRIPTION
This fixes #557. It implements the API, a unit test, an integration
test, and the sample.