### PR TITLE
Implement Client::CreateDefaultObjectAcl().

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -652,7 +652,10 @@ class Client {
   }
 
   /**
-   * Retrieve the list of DefaultObjectAccessControls for a bucket.
+   * Retrieves the default object ACL for a bucket.
+   *
+   * The default object ACL sets the ACL for any object created in the bucket,
+   * unless a different ACL is specified when the object is created.
    *
    * @param bucket_name the name of the bucket.
    * @param options a list of optional query parameters and/or request headers.
@@ -660,6 +663,9 @@ class Client {
    *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc list default object acl
+   *
+   * @see
+   * https://cloud.google.com/storage/docs/access-control/create-manage-lists#defaultobjects
    */
   template <typename... Options>
   std::vector<ObjectAccessControl> ListDefaultObjectAcl(
@@ -667,6 +673,33 @@ class Client {
     internal::ListDefaultObjectAclRequest request(bucket_name);
     request.set_multiple_options(std::forward<Options>(options)...);
     return raw_client_->ListDefaultObjectAcl(request).second.items;
+  }
+
+  /**
+   * Creates a new entry in the default object ACL for a bucket.
+   *
+   * The default object ACL sets the ACL for any object created in the bucket,
+   * unless a different ACL is specified when the object is created.
+   *
+   * @param bucket_name the name of the bucket.
+   * @param entity the name of the entity added to the ACL.
+   * @param role the role of the entity.
+   * @param options a list of optional query parameters and/or request headers.
+   *     Valid types for this operation include `UserProject`.
+   *
+   * @snippet storage_default_object_acl_samples.cc create default object acl
+   *
+   * @see
+   * https://cloud.google.com/storage/docs/access-control/create-manage-lists#defaultobjects
+   */
+  template <typename... Options>
+  ObjectAccessControl CreateDefaultObjectAcl(std::string const& bucket_name,
+                                             std::string const& entity,
+                                             std::string const& role,
+                                             Options&&... options) {
+    internal::CreateDefaultObjectAclRequest request(bucket_name, entity, role);
+    request.set_multiple_options(std::forward<Options>(options)...);
+    return raw_client_->CreateDefaultObjectAcl(request).second;
   }
 
  private:

--- a/google/cloud/storage/client_default_object_acl_test.cc
+++ b/google/cloud/storage/client_default_object_acl_test.cc
@@ -97,6 +97,55 @@ TEST_F(DefaultObjectAccessControlsTest, ListDefaultObjectAclPermanentFailure) {
       "ListDefaultObjectAcl");
 }
 
+TEST_F(DefaultObjectAccessControlsTest, CreateDefaultObjectAcl) {
+  auto expected = ObjectAccessControl::ParseFromString(R"""({
+          "bucket": "test-bucket",
+          "entity": "user-test-user-1",
+          "role": "READER"
+      })""");
+
+  EXPECT_CALL(*mock, CreateDefaultObjectAcl(_))
+      .WillOnce(Return(std::make_pair(TransientError(), ObjectAccessControl{})))
+      .WillOnce(
+          Invoke([&expected](internal::CreateDefaultObjectAclRequest const& r) {
+            EXPECT_EQ("test-bucket", r.bucket_name());
+            EXPECT_EQ("user-test-user-1", r.entity());
+            EXPECT_EQ("READER", r.role());
+
+            return std::make_pair(Status(), expected);
+          }));
+  Client client{std::shared_ptr<internal::RawClient>(mock)};
+
+  ObjectAccessControl actual = client.CreateDefaultObjectAcl(
+      "test-bucket", "user-test-user-1", ObjectAccessControl::ROLE_READER());
+  // Compare just a few fields because the values for most of the fields are
+  // hard to predict when testing against the production environment.
+  EXPECT_EQ(expected.bucket(), actual.bucket());
+  EXPECT_EQ(expected.entity(), actual.entity());
+  EXPECT_EQ(expected.role(), actual.role());
+}
+
+TEST_F(DefaultObjectAccessControlsTest, CreateDefaultObjectAclTooManyFailures) {
+  testing::TooManyFailuresTest<ObjectAccessControl>(
+      mock, EXPECT_CALL(*mock, CreateDefaultObjectAcl(_)),
+      [](Client& client) {
+        client.CreateDefaultObjectAcl("test-bucket-name", "user-test-user-1",
+                                      "READER");
+      },
+      "CreateDefaultObjectAcl");
+}
+
+TEST_F(DefaultObjectAccessControlsTest,
+       CreateDefaultObjectAclPermanentFailure) {
+  testing::PermanentFailureTest<ObjectAccessControl>(
+      *client, EXPECT_CALL(*mock, CreateDefaultObjectAcl(_)),
+      [](Client& client) {
+        client.CreateDefaultObjectAcl("test-bucket-name", "user-test-user",
+                                      "READER");
+      },
+      "CreateDefaultObjectAcl");
+}
+
 }  // namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -95,6 +95,8 @@ run_all_default_object_acl_examples() {
 
   run_example ./storage_default_object_acl_samples list-default-object-acl \
       "${bucket_name}"
+  run_example ./storage_default_object_acl_samples create-default-object-acl \
+      "${bucket_name}" allAuthenticatedUsers READER
 }
 
 ################################################

--- a/google/cloud/storage/examples/storage_default_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_default_object_acl_samples.cc
@@ -63,6 +63,29 @@ void ListDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
   (std::move(client), bucket_name);
 }
 
+void CreateDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
+                            char* argv[]) {
+  if (argc != 4) {
+    throw Usage{"create-bucket-acl <bucket-name> <entity> <role>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  auto entity = ConsumeArg(argc, argv);
+  auto role = ConsumeArg(argc, argv);
+  //! [create default object acl] [START storage_add_default_owner]
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string bucket_name, std::string entity,
+     std::string role) {
+    gcs::ObjectAccessControl result =
+        client.CreateDefaultObjectAcl(bucket_name, entity, role);
+    std::cout << "Role " << result.role() << " will be granted default to "
+              << result.entity() << " on any new object created on bucket "
+              << result.bucket() << "\n"
+              << "Full attributes: " << result << std::endl;
+  }
+  //! [create default object acl] [END storage_add_default_owner]
+  (std::move(client), bucket_name, entity, role);
+}
+
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) try {
@@ -74,6 +97,7 @@ int main(int argc, char* argv[]) try {
       std::function<void(google::cloud::storage::Client, int&, char* [])>;
   std::map<std::string, CommandType> commands = {
       {"list-default-object-acl", &ListDefaultObjectAcl},
+      {"create-default-object-acl", &CreateDefaultObjectAcl},
   };
   for (auto&& kv : commands) {
     try {

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -433,6 +433,27 @@ CurlClient::ListDefaultObjectAcl(ListDefaultObjectAclRequest const& request) {
                     std::move(payload)));
 }
 
+std::pair<Status, ObjectAccessControl> CurlClient::CreateDefaultObjectAcl(
+    CreateDefaultObjectAclRequest const& request) {
+  CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
+                             "/defaultObjectAcl");
+  builder.SetDebugLogging(options_.enable_http_tracing());
+  builder.AddHeader(options_.credentials()->AuthorizationHeader());
+  request.AddOptionsToHttpRequest(builder);
+  nl::json object;
+  object["entity"] = request.entity();
+  object["role"] = request.role();
+  builder.AddHeader("Content-Type: application/json");
+  auto payload = builder.BuildRequest(object.dump()).MakeRequest();
+  if (payload.status_code >= 300) {
+    return std::make_pair(
+        Status{payload.status_code, std::move(payload.payload)},
+        ObjectAccessControl{});
+  }
+  return std::make_pair(Status(),
+                        ObjectAccessControl::ParseFromString(payload.payload));
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -88,6 +88,8 @@ class CurlClient : public RawClient {
 
   std::pair<Status, ListDefaultObjectAclResponse> ListDefaultObjectAcl(
       ListDefaultObjectAclRequest const& request) override;
+  std::pair<Status, ObjectAccessControl> CreateDefaultObjectAcl(
+      CreateDefaultObjectAclRequest const&) override;
 
  private:
   ClientOptions options_;

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -197,6 +197,12 @@ LoggingClient::ListDefaultObjectAcl(
                   __func__);
 }
 
+std::pair<Status, ObjectAccessControl> LoggingClient::CreateDefaultObjectAcl(
+    CreateDefaultObjectAclRequest const& request) {
+  return MakeCall(*client_, &RawClient::CreateDefaultObjectAcl, request,
+                  __func__);
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -80,6 +80,8 @@ class LoggingClient : public RawClient {
 
   std::pair<Status, ListDefaultObjectAclResponse> ListDefaultObjectAcl(
       ListDefaultObjectAclRequest const& request) override;
+  std::pair<Status, ObjectAccessControl> CreateDefaultObjectAcl(
+      CreateDefaultObjectAclRequest const&) override;
 
   std::shared_ptr<RawClient> client() const { return client_; }
 

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -111,6 +111,8 @@ class RawClient {
   /// @name DefaultObjectAccessControls operations.
   virtual std::pair<Status, ListDefaultObjectAclResponse> ListDefaultObjectAcl(
       ListDefaultObjectAclRequest const&) = 0;
+  virtual std::pair<Status, ObjectAccessControl> CreateDefaultObjectAcl(
+      CreateDefaultObjectAclRequest const&) = 0;
   //@}
 };
 

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -288,6 +288,14 @@ RetryClient::ListDefaultObjectAcl(ListDefaultObjectAclRequest const& request) {
                   &RawClient::ListDefaultObjectAcl, request, __func__);
 }
 
+std::pair<Status, ObjectAccessControl> RetryClient::CreateDefaultObjectAcl(
+    CreateDefaultObjectAclRequest const& request) {
+  auto retry_policy = retry_policy_->clone();
+  auto backoff_policy = backoff_policy_->clone();
+  return MakeCall(*retry_policy, *backoff_policy, *client_,
+                  &RawClient::CreateDefaultObjectAcl, request, __func__);
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -95,6 +95,8 @@ class RetryClient : public RawClient {
 
   std::pair<Status, ListDefaultObjectAclResponse> ListDefaultObjectAcl(
       ListDefaultObjectAclRequest const& request) override;
+  std::pair<Status, ObjectAccessControl> CreateDefaultObjectAcl(
+      CreateDefaultObjectAclRequest const&) override;
 
   std::shared_ptr<RawClient> client() const { return client_; }
 

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -86,6 +86,9 @@ class MockClient : public google::cloud::storage::internal::RawClient {
   MOCK_METHOD1(ListDefaultObjectAcl,
                ResponseWrapper<internal::ListDefaultObjectAclResponse>(
                    internal::ListDefaultObjectAclRequest const&));
+  MOCK_METHOD1(CreateDefaultObjectAcl,
+               ResponseWrapper<ObjectAccessControl>(
+                   internal::CreateDefaultObjectAclRequest const&));
 };
 }  // namespace testing
 }  // namespace storage

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -52,7 +52,7 @@ class BucketIntegrationTest : public ::testing::Test {
 
   std::string MakeRandomBucketName() {
     // The total length of this bucket name must be <= 63 characters,
-    static std::string const prefix = "gcs-cpp-test-bucket";
+    static std::string const prefix = "gcs-cpp-test-bucket-";
     static std::size_t const kMaxBucketNameLength = 63;
     std::size_t const max_random_characters =
         kMaxBucketNameLength - prefix.size();
@@ -304,7 +304,7 @@ TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
   // ACL.
   auto meta = client.CreateBucketForProject(
       bucket_name, project_id, BucketMetadata(),
-      PredefinedDefaultObjectAcl("private"), Projection("full"));
+      PredefinedDefaultObjectAcl("projectPrivate"), Projection("full"));
 
   auto entity_name = MakeEntityName();
 

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -295,16 +295,46 @@ TEST_F(BucketIntegrationTest, AccessControlCRUD) {
 }
 
 TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
+  auto project_id = BucketTestEnvironment::project_id();
+  std::string bucket_name = MakeRandomBucketName();
   Client client;
-  auto bucket_name = BucketTestEnvironment::bucket_name();
+
+  // Create a new bucket to run the test, with the "private"
+  // PredefinedDefaultObjectAcl, that way we can predict the the contents of the
+  // ACL.
+  auto meta = client.CreateBucketForProject(
+      bucket_name, project_id, BucketMetadata(),
+      PredefinedDefaultObjectAcl("private"), Projection("full"));
 
   auto entity_name = MakeEntityName();
-  std::vector<ObjectAccessControl> initial_acl =
-      client.ListDefaultObjectAcl(bucket_name);
 
-  // TODO(#833) TODO(#835) - make stronger assertions once we can modify the
-  // ACL.
-  EXPECT_FALSE(initial_acl.empty());
+  auto name_counter = [](std::string const& name,
+                         std::vector<ObjectAccessControl> const& list) {
+    auto name_matcher = [](std::string const& name) {
+      return
+          [name](ObjectAccessControl const& m) { return m.entity() == name; };
+    };
+    return std::count_if(list.begin(), list.end(), name_matcher(name));
+  };
+  ASSERT_FALSE(meta.default_acl().empty())
+      << "Test aborted. Empty ACL returned from newly created bucket <"
+      << bucket_name << "> even though we requested the <full> projection.";
+  ASSERT_EQ(0, name_counter(entity_name, meta.default_acl()))
+      << "Test aborted. The bucket <" << bucket_name << "> has <" << entity_name
+      << "> in its ACL.  This is unexpected because the bucket was just"
+      << " created with a predefine ACL which should preclude this result.";
+
+  ObjectAccessControl result =
+      client.CreateDefaultObjectAcl(bucket_name, entity_name, "OWNER");
+  EXPECT_EQ("OWNER", result.role());
+  auto current_acl = client.ListDefaultObjectAcl(bucket_name);
+  EXPECT_FALSE(current_acl.empty());
+  // Search using the entity name returned by the request, because we use
+  // 'project-editors-<project_id>' this different than the original entity
+  // name, the server "translates" the project id to a project number.
+  EXPECT_EQ(1, name_counter(result.entity(), current_acl));
+
+  client.DeleteBucket(bucket_name);
 }
 
 }  // namespace


### PR DESCRIPTION
This fixes #835. It implements the API, the typical unit tests, extends
the integration test to use the API, adds a sample program and runs the
integration tests and the sample program as part of the CI build.

/cc: @houglum

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/999)
<!-- Reviewable:end -->
