### PR TITLE
Add BucketMetadata::lifecycle field.

### DIFF
--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/bucket_access_control.h"
 #include "google/cloud/storage/internal/common_metadata.h"
 #include "google/cloud/storage/internal/nljson.h"
+#include "google/cloud/storage/lifecycle_rule.h"
 #include "google/cloud/storage/object_access_control.h"
 #include <map>
 #include <tuple>
@@ -122,6 +123,43 @@ inline bool operator>=(CorsEntry const& lhs, CorsEntry const& rhs) {
 //@}
 
 std::ostream& operator<<(std::ostream& os, CorsEntry const& rhs);
+
+/**
+ * The Object Lifecycle configuration for a Bucket.
+ *
+ * @see https://cloud.google.com/storage/docs/managing-lifecycles for general
+ *     information on object lifecycle rules.
+ */
+struct BucketLifecycle {
+  std::vector<LifecycleRule> rule;
+};
+
+//@{
+/// @name Comparison operators for BucketLifecycle.
+inline bool operator==(BucketLifecycle const& lhs, BucketLifecycle const& rhs) {
+  return lhs.rule == rhs.rule;
+}
+
+inline bool operator<(BucketLifecycle const& lhs, BucketLifecycle const& rhs) {
+  return lhs.rule < rhs.rule;
+}
+
+inline bool operator!=(BucketLifecycle const& lhs, BucketLifecycle const& rhs) {
+  return std::rel_ops::operator!=(lhs, rhs);
+}
+
+inline bool operator>(BucketLifecycle const& lhs, BucketLifecycle const& rhs) {
+  return std::rel_ops::operator>(lhs, rhs);
+}
+
+inline bool operator<=(BucketLifecycle const& lhs, BucketLifecycle const& rhs) {
+  return std::rel_ops::operator<=(lhs, rhs);
+}
+
+inline bool operator>=(BucketLifecycle const& lhs, BucketLifecycle const& rhs) {
+  return std::rel_ops::operator>=(lhs, rhs);
+}
+//@}
 
 /*
  * The Logging configuration for a Bucket.
@@ -407,6 +445,30 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   std::string const& label(std::string const& key) const {
     return labels_.at(key);
   }
+
+  //@{
+  /**
+   * @name Accessors and modifiers for object lifecycle rules.
+   *
+   * @see https://cloud.google.com/storage/docs/managing-lifecycles for general
+   *     information on object lifecycle rules.
+   */
+  bool has_lifecycle() const { return lifecycle_.has_value(); }
+  BucketLifecycle const& lifecycle() const { return *lifecycle_; }
+  google::cloud::internal::optional<BucketLifecycle> const&
+  lifecycle_as_optional() const {
+    return lifecycle_;
+  }
+  BucketMetadata& set_lifecycle(BucketLifecycle v) {
+    lifecycle_ = std::move(v);
+    return *this;
+  }
+  BucketMetadata& reset_lifecycle() {
+    lifecycle_.reset();
+    return *this;
+  }
+  //@}
+
   std::string const& location() const { return location_; }
 
   //@{
@@ -485,6 +547,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   std::vector<ObjectAccessControl> default_acl_;
   google::cloud::internal::optional<BucketEncryption> encryption_;
   std::map<std::string, std::string> labels_;
+  google::cloud::internal::optional<BucketLifecycle> lifecycle_;
   std::string location_;
   google::cloud::internal::optional<BucketLogging> logging_;
   std::int64_t project_number_;

--- a/google/cloud/storage/bucket_metadata_test.cc
+++ b/google/cloud/storage/bucket_metadata_test.cc
@@ -23,6 +23,8 @@ inline namespace STORAGE_CLIENT_NS {
 namespace {
 using google::cloud::internal::make_optional;
 using google::cloud::internal::optional;
+using ::testing::HasSubstr;
+using ::testing::Not;
 
 BucketMetadata CreateBucketMetadataForTest() {
   // This metadata object has some impossible combination of fields in it. The
@@ -221,7 +223,6 @@ TEST(BucketMetadataTest, IOStream) {
   std::ostringstream os;
   os << meta;
   auto actual = os.str();
-  using ::testing::HasSubstr;
   EXPECT_THAT(actual, HasSubstr("BucketMetadata"));
 
   // acl()
@@ -310,7 +311,7 @@ TEST(BucketMetadataTest, ResetBilling) {
   EXPECT_NE(expected, copy);
   std::ostringstream os;
   os << copy;
-  EXPECT_THAT(os.str(), ::testing::Not(::testing::HasSubstr("billing")));
+  EXPECT_THAT(os.str(), Not(HasSubstr("billing")));
 }
 
 /// @test Verify we can make changes to one CORS entry in BucketMetadata.
@@ -384,7 +385,7 @@ TEST(BucketMetadataTest, ResetEncryption) {
   EXPECT_NE(expected, copy);
   std::ostringstream os;
   os << copy;
-  EXPECT_THAT(os.str(), ::testing::Not(::testing::HasSubstr("encryption.")));
+  EXPECT_THAT(os.str(), Not(HasSubstr("encryption.")));
 }
 
 /// @test Verify we can reset the Object Lifecycle in BucketMetadata.
@@ -397,7 +398,7 @@ TEST(BucketMetadataTest, ResetLifecycle) {
   EXPECT_NE(expected, copy);
   std::ostringstream os;
   os << copy;
-  EXPECT_THAT(os.str(), ::testing::Not(::testing::HasSubstr("lifecycle.")));
+  EXPECT_THAT(os.str(), Not(HasSubstr("lifecycle.")));
 }
 
 /// @test Verify we can change the Object Lifecycle in BucketMetadata.
@@ -432,7 +433,7 @@ TEST(BucketMetadataTest, ResetLogging) {
   EXPECT_NE(expected, copy);
   std::ostringstream os;
   os << copy;
-  EXPECT_THAT(os.str(), ::testing::Not(::testing::HasSubstr("logging.")));
+  EXPECT_THAT(os.str(), Not(HasSubstr("logging.")));
 }
 
 /// @test Verify we can clear the versioning field in BucketMetadata.
@@ -445,7 +446,7 @@ TEST(BucketMetadataTest, ClearVersioning) {
   EXPECT_NE(copy, expected);
   std::ostringstream os;
   os << copy;
-  EXPECT_THAT(os.str(), ::testing::Not(::testing::HasSubstr("versioning.")));
+  EXPECT_THAT(os.str(), Not(HasSubstr("versioning.")));
 }
 
 /// @test Verify we can set the versioning field in BucketMetadata.
@@ -505,7 +506,7 @@ TEST(BucketMetadataTest, ResetWebsite) {
   EXPECT_NE(copy, expected);
   std::ostringstream os;
   os << copy;
-  EXPECT_THAT(os.str(), ::testing::Not(::testing::HasSubstr("website.")));
+  EXPECT_THAT(os.str(), Not(HasSubstr("website.")));
 }
 
 }  // namespace

--- a/google/cloud/storage/lifecycle_rule.h
+++ b/google/cloud/storage/lifecycle_rule.h
@@ -45,6 +45,26 @@ inline bool operator<(LifecycleRuleAction const& lhs,
          std::tie(lhs.type, lhs.storage_class);
 }
 
+inline bool operator!=(LifecycleRuleAction const& lhs,
+                       LifecycleRuleAction const& rhs) {
+  return std::rel_ops::operator!=(lhs, rhs);
+}
+
+inline bool operator>(LifecycleRuleAction const& lhs,
+                      LifecycleRuleAction const& rhs) {
+  return std::rel_ops::operator>(lhs, rhs);
+}
+
+inline bool operator<=(LifecycleRuleAction const& lhs,
+                       LifecycleRuleAction const& rhs) {
+  return std::rel_ops::operator<=(lhs, rhs);
+}
+
+inline bool operator>=(LifecycleRuleAction const& lhs,
+                       LifecycleRuleAction const& rhs) {
+  return std::rel_ops::operator>=(lhs, rhs);
+}
+
 std::ostream& operator<<(std::ostream& os, LifecycleRuleAction const& rhs);
 
 /// Implement a wrapper for Lifecycle Conditions.
@@ -66,9 +86,32 @@ inline bool operator==(LifecycleRuleCondition const& lhs,
          lhs.num_newer_versions == rhs.num_newer_versions;
 }
 
+inline bool operator<(LifecycleRuleCondition const& lhs,
+                      LifecycleRuleCondition const& rhs) {
+  return std::tie(lhs.age, lhs.created_before, lhs.is_live,
+                  lhs.matches_storage_class, lhs.num_newer_versions) <
+         std::tie(rhs.age, rhs.created_before, rhs.is_live,
+                  rhs.matches_storage_class, rhs.num_newer_versions);
+}
+
 inline bool operator!=(LifecycleRuleCondition const& lhs,
                        LifecycleRuleCondition const& rhs) {
-  return not(lhs == rhs);
+  return std::rel_ops::operator!=(lhs, rhs);
+}
+
+inline bool operator>(LifecycleRuleCondition const& lhs,
+                      LifecycleRuleCondition const& rhs) {
+  return std::rel_ops::operator>(lhs, rhs);
+}
+
+inline bool operator<=(LifecycleRuleCondition const& lhs,
+                       LifecycleRuleCondition const& rhs) {
+  return std::rel_ops::operator<=(lhs, rhs);
+}
+
+inline bool operator>=(LifecycleRuleCondition const& lhs,
+                       LifecycleRuleCondition const& rhs) {
+  return std::rel_ops::operator>=(lhs, rhs);
 }
 
 std::ostream& operator<<(std::ostream& os, LifecycleRuleCondition const& rhs);
@@ -81,6 +124,41 @@ std::ostream& operator<<(std::ostream& os, LifecycleRuleCondition const& rhs);
  */
 class LifecycleRule {
  public:
+  explicit LifecycleRule(LifecycleRuleCondition condition,
+                         LifecycleRuleAction action)
+      : action_(std::move(action)), condition_(std::move(condition)) {}
+
+  static LifecycleRule ParseFromJson(internal::nl::json const& json);
+  static LifecycleRule ParseFromString(std::string const& text);
+
+  LifecycleRuleAction const& action() const { return action_; }
+  LifecycleRuleCondition const& condition() const { return condition_; }
+
+  bool operator==(LifecycleRule const& rhs) const {
+    return std::tie(condition_, action_) ==
+           std::tie(rhs.condition_, rhs.action_);
+  }
+  bool operator<(LifecycleRule const& rhs) const {
+    return std::tie(action_, condition_) <
+           std::tie(rhs.action_, rhs.condition_);
+  }
+
+  bool operator!=(LifecycleRule const& rhs) const {
+    return std::rel_ops::operator!=(*this, rhs);
+  }
+
+  bool operator>(LifecycleRule const& rhs) const {
+    return std::rel_ops::operator>(*this, rhs);
+  }
+
+  bool operator<=(LifecycleRule const& rhs) const {
+    return std::rel_ops::operator<=(*this, rhs);
+  }
+
+  bool operator>=(LifecycleRule const& rhs) const {
+    return std::rel_ops::operator>=(*this, rhs);
+  }
+
   //@{
   /**
    * @name Create different types of LifecycleRule actions.
@@ -215,6 +293,8 @@ class LifecycleRule {
   }
 
  private:
+  LifecycleRule() = default;
+
   static void MergeConditions(LifecycleRuleCondition& result,
                               LifecycleRuleCondition const& rhs);
 
@@ -225,7 +305,12 @@ class LifecycleRule {
     MergeConditions(result, head);
     MergeConditions(result, std::forward<Condition>(tail)...);
   }
+
+  LifecycleRuleAction action_;
+  LifecycleRuleCondition condition_;
 };
+
+std::ostream& operator<<(std::ostream& os, LifecycleRule const& rhs);
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud


### PR DESCRIPTION
This is part of the work for #537. It adds the lifecycle
(optional) field to BucketMetadata.