### PR TITLE
Fix the CI build to test `make install`.

### DIFF
--- a/ci/test-install/CMakeLists.txt
+++ b/ci/test-install/CMakeLists.txt
@@ -27,7 +27,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(Threads REQUIRED)
-find_package(bigtable_client 0.2.0 REQUIRED)
+find_package(bigtable_client 0.3.0 REQUIRED)
 
 # Defining new targets should be easy.
 add_executable(install_integration_test install_integration_test.cc)

--- a/ci/test-install/WORKSPACE
+++ b/ci/test-install/WORKSPACE
@@ -20,8 +20,8 @@ workspace(name="com_github_googlecloudplatform_google_cloud_cpp_test_install")
 #
 # http_archive(
 #     name = "com_github_googlecloudplatform_google_cloud_cpp",
-#     url = "http://github.com/googlecloudplatform/google-cloud-cpp/archive/v0.1.0.tar.gz",
-#     sha256 = "fa198ff055a36adb293447a2a83582c42ce210b93db2acc40c2eff0a27879717",
+#     url = "http://github.com/googlecloudplatform/google-cloud-cpp/archive/v0.2.0.tar.gz",
+#     sha256 = "5fa6577828e5f949178b13ed0411dd634527c9d2d8f00e433edbd6ef9e42a281",
 # )
 #
 # But we want to test that the *current* version is correct.


### PR DESCRIPTION
After updating the version on `master` I forgot to update the
expected library version on the test program.  That broke
the CI builds for master. Ooops.

PS: I am kicking off the CI builds with this PR, they might fail
and I would need to send more commits to fix for realsies.
 