### PR TITLE
Actually use LoggingClient.

### DIFF
--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -126,7 +126,7 @@ TEST_F(ClientTest, OverrideBothPolicies) {
   EXPECT_LE(1, ObservableBackoffPolicy::on_completion_call_count);
 }
 
-/// @test Verify the constructor create the right set of RawClient decorations.
+/// @test Verify the constructor creates the right set of RawClient decorations.
 TEST_F(ClientTest, DefaultDecorators) {
   // Create a client, use the insecure credentials because on the CI environment
   // there may not be other credentials configured.

--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/client.h"
+#include "google/cloud/storage/internal/curl_client.h"
 #include "google/cloud/storage/retry_policy.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
@@ -123,6 +124,23 @@ TEST_F(ClientTest, OverrideBothPolicies) {
   (void)client.GetBucketMetadata("foo-bar-baz");
   EXPECT_LE(1, ObservableRetryPolicy::is_exhausted_call_count);
   EXPECT_LE(1, ObservableBackoffPolicy::on_completion_call_count);
+}
+
+/// @test Verify the constructor create the right set of RawClient decorations.
+TEST_F(ClientTest, DefaultDecorators) {
+  // Create a client, use the insecure credentials because on the CI environment
+  // there may not be other credentials configured.
+  Client tested(CreateInsecureCredentials());
+
+  EXPECT_TRUE(tested.raw_client() != nullptr);
+  auto retry = dynamic_cast<internal::RetryClient*>(tested.raw_client().get());
+  ASSERT_TRUE(retry != nullptr);
+
+  auto logging = dynamic_cast<internal::LoggingClient*>(retry->client().get());
+  ASSERT_TRUE(logging != nullptr);
+
+  auto curl = dynamic_cast<internal::CurlClient*>(logging->client().get());
+  ASSERT_TRUE(curl != nullptr);
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -67,6 +67,8 @@ class LoggingClient : public RawClient {
   std::pair<Status, ObjectAccessControl> UpdateObjectAcl(
       UpdateObjectAclRequest const&) override;
 
+  std::shared_ptr<RawClient> client() const { return client_; }
+
  private:
   std::shared_ptr<RawClient> client_;
 };

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -78,6 +78,8 @@ class RetryClient : public RawClient {
   std::pair<Status, ObjectAccessControl> UpdateObjectAcl(
       UpdateObjectAclRequest const&) override;
 
+  std::shared_ptr<RawClient> client() const { return client_; }
+
  private:
   void Apply(RetryPolicy& policy) { retry_policy_ = policy.clone(); }
 


### PR DESCRIPTION
The storage::Client was supposed to create a chain of decorated
RawClient objects: RetryClient -> LoggingClient -> CurlClient.
Somehow I dropped LoggingClient from the chain.  In this PR I
created a test (such as it is) and fixed the problem.

Matt (Harris) this might not be the best place to start, but it is a
relatively simple bug fix, so not the worst place either.

CC: @houglum 