### PR TITLE
Implement Client::ListDefaultObjectAcl.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -237,6 +237,7 @@ set(storage_client_unit_tests
     bucket_metadata_test.cc
     bucket_test.cc
     client_bucket_acl_test.cc
+    client_default_object_acl_test.cc
     client_object_acl_test.cc
     client_test.cc
     client_write_object_test.cc

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -608,6 +608,24 @@ class Client {
     return raw_client_->PatchObjectAcl(request).second;
   }
 
+  /**
+   * Retrieve the list of DefaultObjectAccessControls for a bucket.
+   *
+   * @param bucket_name the name of the bucket.
+   * @param options a list of optional query parameters and/or request headers.
+   *     Valid types for this operation include `UserProject`.
+   *
+   * @par Example
+   * @snippet storage_default_object_acl_samples.cc list default object acl
+   */
+  template <typename... Options>
+  std::vector<ObjectAccessControl> ListDefaultObjectAcl(
+      std::string const& bucket_name, Options&&... options) {
+    internal::ListDefaultObjectAclRequest request(bucket_name);
+    request.set_multiple_options(std::forward<Options>(options)...);
+    return raw_client_->ListDefaultObjectAcl(request).second.items;
+  }
+
  private:
   BucketMetadata GetBucketMetadataImpl(
       internal::GetBucketMetadataRequest const& request);

--- a/google/cloud/storage/client_default_object_acl_test.cc
+++ b/google/cloud/storage/client_default_object_acl_test.cc
@@ -1,0 +1,104 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/retry_policy.h"
+#include "google/cloud/storage/testing/canonical_errors.h"
+#include "google/cloud/storage/testing/mock_client.h"
+#include "google/cloud/storage/testing/retry_tests.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::ReturnRef;
+using ms = std::chrono::milliseconds;
+using testing::canonical_errors::TransientError;
+
+/**
+ * Test the BucketAccessControls-related functions in storage::Client.
+ */
+class DefaultObjectAccessControlsTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    mock = std::make_shared<testing::MockClient>();
+    EXPECT_CALL(*mock, client_options())
+        .WillRepeatedly(ReturnRef(client_options));
+    client.reset(new Client{std::shared_ptr<internal::RawClient>(mock)});
+  }
+  void TearDown() override {
+    client.reset();
+    mock.reset();
+  }
+
+  std::shared_ptr<testing::MockClient> mock;
+  std::unique_ptr<Client> client;
+  ClientOptions client_options = ClientOptions(CreateInsecureCredentials());
+};
+
+TEST_F(DefaultObjectAccessControlsTest, ListDefaultObjectAcl) {
+  std::vector<ObjectAccessControl> expected{
+      ObjectAccessControl::ParseFromString(R"""({
+          "bucket": "test-bucket",
+          "entity": "user-test-user-1",
+          "role": "OWNER"
+      })"""),
+      ObjectAccessControl::ParseFromString(R"""({
+          "bucket": "test-bucket",
+          "entity": "user-test-user-2",
+          "role": "READER"
+      })"""),
+  };
+
+  EXPECT_CALL(*mock, ListDefaultObjectAcl(_))
+      .WillOnce(Return(std::make_pair(
+          TransientError(), internal::ListDefaultObjectAclResponse{})))
+      .WillOnce(
+          Invoke([&expected](internal::ListDefaultObjectAclRequest const& r) {
+            EXPECT_EQ("test-bucket", r.bucket_name());
+
+            return std::make_pair(
+                Status(), internal::ListDefaultObjectAclResponse{expected});
+          }));
+  Client client{std::shared_ptr<internal::RawClient>(mock)};
+
+  std::vector<ObjectAccessControl> actual =
+      client.ListDefaultObjectAcl("test-bucket");
+  EXPECT_EQ(expected, actual);
+}
+
+TEST_F(DefaultObjectAccessControlsTest, ListDefaultObjectAclTooManyFailures) {
+  testing::TooManyFailuresTest<internal::ListDefaultObjectAclResponse>(
+      mock, EXPECT_CALL(*mock, ListDefaultObjectAcl(_)),
+      [](Client& client) { client.ListDefaultObjectAcl("test-bucket-name"); },
+      "ListDefaultObjectAcl");
+}
+
+TEST_F(DefaultObjectAccessControlsTest, ListDefaultObjectAclPermanentFailure) {
+  testing::PermanentFailureTest<internal::ListDefaultObjectAclResponse>(
+      *client, EXPECT_CALL(*mock, ListDefaultObjectAcl(_)),
+      [](Client& client) { client.ListDefaultObjectAcl("test-bucket-name"); },
+      "ListDefaultObjectAcl");
+}
+
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/examples/BUILD
+++ b/google/cloud/storage/examples/BUILD
@@ -23,6 +23,18 @@ cc_binary(
 )
 
 cc_binary(
+    name = "storage_bucket_acl_samples",
+    srcs = ["storage_bucket_acl_samples.cc"],
+    deps = ["//google/cloud/storage:storage_client"],
+)
+
+cc_binary(
+    name = "storage_default_object_acl_samples",
+    srcs = ["storage_default_object_acl_samples.cc"],
+    deps = ["//google/cloud/storage:storage_client"],
+)
+
+cc_binary(
     name = "storage_object_samples",
     srcs = ["storage_object_samples.cc"],
     deps = ["//google/cloud/storage:storage_client"],

--- a/google/cloud/storage/examples/CMakeLists.txt
+++ b/google/cloud/storage/examples/CMakeLists.txt
@@ -24,6 +24,10 @@ target_link_libraries(storage_bucket_samples storage_client)
 add_executable(storage_bucket_acl_samples storage_bucket_acl_samples.cc)
 target_link_libraries(storage_bucket_acl_samples storage_client)
 
+add_executable(storage_default_object_acl_samples
+               storage_default_object_acl_samples.cc)
+target_link_libraries(storage_default_object_acl_samples storage_client)
+
 add_executable(storage_object_samples storage_object_samples.cc)
 target_link_libraries(storage_object_samples storage_client)
 

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -185,7 +185,7 @@ _EOF_
 }
 
 ################################################
-# Run all Object examples.
+# Run all Bucket ACL examples.
 # Globals:
 #   COLOR_*: colorize output messages, defined in colors.sh
 #   EXIT_STATUS: control the final exit status for the program.
@@ -231,6 +231,54 @@ _EOF_
 
   run_program_examples ./storage_bucket_acl_samples \
       "${BUCKET_ACL_COMMANDS}" \
+      "${bucket_name}"
+}
+
+################################################
+# Run all Default Object ACL examples.
+# Globals:
+#   COLOR_*: colorize output messages, defined in colors.sh
+#   EXIT_STATUS: control the final exit status for the program.
+# Arguments:
+#   bucket_name: the name of the bucket to run the examples against.
+# Returns:
+#   None
+################################################
+run_all_default_object_acl_examples() {
+  local bucket_name=$1
+  shift
+
+  # First create a bucket for the example:
+  if [ ! -x ./storage_bucket_samples ]; then
+    echo "${COLOR_YELLOW}[  SKIPPED ]${COLOR_RESET}" \
+        " storage_bucket_samples is not compiled"
+    return
+  fi
+  log="$(mktemp -t "storage_default_object_acl_setup.XXXXXX")"
+  set +e
+  ./storage_bucket_samples get-bucket-metadata \
+      "${bucket_name}"  >${log} 2>&1
+  if [ $? != 0 ]; then
+    EXIT_STATUS=1
+    echo   "${COLOR_RED}[    ERROR ]${COLOR_RESET}" \
+        " cannot create test bucket"
+    echo "================ [begin ${log}] ================"
+    cat "${log}"
+    echo "================ [end ${log}] ================"
+    set -e
+    return
+  fi
+  set -e
+
+  # The list of commands in the storage_bucket_samples program that we will
+  # test. Currently get-metadata assumes that $bucket_name is already created.
+  readonly DEFAULT_OBJECT_ACL_COMMANDS=$(tr '\n' ',' <<_EOF_
+list-default-object-acl
+_EOF_
+)
+
+  run_program_examples ./storage_default_object_acl_samples \
+      "${DEFAULT_OBJECT_ACL_COMMANDS}" \
       "${bucket_name}"
 }
 
@@ -354,6 +402,7 @@ run_all_storage_examples() {
       " Running Google Cloud Storage Examples"
   run_all_bucket_examples
   run_all_bucket_acl_examples "${BUCKET_NAME}"
+  run_all_default_object_acl_examples "${BUCKET_NAME}"
   run_all_object_examples "${BUCKET_NAME}"
   run_all_object_acl_examples "${BUCKET_NAME}"
   echo "${COLOR_GREEN}[ ======== ]${COLOR_RESET}" \

--- a/google/cloud/storage/examples/storage_default_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_default_object_acl_samples.cc
@@ -1,0 +1,111 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include <functional>
+#include <iostream>
+#include <map>
+#include <sstream>
+
+namespace {
+struct Usage {
+  std::string msg;
+};
+
+char const* ConsumeArg(int& argc, char* argv[]) {
+  if (argc < 2) {
+    return nullptr;
+  }
+  char const* result = argv[1];
+  std::copy(argv + 2, argv + argc, argv + 1);
+  argc--;
+  return result;
+}
+
+std::string command_usage;
+
+void PrintUsage(int argc, char* argv[], std::string const& msg) {
+  std::string const cmd = argv[0];
+  auto last_slash = std::string(cmd).find_last_of('/');
+  auto program = cmd.substr(last_slash + 1);
+  std::cerr << msg << "\nUsage: " << program << " <command> [arguments]\n\n"
+            << "Commands:\n"
+            << command_usage << std::endl;
+}
+
+void ListDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
+                          char* argv[]) {
+  if (argc != 2) {
+    throw Usage{"list-bucket-acl <bucket-name>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  //! [list default object acl] [START storage_print_bucket_default_acl]
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string bucket_name) {
+    std::cout << "ACLs for bucket=" << bucket_name << std::endl;
+    for (gcs::ObjectAccessControl const& acl :
+         client.ListDefaultObjectAcl(bucket_name)) {
+      std::cout << acl.role() << ":" << acl.entity() << std::endl;
+    }
+  }
+  //! [list default object acl] [END storage_print_bucket_default_acl]
+  (std::move(client), bucket_name);
+}
+
+}  // anonymous namespace
+
+int main(int argc, char* argv[]) try {
+  // Create a client to communicate with Google Cloud Storage.
+  google::cloud::storage::Client client;
+
+  // Build the list of commands and the usage string from that list.
+  using CommandType =
+      std::function<void(google::cloud::storage::Client, int&, char* [])>;
+  std::map<std::string, CommandType> commands = {
+      {"list-default-object-acl", &ListDefaultObjectAcl},
+  };
+  for (auto&& kv : commands) {
+    try {
+      int fake_argc = 1;
+      kv.second(client, fake_argc, argv);
+    } catch (Usage const& u) {
+      command_usage += "    ";
+      command_usage += u.msg;
+      command_usage += "\n";
+    }
+  }
+
+  if (argc < 2) {
+    PrintUsage(argc, argv, "Missing command");
+    return 1;
+  }
+
+  std::string const command = ConsumeArg(argc, argv);
+  auto it = commands.find(command);
+  if (commands.end() == it) {
+    PrintUsage(argc, argv, "Unknown command: " + command);
+    return 1;
+  }
+
+  // Call the command with that client.
+  it->second(client, argc, argv);
+
+  return 0;
+} catch (Usage const& ex) {
+  PrintUsage(argc, argv, ex.msg);
+  return 1;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard C++ exception raised: " << ex.what() << std::endl;
+  return 1;
+}

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -377,6 +377,25 @@ std::pair<Status, ObjectAccessControl> CurlClient::PatchObjectAcl(
                         ObjectAccessControl::ParseFromString(payload.payload));
 }
 
+std::pair<Status, ListDefaultObjectAclResponse>
+CurlClient::ListDefaultObjectAcl(ListDefaultObjectAclRequest const& request) {
+  // Assume the bucket name is validated by the caller.
+  CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
+                             "/defaultObjectAcl");
+  builder.SetDebugLogging(options_.enable_http_tracing());
+  builder.AddHeader(options_.credentials()->AuthorizationHeader());
+  request.AddOptionsToHttpRequest(builder);
+  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  if (payload.status_code >= 300) {
+    return std::make_pair(
+        Status{payload.status_code, std::move(payload.payload)},
+        internal::ListDefaultObjectAclResponse{});
+  }
+  return std::make_pair(
+      Status(), internal::ListDefaultObjectAclResponse::FromHttpResponse(
+                    std::move(payload)));
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -82,6 +82,9 @@ class CurlClient : public RawClient {
   std::pair<Status, ObjectAccessControl> PatchObjectAcl(
       PatchObjectAclRequest const&) override;
 
+  std::pair<Status, ListDefaultObjectAclResponse> ListDefaultObjectAcl(
+      ListDefaultObjectAclRequest const& request) override;
+
  private:
   ClientOptions options_;
   std::string storage_endpoint_;

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -180,6 +180,13 @@ std::pair<Status, ObjectAccessControl> LoggingClient::PatchObjectAcl(
   return MakeCall(*client_, &RawClient::PatchObjectAcl, request, __func__);
 }
 
+std::pair<Status, ListDefaultObjectAclResponse>
+LoggingClient::ListDefaultObjectAcl(
+    ListDefaultObjectAclRequest const& request) {
+  return MakeCall(*client_, &RawClient::ListDefaultObjectAcl, request,
+                  __func__);
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -74,6 +74,9 @@ class LoggingClient : public RawClient {
   std::pair<Status, ObjectAccessControl> PatchObjectAcl(
       PatchObjectAclRequest const&) override;
 
+  std::pair<Status, ListDefaultObjectAclResponse> ListDefaultObjectAcl(
+      ListDefaultObjectAclRequest const& request) override;
+
   std::shared_ptr<RawClient> client() const { return client_; }
 
  private:

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -20,6 +20,7 @@
 #include "google/cloud/storage/credentials.h"
 #include "google/cloud/storage/internal/bucket_acl_requests.h"
 #include "google/cloud/storage/internal/bucket_requests.h"
+#include "google/cloud/storage/internal/default_object_acl_requests.h"
 #include "google/cloud/storage/internal/delete_object_request.h"
 #include "google/cloud/storage/internal/empty_response.h"
 #include "google/cloud/storage/internal/get_object_metadata_request.h"
@@ -100,6 +101,12 @@ class RawClient {
       UpdateObjectAclRequest const&) = 0;
   virtual std::pair<Status, ObjectAccessControl> PatchObjectAcl(
       PatchObjectAclRequest const&) = 0;
+  //@}
+
+  //@{
+  /// @name DefaultObjectAccessControls operations.
+  virtual std::pair<Status, ListDefaultObjectAclResponse> ListDefaultObjectAcl(
+      ListDefaultObjectAclRequest const&) = 0;
   //@}
 };
 

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -264,6 +264,14 @@ std::pair<Status, ObjectAccessControl> RetryClient::PatchObjectAcl(
                   &RawClient::PatchObjectAcl, request, __func__);
 }
 
+std::pair<Status, ListDefaultObjectAclResponse>
+RetryClient::ListDefaultObjectAcl(ListDefaultObjectAclRequest const& request) {
+  auto retry_policy = retry_policy_->clone();
+  auto backoff_policy = backoff_policy_->clone();
+  return MakeCall(*retry_policy, *backoff_policy, *client_,
+                  &RawClient::ListDefaultObjectAcl, request, __func__);
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -89,6 +89,9 @@ class RetryClient : public RawClient {
   std::pair<Status, ObjectAccessControl> PatchObjectAcl(
       PatchObjectAclRequest const&) override;
 
+  std::pair<Status, ListDefaultObjectAclResponse> ListDefaultObjectAcl(
+      ListDefaultObjectAclRequest const& request) override;
+
   std::shared_ptr<RawClient> client() const { return client_; }
 
  private:

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -4,6 +4,7 @@ storage_client_unit_tests = [
     "bucket_metadata_test.cc",
     "bucket_test.cc",
     "client_bucket_acl_test.cc",
+    "client_default_object_acl_test.cc",
     "client_object_acl_test.cc",
     "client_test.cc",
     "client_write_object_test.cc",

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -78,6 +78,10 @@ class MockClient : public google::cloud::storage::internal::RawClient {
                                     internal::UpdateObjectAclRequest const&));
   MOCK_METHOD1(PatchObjectAcl, ResponseWrapper<ObjectAccessControl>(
                                    internal::PatchObjectAclRequest const&));
+
+  MOCK_METHOD1(ListDefaultObjectAcl,
+               ResponseWrapper<internal::ListDefaultObjectAclResponse>(
+                   internal::ListDefaultObjectAclRequest const&));
 };
 }  // namespace testing
 }  // namespace storage

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -283,6 +283,19 @@ TEST_F(BucketIntegrationTest, AccessControlCRUD) {
   // state.
 }
 
+TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
+  Client client;
+  auto bucket_name = BucketTestEnvironment::bucket_name();
+
+  auto entity_name = MakeEntityName();
+  std::vector<ObjectAccessControl> initial_acl =
+      client.ListDefaultObjectAcl(bucket_name);
+
+  // TODO(#833) TODO(#835) - make stronger assertions once we can modify the
+  // ACL.
+  EXPECT_FALSE(initial_acl.empty());
+}
+
 }  // namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/tests/testbench.py
+++ b/google/cloud/storage/tests/testbench.py
@@ -373,6 +373,12 @@ class GcsBucket(object):
             canonical_entity_name('project-editors-123456789'), 'OWNER')
         self.insert_acl(
             canonical_entity_name('project-viewers-123456789'), 'READER')
+        self.insert_default_object_acl(
+            canonical_entity_name('project-owners-123456789'), 'OWNER')
+        self.insert_default_object_acl(
+            canonical_entity_name('project-editors-123456789'), 'OWNER')
+        self.insert_default_object_acl(
+            canonical_entity_name('project-viewers-123456789'), 'READER')
 
     def update_from_metadata(self, metadata):
         """Update from a metadata dictionary.


### PR DESCRIPTION
This fixes #836. It implements the API, the unit tests, a basic
integration test, some sample code, and runs both the integration test
and sample code as part of the CI builds.
