### PR TITLE
Implement Client::PatchBucketAcl().

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -479,6 +479,84 @@ class Client {
   }
 
   /**
+   * Patch the value of an existing bucket ACL.
+   *
+   * Compute the delta between a previous value for an BucketAccessControl and
+   * the new value for an BucketAccessControl and apply that delta.
+   *
+   * @par Notes
+   * For changing BucketAccessControl the Patch and Update APIs basically offer
+   * the same functionality. The only field that can be modified by either API
+   * is `role`, and it may only be set to a new value (it cannot be removed).
+   * The API is offered for consistency with the other resource types where
+   * Patch and Update APIs have different semantics.
+   *
+   * @param bucket_name the name of the bucket.
+   * @param entity the identifier for the user, group, service account, or
+   *     predefined set of actors holding the permission.
+   * @param original_acl the original ACL value.
+   * @param new_acl the new ACL value. Note that only changes on writeable
+   *     fields will be accepted by the server.
+   * @param options a list of optional query parameters and/or request headers.
+   *     Valid types for this operation include `UserProject`, and the standard
+   *     options available to all operations.
+   *
+   * @par Example
+   * @snippet storage_bucket_acl_samples.cc patch bucket acl
+   *
+   * @see https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls
+   *     for additional details on what fields are writeable.
+   */
+  template <typename... Options>
+  BucketAccessControl PatchBucketAcl(std::string const& bucket_name,
+                                     std::string const& entity,
+                                     BucketAccessControl const& original_acl,
+                                     BucketAccessControl const& new_acl,
+                                     Options&&... options) {
+    internal::PatchBucketAclRequest request(bucket_name, entity, original_acl,
+                                            new_acl);
+    request.set_multiple_options(std::forward<Options>(options)...);
+    return raw_client_->PatchBucketAcl(request).second;
+  }
+
+  /**
+   * Patch the value of an existing bucket ACL.
+   *
+   * This API allows the application to patch an BucketAccessControl without
+   * having to read the current value.
+   *
+   * @par Notes
+   * For changing BucketAccessControl the Patch and Update APIs basically offer
+   * the same functionality. The only field that can be modified by either API
+   * is `role`, and it may only be set to a new value (it cannot be removed).
+   * The API is offered for consistency with the other resource types where
+   * Patch and Update APIs have different semantics.
+   *
+   * @param bucket_name the name of the bucket that contains the bucket.
+   * @param bucket_name the name of the bucket.
+   * @param entity the identifier for the user, group, service account, or
+   *     predefined set of actors holding the permission.
+   * @param builder a builder ready to create the patch.
+   * @param options a list of optional query parameters and/or request
+   *     headers. Valid types for this operation include `Generation`,
+   *     `UserProject`, `IfMatchEtag`, and `IfNoneMatchEtag`.
+   *
+   * @par Example
+   * @snippet storage_bucket_acl_samples.cc patch bucket acl no-read
+   *
+   * @see https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls
+   *     for additional details on what fields are writeable.
+   */
+  template <typename... Options>
+  BucketAccessControl PatchBucketAcl(
+      std::string const& bucket_name, std::string const& entity,
+      BucketAccessControlPatchBuilder const& builder, Options&&... options) {
+    internal::PatchBucketAclRequest request(bucket_name, entity, builder);
+    request.set_multiple_options(std::forward<Options>(options)...);
+    return raw_client_->PatchBucketAcl(request).second;
+  }
+
+  /**
    * Retrieve the list of ObjectAccessControls for an object.
    *
    * @param bucket_name the name of the bucket that contains the object.

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -77,6 +77,10 @@ run_all_bucket_acl_examples() {
       "${bucket_name}" allAuthenticatedUsers
   run_example ./storage_bucket_acl_samples update-bucket-acl \
       "${bucket_name}" allAuthenticatedUsers OWNER
+  run_example ./storage_bucket_acl_samples patch-bucket-acl \
+      "${bucket_name}" allAuthenticatedUsers READER
+  run_example ./storage_bucket_acl_samples patch-bucket-acl-no-read \
+      "${bucket_name}" allAuthenticatedUsers OWNER
   run_example ./storage_bucket_acl_samples delete-bucket-acl \
       "${bucket_name}" allAuthenticatedUsers
 }

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -317,6 +317,25 @@ std::pair<Status, BucketAccessControl> CurlClient::UpdateBucketAcl(
                         BucketAccessControl::ParseFromString(payload.payload));
 }
 
+std::pair<Status, BucketAccessControl> CurlClient::PatchBucketAcl(
+    PatchBucketAclRequest const& request) {
+  CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
+                             "/acl/" + request.entity());
+  builder.SetDebugLogging(options_.enable_http_tracing());
+  builder.AddHeader(options_.credentials()->AuthorizationHeader());
+  request.AddOptionsToHttpRequest(builder);
+  builder.SetMethod("PATCH");
+  builder.AddHeader("Content-Type: application/json");
+  auto payload = builder.BuildRequest(request.payload()).MakeRequest();
+  if (payload.status_code >= 300) {
+    return std::make_pair(
+        Status{payload.status_code, std::move(payload.payload)},
+        BucketAccessControl{});
+  }
+  return std::make_pair(Status(),
+                        BucketAccessControl::ParseFromString(payload.payload));
+}
+
 std::pair<Status, ListObjectAclResponse> CurlClient::ListObjectAcl(
     ListObjectAclRequest const& request) {
   // Assume the bucket name is validated by the caller.

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -74,6 +74,8 @@ class CurlClient : public RawClient {
       DeleteBucketAclRequest const&) override;
   std::pair<Status, BucketAccessControl> UpdateBucketAcl(
       UpdateBucketAclRequest const&) override;
+  std::pair<Status, BucketAccessControl> PatchBucketAcl(
+      PatchBucketAclRequest const&) override;
 
   std::pair<Status, ListObjectAclResponse> ListObjectAcl(
       ListObjectAclRequest const& request) override;

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -165,6 +165,11 @@ std::pair<Status, BucketAccessControl> LoggingClient::UpdateBucketAcl(
   return MakeCall(*client_, &RawClient::UpdateBucketAcl, request, __func__);
 }
 
+std::pair<Status, BucketAccessControl> LoggingClient::PatchBucketAcl(
+    PatchBucketAclRequest const& request) {
+  return MakeCall(*client_, &RawClient::PatchBucketAcl, request, __func__);
+}
+
 std::pair<Status, ListObjectAclResponse> LoggingClient::ListObjectAcl(
     ListObjectAclRequest const& request) {
   return MakeCall(*client_, &RawClient::ListObjectAcl, request, __func__);

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -66,6 +66,8 @@ class LoggingClient : public RawClient {
       GetBucketAclRequest const&) override;
   std::pair<Status, BucketAccessControl> UpdateBucketAcl(
       UpdateBucketAclRequest const&) override;
+  std::pair<Status, BucketAccessControl> PatchBucketAcl(
+      PatchBucketAclRequest const&) override;
 
   std::pair<Status, ListObjectAclResponse> ListObjectAcl(
       ListObjectAclRequest const& request) override;

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -91,6 +91,8 @@ class RawClient {
       GetBucketAclRequest const&) = 0;
   virtual std::pair<Status, BucketAccessControl> UpdateBucketAcl(
       UpdateBucketAclRequest const&) = 0;
+  virtual std::pair<Status, BucketAccessControl> PatchBucketAcl(
+      PatchBucketAclRequest const&) = 0;
   //@}
 
   //@{

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -248,6 +248,14 @@ std::pair<Status, BucketAccessControl> RetryClient::UpdateBucketAcl(
                   &RawClient::UpdateBucketAcl, request, __func__);
 }
 
+std::pair<Status, BucketAccessControl> RetryClient::PatchBucketAcl(
+    PatchBucketAclRequest const& request) {
+  auto retry_policy = retry_policy_->clone();
+  auto backoff_policy = backoff_policy_->clone();
+  return MakeCall(*retry_policy, *backoff_policy, *client_,
+                  &RawClient::PatchBucketAcl, request, __func__);
+}
+
 std::pair<Status, ObjectAccessControl> RetryClient::CreateObjectAcl(
     CreateObjectAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -81,6 +81,8 @@ class RetryClient : public RawClient {
       GetBucketAclRequest const&) override;
   std::pair<Status, BucketAccessControl> UpdateBucketAcl(
       UpdateBucketAclRequest const&) override;
+  std::pair<Status, BucketAccessControl> PatchBucketAcl(
+      PatchBucketAclRequest const&) override;
 
   std::pair<Status, ListObjectAclResponse> ListObjectAcl(
       ListObjectAclRequest const& request) override;

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -71,6 +71,8 @@ class MockClient : public google::cloud::storage::internal::RawClient {
                                  internal::GetBucketAclRequest const&));
   MOCK_METHOD1(UpdateBucketAcl, ResponseWrapper<BucketAccessControl>(
                                     internal::UpdateBucketAclRequest const&));
+  MOCK_METHOD1(PatchBucketAcl, ResponseWrapper<BucketAccessControl>(
+                                   internal::PatchBucketAclRequest const&));
 
   MOCK_METHOD1(ListObjectAcl, ResponseWrapper<internal::ListObjectAclResponse>(
                                   internal::ListObjectAclRequest const&));

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -219,6 +219,12 @@ TEST_F(BucketIntegrationTest, AccessControlCRUD) {
   get_result = client.GetBucketAcl(bucket_name, entity_name);
   EXPECT_EQ(get_result, updated_result);
 
+  new_acl = get_result;
+  new_acl.set_role("OWNER");
+  get_result = client.PatchBucketAcl(bucket_name, entity_name, get_result,
+                                     new_acl, IfMatchEtag(get_result.etag()));
+  EXPECT_EQ(get_result.role(), new_acl.role());
+
   client.DeleteBucketAcl(bucket_name, entity_name);
   current_acl = client.ListBucketAcl(bucket_name);
   EXPECT_EQ(0, name_counter(result.entity(), current_acl));

--- a/google/cloud/storage/tests/testbench.py
+++ b/google/cloud/storage/tests/testbench.py
@@ -734,6 +734,19 @@ def bucket_acl_update(bucket_name, entity):
     return json.dumps(acl)
 
 
+@gcs.route('/b/<bucket_name>/acl/<entity>', methods=['PATCH'])
+def bucket_acl_patch(bucket_name, entity):
+    """Implement the 'BucketAccessControls: patch' API.
+
+      Patch the access control configuration for a particular entity.
+      """
+    gcs_bucket = GCS_BUCKETS.get(bucket_name)
+    gcs_bucket.check_preconditions(flask.request)
+    payload = json.loads(flask.request.data)
+    acl = gcs_bucket.update_acl(entity, payload.get('role', ''))
+    return json.dumps(acl)
+
+
 @gcs.route('/b/<bucket_name>/defaultObjectAcl')
 def bucket_default_object_acl_list(bucket_name):
     """Implement the 'BucketAccessControls: list' API.


### PR DESCRIPTION
This fixes #830. It implements the API, the unit tests, extends the
integration test to use the new API, adds the examples, and runs the
examples as part of the CI build.

/cc: @houglum 