### PR TITLE
Bump version number for Bigtable [skip ci].

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 # This should be included from the top level CMakeLists file
 set(BIGTABLE_CLIENT_VERSION_MAJOR 0)
-set(BIGTABLE_CLIENT_VERSION_MINOR 2)
+set(BIGTABLE_CLIENT_VERSION_MINOR 3)
 set(BIGTABLE_CLIENT_VERSION_PATCH 0)
 
 # Configure the Compiler options, we will be using C++11 features.


### PR DESCRIPTION
I created the v0.2.x branch and I am cutting a release. This PR
updates the version number on the `master` branch.