### PR TITLE
Fix builds with Ninja.

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -21,6 +21,7 @@ additional_commands = {
         ],
         "kwargs": {
             "BUILD_COMMAND": "+",
+            "BUILD_BYPRODUCTS": "+",
             "COMMAND": "+",
             "CONFIGURE_COMMAND": "+",
             "DEPENDS": "+",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ add_custom_target(doxygen-docs)
 # There are a number of targets we cannot, or do not care to compile with the
 # static analyzer enabled. Either because the build times are too long, or
 # because the code is an external dependency, or generated code, or all of
-# above. These targets are added as depedencies of `skip-scanbuild-targets` and
+# above. These targets are added as dependencies of `skip-scanbuild-targets` and
 # compiled with, obviously, scan-build disabled.
 add_custom_target(skip-scanbuild-targets)
 

--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -58,11 +58,11 @@ function (PROTOBUF_GENERATE_CPP SRCS HDRS)
         list(APPEND ${HDRS} ${HDR})
         add_custom_command(
             OUTPUT ${SRC} ${HDR}
-            COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
+            COMMAND $<TARGET_FILE:protoc>
                     ARGS
                     --cpp_out ${CMAKE_CURRENT_BINARY_DIR}
                               ${_protobuf_include_path} ${FIL}
-            DEPENDS ${FIL} ${PROTOBUF_PROTOC_EXECUTABLE}
+            DEPENDS ${FIL} protoc
             COMMENT "Running C++ protocol buffer compiler on ${FIL}"
             VERBATIM)
     endforeach ()
@@ -144,14 +144,13 @@ function (GRPC_GENERATE_CPP_BASE SRCS HDRS MHDRS WITH_MOCK)
         add_custom_command(
             OUTPUT "${SRC}" "${HDR}"
             COMMAND
-                ${PROTOBUF_PROTOC_EXECUTABLE}
+                protoc
                 ARGS
-                --plugin=protoc-gen-grpc=${PROTOC_GRPCPP_PLUGIN_EXECUTABLE}
+                --plugin=protoc-gen-grpc=$<TARGET_FILE:grpc_cpp_plugin>
                 --grpc_out=${GRPC_OUT_EXTRA}${CMAKE_CURRENT_BINARY_DIR}
                 --cpp_out=${CMAKE_CURRENT_BINARY_DIR} ${_protobuf_include_path}
                                                       ${FIL}
-            DEPENDS ${FIL} ${PROTOBUF_PROTOC_EXECUTABLE}
-                    ${PROTOC_GRPCPP_PLUGIN_EXECUTABLE}
+            DEPENDS ${FIL} protoc grpc_cpp_plugin
             COMMENT "Running gRPC++ protocol buffer compiler on ${FIL}"
             VERBATIM)
     endforeach ()

--- a/cmake/ExternalProjectHelper.cmake
+++ b/cmake/ExternalProjectHelper.cmake
@@ -97,8 +97,11 @@ function (set_library_properties_for_external_project _target _lib)
                  PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${_includepath}")
 endfunction ()
 
-function (set_executable_name_for_external_project VAR _exe)
-    set(${VAR}
-        "${PROJECT_BINARY_DIR}/external/bin/${_exe}${CMAKE_EXECUTABLE_SUFFIX}"
-        PARENT_SCOPE)
+function (set_executable_name_for_external_project _target _exe)
+    set_property(
+        TARGET ${_target}
+        PROPERTY
+            IMPORTED_LOCATION
+            "${PROJECT_BINARY_DIR}/external/bin/${_exe}${CMAKE_EXECUTABLE_SUFFIX}"
+        )
 endfunction ()

--- a/cmake/IncludeGrpc.cmake
+++ b/cmake/IncludeGrpc.cmake
@@ -97,12 +97,13 @@ if ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "external")
                  PROPERTY INTERFACE_LINK_LIBRARIES gRPC::grpc c-ares::cares)
 
     # Discover the protobuf compiler and the gRPC plugin.
-    set_executable_name_for_external_project(PROTOBUF_PROTOC_EXECUTABLE protoc)
-    mark_as_advanced(PROTOBUF_PROTOC_EXECUTABLE)
-    set_executable_name_for_external_project(PROTOC_GRPCPP_PLUGIN_EXECUTABLE
-                                             grpc_cpp_plugin)
-    mark_as_advanced(PROTOC_GRPCPP_PLUGIN_EXECUTABLE)
+    add_executable(protoc IMPORTED)
+    add_dependencies(protoc protobuf_project)
+    set_executable_name_for_external_project(protoc protoc)
 
+    add_executable(grpc_cpp_plugin IMPORTED)
+    add_dependencies(grpc_cpp_plugin grpc_project)
+    set_executable_name_for_external_project(grpc_cpp_plugin grpc_cpp_plugin)
 elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" MATCHES "^(package|vcpkg)$")
     find_package(protobuf REQUIRED protobuf>=3.5.2)
     find_package(gRPC REQUIRED gRPC>=1.9)
@@ -141,6 +142,10 @@ elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" MATCHES "^(package|vcpkg)$")
             ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Release
             ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Debug)
     mark_as_advanced(PROTOBUF_PROTOC_EXECUTABLE)
+    add_executable(protoc IMPORTED)
+    set_property(TARGET protoc
+                 PROPERTY IMPORTED_LOCATION ${PROTOBUF_PROTOC_EXECUTABLE})
+
     find_program(
         PROTOC_GRPCPP_PLUGIN_EXECUTABLE
         NAMES grpc_cpp_plugin
@@ -149,6 +154,10 @@ elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" MATCHES "^(package|vcpkg)$")
             ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Release
             ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Debug)
     mark_as_advanced(PROTOC_GRPCPP_PLUGIN_EXECUTABLE)
+    add_executable(grpc_cpp_plugin IMPORTED)
+    set_property(TARGET grpc_cpp_plugin
+                 PROPERTY IMPORTED_LOCATION ${PROTOC_GRPCPP_PLUGIN_EXECUTABLE})
+
 elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "pkg-config")
 
     # Use pkg-config to find the libraries.
@@ -188,6 +197,10 @@ elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "pkg-config")
             ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Release
             ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Debug)
     mark_as_advanced(PROTOBUF_PROTOC_EXECUTABLE)
+    add_executable(protoc IMPORTED)
+    set_property(TARGET protoc
+                 PROPERTY IMPORTED_LOCATION ${PROTOBUF_PROTOC_EXECUTABLE})
+
     find_program(
         PROTOC_GRPCPP_PLUGIN_EXECUTABLE
         NAMES grpc_cpp_plugin
@@ -196,4 +209,9 @@ elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "pkg-config")
             ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Release
             ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Debug)
     mark_as_advanced(PROTOC_GRPCPP_PLUGIN_EXECUTABLE)
+    add_executable(grpc_cpp_plugin ${PROTOC_GRPC_PLUGIN_EXECUTABLE})
+    set_property(TARGET grpc_cpp_plugin
+                 PROPERTY IMPORTED_LOCATION
+                          ${PROTOC_GRPCPP_CPP_PLUGIN_EXECUTABLE})
+
 endif ()

--- a/cmake/external/c-ares.cmake
+++ b/cmake/external/c-ares.cmake
@@ -49,6 +49,9 @@ if (NOT TARGET c_ares_project)
                         Release
                         --target
                         install
+        BUILD_BYPRODUCTS
+            <INSTALL_DIR>/lib/libcares${CMAKE_SHARED_LIBRARY_SUFFIX}
+            <INSTALL_DIR>/lib/libcares${CMAKE_STATIC_LIBRARY_SUFFIX}
         LOG_DOWNLOAD ON
         LOG_CONFIGURE ON
         LOG_BUILD ON

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -59,6 +59,14 @@ if (NOT TARGET gprc_project)
                         Release
                         --target
                         install
+        BUILD_BYPRODUCTS
+            <INSTALL_DIR>/lib/libgrpc${CMAKE_STATIC_LIBRARY_SUFFIX}
+            <INSTALL_DIR>/lib/libgrpc${CMAKE_SHARED_LIBRARY_SUFFIX}
+            <INSTALL_DIR>/lib/libgrpc++${CMAKE_STATIC_LIBRARY_SUFFIX}
+            <INSTALL_DIR>/lib/libgrpc++${CMAKE_SHARED_LIBRARY_SUFFIX}
+            <INSTALL_DIR>/lib/libgpr${CMAKE_STATIC_LIBRARY_SUFFIX}
+            <INSTALL_DIR>/lib/libgpr${CMAKE_SHARED_LIBRARY_SUFFIX}
+            <INSTALL_DIR>/bin/grpc_cpp_plugin${CMAKE_EXECUTABLE_SUFFIX}
         LOG_DOWNLOAD ON
         LOG_CONFIGURE ON
         LOG_BUILD ON

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -61,6 +61,10 @@ if (NOT TARGET protobuf_project)
                         --target
                         install
         COMMAND ${CMAKE_COMMAND} --build Release --target install
+        BUILD_BYPRODUCTS
+            <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/libprotobuf${CMAKE_STATIC_LIBRARY_SUFFIX}
+            <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/libprotobuf${CMAKE_SHARED_LIBRARY_SUFFIX}
+            <INSTALL_DIR>/bin/protoc${CMAKE_EXECUTABLE_SUFFIX}
         LOG_DOWNLOAD ON
         LOG_CONFIGURE ON
         LOG_BUILD ON

--- a/cmake/external/zlib.cmake
+++ b/cmake/external/zlib.cmake
@@ -50,6 +50,8 @@ if (NOT TARGET zlib_project)
                         Release
                         --target
                         install
+        BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libz${CMAKE_SHARED_LIBRARY_SUFFIX}
+                         <INSTALL_DIR>/lib/libz${CMAKE_STATIC_LIBRARY_SUFFIX}
         LOG_DOWNLOAD ON
         LOG_CONFIGURE ON
         LOG_BUILD ON


### PR DESCRIPTION
We normally do not use Ninja to build, but I use it sometimes
because it has some cool features to diagnose dependency problems.
The introduction of external projects broke the Ninja builds
because Ninja needs to know about the side-effects of
`externalproject_add()`.  More details can be found here:

https://cmake.org/pipermail/cmake/2015-April/060238.html