### PR TITLE
Implement Client::PatchObjectAcl

### DIFF
--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -84,6 +84,9 @@ run_program_examples() {
         update-object-acl)
             arguments="${base_arguments} allAuthenticatedUsers OWNER"
             ;;
+        patch-object-acl)
+            arguments="${base_arguments} allAuthenticatedUsers READER"
+            ;;
         delete-object-acl)
             arguments="${base_arguments} allAuthenticatedUsers"
             ;;
@@ -245,6 +248,7 @@ list-object-acl
 create-object-acl
 get-object-acl
 update-object-acl
+patch-object-acl
 delete-object-acl
 _EOF_
 )

--- a/google/cloud/storage/examples/storage_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_object_acl_samples.cc
@@ -167,13 +167,14 @@ void PatchObjectAcl(gcs::Client client, int& argc, char* argv[]) {
      std::string entity, std::string role) {
     gcs::ObjectAccessControl original_acl =
         client.GetObjectAcl(bucket_name, object_name, entity);
-    auto updated_acl = original_acl;
-    updated_acl.set_role(role);
-    gcs::ObjectAccessControl acl = client.PatchObjectAcl(
-        bucket_name, object_name, entity, original_acl, updated_acl,
-        gcs::IfMatchEtag(original_acl.etag()));
+    auto new_acl = original_acl;
+    new_acl.set_role(role);
+    gcs::ObjectAccessControl updated_acl =
+        client.PatchObjectAcl(bucket_name, object_name, entity, original_acl,
+                              new_acl, gcs::IfMatchEtag(original_acl.etag()));
     std::cout << "ACL entry for " << entity << " in object " << object_name
-              << " in bucket " << bucket_name << " is now " << acl << std::endl;
+              << " in bucket " << bucket_name << " is now " << updated_acl
+              << std::endl;
   }
   //! [patch object acl]
   (std::move(client), bucket_name, object_name, entity, role);

--- a/google/cloud/storage/examples/storage_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_object_acl_samples.cc
@@ -167,11 +167,11 @@ void PatchObjectAcl(gcs::Client client, int& argc, char* argv[]) {
      std::string entity, std::string role) {
     gcs::ObjectAccessControl original_acl =
         client.GetObjectAcl(bucket_name, object_name, entity);
-    auto new_acl = original_acl;
-    new_acl.set_role(role);
-    gcs::ObjectAccessControl acl =
-        client.PatchObjectAcl(bucket_name, object_name, entity, original_acl,
-                              new_acl, gcs::IfMatchEtag(original_acl.etag()));
+    auto updated_acl = original_acl;
+    updated_acl.set_role(role);
+    gcs::ObjectAccessControl acl = client.PatchObjectAcl(
+        bucket_name, object_name, entity, original_acl, updated_acl,
+        gcs::IfMatchEtag(original_acl.etag()));
     std::cout << "ACL entry for " << entity << " in object " << object_name
               << " in bucket " << bucket_name << " is now " << acl << std::endl;
   }

--- a/google/cloud/storage/internal/access_control_common.h
+++ b/google/cloud/storage/internal/access_control_common.h
@@ -113,6 +113,10 @@ class AccessControlCommon {
 
   bool has_project_team() const { return project_team_.has_value(); }
   ProjectTeam const& project_team() const { return *project_team_; }
+  google::cloud::internal::optional<ProjectTeam> const&
+  project_team_as_optional() const {
+    return project_team_;
+  }
 
   std::string const& role() const { return role_; }
   void set_role(std::string r) { role_ = std::move(r); }

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -283,6 +283,26 @@ std::pair<Status, ObjectAccessControl> CurlClient::UpdateObjectAcl(
                         ObjectAccessControl::ParseFromString(payload.payload));
 }
 
+std::pair<Status, ObjectAccessControl> CurlClient::PatchObjectAcl(
+    PatchObjectAclRequest const& request) {
+  CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
+                             "/o/" + request.object_name() + "/acl/" +
+                             request.entity());
+  builder.SetDebugLogging(options_.enable_http_tracing());
+  builder.AddHeader(options_.credentials()->AuthorizationHeader());
+  request.AddOptionsToHttpRequest(builder);
+  builder.SetMethod("PATCH");
+  builder.AddHeader("Content-Type: application/json");
+  auto payload = builder.BuildRequest(request.payload()).MakeRequest();
+  if (payload.status_code >= 300) {
+    return std::make_pair(
+        Status{payload.status_code, std::move(payload.payload)},
+        ObjectAccessControl{});
+  }
+  return std::make_pair(Status(),
+                        ObjectAccessControl::ParseFromString(payload.payload));
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -70,6 +70,8 @@ class CurlClient : public RawClient {
       ObjectAclRequest const&) override;
   std::pair<Status, ObjectAccessControl> UpdateObjectAcl(
       UpdateObjectAclRequest const&) override;
+  std::pair<Status, ObjectAccessControl> PatchObjectAcl(
+      PatchObjectAclRequest const&) override;
 
  private:
   ClientOptions options_;

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -155,6 +155,11 @@ std::pair<Status, ObjectAccessControl> LoggingClient::UpdateObjectAcl(
   return MakeCall(*client_, &RawClient::UpdateObjectAcl, request, __func__);
 }
 
+std::pair<Status, ObjectAccessControl> LoggingClient::PatchObjectAcl(
+    PatchObjectAclRequest const& request) {
+  return MakeCall(*client_, &RawClient::PatchObjectAcl, request, __func__);
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -69,6 +69,8 @@ class LoggingClient : public RawClient {
       ObjectAclRequest const&) override;
   std::pair<Status, ObjectAccessControl> UpdateObjectAcl(
       UpdateObjectAclRequest const&) override;
+  std::pair<Status, ObjectAccessControl> PatchObjectAcl(
+      PatchObjectAclRequest const&) override;
 
   std::shared_ptr<RawClient> client() const { return client_; }
 

--- a/google/cloud/storage/internal/object_acl_requests.cc
+++ b/google/cloud/storage/internal/object_acl_requests.cc
@@ -64,12 +64,10 @@ PatchObjectAclRequest::PatchObjectAclRequest(
   build_patch.AddStringField("kind", original.kind(), new_acl.kind());
   build_patch.AddStringField("object", original.object(), new_acl.object());
 
-  if (original.project_team() != new_acl.project_team()) {
-    auto empty = [](ProjectTeam const& p) {
-      return p.project_number.empty() and p.team.empty();
-    };
-    if (empty(new_acl.project_team())) {
-      if (not empty(original.project_team())) {
+  if (original.project_team_as_optional() !=
+      new_acl.project_team_as_optional()) {
+    if (not new_acl.has_project_team()) {
+      if (original.has_project_team()) {
         build_patch.RemoveField("projectTeam");
       }
     } else {

--- a/google/cloud/storage/internal/object_acl_requests.h
+++ b/google/cloud/storage/internal/object_acl_requests.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/internal/generic_object_request.h"
 #include "google/cloud/storage/internal/http_response.h"
 #include "google/cloud/storage/object_access_control.h"
+#include "google/cloud/storage/well_known_headers.h"
 #include "google/cloud/storage/well_known_parameters.h"
 #include <iosfwd>
 
@@ -106,7 +107,7 @@ std::ostream& operator<<(std::ostream& os, ObjectAclRequest const& r);
  */
 class PatchObjectAclRequest
     : public GenericObjectRequest<PatchObjectAclRequest, Generation,
-                                  UserProject> {
+                                  UserProject, IfMatchEtag, IfNoneMatchEtag> {
  public:
   PatchObjectAclRequest(std::string bucket, std::string object,
                         std::string entity, ObjectAccessControl const& original,

--- a/google/cloud/storage/internal/object_acl_requests_test.cc
+++ b/google/cloud/storage/internal/object_acl_requests_test.cc
@@ -119,11 +119,13 @@ TEST(PatchObjectAclRequestTest, PatchStream) {
 
   PatchObjectAclRequest request("my-bucket", "my-object", "user-test-user",
                                 original, new_acl);
-  request.set_multiple_options(UserProject("my-project"), Generation(7));
+  request.set_multiple_options(UserProject("my-project"), Generation(7),
+                               IfMatchEtag("ABC="));
   std::ostringstream os;
   os << request;
   auto str = os.str();
   EXPECT_THAT(str, HasSubstr("userProject=my-project"));
+  EXPECT_THAT(str, HasSubstr("If-Match: ABC="));
   EXPECT_THAT(str, HasSubstr("generation=7"));
   EXPECT_THAT(str, HasSubstr("my-bucket"));
   EXPECT_THAT(str, HasSubstr("my-object"));

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -90,6 +90,8 @@ class RawClient {
       ObjectAclRequest const&) = 0;
   virtual std::pair<Status, ObjectAccessControl> UpdateObjectAcl(
       UpdateObjectAclRequest const&) = 0;
+  virtual std::pair<Status, ObjectAccessControl> PatchObjectAcl(
+      PatchObjectAclRequest const&) = 0;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -224,6 +224,14 @@ std::pair<Status, ObjectAccessControl> RetryClient::UpdateObjectAcl(
                   &RawClient::UpdateObjectAcl, request, __func__);
 }
 
+std::pair<Status, ObjectAccessControl> RetryClient::PatchObjectAcl(
+    PatchObjectAclRequest const& request) {
+  auto retry_policy = retry_policy_->clone();
+  auto backoff_policy = backoff_policy_->clone();
+  return MakeCall(*retry_policy, *backoff_policy, *client_,
+                  &RawClient::PatchObjectAcl, request, __func__);
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -79,6 +79,8 @@ class RetryClient : public RawClient {
       ObjectAclRequest const&) override;
   std::pair<Status, ObjectAccessControl> UpdateObjectAcl(
       UpdateObjectAclRequest const&) override;
+  std::pair<Status, ObjectAccessControl> PatchObjectAcl(
+      PatchObjectAclRequest const&) override;
 
   std::shared_ptr<RawClient> client() const { return client_; }
 

--- a/google/cloud/storage/object_access_control.h
+++ b/google/cloud/storage/object_access_control.h
@@ -60,6 +60,7 @@ class ObjectAccessControl : private internal::AccessControlCommon {
   using AccessControlCommon::id;
   using AccessControlCommon::kind;
   using AccessControlCommon::project_team;
+  using AccessControlCommon::project_team_as_optional;
 
   using AccessControlCommon::role;
   ObjectAccessControl& set_role(std::string v) {

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -67,6 +67,8 @@ class MockClient : public google::cloud::storage::internal::RawClient {
                                  internal::ObjectAclRequest const&));
   MOCK_METHOD1(UpdateObjectAcl, ResponseWrapper<ObjectAccessControl>(
                                     internal::UpdateObjectAclRequest const&));
+  MOCK_METHOD1(PatchObjectAcl, ResponseWrapper<ObjectAccessControl>(
+                                   internal::PatchObjectAclRequest const&));
 };
 }  // namespace testing
 }  // namespace storage

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -241,6 +241,13 @@ TEST_F(ObjectIntegrationTest, AccessControlCRUD) {
   get_result = client.GetObjectAcl(bucket_name, object_name, entity_name);
   EXPECT_EQ(get_result, updated_result);
 
+  new_acl = get_result;
+  new_acl.set_role("OWNER");
+  get_result =
+      client.PatchObjectAcl(bucket_name, object_name, entity_name, get_result,
+                            new_acl, IfMatchEtag(get_result.etag()));
+  EXPECT_EQ(get_result.role(), new_acl.role());
+
   // Remove an entity and verify it is no longer in the ACL.
   client.DeleteObjectAcl(bucket_name, object_name, entity_name);
   current_acl = client.ListObjectAcl(bucket_name, object_name);

--- a/google/cloud/storage/tests/testbench.py
+++ b/google/cloud/storage/tests/testbench.py
@@ -192,8 +192,8 @@ class GcsObjectVersion(object):
         for acl in self.metadata.get('acl', []):
             if acl.get('entity', '').lower() == entity:
                 return acl
-        raise ErrorResponse('Entity %s not found in object %s' % (entity,
-                                                                  self.name))
+        raise ErrorResponse(
+            'Entity %s not found in object %s' % (entity, self.name))
 
     def update_acl(self, entity, role):
         """
@@ -221,12 +221,11 @@ class GcsObjectVersion(object):
                 'Entity mismatch in ObjectAccessControls: patch, expected=%s, got=%s'
                 % (entity, request_entity))
         etag_match = request.headers.get('if-match')
-        if etag_match is not None \
-                and etag_match != acl.get('etag'):
+        if etag_match is not None and etag_match != acl.get('etag'):
             raise ErrorResponse('Precondition Failed', status_code=412)
         etag_none_match = request.headers.get('if-none-match')
-        if etag_none_match is not None \
-                and etag_none_match != acl.get('etag'):
+        if (etag_none_match is not None
+                and etag_none_match != acl.get('etag')):
             raise ErrorResponse('Precondition Failed', status_code=412)
         role = payload.get('role')
         if role is None:

--- a/google/cloud/storage/tests/testbench.py
+++ b/google/cloud/storage/tests/testbench.py
@@ -143,7 +143,6 @@ class GcsObjectVersion(object):
         """
         entity = canonical_entity_name(entity)
         email = ''
-        entity_id = ''
         if entity.startswith('user-'):
             email = entity
         # Replace or insert the entry
@@ -155,6 +154,7 @@ class GcsObjectVersion(object):
             'bucket': self.bucket_name,
             'email': email,
             'entity': entity,
+            'entity_id': '',
             'etag': self.metadata.get('etag', 'XYZ='),
             'generation': self.generation,
             'id': self.metadata.get('id', '') + '/' + entity,
@@ -192,8 +192,8 @@ class GcsObjectVersion(object):
         for acl in self.metadata.get('acl', []):
             if acl.get('entity', '').lower() == entity:
                 return acl
-        raise ErrorResponse(
-            'Entity %s not found in object %s' % (entity, self.name))
+        raise ErrorResponse('Entity %s not found in object %s' % (entity,
+                                                                  self.name))
 
     def update_acl(self, entity, role):
         """
@@ -203,6 +203,34 @@ class GcsObjectVersion(object):
         :param role:str the new role for the entity.
         :return:dict with the contents of the ObjectAccessControl.
         """
+        return self.insert_acl(entity, role)
+
+    def patch_acl(self, entity, request):
+        """
+        Patch a single AccessControl entry in this Object revision.
+
+        :param entity:str the name of the entity.
+        :param request:flask.Request the parameters for this request.
+        :return:dict with the contents of the ObjectAccessControl.
+        """
+        acl = self.get_acl(entity)
+        payload = json.loads(request.data)
+        request_entity = payload.get('entity')
+        if request_entity is not None and request_entity != entity:
+            raise ErrorResponse(
+                'Entity mismatch in ObjectAccessControls: patch, expected=%s, got=%s'
+                % (entity, request_entity))
+        etag_match = request.headers.get('if-match')
+        if etag_match is not None \
+                and etag_match != acl.get('etag'):
+            raise ErrorResponse('Precondition Failed', status_code=412)
+        etag_none_match = request.headers.get('if-none-match')
+        if etag_none_match is not None \
+                and etag_none_match != acl.get('etag'):
+            raise ErrorResponse('Precondition Failed', status_code=412)
+        role = payload.get('role')
+        if role is None:
+            raise ErrorResponse('Missing role value')
         return self.insert_acl(entity, role)
 
 
@@ -681,6 +709,21 @@ def objects_acl_update(bucket_name, object_name, entity):
     return json.dumps(acl)
 
 
+@gcs.route('/b/<bucket_name>/o/<object_name>/acl/<entity>', methods=['PATCH'])
+def objects_acl_patch(bucket_name, object_name, entity):
+    """Implement the 'ObjectAccessControls: patch' API.
+
+      Patch the access control configuration for a particular entity.
+      """
+    object_path = bucket_name + '/o/' + object_name
+    gcs_object = GCS_OBJECTS.get(object_path,
+                                 GcsObject(bucket_name, object_name))
+    gcs_object.check_preconditions(flask.request)
+    revision = gcs_object.get_revision(flask.request)
+    acl = revision.patch_acl(entity, flask.request)
+    return json.dumps(acl)
+
+
 # Define the WSGI application to handle bucket requests.
 UPLOAD_HANDLER_PATH = '/upload/storage/v1'
 upload = flask.Flask(__name__)
@@ -713,12 +756,12 @@ def objects_insert(bucket_name):
     return json.dumps(current_version.metadata)
 
 
-application = wsgi.DispatcherMiddleware(
-    root, {
-        '/httpbin': httpbin.app,
-        GCS_HANDLER_PATH: gcs,
-        UPLOAD_HANDLER_PATH: upload,
-    })
+application = wsgi.DispatcherMiddleware(root, {
+    '/httpbin': httpbin.app,
+    GCS_HANDLER_PATH: gcs,
+    UPLOAD_HANDLER_PATH: upload,
+})
+
 
 def main():
     """Parse the arguments and run the test bench application."""

--- a/google/cloud/storage/well_known_headers.h
+++ b/google/cloud/storage/well_known_headers.h
@@ -30,19 +30,27 @@ inline namespace STORAGE_CLIENT_NS {
  * @tparam H the type we will use to represent the header.
  * @tparam T the C++ type of the query parameter
  */
-template <typename P, typename T>
+template <typename H, typename T>
 class WellKnownHeader {
  public:
   WellKnownHeader() : value_{} {}
-  explicit WellKnownHeader(T&& value) : value_(std::forward<T>(value)) {}
+  explicit WellKnownHeader(T value) : value_(std::move(value)) {}
 
-  char const* header_name() const { return P::well_known_parameter_name(); }
+  char const* header_name() const { return H::header_name(); }
   bool has_value() const { return value_.has_value(); }
   T const& value() const { return value_.value(); }
 
  private:
   google::cloud::internal::optional<T> value_;
 };
+
+template <typename H, typename T>
+std::ostream& operator<<(std::ostream& os, WellKnownHeader<H, T> const& rhs) {
+  if (rhs.has_value()) {
+    return os << rhs.header_name() << ": " << rhs.value();
+  }
+  return os << rhs.header_name() << ": <not set>";
+}
 
 struct IfMatchEtag : public WellKnownHeader<IfMatchEtag, std::string> {
   using WellKnownHeader<IfMatchEtag, std::string>::WellKnownHeader;


### PR DESCRIPTION
This fixes #843. It implements both overloads for the API: for
read-modify-write and for patch-without-read. It adds unit tests
for the API, an integration test, and sample snippets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/969)
<!-- Reviewable:end -->
