### PR TITLE
Implement Client::DeleteDefaultObjectAcl().

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -702,6 +702,30 @@ class Client {
     return raw_client_->CreateDefaultObjectAcl(request).second;
   }
 
+  /**
+   * Deletes an entry from the default object ACL in a bucket.
+   *
+   * The default object ACL sets the ACL for any object created in the bucket,
+   * unless a different ACL is specified when the object is created.
+   *
+   * @param bucket_name the name of the bucket.
+   * @param entity the name of the entity added to the ACL.
+   * @param options a list of optional query parameters and/or request headers.
+   *     Valid types for this operation include `UserProject`.
+   *
+   * @snippet storage_default_object_acl_samples.cc delete default object acl
+   *
+   * @see
+   * https://cloud.google.com/storage/docs/access-control/create-manage-lists#defaultobjects
+   */
+  template <typename... Options>
+  void DeleteDefaultObjectAcl(std::string const& bucket_name,
+                              std::string const& entity, Options&&... options) {
+    internal::DeleteDefaultObjectAclRequest request(bucket_name, entity);
+    request.set_multiple_options(std::forward<Options>(options)...);
+    raw_client_->DeleteDefaultObjectAcl(request);
+  }
+
  private:
   BucketMetadata GetBucketMetadataImpl(
       internal::GetBucketMetadataRequest const& request);

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -97,6 +97,8 @@ run_all_default_object_acl_examples() {
       "${bucket_name}"
   run_example ./storage_default_object_acl_samples create-default-object-acl \
       "${bucket_name}" allAuthenticatedUsers READER
+  run_example ./storage_default_object_acl_samples delete-default-object-acl \
+      "${bucket_name}" allAuthenticatedUsers
 }
 
 ################################################

--- a/google/cloud/storage/examples/storage_bucket_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_acl_samples.cc
@@ -92,7 +92,6 @@ void DeleteBucketAcl(google::cloud::storage::Client client, int& argc,
   }
   auto bucket_name = ConsumeArg(argc, argv);
   auto entity = ConsumeArg(argc, argv);
-  auto role = ConsumeArg(argc, argv);
   //! [delete bucket acl] [START storage_delete_bucket_acl]
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name, std::string entity) {

--- a/google/cloud/storage/examples/storage_default_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_default_object_acl_samples.cc
@@ -86,6 +86,24 @@ void CreateDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
   (std::move(client), bucket_name, entity, role);
 }
 
+void DeleteDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
+                            char* argv[]) {
+  if (argc != 3) {
+    throw Usage{"delete-default-object-acl <bucket-name> <entity>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  auto entity = ConsumeArg(argc, argv);
+  //! [delete default object acl] [START storage_remove_bucket_default_owner]
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string bucket_name, std::string entity) {
+    client.DeleteDefaultObjectAcl(bucket_name, entity);
+    std::cout << "Deleted ACL entry for " << entity << " in bucket "
+              << bucket_name << std::endl;
+  }
+  //! [delete default object acl] [END storage_remove_bucket_default_owner]
+  (std::move(client), bucket_name, entity);
+}
+
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) try {
@@ -98,6 +116,7 @@ int main(int argc, char* argv[]) try {
   std::map<std::string, CommandType> commands = {
       {"list-default-object-acl", &ListDefaultObjectAcl},
       {"create-default-object-acl", &CreateDefaultObjectAcl},
+      {"delete-default-object-acl", &DeleteDefaultObjectAcl},
   };
   for (auto&& kv : commands) {
     try {

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -454,6 +454,23 @@ std::pair<Status, ObjectAccessControl> CurlClient::CreateDefaultObjectAcl(
                         ObjectAccessControl::ParseFromString(payload.payload));
 }
 
+std::pair<Status, EmptyResponse> CurlClient::DeleteDefaultObjectAcl(
+    DeleteDefaultObjectAclRequest const& request) {
+  CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
+                             "/defaultObjectAcl/" + request.entity());
+  builder.SetDebugLogging(options_.enable_http_tracing());
+  builder.AddHeader(options_.credentials()->AuthorizationHeader());
+  request.AddOptionsToHttpRequest(builder);
+  builder.SetMethod("DELETE");
+  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  if (payload.status_code >= 300) {
+    return std::make_pair(
+        Status{payload.status_code, std::move(payload.payload)},
+        internal::EmptyResponse{});
+  }
+  return std::make_pair(Status(), internal::EmptyResponse{});
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -90,6 +90,8 @@ class CurlClient : public RawClient {
       ListDefaultObjectAclRequest const& request) override;
   std::pair<Status, ObjectAccessControl> CreateDefaultObjectAcl(
       CreateDefaultObjectAclRequest const&) override;
+  std::pair<Status, EmptyResponse> DeleteDefaultObjectAcl(
+      DeleteDefaultObjectAclRequest const&) override;
 
  private:
   ClientOptions options_;

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -203,6 +203,12 @@ std::pair<Status, ObjectAccessControl> LoggingClient::CreateDefaultObjectAcl(
                   __func__);
 }
 
+std::pair<Status, EmptyResponse> LoggingClient::DeleteDefaultObjectAcl(
+    DeleteDefaultObjectAclRequest const& request) {
+  return MakeCall(*client_, &RawClient::DeleteDefaultObjectAcl, request,
+                  __func__);
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -82,6 +82,8 @@ class LoggingClient : public RawClient {
       ListDefaultObjectAclRequest const& request) override;
   std::pair<Status, ObjectAccessControl> CreateDefaultObjectAcl(
       CreateDefaultObjectAclRequest const&) override;
+  std::pair<Status, EmptyResponse> DeleteDefaultObjectAcl(
+      DeleteDefaultObjectAclRequest const&) override;
 
   std::shared_ptr<RawClient> client() const { return client_; }
 

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -113,6 +113,8 @@ class RawClient {
       ListDefaultObjectAclRequest const&) = 0;
   virtual std::pair<Status, ObjectAccessControl> CreateDefaultObjectAcl(
       CreateDefaultObjectAclRequest const&) = 0;
+  virtual std::pair<Status, EmptyResponse> DeleteDefaultObjectAcl(
+      DeleteDefaultObjectAclRequest const&) = 0;
   //@}
 };
 

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -296,6 +296,14 @@ std::pair<Status, ObjectAccessControl> RetryClient::CreateDefaultObjectAcl(
                   &RawClient::CreateDefaultObjectAcl, request, __func__);
 }
 
+std::pair<Status, EmptyResponse> RetryClient::DeleteDefaultObjectAcl(
+    DeleteDefaultObjectAclRequest const& request) {
+  auto retry_policy = retry_policy_->clone();
+  auto backoff_policy = backoff_policy_->clone();
+  return MakeCall(*retry_policy, *backoff_policy, *client_,
+                  &RawClient::DeleteDefaultObjectAcl, request, __func__);
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -97,6 +97,8 @@ class RetryClient : public RawClient {
       ListDefaultObjectAclRequest const& request) override;
   std::pair<Status, ObjectAccessControl> CreateDefaultObjectAcl(
       CreateDefaultObjectAclRequest const&) override;
+  std::pair<Status, EmptyResponse> DeleteDefaultObjectAcl(
+      DeleteDefaultObjectAclRequest const&) override;
 
   std::shared_ptr<RawClient> client() const { return client_; }
 

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -89,6 +89,9 @@ class MockClient : public google::cloud::storage::internal::RawClient {
   MOCK_METHOD1(CreateDefaultObjectAcl,
                ResponseWrapper<ObjectAccessControl>(
                    internal::CreateDefaultObjectAclRequest const&));
+  MOCK_METHOD1(DeleteDefaultObjectAcl,
+               ResponseWrapper<internal::EmptyResponse>(
+                   internal::DeleteDefaultObjectAclRequest const&));
 };
 }  // namespace testing
 }  // namespace storage

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -254,6 +254,10 @@ TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
   // name, the server "translates" the project id to a project number.
   EXPECT_EQ(1, name_counter(result.entity(), current_acl));
 
+  client.DeleteDefaultObjectAcl(bucket_name, entity_name);
+  current_acl = client.ListDefaultObjectAcl(bucket_name);
+  EXPECT_EQ(0, name_counter(result.entity(), current_acl));
+
   client.DeleteBucket(bucket_name);
 }
 


### PR DESCRIPTION
This fixes #833. It implements the API, the typical unit tests for it,
extends the integration test to use the API, adds a sample program, and
runs both the integration test and the sample as part of the CI build.

/cc: @houglum

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1004)
<!-- Reviewable:end -->
