### PR TITLE
Implement Client::UpdateDefaultObjectAcl().

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -915,7 +915,7 @@ class Client {
   }
 
   /**
-   * Update the value of an existing default object ACL.
+   * Updates the value of an existing default object ACL.
    *
    * The default object ACL sets the ACL for any object created in the bucket,
    * unless a different ACL is specified when the object is created.

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -914,6 +914,34 @@ class Client {
     return raw_client_->GetDefaultObjectAcl(request).second;
   }
 
+  /**
+   * Update the value of an existing default object ACL.
+   *
+   * The default object ACL sets the ACL for any object created in the bucket,
+   * unless a different ACL is specified when the object is created.
+   *
+   * @param bucket_name the name of the bucket.
+   * @param acl the new ACL value. Note that only the writable values of the ACL
+   *   will be modified by the server.
+   * @param options a list of optional query parameters and/or request
+   *     Valid types for this operation include `UserProject`.
+   *
+   * @par Example
+   * @snippet storage_default_object_acl_samples.cc update default object acl
+   *
+   * @see
+   * https://cloud.google.com/storage/docs/access-control/create-manage-lists#defaultobjects
+   */
+  template <typename... Options>
+  ObjectAccessControl UpdateDefaultObjectAcl(std::string const& bucket_name,
+                                             ObjectAccessControl const& acl,
+                                             Options&&... options) {
+    internal::UpdateDefaultObjectAclRequest request(bucket_name, acl.entity(),
+                                                    acl.role());
+    request.set_multiple_options(std::forward<Options>(options)...);
+    return raw_client_->UpdateDefaultObjectAcl(request).second;
+  }
+
  private:
   BucketMetadata GetBucketMetadataImpl(
       internal::GetBucketMetadataRequest const& request);

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -110,6 +110,8 @@ run_all_default_object_acl_examples() {
       "${bucket_name}" allAuthenticatedUsers READER
   run_example ./storage_default_object_acl_samples get-default-object-acl \
       "${bucket_name}" allAuthenticatedUsers
+  run_example ./storage_default_object_acl_samples update-default-object-acl \
+      "${bucket_name}" allAuthenticatedUsers OWNER
   run_example ./storage_default_object_acl_samples delete-default-object-acl \
       "${bucket_name}" allAuthenticatedUsers
 }

--- a/google/cloud/storage/examples/storage_default_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_default_object_acl_samples.cc
@@ -123,6 +123,30 @@ void GetDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
   (std::move(client), bucket_name, entity);
 }
 
+void UpdateDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
+                            char* argv[]) {
+  if (argc != 4) {
+    throw Usage{"update-default-object-acl <bucket-name> <entity> <role>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  auto entity = ConsumeArg(argc, argv);
+  auto role = ConsumeArg(argc, argv);
+  //! [update default object acl]
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string bucket_name, std::string entity,
+     std::string role) {
+    gcs::ObjectAccessControl current_acl =
+        client.GetDefaultObjectAcl(bucket_name, entity);
+    current_acl.set_role(role);
+    gcs::ObjectAccessControl acl =
+        client.UpdateDefaultObjectAcl(bucket_name, current_acl);
+    std::cout << "Default Object ACL entry for " << entity << " in bucket "
+              << bucket_name << " is now " << acl << std::endl;
+  }
+  //! [update default object acl]
+  (std::move(client), bucket_name, entity, role);
+}
+
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) try {
@@ -137,6 +161,7 @@ int main(int argc, char* argv[]) try {
       {"create-default-object-acl", &CreateDefaultObjectAcl},
       {"delete-default-object-acl", &DeleteDefaultObjectAcl},
       {"get-default-object-acl", &GetDefaultObjectAcl},
+      {"update-default-object-acl", &UpdateDefaultObjectAcl},
   };
   for (auto&& kv : commands) {
     try {

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -548,6 +548,28 @@ std::pair<Status, ObjectAccessControl> CurlClient::GetDefaultObjectAcl(
                         ObjectAccessControl::ParseFromString(payload.payload));
 }
 
+std::pair<Status, ObjectAccessControl> CurlClient::UpdateDefaultObjectAcl(
+    UpdateDefaultObjectAclRequest const& request) {
+  CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
+                             "/defaultObjectAcl/" + request.entity());
+  builder.SetDebugLogging(options_.enable_http_tracing());
+  builder.AddHeader(options_.credentials()->AuthorizationHeader());
+  request.AddOptionsToHttpRequest(builder);
+  builder.SetMethod("PUT");
+  nl::json object;
+  object["entity"] = request.entity();
+  object["role"] = request.role();
+  builder.AddHeader("Content-Type: application/json");
+  auto payload = builder.BuildRequest(object.dump()).MakeRequest();
+  if (payload.status_code >= 300) {
+    return std::make_pair(
+        Status{payload.status_code, std::move(payload.payload)},
+        ObjectAccessControl{});
+  }
+  return std::make_pair(Status(),
+                        ObjectAccessControl::ParseFromString(payload.payload));
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -100,6 +100,8 @@ class CurlClient : public RawClient {
       DeleteDefaultObjectAclRequest const&) override;
   std::pair<Status, ObjectAccessControl> GetDefaultObjectAcl(
       GetDefaultObjectAclRequest const&) override;
+  std::pair<Status, ObjectAccessControl> UpdateDefaultObjectAcl(
+      UpdateDefaultObjectAclRequest const&) override;
 
  private:
   ClientOptions options_;

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -229,6 +229,12 @@ std::pair<Status, ObjectAccessControl> LoggingClient::GetDefaultObjectAcl(
   return MakeCall(*client_, &RawClient::GetDefaultObjectAcl, request, __func__);
 }
 
+std::pair<Status, ObjectAccessControl> LoggingClient::UpdateDefaultObjectAcl(
+    UpdateDefaultObjectAclRequest const& request) {
+  return MakeCall(*client_, &RawClient::UpdateDefaultObjectAcl, request,
+                  __func__);
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -92,6 +92,8 @@ class LoggingClient : public RawClient {
       DeleteDefaultObjectAclRequest const&) override;
   std::pair<Status, ObjectAccessControl> GetDefaultObjectAcl(
       GetDefaultObjectAclRequest const&) override;
+  std::pair<Status, ObjectAccessControl> UpdateDefaultObjectAcl(
+      UpdateDefaultObjectAclRequest const&) override;
 
   std::shared_ptr<RawClient> client() const { return client_; }
 

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -119,6 +119,8 @@ class RawClient {
       DeleteDefaultObjectAclRequest const&) = 0;
   virtual std::pair<Status, ObjectAccessControl> GetDefaultObjectAcl(
       GetDefaultObjectAclRequest const&) = 0;
+  virtual std::pair<Status, ObjectAccessControl> UpdateDefaultObjectAcl(
+      UpdateDefaultObjectAclRequest const&) = 0;
   //@}
 };
 

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -336,6 +336,14 @@ std::pair<Status, ObjectAccessControl> RetryClient::GetDefaultObjectAcl(
                   &RawClient::GetDefaultObjectAcl, request, __func__);
 }
 
+std::pair<Status, ObjectAccessControl> RetryClient::UpdateDefaultObjectAcl(
+    UpdateDefaultObjectAclRequest const& request) {
+  auto retry_policy = retry_policy_->clone();
+  auto backoff_policy = backoff_policy_->clone();
+  return MakeCall(*retry_policy, *backoff_policy, *client_,
+                  &RawClient::UpdateDefaultObjectAcl, request, __func__);
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -107,6 +107,8 @@ class RetryClient : public RawClient {
       DeleteDefaultObjectAclRequest const&) override;
   std::pair<Status, ObjectAccessControl> GetDefaultObjectAcl(
       GetDefaultObjectAclRequest const&) override;
+  std::pair<Status, ObjectAccessControl> UpdateDefaultObjectAcl(
+      UpdateDefaultObjectAclRequest const&) override;
 
   std::shared_ptr<RawClient> client() const { return client_; }
 

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -101,6 +101,9 @@ class MockClient : public google::cloud::storage::internal::RawClient {
   MOCK_METHOD1(GetDefaultObjectAcl,
                ResponseWrapper<ObjectAccessControl>(
                    internal::GetDefaultObjectAclRequest const&));
+  MOCK_METHOD1(UpdateDefaultObjectAcl,
+               ResponseWrapper<ObjectAccessControl>(
+                   internal::UpdateDefaultObjectAclRequest const&));
 };
 }  // namespace testing
 }  // namespace storage

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -430,6 +430,13 @@ TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
   auto get_result = client.GetDefaultObjectAcl(bucket_name, entity_name);
   EXPECT_EQ(get_result, result);
 
+  ObjectAccessControl new_acl = get_result;
+  new_acl.set_role("READER");
+  auto updated_result = client.UpdateDefaultObjectAcl(bucket_name, new_acl);
+  EXPECT_EQ(updated_result.role(), "READER");
+  get_result = client.GetDefaultObjectAcl(bucket_name, entity_name);
+  EXPECT_EQ(get_result, updated_result);
+
   client.DeleteDefaultObjectAcl(bucket_name, entity_name);
   current_acl = client.ListDefaultObjectAcl(bucket_name);
   EXPECT_EQ(0, name_counter(result.entity(), current_acl));

--- a/google/cloud/storage/tests/testbench.py
+++ b/google/cloud/storage/tests/testbench.py
@@ -571,7 +571,7 @@ class GcsBucket(object):
         :param role:str the new role for the entity.
         :return:dict with the contents of the ObjectAccessControl.
         """
-        return self.insert_acl(entity, role)
+        return self.insert_default_object_acl(entity, role)
 
 
 # Define the collection of GcsObjects indexed by <bucket_name>/o/<object_name>


### PR DESCRIPTION
This fixes #817. It implements the API, the usual unit tests, extends
the integration test to use the API, adds and example and runs the
example as part of the CI build.

/cc: @houglum

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1014)
<!-- Reviewable:end -->
