### PR TITLE
Remove workaround for BlockAll filter on emulator.

### DIFF
--- a/google/cloud/bigtable/tests/filters_integration_test.cc
+++ b/google/cloud/bigtable/tests/filters_integration_test.cc
@@ -107,11 +107,6 @@ TEST_F(FilterIntegrationTest, PassAll) {
 }
 
 TEST_F(FilterIntegrationTest, BlockAll) {
-  // TODO(#151) - remove workarounds for emulator bug(s).
-  if (UsingCloudBigtableEmulator()) {
-    return;
-  }
-
   std::string const table_id = RandomTableId();
   auto table = CreateTable(table_id, table_config);
   std::string const row_key = "block-all-row-key";


### PR DESCRIPTION
The emulator supports the BlockAll filter correctly, no need to
workaround it.  This is part of the fixes for #151.