### PR TITLE
Use lambda for code samples.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -198,7 +198,7 @@ class Client {
    *   current policies.
    *
    * @par Example
-   * @snippet storage_bucket_samples.cc list objects
+   * @snippet storage_object_samples.cc list objects
    */
   template <typename... Options>
   ListObjectsReader ListObjects(std::string const& bucket_name,

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -156,7 +156,6 @@ run_all_bucket_examples() {
 list-buckets
 list-buckets-for-project
 get-bucket-metadata
-list-objects
 _EOF_
 )
 
@@ -183,6 +182,7 @@ run_all_object_examples() {
   # test. Currently get-metadata assumes that $bucket_name is already created.
   readonly OBJECT_EXAMPLES_COMMANDS=$(tr '\n' ',' <<_EOF_
 insert-object
+list-objects
 get-object-metadata
 read-object
 write-object

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -97,7 +97,7 @@ void GetBucketMetadata(google::cloud::storage::Client client, int& argc,
   //! [get bucket metadata] [START storage_get_bucket_metadata]
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name) {
-    auto meta = client.GetBucketMetadata(bucket_name);
+    gcs::BucketMetadata meta = client.GetBucketMetadata(bucket_name);
     std::cout << "The metadata is " << meta << std::endl;
   }
   //! [get bucket metadata] [END storage_get_bucket_metadata]

--- a/google/cloud/storage/examples/storage_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_object_acl_samples.cc
@@ -53,11 +53,12 @@ void ListObjectAcl(gcs::Client client, int& argc, char* argv[]) {
   auto bucket_name = ConsumeArg(argc, argv);
   auto object_name = ConsumeArg(argc, argv);
   //! [list object acl] [START storage_print_file_acl]
-  [](google::cloud::storage::Client client, std::string bucket_name,
-     std::string object_name) {
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string bucket_name, std::string object_name) {
     std::cout << "ACLs for object=" << object_name << " in bucket "
               << bucket_name << std::endl;
-    for (auto&& acl : client.ListObjectAcl(bucket_name, object_name)) {
+    for (gcs::ObjectAccessControl const& acl :
+         client.ListObjectAcl(bucket_name, object_name)) {
       std::cout << acl.role() << ":" << acl.entity() << std::endl;
     }
   }
@@ -75,9 +76,10 @@ void CreateObjectAcl(gcs::Client client, int& argc, char* argv[]) {
   auto entity = ConsumeArg(argc, argv);
   auto role = ConsumeArg(argc, argv);
   //! [create object acl] [START storage_create_file_acl]
-  [](google::cloud::storage::Client client, std::string bucket_name,
-     std::string object_name, std::string entity, std::string role) {
-    auto result =
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string bucket_name, std::string object_name,
+     std::string entity, std::string role) {
+    gcs::ObjectAccessControl result =
         client.CreateObjectAcl(bucket_name, object_name, entity, role);
     std::cout << "Role " << result.role() << " granted to " << result.entity()
               << " on " << result.object() << "\n"
@@ -95,8 +97,9 @@ void DeleteObjectAcl(gcs::Client client, int& argc, char* argv[]) {
   auto object_name = ConsumeArg(argc, argv);
   auto entity = ConsumeArg(argc, argv);
   //! [delete object acl] [START storage_delete_file_acl]
-  [](google::cloud::storage::Client client, std::string bucket_name,
-     std::string object_name, std::string entity) {
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string bucket_name, std::string object_name,
+     std::string entity) {
     client.DeleteObjectAcl(bucket_name, object_name, entity);
     std::cout << "Deleted ACL entry for " << entity << " in object "
               << object_name << " in bucket " << bucket_name << std::endl;

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -71,7 +71,7 @@ void InsertObject(google::cloud::storage::Client client, int& argc,
   auto bucket_name = ConsumeArg(argc, argv);
   auto object_name = ConsumeArg(argc, argv);
   auto contents = ConsumeArg(argc, argv);
-  //! [insert object] [START upload_file]
+  //! [insert object] [START storage_upload_file]
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string contents) {
@@ -79,7 +79,7 @@ void InsertObject(google::cloud::storage::Client client, int& argc,
         client.InsertObject(bucket_name, object_name, std::move(contents));
     std::cout << "The new object metadata is " << meta << std::endl;
   }
-  //! [insert object] [END upload_file]
+  //! [insert object] [END storage_upload_file]
   (std::move(client), bucket_name, object_name, contents);
 }
 

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -77,7 +77,8 @@ void InsertObject(google::cloud::storage::Client client, int& argc,
      std::string contents) {
     gcs::ObjectMetadata meta =
         client.InsertObject(bucket_name, object_name, std::move(contents));
-    std::cout << "The new object metadata is " << meta << std::endl;
+    std::cout << "The file was uploaded. The new object metadata is " << meta
+              << std::endl;
   }
   //! [insert object] [END storage_upload_file]
   (std::move(client), bucket_name, object_name, contents);

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -71,7 +71,7 @@ void InsertObject(google::cloud::storage::Client client, int& argc,
   auto bucket_name = ConsumeArg(argc, argv);
   auto object_name = ConsumeArg(argc, argv);
   auto contents = ConsumeArg(argc, argv);
-  //! [insert object] [START createBlobFromByteArray]
+  //! [insert object] [START upload_file]
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string contents) {
@@ -79,7 +79,7 @@ void InsertObject(google::cloud::storage::Client client, int& argc,
         client.InsertObject(bucket_name, object_name, std::move(contents));
     std::cout << "The new object metadata is " << meta << std::endl;
   }
-  //! [insert object] [END createBlobFromByteArray]
+  //! [insert object] [END upload_file]
   (std::move(client), bucket_name, object_name, contents);
 }
 
@@ -152,7 +152,7 @@ void WriteObject(google::cloud::storage::Client client, int& argc,
   auto object_name = ConsumeArg(argc, argv);
   auto desired_line_count = std::stol(ConsumeArg(argc, argv));
 
-  //! [write object] [START storage_upload_file]
+  //! [write object]
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      long desired_line_count) {
@@ -168,7 +168,7 @@ void WriteObject(google::cloud::storage::Client client, int& argc,
     gcs::ObjectMetadata meta = stream.Close();
     std::cout << "The resulting object size is: " << meta.size() << std::endl;
   }
-  //! [write object] [END storage_upload_file]
+  //! [write object]
   (std::move(client), bucket_name, object_name, desired_line_count);
 }
 

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -53,7 +53,7 @@ void ListObjects(google::cloud::storage::Client client, int& argc,
   //! [list objects] [START storage_list_files]
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name) {
-    for (auto const& meta : client.ListObjects(bucket_name)) {
+    for (gcs::ObjectMetadata const& meta : client.ListObjects(bucket_name)) {
       std::cout << "bucket_name=" << meta.bucket()
                 << ", object_name=" << meta.name() << std::endl;
     }
@@ -75,7 +75,7 @@ void InsertObject(google::cloud::storage::Client client, int& argc,
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string contents) {
-    auto meta =
+    gcs::ObjectMetadata meta =
         client.InsertObject(bucket_name, object_name, std::move(contents));
     std::cout << "The new object metadata is " << meta << std::endl;
   }
@@ -111,7 +111,7 @@ void ReadObject(google::cloud::storage::Client client, int& argc,
   //! [read object]
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
-    auto stream = client.ReadObject(bucket_name, object_name);
+    gcs::ObjectReadStream stream = client.ReadObject(bucket_name, object_name);
     int count = 0;
     while (not stream.eof()) {
       std::string line;
@@ -157,7 +157,8 @@ void WriteObject(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      long desired_line_count) {
     std::string const text = "Lorem ipsum dolor sit amet";
-    auto stream = client.WriteObject(bucket_name, object_name);
+    gcs::ObjectWriteStream stream =
+        client.WriteObject(bucket_name, object_name);
 
     for (int lineno = 0; lineno != desired_line_count; ++lineno) {
       // Add 1 to the counter, because it is conventional to number lines


### PR DESCRIPTION
This fixes #878. It puts each example in a small lambda, so we
can show application developers the inputs to the examples, with
their types, without having to include all the command-line
argument parsing noise.