### PR TITLE
Refactor driver scripts for examples.

### DIFF
--- a/google/cloud/bigtable/examples/run_examples_emulator.sh
+++ b/google/cloud/bigtable/examples/run_examples_emulator.sh
@@ -29,19 +29,8 @@ start_emulators
 readonly PROJECT_ID="project-$(date +%s)"
 readonly ZONE_ID="fake-zone"
 
-# The examples are noisy,
-log="$(mktemp -t "bigtable_examples.XXXXXX")"
-for example in instance_admin table_admin data; do
-  echo "${COLOR_GREEN}[ RUN      ]${COLOR_RESET} ${example}"
-  run_all_${example}_examples "${PROJECT_ID}" "${ZONE_ID}" >${log} 2>&1 </dev/null
-  if [ $? = 0 ]; then
-    echo "${COLOR_GREEN}[       OK ]${COLOR_RESET} ${example} examples"
-  else
-    echo   "${COLOR_RED}[    ERROR ]${COLOR_RESET} ${example} examples"
-    echo
-    echo "================ ${log} ================"
-    cat ${log}
-    echo "================ ${log} ================"
-  fi
-  /bin/rm "${log}"
-done
+run_all_data_examples "${PROJECT_ID}" "${ZONE_ID}"
+run_all_table_admin_examples "${PROJECT_ID}" "${ZONE_ID}"
+run_all_instance_admin_examples "${PROJECT_ID}" "${ZONE_ID}"
+
+exit ${EXIT_STATUS}

--- a/google/cloud/bigtable/examples/run_examples_production.sh
+++ b/google/cloud/bigtable/examples/run_examples_production.sh
@@ -21,3 +21,5 @@ source "${BINDIR}/run_examples_utils.sh"
 # Run only the data examples in production. The CI systems go over project
 # quotas for admin operations if we run the admin examples too.
 run_all_data_examples "${PROJECT_ID}" "${ZONE_ID}"
+
+exit ${EXIT_STATUS}

--- a/google/cloud/bigtable/examples/run_examples_utils.sh
+++ b/google/cloud/bigtable/examples/run_examples_utils.sh
@@ -15,6 +15,11 @@
 
 set -eu
 
+if [ -z "${PROJECT_ROOT+x}" ]; then
+  readonly PROJECT_ROOT="$(cd "$(dirname $0)/../../../.."; pwd)"
+fi
+source "${PROJECT_ROOT}/ci/colors.sh"
+
 # If an example fails, this is set to 1 and the program exits with failure.
 EXIT_STATUS=0
 


### PR DESCRIPTION
The drivers to run the examples during the CI build were masking some
failures. Refactor them to make this less likely and (I think) easier to maintain.

I am planning to reuse this function (after some refactoring) in the storage tests too,
because there is too much magic in those, e.g.:

https://github.com/GoogleCloudPlatform/google-cloud-cpp/blob/d00b5214b0468890eb0d374d1fd3bc5fdae95069/google/cloud/storage/examples/run_examples_utils.sh#L89

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/993)
<!-- Reviewable:end -->
