### PR TITLE
URGENT: Fix windows builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,7 @@ environment:
       APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
 cache:
-  - c:\projects\vcpkg\installed -> ci\install-windows.ps1
+  - c:\projects\vcpkg\installed -> ci\appveyor\install-windows.ps1
 
 install:
   - git submodule update --init

--- a/ci/appveyor/install-windows.ps1
+++ b/ci/appveyor/install-windows.ps1
@@ -37,7 +37,6 @@ if ($env:PROVIDER -eq "module") {
 cd ..
 if (Test-Path vcpkg\.git) {
     cd vcpkg
-    git pull
 } elseif (Test-Path vcpkg\installed) {
     move vcpkg vcpkg-tmp
     git clone https://github.com/Microsoft/vcpkg
@@ -50,6 +49,12 @@ if (Test-Path vcpkg\.git) {
 if ($LastExitCode) {
     throw "git setup failed with exit code $LastExitCode"
 }
+
+# Pin to a particular version because later versions include protobuf-3.6.0,
+# which suffers from:
+#   https://github.com/google/protobuf/issues/4773
+# TODO(#946) - update the Windows builds to use the right vcpkg version.
+git checkout 8d389323a75c49c09647a1f87184b1a0ef4fbbf6
 
 # Build the tool each time, it is fast to do so.
 powershell -exec bypass scripts\bootstrap.ps1

--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -58,7 +58,7 @@ function (PROTOBUF_GENERATE_CPP SRCS HDRS)
         list(APPEND ${HDRS} ${HDR})
         add_custom_command(
             OUTPUT ${SRC} ${HDR}
-            COMMAND $<TARGET_FILE:protoc>
+            COMMAND protoc
                     ARGS
                     --cpp_out ${CMAKE_CURRENT_BINARY_DIR}
                               ${_protobuf_include_path} ${FIL}

--- a/cmake/IncludeGrpc.cmake
+++ b/cmake/IncludeGrpc.cmake
@@ -104,9 +104,16 @@ if ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "external")
     add_executable(grpc_cpp_plugin IMPORTED)
     add_dependencies(grpc_cpp_plugin grpc_project)
     set_executable_name_for_external_project(grpc_cpp_plugin grpc_cpp_plugin)
+
+    list(APPEND PROTOBUF_IMPORT_DIRS "${PROJECT_BINARY_DIR}/external/include")
+
 elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" MATCHES "^(package|vcpkg)$")
     find_package(protobuf REQUIRED protobuf>=3.5.2)
     find_package(gRPC REQUIRED gRPC>=1.9)
+
+    if (NOT TARGET protobuf::libprotobuf)
+      message(FATAL_ERROR "Expected protobuf::libprotobuf target created by FindProtobuf")
+    endif ()
 
     if (VCPKG_TARGET_TRIPLET MATCHES "-static$")
         message(STATUS " RELEASE=${CMAKE_CXX_FLAGS_RELEASE}")
@@ -158,6 +165,12 @@ elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" MATCHES "^(package|vcpkg)$")
     set_property(TARGET grpc_cpp_plugin
                  PROPERTY IMPORTED_LOCATION ${PROTOC_GRPCPP_PLUGIN_EXECUTABLE})
 
+    if ("${Protobuf_IMPORT_DIRS}" STREQUAL "")
+        list(APPEND PROTOBUF_IMPORT_DIRS ${Protobuf_INCLUDE_DIRS})
+    else ()
+        list(APPEND PROTOBUF_IMPORT_DIRS ${Protobuf_IMPORT_DIRS})
+    endif ()
+
 elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "pkg-config")
 
     # Use pkg-config to find the libraries.
@@ -173,6 +186,7 @@ elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "pkg-config")
     set_property(TARGET protobuf::libprotobuf
                  APPEND
                  PROPERTY INTERFACE_LINK_LIBRARIES Threads::Threads)
+    list(APPEND PROTOBUF_IMPORT_DIRS ${Protobuf_INCLUDE_DIRS})
 
     pkg_check_modules(gRPC REQUIRED grpc>=1.9)
     add_library(gRPC::grpc INTERFACE IMPORTED)

--- a/cmake/IncludeGrpc.cmake
+++ b/cmake/IncludeGrpc.cmake
@@ -112,7 +112,9 @@ elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" MATCHES "^(package|vcpkg)$")
     find_package(gRPC REQUIRED gRPC>=1.9)
 
     if (NOT TARGET protobuf::libprotobuf)
-      message(FATAL_ERROR "Expected protobuf::libprotobuf target created by FindProtobuf")
+        message(
+            FATAL_ERROR
+                "Expected protobuf::libprotobuf target created by FindProtobuf")
     endif ()
 
     if (VCPKG_TARGET_TRIPLET MATCHES "-static$")
@@ -167,7 +169,7 @@ elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" MATCHES "^(package|vcpkg)$")
 
     if ("${Protobuf_IMPORT_DIRS}" STREQUAL "")
         list(APPEND PROTOBUF_IMPORT_DIRS ${Protobuf_INCLUDE_DIRS})
-    else ()
+    else()
         list(APPEND PROTOBUF_IMPORT_DIRS ${Protobuf_IMPORT_DIRS})
     endif ()
 

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -55,9 +55,8 @@ add_library(bigtable_common_options INTERFACE)
 google_cloud_cpp_add_common_options(bigtable_common_options)
 
 # Configure the location of proto files, particulary the googleapis protos.
-list(APPEND PROTOBUF_IMPORT_DIRS
-    "${PROJECT_THIRD_PARTY_DIR}/googleapis"
-    "${PROJECT_SOURCE_DIR}")
+list(APPEND PROTOBUF_IMPORT_DIRS "${PROJECT_THIRD_PARTY_DIR}/googleapis"
+            "${PROJECT_SOURCE_DIR}")
 
 # Include the functions to compile proto files.
 include(CompileProtos)

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -55,12 +55,9 @@ add_library(bigtable_common_options INTERFACE)
 google_cloud_cpp_add_common_options(bigtable_common_options)
 
 # Configure the location of proto files, particulary the googleapis protos.
-set(PROTOBUF_IMPORT_DIRS "${PROJECT_THIRD_PARTY_DIR}/googleapis"
+list(APPEND PROTOBUF_IMPORT_DIRS
+    "${PROJECT_THIRD_PARTY_DIR}/googleapis"
     "${PROJECT_SOURCE_DIR}")
-if (GRPC_ROOT_DIR)
-    list(INSERT PROTOBUF_IMPORT_DIRS 0
-                "${GRPC_ROOT_DIR}/third_party/protobuf/src")
-endif (GRPC_ROOT_DIR)
 
 # Include the functions to compile proto files.
 include(CompileProtos)


### PR DESCRIPTION
Today was not a good day.  The Windows build broke over the weekend (maybe
late last week, but I did not notice until the weekend).

This morning I could not even troubleshoot the problem because `strawberryperl.com`
was down, and we use that (indirectly) to build openssl on Windows:

https://github.com/Microsoft/vcpkg/issues/3973

I tried to do other stuff, without success. Late in the morning the site was back up.
At first, I thought it was just a matter of adapting to the newer protobuf (3.6.0) that
we got as part of a regular vcpkg update:

https://github.com/Microsoft/vcpkg/commit/c95b6bfdc448295b66da22cfd35d34ed8302aa4d

Well, the changes I made in our `cmake/*` files (included in this PR) did fix the build,
and look like useful changes.  But then the unit tests would not pass because of:

https://github.com/google/protobuf/issues/4773

Which is "Not Good"[tm].  I decided to revert the vcpkg version for now, that got the
tests to compile and pass on my Windows machine.  The programming gods wanted
to toy with this mortal today. Because the `.appveyor.yml` file was not properly clearing
the cache, and the builds on appveyor.com still used the protobuf 3.6 artifacts already
cached there.

BTW, this is probably why the builds did not break immediately: vcpkg reused the cached
versions even other stuff had changed.  Our builds continued to work after that commit
made it through.

I think all the necessary changes are in now.  I will commute home and fix anything else
that is broken when I get there.  May the programming gods be kind to you, oh faithful
reviewer.
