### PR TITLE
Use random object names in integration test.

### DIFF
--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -56,8 +56,15 @@ class BucketIntegrationTest : public ::testing::Test {
     static std::size_t const kMaxBucketNameLength = 63;
     std::size_t const max_random_characters =
         kMaxBucketNameLength - prefix.size();
-    return prefix + google::cloud::internal::Sample(generator_,
-                                                    max_random_characters,
+    return prefix + google::cloud::internal::Sample(
+                        generator_, static_cast<int>(max_random_characters),
+                        "abcdefghijklmnopqrstuvwxyz012456789");
+  }
+
+  std::string MakeRandomObjectName() {
+    static std::string const prefix = "bucket-integration-test-";
+    return prefix + google::cloud::internal::Sample(generator_, 64,
+                                                    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                                     "abcdefghijklmnopqrstuvwxyz"
                                                     "012456789");
   }
@@ -150,13 +157,9 @@ TEST_F(BucketIntegrationTest, GetMetadataIfMetaGenerationNotMatch_Failure) {
 }
 
 TEST_F(BucketIntegrationTest, InsertObjectMedia) {
-  // TODO(#681) - use random names for the object and buckets in the tests.
   auto bucket_name = BucketTestEnvironment::bucket_name();
   Client client;
-  auto object_name =
-      std::string("the-test-object-") +
-      std::to_string(
-          std::chrono::system_clock::now().time_since_epoch().count());
+  auto object_name = MakeRandomObjectName();
 
   auto metadata = client.InsertObject(bucket_name, object_name, "blah blah");
   EXPECT_EQ(bucket_name, metadata.bucket());
@@ -165,13 +168,9 @@ TEST_F(BucketIntegrationTest, InsertObjectMedia) {
 }
 
 TEST_F(BucketIntegrationTest, InsertObjectMediaIfGenerationMatch) {
-  // TODO(#681) - use random names for the object and buckets in the tests.
   auto bucket_name = BucketTestEnvironment::bucket_name();
   Client client;
-  auto object_name =
-      std::string("the-test-object-") +
-      std::to_string(
-          std::chrono::system_clock::now().time_since_epoch().count());
+  auto object_name = MakeRandomObjectName();
 
   auto original = client.InsertObject(bucket_name, object_name, "blah blah",
                                       storage::IfGenerationMatch(0));
@@ -191,13 +190,9 @@ TEST_F(BucketIntegrationTest, InsertObjectMediaIfGenerationMatch) {
 }
 
 TEST_F(BucketIntegrationTest, InsertObjectMediaIfGenerationNotMatch) {
-  // TODO(#681) - use random names for the object and buckets in the tests.
   auto bucket_name = BucketTestEnvironment::bucket_name();
   Client client;
-  auto object_name =
-      std::string("the-test-object-") +
-      std::to_string(
-          std::chrono::system_clock::now().time_since_epoch().count());
+  auto object_name = MakeRandomObjectName();
 
   auto original = client.InsertObject(bucket_name, object_name, "blah blah",
                                       storage::IfGenerationMatch(0));
@@ -216,11 +211,8 @@ TEST_F(BucketIntegrationTest, ListObjects) {
   auto bucket_name = BucketTestEnvironment::bucket_name();
   Client client;
 
-  auto gen = google::cloud::internal::MakeDefaultPRNG();
-  auto create_small_object = [&client, &bucket_name, &gen] {
-    auto object_name =
-        "object-" + google::cloud::internal::Sample(
-                        gen, 16, "abcdefghijklmnopqrstuvwxyz0123456789");
+  auto create_small_object = [&client, &bucket_name, this] {
+    auto object_name = MakeRandomObjectName();
     auto meta = client.InsertObject(bucket_name, object_name, "blah blah",
                                     storage::IfGenerationMatch(0));
     return meta.name();


### PR DESCRIPTION
This fixes #681. Random object names make it less likely that two tests
running simultaneously will conflict with each other. When I first wrote
this test we did not have the pseudo-random number helpers in
google::cloud, and left a TODO to fix them, time to do that.

/cc: @houglum

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/991)
<!-- Reviewable:end -->
