### PR TITLE
Move make_unique to google/cloud/internal.

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -77,6 +77,7 @@ add_library(google_cloud_cpp_common
             internal/backoff_policy.cc
             internal/build_info.h
             ${CMAKE_CURRENT_BINARY_DIR}/internal/build_info.cc
+            internal/make_unique.h
             internal/optional.h
             internal/port_platform.h
             internal/random.h

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -151,7 +151,6 @@ add_library(bigtable_client
             internal/grpc_error_delegate.cc
             internal/instance_admin.h
             internal/instance_admin.cc
-            internal/make_unique.h
             internal/prefix_range_end.h
             internal/prefix_range_end.cc
             internal/readrowsparser.h

--- a/google/cloud/bigtable/bigtable_client.bzl
+++ b/google/cloud/bigtable/bigtable_client.bzl
@@ -21,7 +21,6 @@ bigtable_client_HDRS = [
     "internal/endian.h",
     "internal/grpc_error_delegate.h",
     "internal/instance_admin.h",
-    "internal/make_unique.h",
     "internal/prefix_range_end.h",
     "internal/readrowsparser.h",
     "internal/rowreaderiterator.h",

--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -14,8 +14,8 @@
 
 #include "google/cloud/bigtable/instance_admin.h"
 #include "google/cloud/bigtable/grpc_error.h"
-#include "google/cloud/bigtable/internal/make_unique.h"
 #include "google/cloud/bigtable/testing/mock_instance_admin_client.h"
+#include "google/cloud/internal/make_unique.h"
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
 #include <gmock/gmock.h>
@@ -320,7 +320,8 @@ TEST_F(InstanceAdminTest, CreateInstance) {
                       google::longrunning::GetOperationRequest const& request,
                       google::longrunning::Operation* operation) {
             operation->set_done(true);
-            auto any = bigtable::internal::make_unique<google::protobuf::Any>();
+            auto any =
+                google::cloud::internal::make_unique<google::protobuf::Any>();
             any->PackFrom(expected);
             operation->set_allocated_response(any.release());
             return grpc::Status::OK;
@@ -362,7 +363,8 @@ TEST_F(InstanceAdminTest, CreateInstanceImmediatelyReady) {
             EXPECT_EQ(project_name, request.parent());
             response->set_done(true);
             response->set_name("operation-name");
-            auto any = bigtable::internal::make_unique<google::protobuf::Any>();
+            auto any =
+                google::cloud::internal::make_unique<google::protobuf::Any>();
             any->PackFrom(expected);
             response->set_allocated_response(any.release());
             return grpc::Status::OK;
@@ -421,7 +423,8 @@ TEST_F(InstanceAdminTest, CreateInstancePollRecoverableFailures) {
                       google::longrunning::GetOperationRequest const& request,
                       google::longrunning::Operation* operation) {
             operation->set_done(true);
-            auto any = bigtable::internal::make_unique<google::protobuf::Any>();
+            auto any =
+                google::cloud::internal::make_unique<google::protobuf::Any>();
             any->PackFrom(expected);
             operation->set_allocated_response(any.release());
             return grpc::Status::OK;
@@ -512,7 +515,8 @@ TEST_F(InstanceAdminTest, CreateInstancePollReturnsFailure) {
                     google::longrunning::GetOperationRequest const& request,
                     google::longrunning::Operation* operation) {
             operation->set_done(true);
-            auto error = bigtable::internal::make_unique<google::rpc::Status>();
+            auto error =
+                google::cloud::internal::make_unique<google::rpc::Status>();
             error->set_code(grpc::StatusCode::FAILED_PRECONDITION);
             error->set_message("something is broken");
             operation->set_allocated_error(error.release());
@@ -593,7 +597,8 @@ TEST_F(InstanceAdminTest, UpdateInstancePollReturnsFailure) {
                     google::longrunning::GetOperationRequest const& request,
                     google::longrunning::Operation* operation) {
             operation->set_done(true);
-            auto error = bigtable::internal::make_unique<google::rpc::Status>();
+            auto error =
+                google::cloud::internal::make_unique<google::rpc::Status>();
             error->set_code(grpc::StatusCode::FAILED_PRECONDITION);
             error->set_message("something is broken");
             operation->set_allocated_error(error.release());
@@ -672,7 +677,8 @@ TEST_F(InstanceAdminTest, UpdateClusterPollReturnsFailure) {
                     google::longrunning::GetOperationRequest const& request,
                     google::longrunning::Operation* operation) {
             operation->set_done(true);
-            auto error = bigtable::internal::make_unique<google::rpc::Status>();
+            auto error =
+                google::cloud::internal::make_unique<google::rpc::Status>();
             error->set_code(grpc::StatusCode::FAILED_PRECONDITION);
             error->set_message("something is broken");
             operation->set_allocated_error(error.release());
@@ -745,7 +751,8 @@ TEST_F(InstanceAdminTest, UpdateInstance) {
                      google::longrunning::GetOperationRequest const& request,
                      google::longrunning::Operation* operation) {
             operation->set_done(true);
-            auto any = bigtable::internal::make_unique<google::protobuf::Any>();
+            auto any =
+                google::cloud::internal::make_unique<google::protobuf::Any>();
             any->PackFrom(expected_copy);
             operation->set_allocated_response(any.release());
             return grpc::Status::OK;
@@ -792,7 +799,8 @@ TEST_F(InstanceAdminTest, UpdateInstanceImmediatelyReady) {
             EXPECT_EQ(instance_name, request.instance().name());
             response->set_done(true);
             response->set_name("operation-name");
-            auto any = bigtable::internal::make_unique<google::protobuf::Any>();
+            auto any =
+                google::cloud::internal::make_unique<google::protobuf::Any>();
             any->PackFrom(expected_copy);
             response->set_allocated_response(any.release());
             return grpc::Status::OK;
@@ -857,7 +865,8 @@ TEST_F(InstanceAdminTest, UpdateInstancePollRecoverableFailures) {
                      google::longrunning::GetOperationRequest const& request,
                      google::longrunning::Operation* operation) {
             operation->set_done(true);
-            auto any = bigtable::internal::make_unique<google::protobuf::Any>();
+            auto any =
+                google::cloud::internal::make_unique<google::protobuf::Any>();
             any->PackFrom(expected_copy);
             operation->set_allocated_response(any.release());
             return grpc::Status::OK;
@@ -1147,7 +1156,8 @@ TEST_F(InstanceAdminTest, CreateCluster) {
                       google::longrunning::GetOperationRequest const& request,
                       google::longrunning::Operation* operation) {
             operation->set_done(true);
-            auto any = bigtable::internal::make_unique<google::protobuf::Any>();
+            auto any =
+                google::cloud::internal::make_unique<google::protobuf::Any>();
             any->PackFrom(expected);
             operation->set_allocated_response(any.release());
             return grpc::Status::OK;
@@ -1189,7 +1199,8 @@ TEST_F(InstanceAdminTest, CreateClusterImmediatelyReady) {
         EXPECT_EQ(project_name, request.parent());
         response->set_done(true);
         response->set_name("operation-name");
-        auto any = bigtable::internal::make_unique<google::protobuf::Any>();
+        auto any =
+            google::cloud::internal::make_unique<google::protobuf::Any>();
         any->PackFrom(expected);
         response->set_allocated_response(any.release());
         return grpc::Status::OK;
@@ -1253,7 +1264,8 @@ TEST_F(InstanceAdminTest, CreateClusterPollRecoverableFailures) {
                       google::longrunning::GetOperationRequest const& request,
                       google::longrunning::Operation* operation) {
             operation->set_done(true);
-            auto any = bigtable::internal::make_unique<google::protobuf::Any>();
+            auto any =
+                google::cloud::internal::make_unique<google::protobuf::Any>();
             any->PackFrom(expected);
             operation->set_allocated_response(any.release());
             return grpc::Status::OK;
@@ -1322,7 +1334,8 @@ TEST_F(InstanceAdminTest, UpdateCluster) {
                      google::longrunning::GetOperationRequest const& request,
                      google::longrunning::Operation* operation) {
             operation->set_done(true);
-            auto any = bigtable::internal::make_unique<google::protobuf::Any>();
+            auto any =
+                google::cloud::internal::make_unique<google::protobuf::Any>();
             any->PackFrom(expected_copy);
             operation->set_allocated_response(any.release());
             return grpc::Status::OK;
@@ -1369,7 +1382,8 @@ TEST_F(InstanceAdminTest, UpdateClusterImmediatelyReady) {
         EXPECT_EQ(cluster_name, request.name());
         response->set_done(true);
         response->set_name("operation-name");
-        auto any = bigtable::internal::make_unique<google::protobuf::Any>();
+        auto any =
+            google::cloud::internal::make_unique<google::protobuf::Any>();
         any->PackFrom(expected_copy);
         response->set_allocated_response(any.release());
         return grpc::Status::OK;
@@ -1434,7 +1448,8 @@ TEST_F(InstanceAdminTest, UpdateClusterPollRecoverableFailures) {
                      google::longrunning::GetOperationRequest const& request,
                      google::longrunning::Operation* operation) {
             operation->set_done(true);
-            auto any = bigtable::internal::make_unique<google::protobuf::Any>();
+            auto any =
+                google::cloud::internal::make_unique<google::protobuf::Any>();
             any->PackFrom(expected_copy);
             operation->set_allocated_response(any.release());
             return grpc::Status::OK;
@@ -1500,7 +1515,8 @@ TEST_F(InstanceAdminTest, UpdateAppProfile) {
                      google::longrunning::GetOperationRequest const& request,
                      google::longrunning::Operation* operation) {
             operation->set_done(true);
-            auto any = bigtable::internal::make_unique<google::protobuf::Any>();
+            auto any =
+                google::cloud::internal::make_unique<google::protobuf::Any>();
             any->PackFrom(expected_copy);
             operation->set_allocated_response(any.release());
             return grpc::Status::OK;
@@ -1550,7 +1566,8 @@ TEST_F(InstanceAdminTest, UpdateAppProfileImmediatelyReady) {
                 "my-profile";
             EXPECT_EQ(expected_profile_name, request.app_profile().name());
             response->set_done(true);
-            auto any = bigtable::internal::make_unique<google::protobuf::Any>();
+            auto any =
+                google::cloud::internal::make_unique<google::protobuf::Any>();
             any->PackFrom(expected_copy);
             response->set_allocated_response(any.release());
             return grpc::Status::OK;
@@ -1607,7 +1624,8 @@ TEST_F(InstanceAdminTest, UpdateAppProfileRecoverableFailures) {
                 "my-profile";
             EXPECT_EQ(expected_profile_name, request.app_profile().name());
             response->set_done(true);
-            auto any = bigtable::internal::make_unique<google::protobuf::Any>();
+            auto any =
+                google::cloud::internal::make_unique<google::protobuf::Any>();
             any->PackFrom(expected_copy);
             response->set_allocated_response(any.release());
             return grpc::Status::OK;
@@ -1732,7 +1750,8 @@ TEST_F(InstanceAdminTest, UpdateAppProfilePollRecoverableFailures) {
                      google::longrunning::GetOperationRequest const& request,
                      google::longrunning::Operation* operation) {
             operation->set_done(true);
-            auto any = bigtable::internal::make_unique<google::protobuf::Any>();
+            auto any =
+                google::cloud::internal::make_unique<google::protobuf::Any>();
             any->PackFrom(expected_copy);
             operation->set_allocated_response(any.release());
             return grpc::Status::OK;
@@ -1795,7 +1814,8 @@ TEST_F(InstanceAdminTest, UpdateAppProfileOperationFailure) {
                      google::longrunning::GetOperationRequest const& request,
                      google::longrunning::Operation* operation) {
             operation->set_done(true);
-            auto any = bigtable::internal::make_unique<google::protobuf::Any>();
+            auto any =
+                google::cloud::internal::make_unique<google::protobuf::Any>();
             any->PackFrom(expected_copy);
             operation->set_allocated_response(any.release());
             return grpc::Status::OK;

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/internal/bulk_mutator.h"
-#include "google/cloud/bigtable/internal/make_unique.h"
 #include "google/cloud/bigtable/testing/chrono_literals.h"
 #include "google/cloud/bigtable/testing/mock_data_client.h"
 #include "google/cloud/bigtable/testing/mock_mutate_rows_reader.h"
+#include "google/cloud/internal/make_unique.h"
 
 /// Define types and functions used in the tests.
 namespace {
@@ -40,7 +40,7 @@ TEST(MultipleRowsMutatorTest, Simple) {
   // Prepare the mocks.  The mutator should issue a RPC which must return a
   // stream of responses, we prepare the stream first because it is easier than
   // to create one of the fly.
-  auto reader = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto reader = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*reader, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -92,7 +92,7 @@ TEST(MultipleRowsMutatorTest, BulkApply_AppProfileId) {
   // Prepare the mocks.  The mutator should issue a RPC which must return a
   // stream of responses, we prepare the stream first because it is easier than
   // to create one of the fly.
-  auto reader = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto reader = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*reader, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -144,7 +144,7 @@ TEST(MultipleRowsMutatorTest, RetryPartialFailure) {
 
   // Prepare the mocks for the request.  First create a stream response which
   // indicates a partial failure.
-  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r1 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         // Simulate a partial (and recoverable) failure.
@@ -161,7 +161,7 @@ TEST(MultipleRowsMutatorTest, RetryPartialFailure) {
 
   // Prepare a second stream response, because the client should retry after
   // the partial failure.
-  auto r2 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r2 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r2, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -214,7 +214,7 @@ TEST(MultipleRowsMutatorTest, PermanentFailure) {
       bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0_ms, "qux")}));
 
   // Make the first RPC return one recoverable and one unrecoverable failures.
-  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r1 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         // Simulate a partial failure, which is recoverable for this first
@@ -233,7 +233,7 @@ TEST(MultipleRowsMutatorTest, PermanentFailure) {
 
   // The BulkMutator should issue a second request, which will return success
   // for the remaining mutation.
-  auto r2 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r2 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r2, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -281,7 +281,7 @@ TEST(MultipleRowsMutatorTest, PartialStream) {
 
   // This will be the stream returned by the first request.  It is missing
   // information about one of the mutations.
-  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r1 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         auto& e0 = *r->add_entries();
@@ -295,7 +295,7 @@ TEST(MultipleRowsMutatorTest, PartialStream) {
   // The BulkMutation should issue a second request, this is the stream returned
   // by the second request, which indicates success for the missed mutation
   // on r1.
-  auto r2 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r2 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r2, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -340,7 +340,7 @@ TEST(MultipleRowsMutatorTest, RetryOnlyIdempotent) {
 
   // We will setup the mock to return recoverable failures for idempotent
   // mutations.
-  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r1 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         // Simulate recoverable failures for both elements.
@@ -357,7 +357,7 @@ TEST(MultipleRowsMutatorTest, RetryOnlyIdempotent) {
 
   // The BulkMutator should issue a second request, with only the idempotent
   // mutations, make the mocks return success for them.
-  auto r2 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r2 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r2, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {

--- a/google/cloud/bigtable/internal/readrowsparser.h
+++ b/google/cloud/bigtable/internal/readrowsparser.h
@@ -16,8 +16,8 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_READROWSPARSER_H_
 
 #include "google/cloud/bigtable/cell.h"
-#include "google/cloud/bigtable/internal/make_unique.h"
 #include "google/cloud/bigtable/row.h"
+#include "google/cloud/internal/make_unique.h"
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
 #include <vector>
 
@@ -146,7 +146,7 @@ class ReadRowsParserFactory {
 
   /// Returns a newly created parser instance.
   virtual std::unique_ptr<ReadRowsParser> Create() {
-    return bigtable::internal::make_unique<ReadRowsParser>();
+    return google::cloud::internal::make_unique<ReadRowsParser>();
   }
 };
 }  // namespace internal

--- a/google/cloud/bigtable/internal/table.cc
+++ b/google/cloud/bigtable/internal/table.cc
@@ -14,8 +14,8 @@
 
 #include "google/cloud/bigtable/internal/table.h"
 #include "google/cloud/bigtable/internal/bulk_mutator.h"
-#include "google/cloud/bigtable/internal/make_unique.h"
 #include "google/cloud/bigtable/internal/unary_client_utils.h"
+#include "google/cloud/internal/make_unique.h"
 #include <thread>
 #include <type_traits>
 
@@ -128,7 +128,7 @@ RowReader Table::ReadRows(RowSet row_set, Filter filter, bool raise_on_error) {
                    RowReader::NO_ROWS_LIMIT, std::move(filter),
                    rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
                    metadata_update_policy_,
-                   bigtable::internal::make_unique<
+                   google::cloud::internal::make_unique<
                        bigtable::internal::ReadRowsParserFactory>(),
                    raise_on_error);
 }
@@ -138,7 +138,7 @@ RowReader Table::ReadRows(RowSet row_set, std::int64_t rows_limit,
   return RowReader(client_, app_profile_id_, table_name_, std::move(row_set),
                    rows_limit, std::move(filter), rpc_retry_policy_->clone(),
                    rpc_backoff_policy_->clone(), metadata_update_policy_,
-                   bigtable::internal::make_unique<
+                   google::cloud::internal::make_unique<
                        bigtable::internal::ReadRowsParserFactory>(),
                    raise_on_error);
 }

--- a/google/cloud/bigtable/internal/table_admin_test.cc
+++ b/google/cloud/bigtable/internal/table_admin_test.cc
@@ -14,9 +14,9 @@
 
 #include "google/cloud/bigtable/internal/table_admin.h"
 #include "google/cloud/bigtable/grpc_error.h"
-#include "google/cloud/bigtable/internal/make_unique.h"
 #include "google/cloud/bigtable/testing/chrono_literals.h"
 #include "google/cloud/bigtable/testing/mock_admin_client.h"
+#include "google/cloud/internal/make_unique.h"
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
 #include <gmock/gmock.h>

--- a/google/cloud/bigtable/internal/table_test.cc
+++ b/google/cloud/bigtable/internal/table_test.cc
@@ -158,7 +158,7 @@ commit_row: true
                                                               status);
   EXPECT_TRUE(status.ok());
 
-  auto stream = bigtable::internal::make_unique<MockReadRowsReader>();
+  auto stream = google::cloud::internal::make_unique<MockReadRowsReader>();
   EXPECT_CALL(*stream, Read(_))
       .WillOnce(Invoke([&response](btproto::ReadRowsResponse* r) {
         *r = response;
@@ -202,7 +202,7 @@ commit_row: true
                                                               status);
   EXPECT_TRUE(status.ok());
 
-  auto stream = bigtable::internal::make_unique<MockReadRowsReader>();
+  auto stream = google::cloud::internal::make_unique<MockReadRowsReader>();
   EXPECT_CALL(*stream, Read(_))
       .WillOnce(Invoke([&response](btproto::ReadRowsResponse* r) {
         *r = response;
@@ -238,7 +238,7 @@ TEST_F(NoexTableTest, ReadRowMissing) {
   using namespace ::testing;
   namespace btproto = ::google::bigtable::v2;
 
-  auto stream = bigtable::internal::make_unique<MockReadRowsReader>();
+  auto stream = google::cloud::internal::make_unique<MockReadRowsReader>();
   EXPECT_CALL(*stream, Read(_)).WillOnce(Return(false));
   EXPECT_CALL(*stream, Finish()).WillOnce(Return(grpc::Status::OK));
 
@@ -261,7 +261,7 @@ TEST_F(NoexTableTest, ReadRowError) {
   using namespace ::testing;
   namespace btproto = ::google::bigtable::v2;
 
-  auto stream = bigtable::internal::make_unique<MockReadRowsReader>();
+  auto stream = google::cloud::internal::make_unique<MockReadRowsReader>();
   EXPECT_CALL(*stream, Read(_)).WillOnce(Return(false));
   EXPECT_CALL(*stream, Finish())
       .WillOnce(
@@ -298,7 +298,7 @@ commit_row: true
                                                               status);
   EXPECT_TRUE(status.ok());
 
-  auto stream = bigtable::internal::make_unique<MockReadRowsReader>();
+  auto stream = google::cloud::internal::make_unique<MockReadRowsReader>();
   EXPECT_CALL(*stream, Read(testing::_))
       .WillOnce(DoAll(SetArgPointee<0>(response), Return(true)))
       .WillOnce(Return(false));
@@ -348,8 +348,9 @@ commit_row: true
                                                               status);
   EXPECT_TRUE(status.ok());
 
-  auto stream = bigtable::internal::make_unique<MockReadRowsReader>();
-  auto stream_retry = bigtable::internal::make_unique<MockReadRowsReader>();
+  auto stream = google::cloud::internal::make_unique<MockReadRowsReader>();
+  auto stream_retry =
+      google::cloud::internal::make_unique<MockReadRowsReader>();
 
   EXPECT_CALL(*stream, Read(_))
       .WillOnce(DoAll(SetArgPointee<0>(response), Return(true)))
@@ -489,7 +490,7 @@ TEST_F(NoexTableTest, BulkApplySimple) {
   namespace btproto = ::google::bigtable::v2;
   namespace bt = ::bigtable;
 
-  auto reader = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto reader = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*reader, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -526,7 +527,7 @@ TEST_F(NoexTableTest, BulkApply_AppProfileId) {
   namespace btproto = ::google::bigtable::v2;
   namespace bt = ::bigtable;
 
-  auto reader = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto reader = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*reader, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -572,7 +573,7 @@ TEST_F(NoexTableTest, BulkApplyRetryPartialFailure) {
   namespace btproto = ::google::bigtable::v2;
   namespace bt = ::bigtable;
 
-  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r1 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         // Simulate a partial (recoverable) failure.
@@ -587,7 +588,7 @@ TEST_F(NoexTableTest, BulkApplyRetryPartialFailure) {
       .WillOnce(Return(false));
   EXPECT_CALL(*r1, Finish()).WillOnce(Return(grpc::Status::OK));
 
-  auto r2 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r2 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r2, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -622,7 +623,7 @@ TEST_F(NoexTableTest, BulkApplyPermanentFailure) {
   namespace btproto = ::google::bigtable::v2;
   namespace bt = ::bigtable;
 
-  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r1 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -662,7 +663,7 @@ TEST_F(NoexTableTest, BulkApplyCanceledStream) {
   // the BulkApply() operation to retry the request, because the mutation is in
   // an undetermined state.  Well, it should retry assuming it is idempotent,
   // which happens to be the case in this test.
-  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r1 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -676,7 +677,7 @@ TEST_F(NoexTableTest, BulkApplyCanceledStream) {
   EXPECT_CALL(*r1, Finish()).WillOnce(Return(grpc::Status::OK));
 
   // Create a second stream returned by the mocks when the client retries.
-  auto r2 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r2 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r2, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -722,7 +723,7 @@ TEST_F(NoexTableTest, BulkApplyTooManyFailures) {
       bt::ExponentialBackoffPolicy(10_us, 40_us));
 
   // Setup the mocks to fail more than 3 times.
-  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r1 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -738,7 +739,7 @@ TEST_F(NoexTableTest, BulkApplyTooManyFailures) {
 
   auto create_cancelled_stream = [&](grpc::ClientContext*,
                                      btproto::MutateRowsRequest const&) {
-    auto stream = bigtable::internal::make_unique<MockMutateRowsReader>();
+    auto stream = google::cloud::internal::make_unique<MockMutateRowsReader>();
     EXPECT_CALL(*stream, Read(_)).WillOnce(Return(false));
     EXPECT_CALL(*stream, Finish())
         .WillOnce(Return(grpc::Status(grpc::StatusCode::ABORTED, "yikes")));
@@ -769,11 +770,11 @@ TEST_F(NoexTableTest, BulkApplyRetryOnlyIdempotent) {
   // We will send both idempotent and non-idempotent mutations.  We prepare the
   // mocks to return an empty stream in the first RPC request.  That will force
   // the client to only retry the idempotent mutations.
-  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r1 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_)).WillOnce(Return(false));
   EXPECT_CALL(*r1, Finish()).WillOnce(Return(grpc::Status::OK));
 
-  auto r2 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r2 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r2, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -810,7 +811,7 @@ TEST_F(NoexTableTest, BulkApplyFailedRPC) {
   namespace btproto = ::google::bigtable::v2;
   namespace bt = ::bigtable;
 
-  auto reader = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto reader = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*reader, Read(_)).WillOnce(Return(false));
   EXPECT_CALL(*reader, Finish())
       .WillOnce(Return(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
@@ -890,7 +891,7 @@ TEST_F(NoexTableTest, SampleRowsDefaultParameterTest) {
   using namespace ::testing;
   namespace btproto = ::google::bigtable::v2;
 
-  auto reader = bigtable::internal::make_unique<MockSampleRowKeysReader>();
+  auto reader = google::cloud::internal::make_unique<MockSampleRowKeysReader>();
   EXPECT_CALL(*reader, Read(_))
       .WillOnce(Invoke([](btproto::SampleRowKeysResponse* r) {
         {
@@ -920,7 +921,7 @@ TEST_F(NoexTableTest, SampleRowKeys_AppProfileId) {
   namespace btproto = ::google::bigtable::v2;
 
   std::string expected_id = "test-id";
-  auto reader = bigtable::internal::make_unique<MockSampleRowKeysReader>();
+  auto reader = google::cloud::internal::make_unique<MockSampleRowKeysReader>();
   EXPECT_CALL(*client_, SampleRowKeys(_, _))
       .WillOnce(
           Invoke([expected_id, &reader](grpc::ClientContext* ctx,
@@ -945,7 +946,7 @@ TEST_F(NoexTableTest, SampleRowsSimpleVectorTest) {
   using namespace ::testing;
   namespace btproto = ::google::bigtable::v2;
 
-  auto reader = bigtable::internal::make_unique<MockSampleRowKeysReader>();
+  auto reader = google::cloud::internal::make_unique<MockSampleRowKeysReader>();
   EXPECT_CALL(*reader, Read(_))
       .WillOnce(Invoke([](btproto::SampleRowKeysResponse* r) {
         {
@@ -975,7 +976,7 @@ TEST_F(NoexTableTest, SampleRowsSimpleListTest) {
   using namespace ::testing;
   namespace btproto = ::google::bigtable::v2;
 
-  auto reader = bigtable::internal::make_unique<MockSampleRowKeysReader>();
+  auto reader = google::cloud::internal::make_unique<MockSampleRowKeysReader>();
   EXPECT_CALL(*reader, Read(_))
       .WillOnce(Invoke([](btproto::SampleRowKeysResponse* r) {
         {
@@ -1004,9 +1005,9 @@ TEST_F(NoexTableTest, SampleRowsSampleRowKeysRetryTest) {
   using namespace ::testing;
   namespace btproto = ::google::bigtable::v2;
 
-  auto reader = bigtable::internal::make_unique<MockSampleRowKeysReader>();
+  auto reader = google::cloud::internal::make_unique<MockSampleRowKeysReader>();
   auto reader_retry =
-      bigtable::internal::make_unique<MockSampleRowKeysReader>();
+      google::cloud::internal::make_unique<MockSampleRowKeysReader>();
 
   EXPECT_CALL(*reader, Read(_))
       .WillOnce(Invoke([](btproto::SampleRowKeysResponse* r) {
@@ -1077,7 +1078,7 @@ TEST_F(NoexTableTest, SampleRowsTooManyFailures) {
       ::bigtable::SafeIdempotentMutationPolicy());
 
   // Setup the mocks to fail more than 3 times.
-  auto r1 = bigtable::internal::make_unique<MockSampleRowKeysReader>();
+  auto r1 = google::cloud::internal::make_unique<MockSampleRowKeysReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::SampleRowKeysResponse* r) {
         {

--- a/google/cloud/bigtable/metadata_update_policy.cc
+++ b/google/cloud/bigtable/metadata_update_policy.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/metadata_update_policy.h"
-#include "google/cloud/bigtable/internal/make_unique.h"
+#include "google/cloud/internal/make_unique.h"
 
 #include <sstream>
 

--- a/google/cloud/bigtable/metadata_update_policy_test.cc
+++ b/google/cloud/bigtable/metadata_update_policy_test.cc
@@ -14,9 +14,9 @@
 
 #include "google/cloud/bigtable/metadata_update_policy.h"
 #include "google/cloud/bigtable/admin_client.h"
-#include "google/cloud/bigtable/internal/make_unique.h"
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/testing/embedded_server_test_fixture.h"
+#include "google/cloud/internal/make_unique.h"
 #include <gtest/gtest.h>
 #include <map>
 #include <thread>

--- a/google/cloud/bigtable/row_reader.cc
+++ b/google/cloud/bigtable/row_reader.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/row_reader.h"
-#include "google/cloud/bigtable/internal/make_unique.h"
 #include "google/cloud/bigtable/internal/table.h"
+#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/internal/throw_delegate.h"
 #include <thread>
 
@@ -156,7 +156,7 @@ void RowReader::MakeRequest() {
     request.set_rows_limit(rows_limit_ - rows_count_);
   }
 
-  context_ = bigtable::internal::make_unique<grpc::ClientContext>();
+  context_ = google::cloud::internal::make_unique<grpc::ClientContext>();
   retry_policy_->Setup(*context_);
   backoff_policy_->Setup(*context_);
   metadata_update_policy_.Setup(*context_);

--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -14,10 +14,10 @@
 
 #include "google/cloud/bigtable/row_reader.h"
 #include "google/cloud/bigtable/bigtable_strong_types.h"
-#include "google/cloud/bigtable/internal/make_unique.h"
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/testing/mock_read_rows_reader.h"
 #include "google/cloud/bigtable/testing/table_test_fixture.h"
+#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/internal/throw_delegate.h"
 #include <gmock/gmock.h>
 #include <deque>
@@ -178,7 +178,7 @@ TEST_F(RowReaderTest, EmptyReaderHasNoRows) {
 
 TEST_F(RowReaderTest, ReadOneRow) {
   auto* stream = new MockReadRowsReader;  // wrapped in unique_ptr by ReadRows
-  auto parser = bigtable::internal::make_unique<ReadRowsParserMock>();
+  auto parser = google::cloud::internal::make_unique<ReadRowsParserMock>();
   parser->SetRows({"r1"});
   EXPECT_CALL(*parser, HandleEndOfStreamHook(_)).Times(1);
   {
@@ -206,7 +206,7 @@ TEST_F(RowReaderTest, ReadOneRow) {
 TEST_F(RowReaderTest, ReadOneRow_AppProfileId) {
   using namespace ::testing;
   auto* stream = new MockReadRowsReader;  // wrapped in unique_ptr by ReadRows
-  auto parser = bigtable::internal::make_unique<ReadRowsParserMock>();
+  auto parser = google::cloud::internal::make_unique<ReadRowsParserMock>();
   parser->SetRows({"r1"});
   EXPECT_CALL(*parser, HandleEndOfStreamHook(_)).Times(1);
   {
@@ -239,7 +239,7 @@ TEST_F(RowReaderTest, ReadOneRow_AppProfileId) {
 
 TEST_F(RowReaderTest, ReadOneRowIteratorPostincrement) {
   auto* stream = new MockReadRowsReader;  // wrapped in unique_ptr by ReadRows
-  auto parser = bigtable::internal::make_unique<ReadRowsParserMock>();
+  auto parser = google::cloud::internal::make_unique<ReadRowsParserMock>();
   parser->SetRows({"r1"});
   EXPECT_CALL(*parser, HandleEndOfStreamHook(_)).Times(1);
   {
@@ -267,7 +267,7 @@ TEST_F(RowReaderTest, ReadOneRowIteratorPostincrement) {
 
 TEST_F(RowReaderTest, ReadOneOfTwoRowsClosesStream) {
   auto* stream = new MockReadRowsReader;  // wrapped in unique_ptr by ReadRows
-  auto parser = bigtable::internal::make_unique<ReadRowsParserMock>();
+  auto parser = google::cloud::internal::make_unique<ReadRowsParserMock>();
   parser->SetRows({"r1"});
   {
     testing::InSequence s;
@@ -297,7 +297,7 @@ TEST_F(RowReaderTest, ReadOneOfTwoRowsClosesStream) {
 
 TEST_F(RowReaderTest, FailedStreamIsRetried) {
   auto* stream = new MockReadRowsReader;  // wrapped in unique_ptr by ReadRows
-  auto parser = bigtable::internal::make_unique<ReadRowsParserMock>();
+  auto parser = google::cloud::internal::make_unique<ReadRowsParserMock>();
   parser->SetRows({"r1"});
   {
     testing::InSequence s;
@@ -335,7 +335,7 @@ TEST_F(RowReaderTest, FailedStreamIsRetried) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 TEST_F(RowReaderTest, FailedStreamWithNoRetryThrows) {
   auto* stream = new MockReadRowsReader;  // wrapped in unique_ptr by ReadRows
-  auto parser = bigtable::internal::make_unique<ReadRowsParserMock>();
+  auto parser = google::cloud::internal::make_unique<ReadRowsParserMock>();
   {
     testing::InSequence s;
     EXPECT_CALL(*client_, ReadRows(_, _))
@@ -361,7 +361,7 @@ TEST_F(RowReaderTest, FailedStreamWithNoRetryThrows) {
 
 TEST_F(RowReaderTest, FailedStreamWithNoRetryThrowsNoExcept) {
   auto* stream = new MockReadRowsReader;  // wrapped in unique_ptr by ReadRows
-  auto parser = bigtable::internal::make_unique<ReadRowsParserMock>();
+  auto parser = google::cloud::internal::make_unique<ReadRowsParserMock>();
   {
     testing::InSequence s;
     EXPECT_CALL(*client_, ReadRows(_, _))
@@ -388,7 +388,7 @@ TEST_F(RowReaderTest, FailedStreamWithNoRetryThrowsNoExcept) {
 
 TEST_F(RowReaderTest, FailedStreamRetriesSkipAlreadyReadRows) {
   auto* stream = new MockReadRowsReader;  // wrapped in unique_ptr by ReadRows
-  auto parser = bigtable::internal::make_unique<ReadRowsParserMock>();
+  auto parser = google::cloud::internal::make_unique<ReadRowsParserMock>();
   parser->SetRows({"r1"});
   {
     testing::InSequence s;
@@ -432,7 +432,7 @@ using testing::Throw;
 
 TEST_F(RowReaderTest, FailedParseIsRetried) {
   auto* stream = new MockReadRowsReader;  // wrapped in unique_ptr by ReadRows
-  auto parser = bigtable::internal::make_unique<ReadRowsParserMock>();
+  auto parser = google::cloud::internal::make_unique<ReadRowsParserMock>();
   parser->SetRows({"r1"});
   auto response = bigtable::testing::ReadRowsResponseFromString("chunks {}");
   {
@@ -472,7 +472,7 @@ TEST_F(RowReaderTest, FailedParseIsRetried) {
 
 TEST_F(RowReaderTest, FailedParseWithNoRetryThrows) {
   auto* stream = new MockReadRowsReader;  // wrapped in unique_ptr by ReadRows
-  auto parser = bigtable::internal::make_unique<ReadRowsParserMock>();
+  auto parser = google::cloud::internal::make_unique<ReadRowsParserMock>();
   {
     testing::InSequence s;
     EXPECT_CALL(*client_, ReadRows(_, _))
@@ -500,7 +500,7 @@ TEST_F(RowReaderTest, FailedParseWithNoRetryThrows) {
 
 TEST_F(RowReaderTest, FailedParseRetriesSkipAlreadyReadRows) {
   auto* stream = new MockReadRowsReader;  // wrapped in unique_ptr by ReadRows
-  auto parser = bigtable::internal::make_unique<ReadRowsParserMock>();
+  auto parser = google::cloud::internal::make_unique<ReadRowsParserMock>();
   parser->SetRows({"r1"});
   {
     testing::InSequence s;
@@ -544,7 +544,7 @@ TEST_F(RowReaderTest, FailedParseRetriesSkipAlreadyReadRows) {
 
 TEST_F(RowReaderTest, FailedParseWithNoRetryThrowsNoExcept) {
   auto* stream = new MockReadRowsReader;  // wrapped in unique_ptr by ReadRows
-  auto parser = bigtable::internal::make_unique<ReadRowsParserMock>();
+  auto parser = google::cloud::internal::make_unique<ReadRowsParserMock>();
   {
     testing::InSequence s;
 
@@ -574,7 +574,7 @@ TEST_F(RowReaderTest, FailedParseWithNoRetryThrowsNoExcept) {
 
 TEST_F(RowReaderTest, FailedStreamWithAllRequiedRowsSeenShouldNotRetry) {
   auto* stream = new MockReadRowsReader;  // wrapped in unique_ptr by ReadRows
-  auto parser = bigtable::internal::make_unique<ReadRowsParserMock>();
+  auto parser = google::cloud::internal::make_unique<ReadRowsParserMock>();
   parser->SetRows({"r2"});
   {
     testing::InSequence s;
@@ -626,7 +626,7 @@ TEST_F(RowReaderTest, RowLimitIsSent) {
 
 TEST_F(RowReaderTest, RowLimitIsDecreasedOnRetry) {
   auto* stream = new MockReadRowsReader;  // wrapped in unique_ptr by ReadRows
-  auto parser = bigtable::internal::make_unique<ReadRowsParserMock>();
+  auto parser = google::cloud::internal::make_unique<ReadRowsParserMock>();
   parser->SetRows({"r1"});
   {
     testing::InSequence s;
@@ -665,7 +665,7 @@ TEST_F(RowReaderTest, RowLimitIsDecreasedOnRetry) {
 
 TEST_F(RowReaderTest, RowLimitIsNotDecreasedToZero) {
   auto* stream = new MockReadRowsReader;  // wrapped in unique_ptr by ReadRows
-  auto parser = bigtable::internal::make_unique<ReadRowsParserMock>();
+  auto parser = google::cloud::internal::make_unique<ReadRowsParserMock>();
   parser->SetRows({"r1"});
   {
     testing::InSequence s;
@@ -697,7 +697,7 @@ TEST_F(RowReaderTest, RowLimitIsNotDecreasedToZero) {
 
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 TEST_F(RowReaderTest, BeginThrowsAfterCancelClosesStream) {
-  auto parser = bigtable::internal::make_unique<ReadRowsParserMock>();
+  auto parser = google::cloud::internal::make_unique<ReadRowsParserMock>();
   parser->SetRows({"r1"});
   auto* stream = new MockReadRowsReader;
   {
@@ -741,7 +741,7 @@ TEST_F(RowReaderTest, BeginThrowsAfterImmediateCancel) {
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 
 TEST_F(RowReaderTest, BeginThrowsAfterCancelClosesStreamNoExcept) {
-  auto parser = bigtable::internal::make_unique<ReadRowsParserMock>();
+  auto parser = google::cloud::internal::make_unique<ReadRowsParserMock>();
   parser->SetRows({"r1"});
   auto* stream = new MockReadRowsReader;
   {
@@ -817,7 +817,7 @@ TEST_F(RowReaderTest, FailedStreamRetryNewContext) {
   using namespace ::testing;
   // Every retry should use a new ClientContext object.
   auto* stream = new MockReadRowsReader;  // wrapped in unique_ptr by ReadRows
-  auto parser = bigtable::internal::make_unique<ReadRowsParserMock>();
+  auto parser = google::cloud::internal::make_unique<ReadRowsParserMock>();
   parser->SetRows({"r1"});
 
   void* previous_context = nullptr;

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -15,7 +15,7 @@
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/internal/bulk_mutator.h"
 #include "google/cloud/bigtable/internal/grpc_error_delegate.h"
-#include "google/cloud/bigtable/internal/make_unique.h"
+#include "google/cloud/internal/make_unique.h"
 #include <thread>
 #include <type_traits>
 

--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -14,9 +14,9 @@
 
 #include "google/cloud/bigtable/table_admin.h"
 #include "google/cloud/bigtable/grpc_error.h"
-#include "google/cloud/bigtable/internal/make_unique.h"
 #include "google/cloud/bigtable/testing/chrono_literals.h"
 #include "google/cloud/bigtable/testing/mock_admin_client.h"
+#include "google/cloud/internal/make_unique.h"
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
 #include <gmock/gmock.h>

--- a/google/cloud/bigtable/table_bulk_apply_test.cc
+++ b/google/cloud/bigtable/table_bulk_apply_test.cc
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/bigtable/internal/make_unique.h"
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/testing/chrono_literals.h"
 #include "google/cloud/bigtable/testing/mock_mutate_rows_reader.h"
 #include "google/cloud/bigtable/testing/table_test_fixture.h"
+#include "google/cloud/internal/make_unique.h"
 
 namespace btproto = google::bigtable::v2;
 namespace bigtable = google::cloud::bigtable;
@@ -33,7 +33,7 @@ using bigtable::testing::MockMutateRowsReader;
 /// @test Verify that Table::BulkApply() works in the easy case.
 
 TEST_F(TableBulkApplyTest, Simple) {
-  auto reader = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto reader = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*reader, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -62,7 +62,7 @@ TEST_F(TableBulkApplyTest, Simple) {
 
 /// @test Verify that Table::BulkApply() retries partial failures.
 TEST_F(TableBulkApplyTest, RetryPartialFailure) {
-  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r1 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         // Simulate a partial (recoverable) failure.
@@ -77,7 +77,7 @@ TEST_F(TableBulkApplyTest, RetryPartialFailure) {
       .WillOnce(Return(false));
   EXPECT_CALL(*r1, Finish()).WillOnce(Return(grpc::Status::OK));
 
-  auto r2 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r2 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r2, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -105,7 +105,7 @@ TEST_F(TableBulkApplyTest, RetryPartialFailure) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 /// @test Verify that Table::BulkApply() handles permanent failures.
 TEST_F(TableBulkApplyTest, PermanentFailure) {
-  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r1 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -141,7 +141,7 @@ TEST_F(TableBulkApplyTest, CanceledStream) {
   // the BulkApply() operation to retry the request, because the mutation is in
   // an undetermined state.  Well, it should retry assuming it is idempotent,
   // which happens to be the case in this test.
-  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r1 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -155,7 +155,7 @@ TEST_F(TableBulkApplyTest, CanceledStream) {
   EXPECT_CALL(*r1, Finish()).WillOnce(Return(grpc::Status::OK));
 
   // Create a second stream returned by the mocks when the client retries.
-  auto r2 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r2 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r2, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -192,7 +192,7 @@ TEST_F(TableBulkApplyTest, TooManyFailures) {
       bt::ExponentialBackoffPolicy(10_us, 40_us));
 
   // Setup the mocks to fail more than 3 times.
-  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r1 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -208,7 +208,7 @@ TEST_F(TableBulkApplyTest, TooManyFailures) {
 
   auto create_cancelled_stream = [&](grpc::ClientContext*,
                                      btproto::MutateRowsRequest const&) {
-    auto stream = bigtable::internal::make_unique<MockMutateRowsReader>();
+    auto stream = google::cloud::internal::make_unique<MockMutateRowsReader>();
     EXPECT_CALL(*stream, Read(_)).WillOnce(Return(false));
     EXPECT_CALL(*stream, Finish())
         .WillOnce(Return(grpc::Status(grpc::StatusCode::ABORTED, "")));
@@ -233,11 +233,11 @@ TEST_F(TableBulkApplyTest, RetryOnlyIdempotent) {
   // We will send both idempotent and non-idempotent mutations.  We prepare the
   // mocks to return an empty stream in the first RPC request.  That will force
   // the client to only retry the idempotent mutations.
-  auto r1 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r1 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r1, Read(_)).WillOnce(Return(false));
   EXPECT_CALL(*r1, Finish()).WillOnce(Return(grpc::Status::OK));
 
-  auto r2 = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto r2 = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*r2, Read(_))
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r) {
         {
@@ -273,7 +273,7 @@ TEST_F(TableBulkApplyTest, RetryOnlyIdempotent) {
 
 /// @test Verify that Table::BulkApply() works when the RPC fails.
 TEST_F(TableBulkApplyTest, FailedRPC) {
-  auto reader = bigtable::internal::make_unique<MockMutateRowsReader>();
+  auto reader = google::cloud::internal::make_unique<MockMutateRowsReader>();
   EXPECT_CALL(*reader, Read(_)).WillOnce(Return(false));
   EXPECT_CALL(*reader, Finish())
       .WillOnce(Return(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,

--- a/google/cloud/bigtable/table_readrow_test.cc
+++ b/google/cloud/bigtable/table_readrow_test.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/bigtable/internal/make_unique.h"
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/testing/mock_read_rows_reader.h"
 #include "google/cloud/bigtable/testing/table_test_fixture.h"
+#include "google/cloud/internal/make_unique.h"
 
 namespace bigtable = google::cloud::bigtable;
 
@@ -40,7 +40,7 @@ TEST_F(TableReadRowTest, ReadRowSimple) {
       }
 )");
 
-  auto stream = bigtable::internal::make_unique<MockReadRowsReader>();
+  auto stream = google::cloud::internal::make_unique<MockReadRowsReader>();
   EXPECT_CALL(*stream, Read(_))
       .WillOnce(Invoke([&response](btproto::ReadRowsResponse* r) {
         *r = response;
@@ -69,7 +69,7 @@ TEST_F(TableReadRowTest, ReadRowMissing) {
   using namespace ::testing;
   namespace btproto = ::google::bigtable::v2;
 
-  auto stream = bigtable::internal::make_unique<MockReadRowsReader>();
+  auto stream = google::cloud::internal::make_unique<MockReadRowsReader>();
   EXPECT_CALL(*stream, Read(_)).WillOnce(Return(false));
   EXPECT_CALL(*stream, Finish()).WillOnce(Return(grpc::Status::OK));
 
@@ -91,7 +91,7 @@ TEST_F(TableReadRowTest, UnrecoverableFailure) {
   using namespace ::testing;
   namespace btproto = ::google::bigtable::v2;
 
-  auto stream = bigtable::internal::make_unique<MockReadRowsReader>();
+  auto stream = google::cloud::internal::make_unique<MockReadRowsReader>();
   EXPECT_CALL(*stream, Read(_)).WillRepeatedly(Return(false));
   EXPECT_CALL(*stream, Finish())
       .WillRepeatedly(

--- a/google/cloud/bigtable/table_sample_row_keys_test.cc
+++ b/google/cloud/bigtable/table_sample_row_keys_test.cc
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/bigtable/internal/make_unique.h"
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/testing/chrono_literals.h"
 #include "google/cloud/bigtable/testing/mock_sample_row_keys_reader.h"
 #include "google/cloud/bigtable/testing/table_test_fixture.h"
+#include "google/cloud/internal/make_unique.h"
 #include <typeinfo>
 
 namespace bigtable = google::cloud::bigtable;

--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/testing/table_integration_test.h"
-#include "google/cloud/bigtable/internal/make_unique.h"
+#include "google/cloud/internal/make_unique.h"
 #include <google/protobuf/text_format.h>
 #include <algorithm>
 #include <cctype>
@@ -29,7 +29,7 @@ std::string TableTestEnvironment::instance_id_;
 void TableIntegrationTest::SetUp() {
   admin_client_ = bigtable::CreateDefaultAdminClient(
       TableTestEnvironment::project_id(), ClientOptions());
-  table_admin_ = bigtable::internal::make_unique<bigtable::TableAdmin>(
+  table_admin_ = google::cloud::internal::make_unique<bigtable::TableAdmin>(
       admin_client_, TableTestEnvironment::instance_id());
   data_client_ = bigtable::CreateDefaultDataClient(
       TableTestEnvironment::project_id(), TableTestEnvironment::instance_id(),
@@ -39,8 +39,8 @@ void TableIntegrationTest::SetUp() {
 std::unique_ptr<bigtable::Table> TableIntegrationTest::CreateTable(
     std::string const& table_name, bigtable::TableConfig& table_config) {
   table_admin_->CreateTable(table_name, table_config);
-  return bigtable::internal::make_unique<bigtable::Table>(data_client_,
-                                                          table_name);
+  return google::cloud::internal::make_unique<bigtable::Table>(data_client_,
+                                                               table_name);
 }
 
 void TableIntegrationTest::DeleteTable(std::string const& table_name) {

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/grpc_error.h"
-#include "google/cloud/bigtable/internal/make_unique.h"
 #include "google/cloud/bigtable/testing/table_integration_test.h"
+#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>
@@ -35,7 +35,7 @@ class AdminIntegrationTest : public bigtable::testing::TableIntegrationTest {
         bigtable::CreateDefaultAdminClient(
             bigtable::testing::TableTestEnvironment::project_id(),
             bigtable::ClientOptions());
-    table_admin_ = bigtable::internal::make_unique<bigtable::TableAdmin>(
+    table_admin_ = google::cloud::internal::make_unique<bigtable::TableAdmin>(
         admin_client, bigtable::testing::TableTestEnvironment::instance_id());
   }
 

--- a/google/cloud/bigtable/tests/instance_admin_emulator.cc
+++ b/google/cloud/bigtable/tests/instance_admin_emulator.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/bigtable/internal/make_unique.h"
 #include "google/cloud/bigtable/internal/prefix_range_end.h"
+#include "google/cloud/internal/make_unique.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h>
 #include <google/longrunning/operations.grpc.pb.h>
 #include <google/protobuf/text_format.h>
@@ -52,7 +52,8 @@ class InstanceAdminEmulator final
       stored_instance.set_state(btadmin::Instance::READY);
       response->set_name("create-instance/" + name);
       response->set_done(true);
-      auto contents = bigtable::internal::make_unique<google::protobuf::Any>();
+      auto contents =
+          google::cloud::internal::make_unique<google::protobuf::Any>();
       contents->PackFrom(stored_instance);
       response->set_allocated_response(contents.release());
 
@@ -155,7 +156,8 @@ class InstanceAdminEmulator final
     }
     response->set_name("update-instance/" + name);
     response->set_done(true);
-    auto contents = bigtable::internal::make_unique<google::protobuf::Any>();
+    auto contents =
+        google::cloud::internal::make_unique<google::protobuf::Any>();
     contents->PackFrom(stored_instance);
     response->set_allocated_response(contents.release());
     return grpc::Status::OK;
@@ -199,7 +201,8 @@ class InstanceAdminEmulator final
       stored_cluster.set_state(btadmin::Cluster::READY);
       response->set_name("create-cluster/" + name);
       response->set_done(true);
-      auto contents = bigtable::internal::make_unique<google::protobuf::Any>();
+      auto contents =
+          google::cloud::internal::make_unique<google::protobuf::Any>();
       contents->PackFrom(stored_cluster);
       response->set_allocated_response(contents.release());
       return grpc::Status::OK;
@@ -279,7 +282,8 @@ class InstanceAdminEmulator final
     stored_cluster.CopyFrom(*request);
     response->set_name("update-cluster/" + name);
     response->set_done(true);
-    auto contents = bigtable::internal::make_unique<google::protobuf::Any>();
+    auto contents =
+        google::cloud::internal::make_unique<google::protobuf::Any>();
     contents->PackFrom(stored_cluster);
     response->set_allocated_response(contents.release());
     return grpc::Status::OK;
@@ -386,7 +390,8 @@ class InstanceAdminEmulator final
     }
     response->set_name("update-app-profile/" + name);
     response->set_done(true);
-    auto contents = bigtable::internal::make_unique<google::protobuf::Any>();
+    auto contents =
+        google::cloud::internal::make_unique<google::protobuf::Any>();
     contents->PackFrom(stored_app_profile);
     response->set_allocated_response(contents.release());
     return grpc::Status::OK;

--- a/google/cloud/bigtable/tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_integration_test.cc
@@ -14,7 +14,7 @@
 
 #include "google/cloud/bigtable/grpc_error.h"
 #include "google/cloud/bigtable/instance_admin.h"
-#include "google/cloud/bigtable/internal/make_unique.h"
+#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 #include <google/protobuf/text_format.h>
@@ -44,8 +44,9 @@ class InstanceAdminIntegrationTest : public ::testing::Test {
   void SetUp() override {
     auto instance_admin_client = bigtable::CreateDefaultInstanceAdminClient(
         InstanceTestEnvironment::project_id(), bigtable::ClientOptions());
-    instance_admin_ = bigtable::internal::make_unique<bigtable::InstanceAdmin>(
-        instance_admin_client);
+    instance_admin_ =
+        google::cloud::internal::make_unique<bigtable::InstanceAdmin>(
+            instance_admin_client);
   }
 
  protected:

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -5,6 +5,7 @@ google_cloud_cpp_common_HDRS = [
     "iam_policy.h",
     "internal/backoff_policy.h",
     "internal/build_info.h",
+    "internal/make_unique.h",
     "internal/optional.h",
     "internal/port_platform.h",
     "internal/random.h",

--- a/google/cloud/internal/make_unique.h
+++ b/google/cloud/internal/make_unique.h
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_MAKE_UNIQUE_H_
-#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_MAKE_UNIQUE_H_
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_MAKE_UNIQUE_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_MAKE_UNIQUE_H_
 
-#include "google/cloud/bigtable/version.h"
-
+#include "google/cloud/version.h"
 #include <memory>
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-inline namespace BIGTABLE_CLIENT_NS {
+inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 /**
  * A naive implementation of std::make_unique for C++11.
@@ -46,9 +44,8 @@ std::unique_ptr<T> make_unique(Args&&... a) {
 }
 
 }  // namespace internal
-}  // namespace BIGTABLE_CLIENT_NS
-}  // namespace bigtable
+}  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_MAKE_UNIQUE_H_
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_MAKE_UNIQUE_H_


### PR DESCRIPTION
This is generally useful, and we miss it in google/cloud/storage
sometimes.