### PR TITLE
Implement Client::DeleteBucketAcl.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -391,6 +391,24 @@ class Client {
   }
 
   /**
+   * Deletes an entry from a bucket ACL.
+   *
+   * @param bucket_name the name of the bucket.
+   * @param entity the name of the entity added to the ACL.
+   * @param options a list of optional query parameters and/or request headers.
+   *     Valid types for this operation include `UserProject`.
+   *
+   * @snippet storage_bucket_acl_samples.cc delete bucket acl
+   */
+  template <typename... Options>
+  void DeleteBucketAcl(std::string const& bucket_name,
+                       std::string const& entity, Options&&... options) {
+    internal::DeleteBucketAclRequest request(bucket_name, entity);
+    request.set_multiple_options(std::forward<Options>(options)...);
+    raw_client_->DeleteBucketAcl(request);
+  }
+
+  /**
    * Get the value of an existing bucket ACL.
    *
    * @param bucket_name the name of the bucket to query.

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -88,6 +88,9 @@ run_program_examples() {
         get-bucket-acl)
             arguments="${base_arguments} allAuthenticatedUsers"
             ;;
+        delete-bucket-acl)
+            arguments="${base_arguments} allAuthenticatedUsers"
+            ;;
         create-object-acl)
             arguments="${base_arguments} allAuthenticatedUsers READER"
             ;;
@@ -226,6 +229,7 @@ run_all_bucket_acl_examples() {
 list-bucket-acl
 create-bucket-acl
 get-bucket-acl
+delete-bucket-acl
 _EOF_
 )
 

--- a/google/cloud/storage/examples/storage_bucket_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_acl_samples.cc
@@ -85,6 +85,25 @@ void CreateBucketAcl(google::cloud::storage::Client client, int& argc,
   (std::move(client), bucket_name, entity, role);
 }
 
+void DeleteBucketAcl(google::cloud::storage::Client client, int& argc,
+                     char* argv[]) {
+  if (argc != 3) {
+    throw Usage{"delete-bucket-acl <bucket-name> <entity>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  auto entity = ConsumeArg(argc, argv);
+  auto role = ConsumeArg(argc, argv);
+  //! [delete bucket acl] [START storage_delete_bucket_acl]
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string bucket_name, std::string entity) {
+    client.DeleteBucketAcl(bucket_name, entity);
+    std::cout << "Deleted ACL entry for " << entity << " in bucket "
+              << bucket_name << std::endl;
+  }
+  //! [delete bucket acl] [END storage_delete_bucket_acl]
+  (std::move(client), bucket_name, entity);
+}
+
 void GetBucketAcl(google::cloud::storage::Client client, int& argc,
                   char* argv[]) {
   if (argc != 3) {
@@ -115,6 +134,7 @@ int main(int argc, char* argv[]) try {
   std::map<std::string, CommandType> commands = {
       {"list-bucket-acl", &ListBucketAcl},
       {"create-bucket-acl", &CreateBucketAcl},
+      {"delete-bucket-acl", &DeleteBucketAcl},
       {"get-bucket-acl", &GetBucketAcl},
   };
   for (auto&& kv : commands) {

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -258,6 +258,23 @@ std::pair<Status, BucketAccessControl> CurlClient::CreateBucketAcl(
                         BucketAccessControl::ParseFromString(payload.payload));
 }
 
+std::pair<Status, EmptyResponse> CurlClient::DeleteBucketAcl(
+    DeleteBucketAclRequest const& request) {
+  CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
+                             "/acl/" + request.entity());
+  builder.SetDebugLogging(options_.enable_http_tracing());
+  builder.AddHeader(options_.credentials()->AuthorizationHeader());
+  request.AddOptionsToHttpRequest(builder);
+  builder.SetMethod("DELETE");
+  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  if (payload.status_code >= 300) {
+    return std::make_pair(
+        Status{payload.status_code, std::move(payload.payload)},
+        internal::EmptyResponse{});
+  }
+  return std::make_pair(Status(), internal::EmptyResponse{});
+}
+
 std::pair<Status, ListObjectAclResponse> CurlClient::ListObjectAcl(
     ListObjectAclRequest const& request) {
   // Assume the bucket name is validated by the caller.

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -68,6 +68,8 @@ class CurlClient : public RawClient {
       CreateBucketAclRequest const&) override;
   std::pair<Status, BucketAccessControl> GetBucketAcl(
       GetBucketAclRequest const&) override;
+  std::pair<Status, EmptyResponse> DeleteBucketAcl(
+      DeleteBucketAclRequest const&) override;
 
   std::pair<Status, ListObjectAclResponse> ListObjectAcl(
       ListObjectAclRequest const& request) override;

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -150,6 +150,11 @@ std::pair<Status, BucketAccessControl> LoggingClient::CreateBucketAcl(
   return MakeCall(*client_, &RawClient::CreateBucketAcl, request, __func__);
 }
 
+std::pair<Status, EmptyResponse> LoggingClient::DeleteBucketAcl(
+    DeleteBucketAclRequest const& request) {
+  return MakeCall(*client_, &RawClient::DeleteBucketAcl, request, __func__);
+}
+
 std::pair<Status, ListObjectAclResponse> LoggingClient::ListObjectAcl(
     ListObjectAclRequest const& request) {
   return MakeCall(*client_, &RawClient::ListObjectAcl, request, __func__);

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -58,6 +58,8 @@ class LoggingClient : public RawClient {
       ListBucketAclRequest const& request) override;
   std::pair<Status, BucketAccessControl> CreateBucketAcl(
       CreateBucketAclRequest const&) override;
+  std::pair<Status, EmptyResponse> DeleteBucketAcl(
+      DeleteBucketAclRequest const&) override;
   std::pair<Status, BucketAccessControl> GetBucketAcl(
       GetBucketAclRequest const&) override;
 

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -82,6 +82,8 @@ class RawClient {
       ListBucketAclRequest const&) = 0;
   virtual std::pair<Status, BucketAccessControl> CreateBucketAcl(
       CreateBucketAclRequest const&) = 0;
+  virtual std::pair<Status, EmptyResponse> DeleteBucketAcl(
+      DeleteBucketAclRequest const&) = 0;
   virtual std::pair<Status, BucketAccessControl> GetBucketAcl(
       GetBucketAclRequest const&) = 0;
   //@}

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -216,6 +216,14 @@ std::pair<Status, BucketAccessControl> RetryClient::CreateBucketAcl(
                   &RawClient::CreateBucketAcl, request, __func__);
 }
 
+std::pair<Status, EmptyResponse> RetryClient::DeleteBucketAcl(
+    DeleteBucketAclRequest const& request) {
+  auto retry_policy = retry_policy_->clone();
+  auto backoff_policy = backoff_policy_->clone();
+  return MakeCall(*retry_policy, *backoff_policy, *client_,
+                  &RawClient::DeleteBucketAcl, request, __func__);
+}
+
 std::pair<Status, ListObjectAclResponse> RetryClient::ListObjectAcl(
     ListObjectAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -73,6 +73,8 @@ class RetryClient : public RawClient {
       ListBucketAclRequest const& request) override;
   std::pair<Status, BucketAccessControl> CreateBucketAcl(
       CreateBucketAclRequest const&) override;
+  std::pair<Status, EmptyResponse> DeleteBucketAcl(
+      DeleteBucketAclRequest const&) override;
   std::pair<Status, BucketAccessControl> GetBucketAcl(
       GetBucketAclRequest const&) override;
 

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -63,6 +63,8 @@ class MockClient : public google::cloud::storage::internal::RawClient {
                                   internal::ListBucketAclRequest const&));
   MOCK_METHOD1(CreateBucketAcl, ResponseWrapper<BucketAccessControl>(
                                     internal::CreateBucketAclRequest const&));
+  MOCK_METHOD1(DeleteBucketAcl, ResponseWrapper<internal::EmptyResponse>(
+                                    internal::DeleteBucketAclRequest const&));
   MOCK_METHOD1(GetBucketAcl, ResponseWrapper<BucketAccessControl>(
                                  internal::GetBucketAclRequest const&));
 

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -271,7 +271,7 @@ TEST_F(BucketIntegrationTest, AccessControlCRUD) {
   ASSERT_EQ(0, name_counter(entity_name, meta.acl()))
       << "Test aborted. The bucket <" << bucket_name << "> has <" << entity_name
       << "> in its ACL.  This is unexpected because the bucket was just"
-      << " created with an predefine ACL that should preclude this result.";
+      << " created with a predefine ACL which should preclude this result.";
 
   BucketAccessControl result =
       client.CreateBucketAcl(bucket_name, entity_name, "OWNER");

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -245,12 +245,17 @@ TEST_F(BucketIntegrationTest, ListObjects) {
 }
 
 TEST_F(BucketIntegrationTest, AccessControlCRUD) {
+  auto project_id = BucketTestEnvironment::project_id();
+  std::string bucket_name = MakeRandomBucketName();
   Client client;
-  auto bucket_name = BucketTestEnvironment::bucket_name();
+
+  // Create a new bucket to run the test, with the "private" PredefinedAcl so
+  // we know what the contents of the ACL will be.
+  auto meta = client.CreateBucketForProject(
+      bucket_name, project_id, BucketMetadata(), PredefinedAcl("private"),
+      Projection("full"));
 
   auto entity_name = MakeEntityName();
-  std::vector<BucketAccessControl> initial_acl =
-      client.ListBucketAcl(bucket_name);
 
   auto name_counter = [](std::string const& name,
                          std::vector<BucketAccessControl> const& list) {
@@ -260,14 +265,13 @@ TEST_F(BucketIntegrationTest, AccessControlCRUD) {
     };
     return std::count_if(list.begin(), list.end(), name_matcher(name));
   };
-  // TODO(#827) - handle this more gracefully, delete the entry.  Or ...
-  // TODO(#821) TODO(#820) - use a new bucket to simplify this test.
-  EXPECT_EQ(0, name_counter(entity_name, initial_acl))
-      << "Test aborted (without failure). The entity <" << entity_name
-      << "> already exists, and DeleteBucketAcl() is not implemented.";
-  if (name_counter(entity_name, initial_acl) == 0) {
-    return;
-  }
+  ASSERT_FALSE(meta.acl().empty())
+      << "Test aborted. Empty ACL returned from newly created bucket <"
+      << bucket_name << "> even though we requested the <full> projection.";
+  ASSERT_EQ(0, name_counter(entity_name, meta.acl()))
+      << "Test aborted. The bucket <" << bucket_name << "> has <" << entity_name
+      << "> in its ACL.  This is unexpected because the bucket was just"
+      << " created with an predefine ACL that should preclude this result.";
 
   BucketAccessControl result =
       client.CreateBucketAcl(bucket_name, entity_name, "OWNER");
@@ -279,8 +283,11 @@ TEST_F(BucketIntegrationTest, AccessControlCRUD) {
   // name, the server "translates" the project id to a project number.
   EXPECT_EQ(1, name_counter(result.entity(), current_acl));
 
-  // TODO(#827) - delete the new entry to leave the bucket in the original
-  // state.
+  client.DeleteBucketAcl(bucket_name, entity_name);
+  current_acl = client.ListBucketAcl(bucket_name);
+  EXPECT_EQ(0, name_counter(result.entity(), current_acl));
+
+  client.DeleteBucket(bucket_name);
 }
 
 }  // namespace


### PR DESCRIPTION
This fixes #827. It implements the API, the basic unit tests,
extends the integration test to use the API, adds a code sample,
and runs the code sample, integration test, and unit tests as
part of the CI builds.

/cc: @houglum

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/992)
<!-- Reviewable:end -->
