### PR TITLE
Complete and cleanup *AclRequest classes.

### DIFF
--- a/google/cloud/storage/bucket_access_control.h
+++ b/google/cloud/storage/bucket_access_control.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BUCKET_ACCESS_CONTROL_H_
 
 #include "google/cloud/storage/internal/access_control_common.h"
+#include "google/cloud/storage/internal/patch_builder.h"
 
 namespace google {
 namespace cloud {
@@ -75,6 +76,50 @@ class BucketAccessControl : private internal::AccessControlCommon {
 };
 
 std::ostream& operator<<(std::ostream& os, BucketAccessControl const& rhs);
+
+/**
+ * Prepare a patch for a BucketAccessControl resource.
+ *
+ * The BucketAccessControl resource only has two modifiable fields: entity
+ * and role. This class allows application developers to setup a PATCH message,
+ * note that some of the possible PATCH messages may result in errors from the
+ * server, for example: while it is possible to express "change the value of the
+ * entity field" with a PATCH request, the server rejects such changes.
+ *
+ * @see
+ * https://cloud.google.com/storage/docs/json_api/v1/how-tos/performance#patch
+ *     for general information on PATCH requests for the Google Cloud Storage
+ *     JSON API.
+ */
+class BucketAccessControlPatchBuilder {
+ public:
+  BucketAccessControlPatchBuilder() = default;
+
+  std::string BuildPatch() const { return impl_.ToString(); }
+
+  BucketAccessControlPatchBuilder& set_entity(std::string const& v) {
+    impl_.SetStringField("entity", v);
+    return *this;
+  }
+
+  BucketAccessControlPatchBuilder& delete_entity() {
+    impl_.RemoveField("entity");
+    return *this;
+  }
+
+  BucketAccessControlPatchBuilder& set_role(std::string const& v) {
+    impl_.SetStringField("role", v);
+    return *this;
+  }
+
+  BucketAccessControlPatchBuilder& delete_role() {
+    impl_.RemoveField("role");
+    return *this;
+  }
+
+ private:
+  internal::PatchBuilder impl_;
+};
 
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -515,7 +515,7 @@ class Client {
   void DeleteObjectAcl(std::string const& bucket_name,
                        std::string const& object_name,
                        std::string const& entity, Options&&... options) {
-    internal::ObjectAclRequest request(bucket_name, object_name, entity);
+    internal::DeleteObjectAclRequest request(bucket_name, object_name, entity);
     request.set_multiple_options(std::forward<Options>(options)...);
     raw_client_->DeleteObjectAcl(request);
   }
@@ -537,7 +537,7 @@ class Client {
                                    std::string const& object_name,
                                    std::string const& entity,
                                    Options&&... options) {
-    internal::ObjectAclRequest request(bucket_name, object_name, entity);
+    internal::GetObjectAclRequest request(bucket_name, object_name, entity);
     request.set_multiple_options(std::forward<Options>(options)...);
     return raw_client_->GetObjectAcl(request).second;
   }

--- a/google/cloud/storage/client_object_acl_test.cc
+++ b/google/cloud/storage/client_object_acl_test.cc
@@ -157,7 +157,7 @@ TEST_F(ObjectAccessControlsTest, DeleteObjectAcl) {
   EXPECT_CALL(*mock, DeleteObjectAcl(_))
       .WillOnce(
           Return(std::make_pair(TransientError(), internal::EmptyResponse{})))
-      .WillOnce(Invoke([](internal::ObjectAclRequest const& r) {
+      .WillOnce(Invoke([](internal::DeleteObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-object", r.object_name());
         EXPECT_EQ("user-test-user", r.entity());
@@ -200,7 +200,7 @@ TEST_F(ObjectAccessControlsTest, GetObjectAcl) {
 
   EXPECT_CALL(*mock, GetObjectAcl(_))
       .WillOnce(Return(std::make_pair(TransientError(), ObjectAccessControl{})))
-      .WillOnce(Invoke([&expected](internal::ObjectAclRequest const& r) {
+      .WillOnce(Invoke([&expected](internal::GetObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-object", r.object_name());
         EXPECT_EQ("user-test-user-1", r.entity());

--- a/google/cloud/storage/internal/bucket_acl_requests.cc
+++ b/google/cloud/storage/internal/bucket_acl_requests.cc
@@ -69,6 +69,36 @@ std::ostream& operator<<(std::ostream& os, CreateBucketAclRequest const& r) {
   return os << "}";
 }
 
+std::ostream& operator<<(std::ostream& os, UpdateBucketAclRequest const& r) {
+  os << "UpdateBucketAclRequest={bucket_name=" << r.bucket_name()
+     << ", entity=" << r.entity() << ", role=" << r.role();
+  r.DumpOptions(os, ", ");
+  return os << "}";
+}
+
+PatchBucketAclRequest::PatchBucketAclRequest(
+    std::string bucket, std::string entity, BucketAccessControl const& original,
+    BucketAccessControl const& new_acl)
+    : GenericBucketAclRequest(std::move(bucket), std::move(entity)) {
+  PatchBuilder build_patch;
+  build_patch.AddStringField("entity", original.entity(), new_acl.entity());
+  build_patch.AddStringField("role", original.role(), new_acl.role());
+  payload_ = build_patch.ToString();
+}
+
+PatchBucketAclRequest::PatchBucketAclRequest(
+    std::string bucket, std::string entity,
+    BucketAccessControlPatchBuilder const& patch)
+    : GenericBucketAclRequest(std::move(bucket), std::move(entity)),
+      payload_(patch.BuildPatch()) {}
+
+std::ostream& operator<<(std::ostream& os, PatchBucketAclRequest const& r) {
+  os << "BucketAclRequest={bucket_name=" << r.bucket_name()
+     << ", entity=" << r.entity();
+  r.DumpOptions(os, ", ");
+  return os << ", payload=" << r.payload() << "}";
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -336,7 +336,7 @@ std::pair<Status, ObjectAccessControl> CurlClient::CreateObjectAcl(
 }
 
 std::pair<Status, EmptyResponse> CurlClient::DeleteObjectAcl(
-    ObjectAclRequest const& request) {
+    DeleteObjectAclRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
                              "/o/" + request.object_name() + "/acl/" +
                              request.entity());
@@ -354,7 +354,7 @@ std::pair<Status, EmptyResponse> CurlClient::DeleteObjectAcl(
 }
 
 std::pair<Status, ObjectAccessControl> CurlClient::GetObjectAcl(
-    ObjectAclRequest const& request) {
+    GetObjectAclRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
                              "/o/" + request.object_name() + "/acl/" +
                              request.entity());

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -78,9 +78,9 @@ class CurlClient : public RawClient {
   std::pair<Status, ObjectAccessControl> CreateObjectAcl(
       CreateObjectAclRequest const&) override;
   std::pair<Status, EmptyResponse> DeleteObjectAcl(
-      ObjectAclRequest const&) override;
+      DeleteObjectAclRequest const&) override;
   std::pair<Status, ObjectAccessControl> GetObjectAcl(
-      ObjectAclRequest const&) override;
+      GetObjectAclRequest const&) override;
   std::pair<Status, ObjectAccessControl> UpdateObjectAcl(
       UpdateObjectAclRequest const&) override;
   std::pair<Status, ObjectAccessControl> PatchObjectAcl(

--- a/google/cloud/storage/internal/default_object_acl_requests.cc
+++ b/google/cloud/storage/internal/default_object_acl_requests.cc
@@ -74,47 +74,21 @@ std::ostream& operator<<(std::ostream& os,
   return os << "}";
 }
 
+std::ostream& operator<<(std::ostream& os,
+                         UpdateDefaultObjectAclRequest const& r) {
+  os << "UpdateDefaultObjectAclRequest={bucket_name=" << r.bucket_name()
+     << ", entity=" << r.entity() << ", role=" << r.role();
+  r.DumpOptions(os, ", ");
+  return os << "}";
+}
+
 PatchDefaultObjectAclRequest::PatchDefaultObjectAclRequest(
     std::string bucket, std::string entity, ObjectAccessControl const& original,
     ObjectAccessControl const& new_acl)
     : GenericDefaultObjectAclRequest(std::move(bucket), std::move(entity)) {
   PatchBuilder build_patch;
-  build_patch.AddStringField("bucket", original.bucket(), new_acl.bucket());
-  build_patch.AddStringField("domain", original.domain(), new_acl.domain());
-  build_patch.AddStringField("email", original.email(), new_acl.email());
   build_patch.AddStringField("entity", original.entity(), new_acl.entity());
-  build_patch.AddStringField("entityId", original.entity_id(),
-                             new_acl.entity_id());
-  build_patch.AddStringField("etag", original.etag(), new_acl.etag());
-  build_patch.AddIntField("generation", original.generation(),
-                          new_acl.generation());
-  build_patch.AddStringField("id", original.id(), new_acl.id());
-  build_patch.AddStringField("kind", original.kind(), new_acl.kind());
-  build_patch.AddStringField("object", original.object(), new_acl.object());
-
-  if (original.project_team() != new_acl.project_team()) {
-    auto empty = [](ProjectTeam const& p) {
-      return p.project_number.empty() and p.team.empty();
-    };
-    if (empty(new_acl.project_team())) {
-      if (not empty(original.project_team())) {
-        build_patch.RemoveField("projectTeam");
-      }
-    } else {
-      PatchBuilder project_team_patch;
-      project_team_patch
-          .AddStringField("project_number",
-                          original.project_team().project_number,
-                          new_acl.project_team().project_number)
-          .AddStringField("team", original.project_team().team,
-                          new_acl.project_team().team);
-      build_patch.AddSubPatch("projectTeam", project_team_patch);
-    }
-  }
-
   build_patch.AddStringField("role", original.role(), new_acl.role());
-  build_patch.AddStringField("selfLink", original.self_link(),
-                             new_acl.self_link());
   payload_ = build_patch.ToString();
 }
 

--- a/google/cloud/storage/internal/default_object_acl_requests.h
+++ b/google/cloud/storage/internal/default_object_acl_requests.h
@@ -64,8 +64,7 @@ std::ostream& operator<<(std::ostream& os,
  */
 template <typename Derived>
 class GenericDefaultObjectAclRequest
-    : public GenericRequest<Derived, IfMatchEtag, IfNoneMatchEtag,
-                            UserProject> {
+    : public GenericRequest<Derived, UserProject> {
  public:
   GenericDefaultObjectAclRequest() = default;
   GenericDefaultObjectAclRequest(std::string bucket, std::string entity)
@@ -101,23 +100,41 @@ std::ostream& operator<<(std::ostream& os,
                          DeleteDefaultObjectAclRequest const& r);
 
 /**
- * Represents a request to call the `DefaultObjectAccessControls: insert` API.
+ * Represents common attributes to multiple `DefaultObjectAccessControls`
+ * request types.
+ *
+ * The classes that represent requests for the
+ * `DefaultObjectAccessControls: create`, `patch`, and `update` APIs have a lot
+ * of commonality. This template class refactors that code.
  */
-class CreateDefaultObjectAclRequest
-    : public GenericDefaultObjectAclRequest<CreateDefaultObjectAclRequest> {
+template <typename Derived>
+class GenericChangeDefaultObjectAclRequest
+    : public GenericDefaultObjectAclRequest<Derived> {
  public:
-  CreateDefaultObjectAclRequest() = default;
+  GenericChangeDefaultObjectAclRequest() = default;
 
-  explicit CreateDefaultObjectAclRequest(std::string bucket, std::string entity,
-                                         std::string role)
-      : GenericDefaultObjectAclRequest<CreateDefaultObjectAclRequest>(
-            std::move(bucket), std::move(entity)),
+  explicit GenericChangeDefaultObjectAclRequest(std::string bucket,
+                                                std::string entity,
+                                                std::string role)
+      : GenericDefaultObjectAclRequest<Derived>(std::move(bucket),
+                                                std::move(entity)),
         role_(std::move(role)) {}
 
   std::string const& role() const { return role_; }
 
  private:
   std::string role_;
+};
+
+/**
+ * Represents a request to call the `DefaultObjectAccessControls: insert` API.
+ */
+class CreateDefaultObjectAclRequest
+    : public GenericChangeDefaultObjectAclRequest<
+          CreateDefaultObjectAclRequest> {
+ public:
+  using GenericChangeDefaultObjectAclRequest::
+      GenericChangeDefaultObjectAclRequest;
 };
 
 std::ostream& operator<<(std::ostream& os,
@@ -127,20 +144,11 @@ std::ostream& operator<<(std::ostream& os,
  * Represents a request to call the `DefaultObjectAccessControls: update` API.
  */
 class UpdateDefaultObjectAclRequest
-    : public GenericDefaultObjectAclRequest<UpdateDefaultObjectAclRequest> {
+    : public GenericChangeDefaultObjectAclRequest<
+          UpdateDefaultObjectAclRequest> {
  public:
-  UpdateDefaultObjectAclRequest() = default;
-
-  explicit UpdateDefaultObjectAclRequest(std::string bucket, std::string entity,
-                                         std::string role)
-      : GenericDefaultObjectAclRequest<UpdateDefaultObjectAclRequest>(
-            std::move(bucket), std::move(entity)),
-        role_(std::move(role)) {}
-
-  std::string const& role() const { return role_; }
-
- private:
-  std::string role_;
+  using GenericChangeDefaultObjectAclRequest::
+      GenericChangeDefaultObjectAclRequest;
 };
 
 std::ostream& operator<<(std::ostream& os,

--- a/google/cloud/storage/internal/default_object_acl_requests_test.cc
+++ b/google/cloud/storage/internal/default_object_acl_requests_test.cc
@@ -35,7 +35,7 @@ TEST(DefaultObjectAclRequestTest, List) {
   EXPECT_THAT(str, HasSubstr("my-bucket"));
 }
 
-TEST(DefaultObjectAclResponseTest, Simple) {
+TEST(DefaultObjectAclRequestTest, ListResponse) {
   std::string text = R"""({
       "items": [{
           "bucket": "test-bucket-name",
@@ -64,7 +64,7 @@ TEST(DefaultObjectAclResponseTest, Simple) {
   EXPECT_THAT(str, HasSubstr("ObjectAccessControl={"));
 }
 
-TEST(GetDefaultObjectAclRequestTest, Simple) {
+TEST(DefaultObjectAclRequestTest, Get) {
   GetDefaultObjectAclRequest request("my-bucket", "user-testuser");
   request.set_multiple_options(UserProject("my-project"), IfMatchEtag("ABC="));
   EXPECT_EQ("my-bucket", request.bucket_name());
@@ -79,7 +79,21 @@ TEST(GetDefaultObjectAclRequestTest, Simple) {
   EXPECT_THAT(str, HasSubstr("If-Match: ABC="));
 }
 
-TEST(CreateDefaultObjectAclRequestTest, Simple) {
+TEST(DefaultObjectAclRequestTest, Delete) {
+  DeleteDefaultObjectAclRequest request("my-bucket", "user-testuser");
+  request.set_multiple_options(UserProject("my-project"));
+  EXPECT_EQ("my-bucket", request.bucket_name());
+  EXPECT_EQ("user-testuser", request.entity());
+
+  std::ostringstream os;
+  os << request;
+  auto str = os.str();
+  EXPECT_THAT(str, HasSubstr("userProject=my-project"));
+  EXPECT_THAT(str, HasSubstr("my-bucket"));
+  EXPECT_THAT(str, HasSubstr("user-testuser"));
+}
+
+TEST(DefaultObjectAclRequestTest, Create) {
   CreateDefaultObjectAclRequest request("my-bucket", "user-testuser", "READER");
   request.set_multiple_options(UserProject("my-project"));
   EXPECT_EQ("my-bucket", request.bucket_name());
@@ -95,22 +109,8 @@ TEST(CreateDefaultObjectAclRequestTest, Simple) {
   EXPECT_THAT(str, HasSubstr("READER"));
 }
 
-TEST(DeleteDefaultObjectAclRequestTest, Simple) {
-  DeleteDefaultObjectAclRequest request("my-bucket", "user-testuser");
-  request.set_multiple_options(UserProject("my-project"));
-  EXPECT_EQ("my-bucket", request.bucket_name());
-  EXPECT_EQ("user-testuser", request.entity());
-
-  std::ostringstream os;
-  os << request;
-  auto str = os.str();
-  EXPECT_THAT(str, HasSubstr("userProject=my-project"));
-  EXPECT_THAT(str, HasSubstr("my-bucket"));
-  EXPECT_THAT(str, HasSubstr("user-testuser"));
-}
-
-TEST(UpdateDefaultObjectAclRequestTest, Simple) {
-  CreateDefaultObjectAclRequest request("my-bucket", "user-testuser", "READER");
+TEST(DefaultObjectAclRequestTest, Update) {
+  UpdateDefaultObjectAclRequest request("my-bucket", "user-testuser", "READER");
   request.set_multiple_options(UserProject("my-project"));
   EXPECT_EQ("my-bucket", request.bucket_name());
   EXPECT_EQ("user-testuser", request.entity());
@@ -144,7 +144,7 @@ ObjectAccessControl CreateDefaultObjectAccessControlForTest() {
   return ObjectAccessControl::ParseFromString(text);
 }
 
-TEST(PatchDefaultObjectAclRequestTest, ReadModifyWrite) {
+TEST(DefaultObjectAclRequestTest, PatchDiff) {
   ObjectAccessControl original = CreateDefaultObjectAccessControlForTest();
   ObjectAccessControl new_acl =
       CreateDefaultObjectAccessControlForTest().set_role("READER");
@@ -158,7 +158,7 @@ TEST(PatchDefaultObjectAclRequestTest, ReadModifyWrite) {
   EXPECT_EQ(expected, actual);
 }
 
-TEST(PatchDefaultObjectAclRequestTest, Patch) {
+TEST(DefaultObjectAclRequestTest, PatchBuilder) {
   PatchDefaultObjectAclRequest request(
       "my-bucket", "user-test-user",
       ObjectAccessControlPatchBuilder().set_role("READER").delete_entity());
@@ -167,7 +167,7 @@ TEST(PatchDefaultObjectAclRequestTest, Patch) {
   EXPECT_EQ(expected, actual);
 }
 
-TEST(PatchDefaultObjectAclRequestTest, PatchStream) {
+TEST(DefaultObjectAclRequestTest, PatchStream) {
   ObjectAccessControl original = CreateDefaultObjectAccessControlForTest();
   ObjectAccessControl new_acl =
       CreateDefaultObjectAccessControlForTest().set_role("READER");

--- a/google/cloud/storage/internal/generic_request.h
+++ b/google/cloud/storage/internal/generic_request.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GENERIC_REQUEST_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GENERIC_REQUEST_H_
 
-#include "google/cloud/storage/version.h"
+#include "google/cloud/storage/well_known_headers.h"
 #include <iostream>
 #include <utility>
 
@@ -140,11 +140,15 @@ class GenericRequestBase : public GenericRequestBase<Derived, Options...> {
  * @tparam Options the list of options that the Request class will support.
  */
 template <typename Derived, typename... Options>
-class GenericRequest : public GenericRequestBase<Derived, Options...> {
+class GenericRequest : public GenericRequestBase<Derived, IfMatchEtag,
+                                                 IfNoneMatchEtag, Options...> {
  public:
+  using Super =
+      GenericRequestBase<Derived, IfMatchEtag, IfNoneMatchEtag, Options...>;
+
   template <typename H, typename... T>
   Derived& set_multiple_options(H&& h, T&&... tail) {
-    GenericRequestBase<Derived, Options...>::set_option(std::forward<H>(h));
+    Super::set_option(std::forward<H>(h));
     return set_multiple_options(std::forward<T>(tail)...);
   }
 

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -171,12 +171,12 @@ std::pair<Status, ObjectAccessControl> LoggingClient::CreateObjectAcl(
 }
 
 std::pair<Status, EmptyResponse> LoggingClient::DeleteObjectAcl(
-    ObjectAclRequest const& request) {
+    DeleteObjectAclRequest const& request) {
   return MakeCall(*client_, &RawClient::DeleteObjectAcl, request, __func__);
 }
 
 std::pair<Status, ObjectAccessControl> LoggingClient::GetObjectAcl(
-    ObjectAclRequest const& request) {
+    GetObjectAclRequest const& request) {
   return MakeCall(*client_, &RawClient::GetObjectAcl, request, __func__);
 }
 

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -70,9 +70,9 @@ class LoggingClient : public RawClient {
   std::pair<Status, ObjectAccessControl> CreateObjectAcl(
       CreateObjectAclRequest const&) override;
   std::pair<Status, EmptyResponse> DeleteObjectAcl(
-      ObjectAclRequest const&) override;
+      DeleteObjectAclRequest const&) override;
   std::pair<Status, ObjectAccessControl> GetObjectAcl(
-      ObjectAclRequest const&) override;
+      GetObjectAclRequest const&) override;
   std::pair<Status, ObjectAccessControl> UpdateObjectAcl(
       UpdateObjectAclRequest const&) override;
   std::pair<Status, ObjectAccessControl> PatchObjectAcl(

--- a/google/cloud/storage/internal/object_acl_requests.cc
+++ b/google/cloud/storage/internal/object_acl_requests.cc
@@ -50,6 +50,20 @@ std::ostream& operator<<(std::ostream& os, ListObjectAclResponse const& r) {
   return os << "}}";
 }
 
+std::ostream& operator<<(std::ostream& os, GetObjectAclRequest const& r) {
+  os << "GetObjectAclRequest={bucket_name=" << r.bucket_name()
+     << ", object_name=" << r.object_name() << ", entity=" << r.entity();
+  r.DumpOptions(os, ", ");
+  return os << "}";
+}
+
+std::ostream& operator<<(std::ostream& os, DeleteObjectAclRequest const& r) {
+  os << "DeleteObjectAclRequest={bucket_name=" << r.bucket_name()
+     << ", object_name=" << r.object_name() << ", entity=" << r.entity();
+  r.DumpOptions(os, ", ");
+  return os << "}";
+}
+
 std::ostream& operator<<(std::ostream& os, CreateObjectAclRequest const& r) {
   os << "CreateObjectAclRequest={bucket_name=" << r.bucket_name()
      << ", object_name=" << r.object_name() << ", entity=" << r.entity()
@@ -66,69 +80,29 @@ std::ostream& operator<<(std::ostream& os, UpdateObjectAclRequest const& r) {
   return os << "}";
 }
 
-std::ostream& operator<<(std::ostream& os, ObjectAclRequest const& r) {
-  os << "ObjectAclRequest={bucket_name=" << r.bucket_name()
-     << ", object_name=" << r.object_name() << ", entity=" << r.entity();
-  r.DumpOptions(os, ", ");
-  return os << "}";
-}
-
 PatchObjectAclRequest::PatchObjectAclRequest(
     std::string bucket, std::string object, std::string entity,
     ObjectAccessControl const& original, ObjectAccessControl const& new_acl)
-    : GenericObjectRequest(std::move(bucket), std::move(object)),
-      entity_(std::move(entity)) {
+    : GenericObjectAclRequest(std::move(bucket), std::move(object),
+                              std::move(entity)) {
   PatchBuilder build_patch;
-  build_patch.AddStringField("bucket", original.bucket(), new_acl.bucket());
-  build_patch.AddStringField("domain", original.domain(), new_acl.domain());
-  build_patch.AddStringField("email", original.email(), new_acl.email());
   build_patch.AddStringField("entity", original.entity(), new_acl.entity());
-  build_patch.AddStringField("entityId", original.entity_id(),
-                             new_acl.entity_id());
-  build_patch.AddStringField("etag", original.etag(), new_acl.etag());
-  build_patch.AddIntField("generation", original.generation(),
-                          new_acl.generation());
-  build_patch.AddStringField("id", original.id(), new_acl.id());
-  build_patch.AddStringField("kind", original.kind(), new_acl.kind());
-  build_patch.AddStringField("object", original.object(), new_acl.object());
-
-  if (original.project_team_as_optional() !=
-      new_acl.project_team_as_optional()) {
-    if (not new_acl.has_project_team()) {
-      if (original.has_project_team()) {
-        build_patch.RemoveField("projectTeam");
-      }
-    } else {
-      PatchBuilder project_team_patch;
-      project_team_patch
-          .AddStringField("project_number",
-                          original.project_team().project_number,
-                          new_acl.project_team().project_number)
-          .AddStringField("team", original.project_team().team,
-                          new_acl.project_team().team);
-      build_patch.AddSubPatch("projectTeam", project_team_patch);
-    }
-  }
-
   build_patch.AddStringField("role", original.role(), new_acl.role());
-  build_patch.AddStringField("selfLink", original.self_link(),
-                             new_acl.self_link());
   payload_ = build_patch.ToString();
 }
 
 PatchObjectAclRequest::PatchObjectAclRequest(
     std::string bucket, std::string object, std::string entity,
     ObjectAccessControlPatchBuilder const& patch)
-    : GenericObjectRequest(std::move(bucket), std::move(object)),
-      entity_(std::move(entity)),
+    : GenericObjectAclRequest(std::move(bucket), std::move(object),
+                              std::move(entity)),
       payload_(patch.BuildPatch()) {}
 
 std::ostream& operator<<(std::ostream& os, PatchObjectAclRequest const& r) {
   os << "ObjectAclRequest={bucket_name=" << r.bucket_name()
      << ", object_name=" << r.object_name() << ", entity=" << r.entity();
   r.DumpOptions(os, ", ");
-  os << ", payload=" << r.payload();
-  return os << "}";
+  return os << ", payload=" << r.payload() << "}";
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -98,9 +98,9 @@ class RawClient {
   virtual std::pair<Status, ObjectAccessControl> CreateObjectAcl(
       CreateObjectAclRequest const&) = 0;
   virtual std::pair<Status, EmptyResponse> DeleteObjectAcl(
-      ObjectAclRequest const&) = 0;
+      DeleteObjectAclRequest const&) = 0;
   virtual std::pair<Status, ObjectAccessControl> GetObjectAcl(
-      ObjectAclRequest const&) = 0;
+      GetObjectAclRequest const&) = 0;
   virtual std::pair<Status, ObjectAccessControl> UpdateObjectAcl(
       UpdateObjectAclRequest const&) = 0;
   virtual std::pair<Status, ObjectAccessControl> PatchObjectAcl(

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -249,7 +249,7 @@ std::pair<Status, ObjectAccessControl> RetryClient::CreateObjectAcl(
 }
 
 std::pair<Status, EmptyResponse> RetryClient::DeleteObjectAcl(
-    ObjectAclRequest const& request) {
+    DeleteObjectAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
   return MakeCall(*retry_policy, *backoff_policy, *client_,
@@ -257,7 +257,7 @@ std::pair<Status, EmptyResponse> RetryClient::DeleteObjectAcl(
 }
 
 std::pair<Status, ObjectAccessControl> RetryClient::GetObjectAcl(
-    ObjectAclRequest const& request) {
+    GetObjectAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
   return MakeCall(*retry_policy, *backoff_policy, *client_,

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -85,9 +85,9 @@ class RetryClient : public RawClient {
   std::pair<Status, ObjectAccessControl> CreateObjectAcl(
       CreateObjectAclRequest const&) override;
   std::pair<Status, EmptyResponse> DeleteObjectAcl(
-      ObjectAclRequest const&) override;
+      DeleteObjectAclRequest const&) override;
   std::pair<Status, ObjectAccessControl> GetObjectAcl(
-      ObjectAclRequest const&) override;
+      GetObjectAclRequest const&) override;
   std::pair<Status, ObjectAccessControl> UpdateObjectAcl(
       UpdateObjectAclRequest const&) override;
   std::pair<Status, ObjectAccessControl> PatchObjectAcl(

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -75,9 +75,9 @@ class MockClient : public google::cloud::storage::internal::RawClient {
   MOCK_METHOD1(CreateObjectAcl, ResponseWrapper<ObjectAccessControl>(
                                     internal::CreateObjectAclRequest const&));
   MOCK_METHOD1(DeleteObjectAcl, ResponseWrapper<internal::EmptyResponse>(
-                                    internal::ObjectAclRequest const&));
+                                    internal::DeleteObjectAclRequest const&));
   MOCK_METHOD1(GetObjectAcl, ResponseWrapper<ObjectAccessControl>(
-                                 internal::ObjectAclRequest const&));
+                                 internal::GetObjectAclRequest const&));
   MOCK_METHOD1(UpdateObjectAcl, ResponseWrapper<ObjectAccessControl>(
                                     internal::UpdateObjectAclRequest const&));
   MOCK_METHOD1(PatchObjectAcl, ResponseWrapper<ObjectAccessControl>(


### PR DESCRIPTION
Implement the remaining *AclRequest classes. Cleanup the code to
consistently use the same class naming and structure across
*ObjectAclRequest, *BucketAclRequest, and *DefaultObjectAclRequest
classes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/996)
<!-- Reviewable:end -->
