### PR TITLE
Implement Client::GetDefaultObjectAcl().

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -810,6 +810,32 @@ class Client {
     raw_client_->DeleteDefaultObjectAcl(request);
   }
 
+  /**
+   * Get the value of a default object ACL in a bucket.
+   *
+   * The default object ACL sets the ACL for any object created in the bucket,
+   * unless a different ACL is specified when the object is created.
+   *
+   * @param bucket_name the name of the bucket.
+   * @param entity the name of the entity.
+   * @param options a list of optional query parameters and/or request headers.
+   *     Valid types for this operation include `UserProject`.
+   *
+   * @par Example
+   * @snippet storage_default_object_acl_samples.cc get default object acl
+   *
+   * @see
+   * https://cloud.google.com/storage/docs/access-control/create-manage-lists#defaultobjects
+   */
+  template <typename... Options>
+  ObjectAccessControl GetDefaultObjectAcl(std::string const& bucket_name,
+                                          std::string const& entity,
+                                          Options&&... options) {
+    internal::GetDefaultObjectAclRequest request(bucket_name, entity);
+    request.set_multiple_options(std::forward<Options>(options)...);
+    return raw_client_->GetDefaultObjectAcl(request).second;
+  }
+
  private:
   BucketMetadata GetBucketMetadataImpl(
       internal::GetBucketMetadataRequest const& request);

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -493,7 +493,7 @@ class Client {
   }
 
   /**
-   * Get the value of an existing bucket ACL.
+   * Gets the value of an existing bucket ACL.
    *
    * @param bucket_name the name of the bucket to query.
    * @param entity the name of the entity to query.
@@ -811,7 +811,7 @@ class Client {
   }
 
   /**
-   * Get the value of a default object ACL in a bucket.
+   * Gets the value of a default object ACL in a bucket.
    *
    * The default object ACL sets the ACL for any object created in the bucket,
    * unless a different ACL is specified when the object is created.

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -104,6 +104,8 @@ run_all_default_object_acl_examples() {
       "${bucket_name}"
   run_example ./storage_default_object_acl_samples create-default-object-acl \
       "${bucket_name}" allAuthenticatedUsers READER
+  run_example ./storage_default_object_acl_samples get-default-object-acl \
+      "${bucket_name}" allAuthenticatedUsers
   run_example ./storage_default_object_acl_samples delete-default-object-acl \
       "${bucket_name}" allAuthenticatedUsers
 }

--- a/google/cloud/storage/examples/storage_default_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_default_object_acl_samples.cc
@@ -104,6 +104,25 @@ void DeleteDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
   (std::move(client), bucket_name, entity);
 }
 
+void GetDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
+                         char* argv[]) {
+  if (argc != 3) {
+    throw Usage{"get-default-object-acl <bucket-name> <entity>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  auto entity = ConsumeArg(argc, argv);
+  //! [get default object acl]
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string bucket_name, std::string entity) {
+    gcs::ObjectAccessControl acl =
+        client.GetDefaultObjectAcl(bucket_name, entity);
+    std::cout << "Default Object ACL entry for " << entity << " in bucket "
+              << bucket_name << " is " << acl << std::endl;
+  }
+  //! [get default object acl]
+  (std::move(client), bucket_name, entity);
+}
+
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) try {
@@ -117,6 +136,7 @@ int main(int argc, char* argv[]) try {
       {"list-default-object-acl", &ListDefaultObjectAcl},
       {"create-default-object-acl", &CreateDefaultObjectAcl},
       {"delete-default-object-acl", &DeleteDefaultObjectAcl},
+      {"get-default-object-acl", &GetDefaultObjectAcl},
   };
   for (auto&& kv : commands) {
     try {

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -512,6 +512,23 @@ std::pair<Status, EmptyResponse> CurlClient::DeleteDefaultObjectAcl(
   return std::make_pair(Status(), internal::EmptyResponse{});
 }
 
+std::pair<Status, ObjectAccessControl> CurlClient::GetDefaultObjectAcl(
+    GetDefaultObjectAclRequest const& request) {
+  CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
+                             "/defaultObjectAcl/" + request.entity());
+  builder.SetDebugLogging(options_.enable_http_tracing());
+  builder.AddHeader(options_.credentials()->AuthorizationHeader());
+  request.AddOptionsToHttpRequest(builder);
+  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  if (payload.status_code >= 300) {
+    return std::make_pair(
+        Status{payload.status_code, std::move(payload.payload)},
+        ObjectAccessControl{});
+  }
+  return std::make_pair(Status(),
+                        ObjectAccessControl::ParseFromString(payload.payload));
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -96,6 +96,8 @@ class CurlClient : public RawClient {
       CreateDefaultObjectAclRequest const&) override;
   std::pair<Status, EmptyResponse> DeleteDefaultObjectAcl(
       DeleteDefaultObjectAclRequest const&) override;
+  std::pair<Status, ObjectAccessControl> GetDefaultObjectAcl(
+      GetDefaultObjectAclRequest const&) override;
 
  private:
   ClientOptions options_;

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -219,6 +219,11 @@ std::pair<Status, EmptyResponse> LoggingClient::DeleteDefaultObjectAcl(
                   __func__);
 }
 
+std::pair<Status, ObjectAccessControl> LoggingClient::GetDefaultObjectAcl(
+    GetDefaultObjectAclRequest const& request) {
+  return MakeCall(*client_, &RawClient::GetDefaultObjectAcl, request, __func__);
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -88,6 +88,8 @@ class LoggingClient : public RawClient {
       CreateDefaultObjectAclRequest const&) override;
   std::pair<Status, EmptyResponse> DeleteDefaultObjectAcl(
       DeleteDefaultObjectAclRequest const&) override;
+  std::pair<Status, ObjectAccessControl> GetDefaultObjectAcl(
+      GetDefaultObjectAclRequest const&) override;
 
   std::shared_ptr<RawClient> client() const { return client_; }
 

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -119,6 +119,8 @@ class RawClient {
       CreateDefaultObjectAclRequest const&) = 0;
   virtual std::pair<Status, EmptyResponse> DeleteDefaultObjectAcl(
       DeleteDefaultObjectAclRequest const&) = 0;
+  virtual std::pair<Status, ObjectAccessControl> GetDefaultObjectAcl(
+      GetDefaultObjectAclRequest const&) = 0;
   //@}
 };
 

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -320,6 +320,14 @@ std::pair<Status, EmptyResponse> RetryClient::DeleteDefaultObjectAcl(
                   &RawClient::DeleteDefaultObjectAcl, request, __func__);
 }
 
+std::pair<Status, ObjectAccessControl> RetryClient::GetDefaultObjectAcl(
+    GetDefaultObjectAclRequest const& request) {
+  auto retry_policy = retry_policy_->clone();
+  auto backoff_policy = backoff_policy_->clone();
+  return MakeCall(*retry_policy, *backoff_policy, *client_,
+                  &RawClient::GetDefaultObjectAcl, request, __func__);
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -103,6 +103,8 @@ class RetryClient : public RawClient {
       CreateDefaultObjectAclRequest const&) override;
   std::pair<Status, EmptyResponse> DeleteDefaultObjectAcl(
       DeleteDefaultObjectAclRequest const&) override;
+  std::pair<Status, ObjectAccessControl> GetDefaultObjectAcl(
+      GetDefaultObjectAclRequest const&) override;
 
   std::shared_ptr<RawClient> client() const { return client_; }
 

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -96,6 +96,9 @@ class MockClient : public google::cloud::storage::internal::RawClient {
   MOCK_METHOD1(DeleteDefaultObjectAcl,
                ResponseWrapper<internal::EmptyResponse>(
                    internal::DeleteDefaultObjectAclRequest const&));
+  MOCK_METHOD1(GetDefaultObjectAcl,
+               ResponseWrapper<ObjectAccessControl>(
+                   internal::GetDefaultObjectAclRequest const&));
 };
 }  // namespace testing
 }  // namespace storage

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -421,6 +421,9 @@ TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
   // name, the server "translates" the project id to a project number.
   EXPECT_EQ(1, name_counter(result.entity(), current_acl));
 
+  auto get_result = client.GetDefaultObjectAcl(bucket_name, entity_name);
+  EXPECT_EQ(get_result, result);
+
   client.DeleteDefaultObjectAcl(bucket_name, entity_name);
   current_acl = client.ListDefaultObjectAcl(bucket_name);
   EXPECT_EQ(0, name_counter(result.entity(), current_acl));


### PR DESCRIPTION
This fixes #834. It implements the API, the usual unit tests, extends
the integration test to use the API, adds the example, and runs the
example as part of the CI build.

/cc: @houglum

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1007)
<!-- Reviewable:end -->
