### PR TITLE
Implement PatchBucketRequest.

### DIFF
--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -499,9 +499,6 @@ BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::ResetEncryption() {
 
 BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetLabel(
     std::string const& label, std::string const& value) {
-  if (value.empty()) {
-    return ResetLabel(label);
-  }
   labels_subpatch_.SetStringField(label.c_str(), value);
   labels_subpatch_dirty_ = true;
   return *this;

--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -384,12 +384,13 @@ std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs) {
   return os << "}";
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_acl(
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetAcl(
     std::vector<BucketAccessControl> const& v) {
   if (v.empty()) {
-    return reset_acl();
+    return ResetAcl();
   }
   std::vector<internal::nl::json> array;
+  array.reserve(v.size());
   for (auto const& a : v) {
     array.emplace_back(internal::nl::json{
         {"entity", a.entity()},
@@ -400,29 +401,30 @@ BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_acl(
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_acl() {
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::ResetAcl() {
   impl_.RemoveField("acl");
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_billing(
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetBilling(
     BucketBilling const& v) {
   impl_.AddSubPatch("billing", internal::PatchBuilder().SetBoolField(
                                    "requesterPays", v.requester_pays));
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_billing() {
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::ResetBilling() {
   impl_.RemoveField("billing");
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_cors(
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetCors(
     std::vector<CorsEntry> const& v) {
   if (v.empty()) {
-    return reset_cors();
+    return ResetCors();
   }
   std::vector<internal::nl::json> array;
+  array.reserve(v.size());
   for (auto const& a : v) {
     internal::nl::json entry;
     if (a.max_age_seconds.has_value()) {
@@ -443,17 +445,18 @@ BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_cors(
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_cors() {
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::ResetCors() {
   impl_.RemoveField("cors");
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_default_acl(
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetDefaultAcl(
     std::vector<ObjectAccessControl> const& v) {
   if (v.empty()) {
-    return reset_default_acl();
+    return ResetDefaultAcl();
   }
   std::vector<internal::nl::json> array;
+  array.reserve(v.size());
   for (auto const& a : v) {
     array.emplace_back(internal::nl::json{
         {"entity", a.entity()},
@@ -464,12 +467,12 @@ BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_default_acl(
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_default_acl() {
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::ResetDefaultAcl() {
   impl_.RemoveField("defaultObjectAcl");
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_encryption(
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetEncryption(
     BucketEncryption const& v) {
   impl_.AddSubPatch("encryption",
                     internal::PatchBuilder().SetStringField(
@@ -477,15 +480,15 @@ BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_encryption(
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_encryption() {
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::ResetEncryption() {
   impl_.RemoveField("encryption");
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_label(
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetLabel(
     std::map<std::string, std::string> const& v) {
   if (v.empty()) {
-    return reset_label();
+    return ResetLabel();
   }
   internal::PatchBuilder subpatch;
   for (auto const& kv : v) {
@@ -495,18 +498,19 @@ BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_label(
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_label() {
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::ResetLabel() {
   impl_.RemoveField("label");
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_lifecycle(
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetLifecycle(
     BucketLifecycle const& v) {
   if (v.rule.empty()) {
-    return reset_lifecycle();
+    return ResetLifecycle();
   }
   internal::PatchBuilder subpatch;
   std::vector<internal::nl::json> array;
+  array.reserve(v.rule.size());
   for (auto const& a : v.rule) {
     internal::nl::json condition;
     auto const& c = a.condition();
@@ -542,26 +546,26 @@ BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_lifecycle(
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_lifecycle() {
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::ResetLifecycle() {
   impl_.RemoveField("lifecycle");
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_location(
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetLocation(
     std::string const& v) {
   if (v.empty()) {
-    return reset_location();
+    return ResetLocation();
   }
   impl_.SetStringField("location", v);
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_location() {
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::ResetLocation() {
   impl_.RemoveField("location");
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_logging(
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetLogging(
     BucketLogging const& v) {
   impl_.AddSubPatch("logging", internal::PatchBuilder()
                                    .SetStringField("logBucket", v.log_bucket)
@@ -569,52 +573,52 @@ BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_logging(
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_logging() {
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::ResetLogging() {
   impl_.RemoveField("logging");
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_name(
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetName(
     std::string const& v) {
   if (v.empty()) {
-    return reset_name();
+    return ResetName();
   }
   impl_.SetStringField("name", v);
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_name() {
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::ResetName() {
   impl_.RemoveField("name");
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_storage_class(
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetStorageClass(
     std::string const& v) {
   if (v.empty()) {
-    return reset_storage_class();
+    return ResetStorageClass();
   }
   impl_.SetStringField("storageClass", v);
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_storage_class() {
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::ResetStorageClass() {
   impl_.RemoveField("storageClass");
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_versioning(
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetVersioning(
     BucketVersioning const& v) {
   impl_.AddSubPatch("versioning", internal::PatchBuilder().SetBoolField(
                                       "enabled", v.enabled));
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_versioning() {
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::ResetVersioning() {
   impl_.RemoveField("versioning");
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_website(
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetWebsite(
     BucketWebsite const& v) {
   impl_.AddSubPatch("website",
                     internal::PatchBuilder()
@@ -623,7 +627,7 @@ BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_website(
   return *this;
 }
 
-BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_website() {
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::ResetWebsite() {
   impl_.RemoveField("website");
   return *this;
 }

--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -384,6 +384,250 @@ std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs) {
   return os << "}";
 }
 
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_acl(
+    std::vector<BucketAccessControl> const& v) {
+  if (v.empty()) {
+    return reset_acl();
+  }
+  std::vector<internal::nl::json> array;
+  for (auto const& a : v) {
+    array.emplace_back(internal::nl::json{
+        {"entity", a.entity()},
+        {"role", a.role()},
+    });
+  }
+  impl_.SetArrayField("acl", array);
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_acl() {
+  impl_.RemoveField("acl");
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_billing(
+    BucketBilling const& v) {
+  impl_.AddSubPatch("billing", internal::PatchBuilder().SetBoolField(
+                                   "requesterPays", v.requester_pays));
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_billing() {
+  impl_.RemoveField("billing");
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_cors(
+    std::vector<CorsEntry> const& v) {
+  if (v.empty()) {
+    return reset_cors();
+  }
+  std::vector<internal::nl::json> array;
+  for (auto const& a : v) {
+    internal::nl::json entry;
+    if (a.max_age_seconds.has_value()) {
+      entry["maxAgeSeconds"] = *a.max_age_seconds;
+    }
+    if (not a.method.empty()) {
+      entry["method"] = a.method;
+    }
+    if (not a.origin.empty()) {
+      entry["origin"] = a.origin;
+    }
+    if (not a.response_header.empty()) {
+      entry["responseHeader"] = a.response_header;
+    }
+    array.emplace_back(std::move(entry));
+  }
+  impl_.SetArrayField("cors", array);
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_cors() {
+  impl_.RemoveField("cors");
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_default_acl(
+    std::vector<ObjectAccessControl> const& v) {
+  if (v.empty()) {
+    return reset_default_acl();
+  }
+  std::vector<internal::nl::json> array;
+  for (auto const& a : v) {
+    array.emplace_back(internal::nl::json{
+        {"entity", a.entity()},
+        {"role", a.role()},
+    });
+  }
+  impl_.SetArrayField("defaultObjectAcl", array);
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_default_acl() {
+  impl_.RemoveField("defaultObjectAcl");
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_encryption(
+    BucketEncryption const& v) {
+  impl_.AddSubPatch("encryption",
+                    internal::PatchBuilder().SetStringField(
+                        "defaultKmsKeyName", v.default_kms_key_name));
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_encryption() {
+  impl_.RemoveField("encryption");
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_label(
+    std::map<std::string, std::string> const& v) {
+  if (v.empty()) {
+    return reset_label();
+  }
+  internal::PatchBuilder subpatch;
+  for (auto const& kv : v) {
+    subpatch.SetStringField(kv.first.c_str(), kv.second);
+  }
+  impl_.AddSubPatch("label", subpatch);
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_label() {
+  impl_.RemoveField("label");
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_lifecycle(
+    BucketLifecycle const& v) {
+  if (v.rule.empty()) {
+    return reset_lifecycle();
+  }
+  internal::PatchBuilder subpatch;
+  std::vector<internal::nl::json> array;
+  for (auto const& a : v.rule) {
+    internal::nl::json condition;
+    auto const& c = a.condition();
+    if (c.age.has_value()) {
+      condition["age"] = *c.age;
+    }
+    if (c.created_before.has_value()) {
+      condition["createdBefore"] = internal::FormatRfc3339(*c.created_before);
+    }
+    if (c.is_live.has_value()) {
+      condition["isLive"] = *c.is_live;
+    }
+    if (c.matches_storage_class.has_value()) {
+      condition["matchesStorageClass"] = *c.matches_storage_class;
+    }
+    if (c.num_newer_versions.has_value()) {
+      condition["numNewerVersions"] = *c.num_newer_versions;
+    }
+    internal::nl::json action;
+    if (not a.action().type.empty()) {
+      action["type"] = a.action().type;
+    }
+    if (not a.action().storage_class.empty()) {
+      action["storageClass"] = a.action().storage_class;
+    }
+    array.emplace_back(internal::nl::json{
+        {"action", action},
+        {"condition", condition},
+    });
+  }
+  subpatch.SetArrayField("rule", array);
+  impl_.AddSubPatch("lifecycle", subpatch);
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_lifecycle() {
+  impl_.RemoveField("lifecycle");
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_location(
+    std::string const& v) {
+  if (v.empty()) {
+    return reset_location();
+  }
+  impl_.SetStringField("location", v);
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_location() {
+  impl_.RemoveField("location");
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_logging(
+    BucketLogging const& v) {
+  impl_.AddSubPatch("logging", internal::PatchBuilder()
+                                   .SetStringField("logBucket", v.log_bucket)
+                                   .SetStringField("logPrefix", v.log_prefix));
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_logging() {
+  impl_.RemoveField("logging");
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_name(
+    std::string const& v) {
+  if (v.empty()) {
+    return reset_name();
+  }
+  impl_.SetStringField("name", v);
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_name() {
+  impl_.RemoveField("name");
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_storage_class(
+    std::string const& v) {
+  if (v.empty()) {
+    return reset_storage_class();
+  }
+  impl_.SetStringField("storageClass", v);
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_storage_class() {
+  impl_.RemoveField("storageClass");
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_versioning(
+    BucketVersioning const& v) {
+  impl_.AddSubPatch("versioning", internal::PatchBuilder().SetBoolField(
+                                      "enabled", v.enabled));
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_versioning() {
+  impl_.RemoveField("versioning");
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::set_website(
+    BucketWebsite const& v) {
+  impl_.AddSubPatch("website",
+                    internal::PatchBuilder()
+                        .SetStringField("mainPageSuffix", v.main_page_suffix)
+                        .SetStringField("notFoundPage", v.not_found_page));
+  return *this;
+}
+
+BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::reset_website() {
+  impl_.RemoveField("website");
+  return *this;
+}
+
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -611,47 +611,46 @@ class BucketMetadataPatchBuilder {
 
   std::string BuildPatch() const { return impl_.ToString(); }
 
-  BucketMetadataPatchBuilder& set_acl(
-      std::vector<BucketAccessControl> const& v);
-  BucketMetadataPatchBuilder& reset_acl();
+  BucketMetadataPatchBuilder& SetAcl(std::vector<BucketAccessControl> const& v);
+  BucketMetadataPatchBuilder& ResetAcl();
 
-  BucketMetadataPatchBuilder& set_billing(BucketBilling const& v);
-  BucketMetadataPatchBuilder& reset_billing();
+  BucketMetadataPatchBuilder& SetBilling(BucketBilling const& v);
+  BucketMetadataPatchBuilder& ResetBilling();
 
-  BucketMetadataPatchBuilder& set_cors(std::vector<CorsEntry> const& v);
-  BucketMetadataPatchBuilder& reset_cors();
+  BucketMetadataPatchBuilder& SetCors(std::vector<CorsEntry> const& v);
+  BucketMetadataPatchBuilder& ResetCors();
 
-  BucketMetadataPatchBuilder& set_default_acl(
+  BucketMetadataPatchBuilder& SetDefaultAcl(
       std::vector<ObjectAccessControl> const& v);
-  BucketMetadataPatchBuilder& reset_default_acl();
+  BucketMetadataPatchBuilder& ResetDefaultAcl();
 
-  BucketMetadataPatchBuilder& set_encryption(BucketEncryption const& v);
-  BucketMetadataPatchBuilder& reset_encryption();
+  BucketMetadataPatchBuilder& SetEncryption(BucketEncryption const& v);
+  BucketMetadataPatchBuilder& ResetEncryption();
 
-  BucketMetadataPatchBuilder& set_label(
+  BucketMetadataPatchBuilder& SetLabel(
       std::map<std::string, std::string> const& v);
-  BucketMetadataPatchBuilder& reset_label();
+  BucketMetadataPatchBuilder& ResetLabel();
 
-  BucketMetadataPatchBuilder& set_lifecycle(BucketLifecycle const& v);
-  BucketMetadataPatchBuilder& reset_lifecycle();
+  BucketMetadataPatchBuilder& SetLifecycle(BucketLifecycle const& v);
+  BucketMetadataPatchBuilder& ResetLifecycle();
 
-  BucketMetadataPatchBuilder& set_location(std::string const& v);
-  BucketMetadataPatchBuilder& reset_location();
+  BucketMetadataPatchBuilder& SetLocation(std::string const& v);
+  BucketMetadataPatchBuilder& ResetLocation();
 
-  BucketMetadataPatchBuilder& set_logging(BucketLogging const& v);
-  BucketMetadataPatchBuilder& reset_logging();
+  BucketMetadataPatchBuilder& SetLogging(BucketLogging const& v);
+  BucketMetadataPatchBuilder& ResetLogging();
 
-  BucketMetadataPatchBuilder& set_name(std::string const& v);
-  BucketMetadataPatchBuilder& reset_name();
+  BucketMetadataPatchBuilder& SetName(std::string const& v);
+  BucketMetadataPatchBuilder& ResetName();
 
-  BucketMetadataPatchBuilder& set_storage_class(std::string const& v);
-  BucketMetadataPatchBuilder& reset_storage_class();
+  BucketMetadataPatchBuilder& SetStorageClass(std::string const& v);
+  BucketMetadataPatchBuilder& ResetStorageClass();
 
-  BucketMetadataPatchBuilder& set_versioning(BucketVersioning const& v);
-  BucketMetadataPatchBuilder& reset_versioning();
+  BucketMetadataPatchBuilder& SetVersioning(BucketVersioning const& v);
+  BucketMetadataPatchBuilder& ResetVersioning();
 
-  BucketMetadataPatchBuilder& set_website(BucketWebsite const& v);
-  BucketMetadataPatchBuilder& reset_website();
+  BucketMetadataPatchBuilder& SetWebsite(BucketWebsite const& v);
+  BucketMetadataPatchBuilder& ResetWebsite();
 
  private:
   internal::PatchBuilder impl_;

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -456,9 +456,8 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   std::string const& label(std::string const& key) const {
     return labels_.at(key);
   }
-  std::map<std::string, std::string> const& all_labels() const {
-    return labels_;
-  }
+  std::map<std::string, std::string> const& labels() const { return labels_; }
+  std::map<std::string, std::string>& mutable_labels() { return labels_; }
 
   //@{
   /**
@@ -607,9 +606,9 @@ std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs);
  */
 class BucketMetadataPatchBuilder {
  public:
-  BucketMetadataPatchBuilder() = default;
+  BucketMetadataPatchBuilder() : labels_subpatch_dirty_(false) {}
 
-  std::string BuildPatch() const { return impl_.ToString(); }
+  std::string BuildPatch() const;
 
   BucketMetadataPatchBuilder& SetAcl(std::vector<BucketAccessControl> const& v);
   BucketMetadataPatchBuilder& ResetAcl();
@@ -627,9 +626,10 @@ class BucketMetadataPatchBuilder {
   BucketMetadataPatchBuilder& SetEncryption(BucketEncryption const& v);
   BucketMetadataPatchBuilder& ResetEncryption();
 
-  BucketMetadataPatchBuilder& SetLabel(
-      std::map<std::string, std::string> const& v);
-  BucketMetadataPatchBuilder& ResetLabel();
+  BucketMetadataPatchBuilder& SetLabel(std::string const& label,
+                                       std::string const& value);
+  BucketMetadataPatchBuilder& ResetLabel(std::string const& label);
+  BucketMetadataPatchBuilder& ResetLabels();
 
   BucketMetadataPatchBuilder& SetLifecycle(BucketLifecycle const& v);
   BucketMetadataPatchBuilder& ResetLifecycle();
@@ -654,6 +654,8 @@ class BucketMetadataPatchBuilder {
 
  private:
   internal::PatchBuilder impl_;
+  bool labels_subpatch_dirty_;
+  internal::PatchBuilder labels_subpatch_;
 };
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/bucket_access_control.h"
 #include "google/cloud/storage/internal/common_metadata.h"
 #include "google/cloud/storage/internal/nljson.h"
+#include "google/cloud/storage/internal/patch_builder.h"
 #include "google/cloud/storage/lifecycle_rule.h"
 #include "google/cloud/storage/object_access_control.h"
 #include <map>
@@ -37,6 +38,7 @@ inline namespace STORAGE_CLIENT_NS {
  */
 struct BucketBilling {
   BucketBilling() : requester_pays(false) {}
+  BucketBilling(bool v) : requester_pays(v) {}
 
   bool requester_pays;
 };
@@ -359,6 +361,9 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
    */
   bool has_billing() const { return billing_.has_value(); }
   BucketBilling const& billing() const { return *billing_; }
+  cloud::internal::optional<BucketBilling> const& billing_as_optional() const {
+    return billing_;
+  }
   BucketMetadata& set_billing(BucketBilling const& v) {
     billing_ = v;
     return *this;
@@ -426,6 +431,10 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
    */
   bool has_encryption() const { return encryption_.has_value(); }
   BucketEncryption const& encryption() const { return *encryption_; }
+  cloud::internal::optional<BucketEncryption> const& encryption_as_optional()
+      const {
+    return encryption_;
+  }
   BucketMetadata& set_encryption(BucketEncryption v) {
     encryption_ = std::move(v);
     return *this;
@@ -446,6 +455,9 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   }
   std::string const& label(std::string const& key) const {
     return labels_.at(key);
+  }
+  std::map<std::string, std::string> const& all_labels() const {
+    return labels_;
   }
 
   //@{
@@ -481,6 +493,9 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   /// @name Accessors and modifiers for logging configuration.
   bool has_logging() const { return logging_.has_value(); }
   BucketLogging const& logging() const { return *logging_; }
+  cloud::internal::optional<BucketLogging> const& loggin_as_optional() const {
+    return logging_;
+  }
   BucketMetadata& set_logging(BucketLogging v) {
     logging_ = v;
     return *this;
@@ -519,6 +534,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
       const {
     return versioning_;
   }
+  bool has_versioning() const { return versioning_.has_value(); }
   BucketMetadata& enable_versioning() {
     versioning_.emplace(BucketVersioning{true});
     return *this;
@@ -542,6 +558,9 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   /// @name Accessors and modifiers for website configuration.
   bool has_website() const { return website_.has_value(); }
   BucketWebsite const& website() const { return *website_; }
+  cloud::internal::optional<BucketWebsite> const& website_as_optional() const {
+    return website_;
+  }
   BucketMetadata& set_website(BucketWebsite v) {
     website_ = std::move(v);
     return *this;
@@ -574,6 +593,69 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
 
 std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs);
 
+/**
+ * Prepare a patch for the Bucket resource.
+ *
+ * The Bucket resource has many modifiable fields. The application may send a
+ * patch request to change (or delete) a small fraction of these fields by using
+ * this object.
+ *
+ * @see
+ * https://cloud.google.com/storage/docs/json_api/v1/how-tos/performance#patch
+ *     for general information on PATCH requests for the Google Cloud Storage
+ *     JSON API.
+ */
+class BucketMetadataPatchBuilder {
+ public:
+  BucketMetadataPatchBuilder() = default;
+
+  std::string BuildPatch() const { return impl_.ToString(); }
+
+  BucketMetadataPatchBuilder& set_acl(
+      std::vector<BucketAccessControl> const& v);
+  BucketMetadataPatchBuilder& reset_acl();
+
+  BucketMetadataPatchBuilder& set_billing(BucketBilling const& v);
+  BucketMetadataPatchBuilder& reset_billing();
+
+  BucketMetadataPatchBuilder& set_cors(std::vector<CorsEntry> const& v);
+  BucketMetadataPatchBuilder& reset_cors();
+
+  BucketMetadataPatchBuilder& set_default_acl(
+      std::vector<ObjectAccessControl> const& v);
+  BucketMetadataPatchBuilder& reset_default_acl();
+
+  BucketMetadataPatchBuilder& set_encryption(BucketEncryption const& v);
+  BucketMetadataPatchBuilder& reset_encryption();
+
+  BucketMetadataPatchBuilder& set_label(
+      std::map<std::string, std::string> const& v);
+  BucketMetadataPatchBuilder& reset_label();
+
+  BucketMetadataPatchBuilder& set_lifecycle(BucketLifecycle const& v);
+  BucketMetadataPatchBuilder& reset_lifecycle();
+
+  BucketMetadataPatchBuilder& set_location(std::string const& v);
+  BucketMetadataPatchBuilder& reset_location();
+
+  BucketMetadataPatchBuilder& set_logging(BucketLogging const& v);
+  BucketMetadataPatchBuilder& reset_logging();
+
+  BucketMetadataPatchBuilder& set_name(std::string const& v);
+  BucketMetadataPatchBuilder& reset_name();
+
+  BucketMetadataPatchBuilder& set_storage_class(std::string const& v);
+  BucketMetadataPatchBuilder& reset_storage_class();
+
+  BucketMetadataPatchBuilder& set_versioning(BucketVersioning const& v);
+  BucketMetadataPatchBuilder& reset_versioning();
+
+  BucketMetadataPatchBuilder& set_website(BucketWebsite const& v);
+  BucketMetadataPatchBuilder& reset_website();
+
+ private:
+  internal::PatchBuilder impl_;
+};
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -611,6 +611,12 @@ class BucketMetadataPatchBuilder {
   std::string BuildPatch() const;
 
   BucketMetadataPatchBuilder& SetAcl(std::vector<BucketAccessControl> const& v);
+
+  /**
+   * Clear the ACL for the Bucket.
+   *
+   * @warning Currently the server ignores requests to reset the full ACL.
+   */
   BucketMetadataPatchBuilder& ResetAcl();
 
   BucketMetadataPatchBuilder& SetBilling(BucketBilling const& v);
@@ -621,6 +627,12 @@ class BucketMetadataPatchBuilder {
 
   BucketMetadataPatchBuilder& SetDefaultAcl(
       std::vector<ObjectAccessControl> const& v);
+
+  /**
+   * Clear the ACL for the Bucket.
+   *
+   * @warning Currently the server ignores requests to reset the full ACL.
+   */
   BucketMetadataPatchBuilder& ResetDefaultAcl();
 
   BucketMetadataPatchBuilder& SetEncryption(BucketEncryption const& v);

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -492,7 +492,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   /// @name Accessors and modifiers for logging configuration.
   bool has_logging() const { return logging_.has_value(); }
   BucketLogging const& logging() const { return *logging_; }
-  cloud::internal::optional<BucketLogging> const& loggin_as_optional() const {
+  cloud::internal::optional<BucketLogging> const& logging_as_optional() const {
     return logging_;
   }
   BucketMetadata& set_logging(BucketLogging v) {
@@ -542,7 +542,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
     versioning_.emplace(BucketVersioning{false});
     return *this;
   }
-  BucketMetadata& clear_versioning() {
+  BucketMetadata& reset_versioning() {
     versioning_.reset();
     return *this;
   }

--- a/google/cloud/storage/bucket_metadata_test.cc
+++ b/google/cloud/storage/bucket_metadata_test.cc
@@ -551,7 +551,7 @@ TEST(BucketMetadataTest, ClearVersioning) {
   auto expected = CreateBucketMetadataForTest();
   EXPECT_TRUE(expected.versioning().has_value());
   auto copy = expected;
-  copy.clear_versioning();
+  copy.reset_versioning();
   EXPECT_FALSE(copy.versioning().has_value());
   EXPECT_NE(copy, expected);
   std::ostringstream os;
@@ -577,7 +577,7 @@ TEST(BucketMetadataTest, EnableVersioning) {
   EXPECT_TRUE(expected.versioning().has_value());
   EXPECT_TRUE(expected.versioning()->enabled);
   auto copy = expected;
-  copy.clear_versioning();
+  copy.reset_versioning();
   copy.enable_versioning();
   EXPECT_TRUE(copy.versioning().has_value());
   EXPECT_TRUE(copy.versioning()->enabled);
@@ -751,26 +751,29 @@ TEST(BucketMetadataPatchBuilder, ResetEncryption) {
   ASSERT_TRUE(json["encryption"].is_null()) << json;
 }
 
-TEST(BucketMetadataPatchBuilder, SetLabel) {
+TEST(BucketMetadataPatchBuilder, SetLabels) {
   BucketMetadataPatchBuilder builder;
-  builder.SetLabel({{"test-label1", "v1"}, {"test-label2", "v2"}});
+  builder.SetLabel("test-label1", "v1");
+  builder.SetLabel("test-label2", "v2");
+  builder.ResetLabel("test-label3");
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
-  ASSERT_EQ(1U, json.count("label")) << json;
-  ASSERT_TRUE(json["label"].is_object()) << json;
-  EXPECT_EQ("v1", json["label"].value("test-label1", "")) << json;
-  EXPECT_EQ("v2", json["label"].value("test-label2", "")) << json;
+  ASSERT_EQ(1U, json.count("labels")) << json;
+  ASSERT_TRUE(json["labels"].is_object()) << json;
+  EXPECT_EQ("v1", json["labels"].value("test-label1", "")) << json;
+  EXPECT_EQ("v2", json["labels"].value("test-label2", "")) << json;
+  EXPECT_TRUE(json["labels"]["test-label3"].is_null()) << json;
 }
 
-TEST(BucketMetadataPatchBuilder, ResetLabel) {
+TEST(BucketMetadataPatchBuilder, ResetLabels) {
   BucketMetadataPatchBuilder builder;
-  builder.ResetLabel();
+  builder.ResetLabels();
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
-  ASSERT_EQ(1U, json.count("label")) << json;
-  ASSERT_TRUE(json["label"].is_null()) << json;
+  ASSERT_EQ(1U, json.count("labels")) << json;
+  ASSERT_TRUE(json["labels"].is_null()) << json;
 }
 
 TEST(BucketMetadataPatchBuilder, SetLifecycle) {

--- a/google/cloud/storage/bucket_metadata_test.cc
+++ b/google/cloud/storage/bucket_metadata_test.cc
@@ -621,7 +621,7 @@ TEST(BucketMetadataTest, ResetWebsite) {
 
 TEST(BucketMetadataPatchBuilder, SetAcl) {
   BucketMetadataPatchBuilder builder;
-  builder.set_acl({BucketAccessControl::ParseFromString(
+  builder.SetAcl({BucketAccessControl::ParseFromString(
       R"""({"entity": "user-test-user", "role": "OWNER"})""")});
 
   auto actual = builder.BuildPatch();
@@ -635,7 +635,7 @@ TEST(BucketMetadataPatchBuilder, SetAcl) {
 
 TEST(BucketMetadataPatchBuilder, ResetAcl) {
   BucketMetadataPatchBuilder builder;
-  builder.reset_acl();
+  builder.ResetAcl();
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -645,7 +645,7 @@ TEST(BucketMetadataPatchBuilder, ResetAcl) {
 
 TEST(BucketMetadataPatchBuilder, SetBilling) {
   BucketMetadataPatchBuilder builder;
-  builder.set_billing(BucketBilling{true});
+  builder.SetBilling(BucketBilling{true});
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -656,7 +656,7 @@ TEST(BucketMetadataPatchBuilder, SetBilling) {
 
 TEST(BucketMetadataPatchBuilder, ResetBilling) {
   BucketMetadataPatchBuilder builder;
-  builder.reset_billing();
+  builder.ResetBilling();
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -673,7 +673,7 @@ TEST(BucketMetadataPatchBuilder, SetCors) {
                 {},
                 {"origin1"},
                 {}});
-  builder.set_cors(v);
+  builder.SetCors(v);
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -693,7 +693,7 @@ TEST(BucketMetadataPatchBuilder, SetCors) {
 
 TEST(BucketMetadataPatchBuilder, ResetCors) {
   BucketMetadataPatchBuilder builder;
-  builder.reset_cors();
+  builder.ResetCors();
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -703,7 +703,7 @@ TEST(BucketMetadataPatchBuilder, ResetCors) {
 
 TEST(BucketMetadataPatchBuilder, SetDefaultAcl) {
   BucketMetadataPatchBuilder builder;
-  builder.set_default_acl({ObjectAccessControl::ParseFromString(
+  builder.SetDefaultAcl({ObjectAccessControl::ParseFromString(
       R"""({"entity": "user-test-user", "role": "OWNER"})""")});
 
   auto actual = builder.BuildPatch();
@@ -718,7 +718,7 @@ TEST(BucketMetadataPatchBuilder, SetDefaultAcl) {
 
 TEST(BucketMetadataPatchBuilder, ResetDefaultAcl) {
   BucketMetadataPatchBuilder builder;
-  builder.reset_default_acl();
+  builder.ResetDefaultAcl();
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -731,7 +731,7 @@ TEST(BucketMetadataPatchBuilder, SetEncryption) {
   std::string expected =
       "projects/test-project-name/locations/us-central1/keyRings/"
       "test-keyring-name/cryptoKeys/test-key-name";
-  builder.set_encryption(BucketEncryption{expected});
+  builder.SetEncryption(BucketEncryption{expected});
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -743,7 +743,7 @@ TEST(BucketMetadataPatchBuilder, SetEncryption) {
 
 TEST(BucketMetadataPatchBuilder, ResetEncryption) {
   BucketMetadataPatchBuilder builder;
-  builder.reset_encryption();
+  builder.ResetEncryption();
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -753,7 +753,7 @@ TEST(BucketMetadataPatchBuilder, ResetEncryption) {
 
 TEST(BucketMetadataPatchBuilder, SetLabel) {
   BucketMetadataPatchBuilder builder;
-  builder.set_label({{"test-label1", "v1"}, {"test-label2", "v2"}});
+  builder.SetLabel({{"test-label1", "v1"}, {"test-label2", "v2"}});
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -765,7 +765,7 @@ TEST(BucketMetadataPatchBuilder, SetLabel) {
 
 TEST(BucketMetadataPatchBuilder, ResetLabel) {
   BucketMetadataPatchBuilder builder;
-  builder.reset_label();
+  builder.ResetLabel();
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -783,7 +783,7 @@ TEST(BucketMetadataPatchBuilder, SetLifecycle) {
                    LifecycleRule::SetStorageClassNearline());
   lifecycle.rule.emplace_back(r1);
   lifecycle.rule.emplace_back(r2);
-  builder.set_lifecycle(lifecycle);
+  builder.SetLifecycle(lifecycle);
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -805,7 +805,7 @@ TEST(BucketMetadataPatchBuilder, SetLifecycle) {
 
 TEST(BucketMetadataPatchBuilder, ResetLifecycle) {
   BucketMetadataPatchBuilder builder;
-  builder.reset_lifecycle();
+  builder.ResetLifecycle();
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -815,7 +815,7 @@ TEST(BucketMetadataPatchBuilder, ResetLifecycle) {
 
 TEST(BucketMetadataPatchBuilder, SetLocation) {
   BucketMetadataPatchBuilder builder;
-  builder.set_location("EU");
+  builder.SetLocation("EU");
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -826,7 +826,7 @@ TEST(BucketMetadataPatchBuilder, SetLocation) {
 
 TEST(BucketMetadataPatchBuilder, ResetLocation) {
   BucketMetadataPatchBuilder builder;
-  builder.reset_location();
+  builder.ResetLocation();
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -836,7 +836,7 @@ TEST(BucketMetadataPatchBuilder, ResetLocation) {
 
 TEST(BucketMetadataPatchBuilder, SetLogging) {
   BucketMetadataPatchBuilder builder;
-  builder.set_logging(BucketLogging{"test-log-bucket", "test-log-prefix"});
+  builder.SetLogging(BucketLogging{"test-log-bucket", "test-log-prefix"});
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -848,7 +848,7 @@ TEST(BucketMetadataPatchBuilder, SetLogging) {
 
 TEST(BucketMetadataPatchBuilder, ResetLogging) {
   BucketMetadataPatchBuilder builder;
-  builder.reset_logging();
+  builder.ResetLogging();
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -858,7 +858,7 @@ TEST(BucketMetadataPatchBuilder, ResetLogging) {
 
 TEST(BucketMetadataPatchBuilder, SetName) {
   BucketMetadataPatchBuilder builder;
-  builder.set_name("test-bucket-changed-name");
+  builder.SetName("test-bucket-changed-name");
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -869,7 +869,7 @@ TEST(BucketMetadataPatchBuilder, SetName) {
 
 TEST(BucketMetadataPatchBuilder, ResetName) {
   BucketMetadataPatchBuilder builder;
-  builder.reset_name();
+  builder.ResetName();
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -879,7 +879,7 @@ TEST(BucketMetadataPatchBuilder, ResetName) {
 
 TEST(BucketMetadataPatchBuilder, SetStorageClass) {
   BucketMetadataPatchBuilder builder;
-  builder.set_storage_class("NEARLINE");
+  builder.SetStorageClass("NEARLINE");
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -890,7 +890,7 @@ TEST(BucketMetadataPatchBuilder, SetStorageClass) {
 
 TEST(BucketMetadataPatchBuilder, ResetStorageClass) {
   BucketMetadataPatchBuilder builder;
-  builder.reset_storage_class();
+  builder.ResetStorageClass();
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -900,7 +900,7 @@ TEST(BucketMetadataPatchBuilder, ResetStorageClass) {
 
 TEST(BucketMetadataPatchBuilder, SetVersioning) {
   BucketMetadataPatchBuilder builder;
-  builder.set_versioning(BucketVersioning{true});
+  builder.SetVersioning(BucketVersioning{true});
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -911,7 +911,7 @@ TEST(BucketMetadataPatchBuilder, SetVersioning) {
 
 TEST(BucketMetadataPatchBuilder, ResetVersioning) {
   BucketMetadataPatchBuilder builder;
-  builder.reset_versioning();
+  builder.ResetVersioning();
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -921,7 +921,7 @@ TEST(BucketMetadataPatchBuilder, ResetVersioning) {
 
 TEST(BucketMetadataPatchBuilder, SetWebsite) {
   BucketMetadataPatchBuilder builder;
-  builder.set_website(BucketWebsite{"index.htm", "404.htm"});
+  builder.SetWebsite(BucketWebsite{"index.htm", "404.htm"});
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -933,7 +933,7 @@ TEST(BucketMetadataPatchBuilder, SetWebsite) {
 
 TEST(BucketMetadataPatchBuilder, ResetWebsite) {
   BucketMetadataPatchBuilder builder;
-  builder.reset_website();
+  builder.ResetWebsite();
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -148,7 +148,7 @@ PatchBucketRequest::PatchBucketRequest(std::string bucket,
     builder.SetLocation(updated.location());
   }
 
-  if (original.loggin_as_optional() != updated.loggin_as_optional()) {
+  if (original.logging_as_optional() != updated.logging_as_optional()) {
     if (updated.has_logging()) {
       builder.SetLogging(updated.logging());
     } else {

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -115,11 +115,11 @@ PatchBucketRequest::PatchBucketRequest(std::string bucket,
       std::map<std::string, std::string> difference;
       // Find the keys in the original map that are not in the new map:
       std::set_difference(original.labels().begin(), original.labels().end(),
-          updated.labels().begin(), updated.labels().end(),
-          std::inserter(difference, difference.end()),
-          // We want to compare just keys and ignore values, the map class
-          // provides such a function, so use it:
-          original.labels().value_comp());
+                          updated.labels().begin(), updated.labels().end(),
+                          std::inserter(difference, difference.end()),
+                          // We want to compare just keys and ignore values, the
+                          // map class provides such a function, so use it:
+                          original.labels().value_comp());
       for (auto&& d : difference) {
         builder.ResetLabel(d.first);
       }

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -73,6 +73,102 @@ std::ostream& operator<<(std::ostream& os, UpdateBucketRequest const& r) {
   return os << "}";
 }
 
+PatchBucketRequest::PatchBucketRequest(std::string bucket,
+                                       BucketMetadata const& original,
+                                       BucketMetadata const& updated)
+    : bucket_(std::move(bucket)) {
+  // Compare each modifiable field to build the patch
+  BucketMetadataPatchBuilder builder;
+
+  if (original.acl() != updated.acl()) {
+    builder.set_acl(updated.acl());
+  }
+
+  if (original.billing_as_optional() != updated.billing_as_optional()) {
+    if (updated.has_billing()) {
+      builder.set_billing(updated.billing());
+    } else {
+      builder.reset_billing();
+    }
+  }
+
+  if (original.cors() != updated.cors()) {
+    builder.set_cors(updated.cors());
+  }
+
+  if (original.default_acl() != updated.default_acl()) {
+    builder.set_default_acl(updated.default_acl());
+  }
+
+  if (original.encryption_as_optional() != updated.encryption_as_optional()) {
+    if (updated.has_encryption()) {
+      builder.set_encryption(updated.encryption());
+    } else {
+      builder.reset_encryption();
+    }
+  }
+
+  if (original.all_labels() != updated.all_labels()) {
+    builder.set_label(updated.all_labels());
+  }
+
+  if (original.lifecycle_as_optional() != updated.lifecycle_as_optional()) {
+    if (updated.has_lifecycle()) {
+      builder.set_lifecycle(updated.lifecycle());
+    } else {
+      builder.reset_lifecycle();
+    }
+  }
+
+  if (original.location() != updated.location()) {
+    builder.set_location(updated.location());
+  }
+
+  if (original.loggin_as_optional() != updated.loggin_as_optional()) {
+    if (updated.has_logging()) {
+      builder.set_logging(updated.logging());
+    } else {
+      builder.reset_logging();
+    }
+  }
+
+  if (original.name() != updated.name()) {
+    builder.set_name(updated.name());
+  }
+
+  if (original.storage_class() != updated.storage_class()) {
+    builder.set_storage_class(updated.storage_class());
+  }
+
+  if (original.versioning() != updated.versioning()) {
+    if (updated.has_versioning()) {
+      builder.set_versioning(*updated.versioning());
+    } else {
+      builder.reset_versioning();
+    }
+  }
+
+  if (original.website_as_optional() != updated.website_as_optional()) {
+    if (updated.has_website()) {
+      builder.set_website(updated.website());
+    } else {
+      builder.reset_website();
+    }
+  }
+
+  payload_ = builder.BuildPatch();
+}
+
+PatchBucketRequest::PatchBucketRequest(std::string bucket,
+                                       BucketMetadataPatchBuilder const& patch)
+    : bucket_(std::move(bucket)), payload_(patch.BuildPatch()) {}
+
+std::ostream& operator<<(std::ostream& os, PatchBucketRequest const& r) {
+  os << "PatchBucketRequest={bucket_name=" << r.bucket();
+  r.DumpOptions(os, ", ");
+  return os << ", payload=" << r.payload() << "}";
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -81,78 +81,78 @@ PatchBucketRequest::PatchBucketRequest(std::string bucket,
   BucketMetadataPatchBuilder builder;
 
   if (original.acl() != updated.acl()) {
-    builder.set_acl(updated.acl());
+    builder.SetAcl(updated.acl());
   }
 
   if (original.billing_as_optional() != updated.billing_as_optional()) {
     if (updated.has_billing()) {
-      builder.set_billing(updated.billing());
+      builder.SetBilling(updated.billing());
     } else {
-      builder.reset_billing();
+      builder.ResetBilling();
     }
   }
 
   if (original.cors() != updated.cors()) {
-    builder.set_cors(updated.cors());
+    builder.SetCors(updated.cors());
   }
 
   if (original.default_acl() != updated.default_acl()) {
-    builder.set_default_acl(updated.default_acl());
+    builder.SetDefaultAcl(updated.default_acl());
   }
 
   if (original.encryption_as_optional() != updated.encryption_as_optional()) {
     if (updated.has_encryption()) {
-      builder.set_encryption(updated.encryption());
+      builder.SetEncryption(updated.encryption());
     } else {
-      builder.reset_encryption();
+      builder.ResetEncryption();
     }
   }
 
   if (original.all_labels() != updated.all_labels()) {
-    builder.set_label(updated.all_labels());
+    builder.SetLabel(updated.all_labels());
   }
 
   if (original.lifecycle_as_optional() != updated.lifecycle_as_optional()) {
     if (updated.has_lifecycle()) {
-      builder.set_lifecycle(updated.lifecycle());
+      builder.SetLifecycle(updated.lifecycle());
     } else {
-      builder.reset_lifecycle();
+      builder.ResetLifecycle();
     }
   }
 
   if (original.location() != updated.location()) {
-    builder.set_location(updated.location());
+    builder.SetLocation(updated.location());
   }
 
   if (original.loggin_as_optional() != updated.loggin_as_optional()) {
     if (updated.has_logging()) {
-      builder.set_logging(updated.logging());
+      builder.SetLogging(updated.logging());
     } else {
-      builder.reset_logging();
+      builder.ResetLogging();
     }
   }
 
   if (original.name() != updated.name()) {
-    builder.set_name(updated.name());
+    builder.SetName(updated.name());
   }
 
   if (original.storage_class() != updated.storage_class()) {
-    builder.set_storage_class(updated.storage_class());
+    builder.SetStorageClass(updated.storage_class());
   }
 
   if (original.versioning() != updated.versioning()) {
     if (updated.has_versioning()) {
-      builder.set_versioning(*updated.versioning());
+      builder.SetVersioning(*updated.versioning());
     } else {
-      builder.reset_versioning();
+      builder.ResetVersioning();
     }
   }
 
   if (original.website_as_optional() != updated.website_as_optional()) {
     if (updated.has_website()) {
-      builder.set_website(updated.website());
+      builder.SetWebsite(updated.website());
     } else {
-      builder.reset_website();
+      builder.ResetWebsite();
     }
   }
 

--- a/google/cloud/storage/internal/bucket_requests.h
+++ b/google/cloud/storage/internal/bucket_requests.h
@@ -154,6 +154,31 @@ class UpdateBucketRequest
 };
 
 std::ostream& operator<<(std::ostream& os, UpdateBucketRequest const& r);
+
+/**
+ * Represents a request to the `Buckets: patch` API.
+ */
+class PatchBucketRequest
+    : public GenericRequest<
+          PatchBucketRequest, IfMetaGenerationMatch, IfMetaGenerationNotMatch,
+          PredefinedAcl, PredefinedDefaultObjectAcl, Projection, UserProject> {
+ public:
+  PatchBucketRequest() = default;
+  explicit PatchBucketRequest(std::string bucket,
+                              BucketMetadata const& original,
+                              BucketMetadata const& updated);
+  explicit PatchBucketRequest(std::string bucket,
+                              BucketMetadataPatchBuilder const& patch);
+
+  std::string const& bucket() const { return bucket_; }
+  std::string const& payload() const { return payload_; }
+
+ private:
+  std::string bucket_;
+  std::string payload_;
+};
+
+std::ostream& operator<<(std::ostream& os, PatchBucketRequest const& r);
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -344,6 +344,198 @@ TEST(PatchBucketRequestTest, DiffResetLabels) {
   EXPECT_EQ(expected, patch);
 }
 
+TEST(PatchBucketRequestTest, DiffSetLifecycle) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.reset_lifecycle();;
+  BucketMetadata updated = original;
+  updated.set_lifecycle(BucketLifecycle{{LifecycleRule(
+      LifecycleRule::NumNewerVersions(5), LifecycleRule::Delete())}});
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({
+      "lifecycle": {
+          "rule": [
+              {
+                  "condition": {"numNewerVersions": 5},
+                  "action": {"type": "Delete"}
+              }
+          ]
+       }
+  })""");
+  EXPECT_EQ(expected, patch);
+}
+
+TEST(PatchBucketRequestTest, DiffResetLifecycle) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.set_lifecycle(BucketLifecycle{{LifecycleRule(
+      LifecycleRule::NumNewerVersions(5), LifecycleRule::Delete())}});
+  BucketMetadata updated = original;
+  updated.reset_lifecycle();
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({"lifecycle": null})""");
+  EXPECT_EQ(expected, patch);
+}
+
+TEST(PatchBucketRequestTest, DiffSetLocation) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.set_location("");
+  BucketMetadata updated = original;
+  updated.set_location("EU");
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({"location": "EU"})""");
+  EXPECT_EQ(expected, patch);
+}
+
+TEST(PatchBucketRequestTest, DiffResetLocation) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.set_location("US");
+  BucketMetadata updated = original;
+  updated.set_location("");
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({"location": null})""");
+  EXPECT_EQ(expected, patch);
+}
+
+TEST(PatchBucketRequestTest, DiffSetLogging) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.reset_logging();
+  BucketMetadata updated = original;
+  updated.set_logging(BucketLogging{"test-log-bucket", "test-log-prefix"});
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({
+      "logging": {
+          "logBucket": "test-log-bucket",
+          "logPrefix": "test-log-prefix"
+      }
+  })""");
+  EXPECT_EQ(expected, patch);
+}
+
+TEST(PatchBucketRequestTest, DiffResetLogging) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.set_logging(BucketLogging{"test-log-bucket", "test-log-prefix"});
+  BucketMetadata updated = original;
+  updated.reset_logging();
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({"logging": null})""");
+  EXPECT_EQ(expected, patch);
+}
+
+TEST(PatchBucketRequestTest, DiffSetName) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.set_name("");
+  BucketMetadata updated = original;
+  updated.set_name("new-bucket-name");
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({"name": "new-bucket-name"})""");
+  EXPECT_EQ(expected, patch);
+}
+
+TEST(PatchBucketRequestTest, DiffResetName) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.set_name("bucket-name");
+  BucketMetadata updated = original;
+  updated.set_name("");
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({"name": null})""");
+  EXPECT_EQ(expected, patch);
+}
+
+TEST(PatchBucketRequestTest, DiffSetStorageClass) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.set_storage_class(storage_class::Standard());
+  BucketMetadata updated = original;
+  updated.set_storage_class(storage_class::Coldline());
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({"storageClass": "COLDLINE"})""");
+  EXPECT_EQ(expected, patch);
+}
+
+TEST(PatchBucketRequestTest, DiffResetStorageClass) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.set_storage_class(storage_class::Standard());
+  BucketMetadata updated = original;
+  updated.set_storage_class("");
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({"storageClass": null})""");
+  EXPECT_EQ(expected, patch);
+}
+
+TEST(PatchBucketRequestTest, DiffSetVersioning) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.reset_versioning();
+  BucketMetadata updated = original;
+  updated.disable_versioning();
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({
+      "versioning": {"enabled": false}
+  })""");
+  EXPECT_EQ(expected, patch);
+}
+
+TEST(PatchBucketRequestTest, DiffResetVersioning) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.enable_versioning();
+  BucketMetadata updated = original;
+  updated.reset_versioning();
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({"versioning": null})""");
+  EXPECT_EQ(expected, patch);
+}
+
+TEST(PatchBucketRequestTest, DiffSetWebsite) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.reset_website();
+  BucketMetadata updated = original;
+  updated.set_website(BucketWebsite{"idx.htm", "404.htm"});
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({
+      "website": {
+          "mainPageSuffix": "idx.htm",
+          "notFoundPage": "404.htm"
+      }
+  })""");
+  EXPECT_EQ(expected, patch);
+}
+
+TEST(PatchBucketRequestTest, DiffResetWebsite) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.set_website(BucketWebsite{"idx.htm", "404.htm"});
+  BucketMetadata updated = original;
+  updated.reset_website();
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({"website": null})""");
+  EXPECT_EQ(expected, patch);
+}
+
+
 TEST(PatchBucketRequestTest, DiffOStream) {
   BucketMetadata original = CreateBucketMetadataForTest();
   BucketMetadata updated = original;

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -166,8 +166,8 @@ TEST(PatchBucketRequestTest, Diff) {
 
 TEST(PatchBucketRequestTest, Builder) {
   PatchBucketRequest request("test-bucket", BucketMetadataPatchBuilder()
-                                                .set_storage_class("NEARLINE")
-                                                .reset_default_acl());
+                                                .SetStorageClass("NEARLINE")
+                                                .ResetDefaultAcl());
   request.set_multiple_options(IfMetaGenerationNotMatch(7),
                                UserProject("my-project"));
   EXPECT_EQ("test-bucket", request.bucket());

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -346,7 +346,7 @@ TEST(PatchBucketRequestTest, DiffResetLabels) {
 
 TEST(PatchBucketRequestTest, DiffSetLifecycle) {
   BucketMetadata original = CreateBucketMetadataForTest();
-  original.reset_lifecycle();;
+  original.reset_lifecycle();
   BucketMetadata updated = original;
   updated.set_lifecycle(BucketLifecycle{{LifecycleRule(
       LifecycleRule::NumNewerVersions(5), LifecycleRule::Delete())}});
@@ -534,7 +534,6 @@ TEST(PatchBucketRequestTest, DiffResetWebsite) {
   nl::json expected = nl::json::parse(R"""({"website": null})""");
   EXPECT_EQ(expected, patch);
 }
-
 
 TEST(PatchBucketRequestTest, DiffOStream) {
   BucketMetadata original = CreateBucketMetadataForTest();

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -311,6 +311,39 @@ TEST(PatchBucketRequestTest, DiffResetEncryption) {
   EXPECT_EQ(expected, patch);
 }
 
+TEST(PatchBucketRequestTest, DiffSetLabels) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.mutable_labels() = {
+      {"label1", "v1"},
+      {"label2", "v2"},
+  };
+  BucketMetadata updated = original;
+  updated.mutable_labels().erase("label2");
+  updated.mutable_labels().insert({"label3", "v3"});
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({
+      "labels": {"label2": null, "label3": "v3"}
+  })""");
+  EXPECT_EQ(expected, patch);
+}
+
+TEST(PatchBucketRequestTest, DiffResetLabels) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.mutable_labels() = {
+      {"label1", "v1"},
+      {"label2", "v2"},
+  };
+  BucketMetadata updated = original;
+  updated.mutable_labels().clear();
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({"labels": null})""");
+  EXPECT_EQ(expected, patch);
+}
+
 TEST(PatchBucketRequestTest, DiffOStream) {
   BucketMetadata original = CreateBucketMetadataForTest();
   BucketMetadata updated = original;

--- a/google/cloud/storage/internal/patch_builder.h
+++ b/google/cloud/storage/internal/patch_builder.h
@@ -46,6 +46,9 @@ class PatchBuilder {
   /// Return the patch as a string.
   std::string ToString() const { return patch_.dump(); }
 
+  bool empty() const { return patch_.empty(); }
+  void clear() { patch_.clear(); }
+
   //@{
   /// @name Calculate the delta between the original (`lhs`) and the new (`rhs`)
   /// values and set the patch instructions accordingly.


### PR DESCRIPTION
This is part of the work for #823. This PR introduces classes to
represent a request to the `Buckets: patch` API, and the classes
to support it.

Some of the member function names are ugly (`SetAcl` vs. `set_acl`) I blame the C++ style guide.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/990)
<!-- Reviewable:end -->
