### PR TITLE
Unpin vcpkg version.

### DIFF
--- a/ci/appveyor/install-windows.ps1
+++ b/ci/appveyor/install-windows.ps1
@@ -37,6 +37,7 @@ if ($env:PROVIDER -eq "module") {
 cd ..
 if (Test-Path vcpkg\.git) {
     cd vcpkg
+    git pull
 } elseif (Test-Path vcpkg\installed) {
     move vcpkg vcpkg-tmp
     git clone https://github.com/Microsoft/vcpkg
@@ -49,12 +50,6 @@ if (Test-Path vcpkg\.git) {
 if ($LastExitCode) {
     throw "git setup failed with exit code $LastExitCode"
 }
-
-# Pin to a particular version because later versions include protobuf-3.6.0,
-# which suffers from:
-#   https://github.com/google/protobuf/issues/4773
-# TODO(#946) - update the Windows builds to use the right vcpkg version.
-git checkout 8d389323a75c49c09647a1f87184b1a0ef4fbbf6
 
 # Build the tool each time, it is fast to do so.
 powershell -exec bypass scripts\bootstrap.ps1


### PR DESCRIPTION
This fixes #946. Now that vcpkg points to protobuf 3.6.1 the build
problems on Windows should be no more.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/971)
<!-- Reviewable:end -->
