### PR TITLE
Fix capitalization for Metageneration.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -222,8 +222,8 @@ class Client {
    * @param metadata the new metadata for the Bucket.  The `name` field is
    *     ignored in favor of @p bucket_name.
    * @param options a list of optional query parameters and/or request headers.
-   *     Valid types for this operation include `IfMetaGenerationMatch`,
-   *     `IfMetaGenerationNotMatch`, `PredefinedAcl`,
+   *     Valid types for this operation include `IfMetagenerationMatch`,
+   *     `IfMetagenerationNotMatch`, `PredefinedAcl`,
    *     `PredefinedDefaultObjectAcl`, `Projection`, and `UserProject`.
    *
    * @throw std::runtime_error if the operation fails.

--- a/google/cloud/storage/internal/bucket_requests.h
+++ b/google/cloud/storage/internal/bucket_requests.h
@@ -64,8 +64,8 @@ std::ostream& operator<<(std::ostream& os, ListBucketsResponse const& r);
  * Request the metadata for a bucket.
  */
 class GetBucketMetadataRequest
-    : public GenericRequest<GetBucketMetadataRequest, IfMetaGenerationMatch,
-                            IfMetaGenerationNotMatch, Projection, UserProject> {
+    : public GenericRequest<GetBucketMetadataRequest, IfMetagenerationMatch,
+                            IfMetagenerationNotMatch, Projection, UserProject> {
  public:
   GetBucketMetadataRequest() = default;
   explicit GetBucketMetadataRequest(std::string bucket_name)
@@ -117,8 +117,8 @@ std::ostream& operator<<(std::ostream& os, CreateBucketRequest const& r);
  * Represents a request to the `Buckets: delete` API.
  */
 class DeleteBucketRequest
-    : public GenericRequest<DeleteBucketRequest, IfMetaGenerationMatch,
-                            IfMetaGenerationNotMatch, UserProject> {
+    : public GenericRequest<DeleteBucketRequest, IfMetagenerationMatch,
+                            IfMetagenerationNotMatch, UserProject> {
  public:
   DeleteBucketRequest() = default;
   explicit DeleteBucketRequest(std::string bucket_name)
@@ -137,7 +137,7 @@ std::ostream& operator<<(std::ostream& os, DeleteBucketRequest const& r);
  */
 class UpdateBucketRequest
     : public GenericRequest<
-          UpdateBucketRequest, IfMetaGenerationMatch, IfMetaGenerationNotMatch,
+          UpdateBucketRequest, IfMetagenerationMatch, IfMetagenerationNotMatch,
           PredefinedAcl, PredefinedDefaultObjectAcl, Projection, UserProject> {
  public:
   UpdateBucketRequest() = default;
@@ -160,7 +160,7 @@ std::ostream& operator<<(std::ostream& os, UpdateBucketRequest const& r);
  */
 class PatchBucketRequest
     : public GenericRequest<
-          PatchBucketRequest, IfMetaGenerationMatch, IfMetaGenerationNotMatch,
+          PatchBucketRequest, IfMetagenerationMatch, IfMetagenerationNotMatch,
           PredefinedAcl, PredefinedDefaultObjectAcl, Projection, UserProject> {
  public:
   PatchBucketRequest() = default;

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -33,7 +33,7 @@ TEST(GetBucketMetadataRequestTest, OStreamBasic) {
 
 TEST(GetBucketMetadataRequestTest, OStreamParameter) {
   GetBucketMetadataRequest request("my-bucket");
-  request.set_multiple_options(IfMetaGenerationNotMatch(7),
+  request.set_multiple_options(IfMetagenerationNotMatch(7),
                                UserProject("my-project"));
   std::ostringstream os;
   os << request;
@@ -120,7 +120,7 @@ TEST(CreateBucketsRequestTest, Basic) {
 
 TEST(DeleteBucketRequestTest, OStream) {
   DeleteBucketRequest request("my-bucket");
-  request.set_multiple_options(IfMetaGenerationNotMatch(7),
+  request.set_multiple_options(IfMetagenerationNotMatch(7),
                                UserProject("my-project"));
   EXPECT_EQ("my-bucket", request.bucket_name());
 
@@ -152,7 +152,7 @@ TEST(UpdateBucketRequestTest, Simple) {
   BucketMetadata metadata = CreateBucketMetadataForTest();
   metadata.set_name("my-bucket");
   UpdateBucketRequest request(metadata);
-  request.set_multiple_options(IfMetaGenerationNotMatch(7),
+  request.set_multiple_options(IfMetagenerationNotMatch(7),
                                UserProject("my-project"));
   EXPECT_EQ(metadata, request.metadata());
 
@@ -516,7 +516,7 @@ TEST(PatchBucketRequestTest, DiffOStream) {
   BucketMetadata updated = original;
   updated.set_storage_class("NEARLINE");
   PatchBucketRequest request("test-bucket", original, updated);
-  request.set_multiple_options(IfMetaGenerationNotMatch(7),
+  request.set_multiple_options(IfMetagenerationNotMatch(7),
                                UserProject("my-project"));
   EXPECT_EQ("test-bucket", request.bucket());
 
@@ -534,7 +534,7 @@ TEST(PatchBucketRequestTest, Builder) {
   PatchBucketRequest request("test-bucket", BucketMetadataPatchBuilder()
                                                 .SetStorageClass("NEARLINE")
                                                 .ResetDefaultAcl());
-  request.set_multiple_options(IfMetaGenerationNotMatch(7),
+  request.set_multiple_options(IfMetagenerationNotMatch(7),
                                UserProject("my-project"));
   EXPECT_EQ("test-bucket", request.bucket());
 

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -65,7 +65,7 @@ std::ostream& operator<<(std::ostream& os, ListObjectsResponse const& r);
 class GetObjectMetadataRequest
     : public GenericObjectRequest<
           GetObjectMetadataRequest, Generation, IfGenerationMatch,
-          IfGenerationNotMatch, IfMetaGenerationMatch, IfMetaGenerationNotMatch,
+          IfGenerationNotMatch, IfMetagenerationMatch, IfMetagenerationNotMatch,
           Projection, UserProject> {
  public:
   using GenericObjectRequest::GenericObjectRequest;
@@ -84,7 +84,7 @@ std::ostream& operator<<(std::ostream& os, GetObjectMetadataRequest const& r);
 class InsertObjectMediaRequest
     : public GenericObjectRequest<
           InsertObjectMediaRequest, ContentEncoding, IfGenerationMatch,
-          IfGenerationNotMatch, IfMetaGenerationMatch, IfMetaGenerationNotMatch,
+          IfGenerationNotMatch, IfMetagenerationMatch, IfMetagenerationNotMatch,
           KmsKeyName, PredefinedAcl, Projection, UserProject> {
  public:
   InsertObjectMediaRequest() : GenericObjectRequest(), contents_() {}
@@ -114,7 +114,7 @@ std::ostream& operator<<(std::ostream& os, InsertObjectMediaRequest const& r);
 class InsertObjectStreamingRequest
     : public GenericObjectRequest<
           InsertObjectStreamingRequest, ContentEncoding, IfGenerationMatch,
-          IfGenerationNotMatch, IfMetaGenerationMatch, IfMetaGenerationNotMatch,
+          IfGenerationNotMatch, IfMetagenerationMatch, IfMetagenerationNotMatch,
           KmsKeyName, PredefinedAcl, Projection, UserProject> {
  public:
   using GenericObjectRequest::GenericObjectRequest;
@@ -129,8 +129,8 @@ std::ostream& operator<<(std::ostream& os,
 class ReadObjectRangeRequest
     : public GenericObjectRequest<ReadObjectRangeRequest, Generation,
                                   IfGenerationMatch, IfGenerationNotMatch,
-                                  IfMetaGenerationMatch,
-                                  IfMetaGenerationNotMatch, UserProject> {
+                                  IfMetagenerationMatch,
+                                  IfMetagenerationNotMatch, UserProject> {
  public:
   ReadObjectRangeRequest() : GenericObjectRequest(), begin_(0), end_(0) {}
 
@@ -176,8 +176,8 @@ std::ostream& operator<<(std::ostream& os, ReadObjectRangeResponse const& r);
 class DeleteObjectRequest
     : public GenericObjectRequest<DeleteObjectRequest, Generation,
                                   IfGenerationMatch, IfGenerationNotMatch,
-                                  IfMetaGenerationMatch,
-                                  IfMetaGenerationNotMatch, UserProject> {
+                                  IfMetagenerationMatch,
+                                  IfMetagenerationNotMatch, UserProject> {
  public:
   using GenericObjectRequest::GenericObjectRequest;
 };

--- a/google/cloud/storage/internal/object_requests_test.cc
+++ b/google/cloud/storage/internal/object_requests_test.cc
@@ -93,7 +93,7 @@ TEST(ObjectRequestsTest, ParseListResponse) {
 
 TEST(ObjectRequestsTest, Get) {
   GetObjectMetadataRequest request("my-bucket", "my-object");
-  request.set_multiple_options(Generation(1), IfMetaGenerationMatch(3));
+  request.set_multiple_options(Generation(1), IfMetagenerationMatch(3));
   std::ostringstream os;
   os << request;
   auto str = os.str();
@@ -239,7 +239,7 @@ TEST(ObjectRequestsTest, RangeResponseParseErrors) {
 
 TEST(ObjectRequestsTest, Delete) {
   DeleteObjectRequest request("my-bucket", "my-object");
-  request.set_multiple_options(IfMetaGenerationNotMatch(7),
+  request.set_multiple_options(IfMetagenerationNotMatch(7),
                                UserProject("my-project"));
   std::ostringstream os;
   os << request;

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -284,7 +284,7 @@ TEST_F(BucketIntegrationTest, GetMetadata) {
   EXPECT_EQ("storage#bucket", metadata.kind());
 }
 
-TEST_F(BucketIntegrationTest, GetMetadataIfMetaGenerationMatch_Success) {
+TEST_F(BucketIntegrationTest, GetMetadataIfMetagenerationMatch_Success) {
   auto bucket_name = BucketTestEnvironment::bucket_name();
   Client client;
 
@@ -295,11 +295,11 @@ TEST_F(BucketIntegrationTest, GetMetadataIfMetaGenerationMatch_Success) {
 
   auto metadata2 = client.GetBucketMetadata(
       bucket_name, storage::Projection("noAcl"),
-      storage::IfMetaGenerationMatch(metadata.metageneration()));
+      storage::IfMetagenerationMatch(metadata.metageneration()));
   EXPECT_EQ(metadata2, metadata);
 }
 
-TEST_F(BucketIntegrationTest, GetMetadataIfMetaGenerationNotMatch_Failure) {
+TEST_F(BucketIntegrationTest, GetMetadataIfMetagenerationNotMatch_Failure) {
   auto bucket_name = BucketTestEnvironment::bucket_name();
   Client client;
 
@@ -312,13 +312,13 @@ TEST_F(BucketIntegrationTest, GetMetadataIfMetaGenerationNotMatch_Failure) {
   EXPECT_THROW(
       client.GetBucketMetadata(
           bucket_name, storage::Projection("noAcl"),
-          storage::IfMetaGenerationNotMatch(metadata.metageneration())),
+          storage::IfMetagenerationNotMatch(metadata.metageneration())),
       std::exception);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       client.GetBucketMetadata(
           bucket_name, storage::Projection("noAcl"),
-          storage::IfMetaGenerationNotMatch(metadata.metageneration())),
+          storage::IfMetagenerationNotMatch(metadata.metageneration())),
       "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -237,12 +237,12 @@ TEST(CurlRequestTest, WellKnownQueryParameters_IfGenerationNotMatch) {
   EXPECT_EQ(0U, args.count("ifMetagenerationNotMatch"));
 }
 
-/// @test Verify that the IfMetaGenerationMatch parameter is included if set.
-TEST(CurlRequestTest, WellKnownQueryParameters_IfMetaGenerationMatch) {
+/// @test Verify that the IfMetagenerationMatch parameter is included if set.
+TEST(CurlRequestTest, WellKnownQueryParameters_IfMetagenerationMatch) {
   storage::internal::CurlRequestBuilder request(HttpBinEndpoint() + "/get");
   request.AddHeader("Accept: application/json");
   request.AddHeader("charsets: utf-8");
-  request.AddOption(storage::IfMetaGenerationMatch(42));
+  request.AddOption(storage::IfMetagenerationMatch(42));
 
   auto response = request.BuildRequest(std::string{}).MakeRequest();
   EXPECT_EQ(200, response.status_code);
@@ -257,12 +257,12 @@ TEST(CurlRequestTest, WellKnownQueryParameters_IfMetaGenerationMatch) {
   EXPECT_EQ(0U, args.count("ifMetagenerationNotMatch"));
 }
 
-/// @test Verify that the IfMetaGenerationNotMatch parameter is included if set.
-TEST(CurlRequestTest, WellKnownQueryParameters_IfMetaGenerationNotMatch) {
+/// @test Verify that the IfMetagenerationNotMatch parameter is included if set.
+TEST(CurlRequestTest, WellKnownQueryParameters_IfMetagenerationNotMatch) {
   storage::internal::CurlRequestBuilder request(HttpBinEndpoint() + "/get");
   request.AddHeader("Accept: application/json");
   request.AddHeader("charsets: utf-8");
-  request.AddOption(storage::IfMetaGenerationNotMatch(42));
+  request.AddOption(storage::IfMetagenerationNotMatch(42));
 
   auto response = request.BuildRequest(std::string{}).MakeRequest();
   EXPECT_EQ(200, response.status_code);
@@ -283,7 +283,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_Multiple) {
   request.AddHeader("Accept: application/json");
   request.AddHeader("charsets: utf-8");
   request.AddOption(storage::UserProject("user-project-id"));
-  request.AddOption(storage::IfMetaGenerationMatch(7));
+  request.AddOption(storage::IfMetagenerationMatch(7));
   request.AddOption(storage::IfGenerationNotMatch(42));
 
   auto response = request.BuildRequest(std::string{}).MakeRequest();

--- a/google/cloud/storage/well_known_parameters.h
+++ b/google/cloud/storage/well_known_parameters.h
@@ -79,18 +79,18 @@ struct IfGenerationNotMatch
   }
 };
 
-struct IfMetaGenerationMatch
-    : public WellKnownParameter<IfMetaGenerationMatch, std::int64_t> {
-  using WellKnownParameter<IfMetaGenerationMatch,
+struct IfMetagenerationMatch
+    : public WellKnownParameter<IfMetagenerationMatch, std::int64_t> {
+  using WellKnownParameter<IfMetagenerationMatch,
                            std::int64_t>::WellKnownParameter;
   static char const* well_known_parameter_name() {
     return "ifMetagenerationMatch";
   }
 };
 
-struct IfMetaGenerationNotMatch
-    : public WellKnownParameter<IfMetaGenerationNotMatch, std::int64_t> {
-  using WellKnownParameter<IfMetaGenerationNotMatch,
+struct IfMetagenerationNotMatch
+    : public WellKnownParameter<IfMetagenerationNotMatch, std::int64_t> {
+  using WellKnownParameter<IfMetagenerationNotMatch,
                            std::int64_t>::WellKnownParameter;
   static char const* well_known_parameter_name() {
     return "ifMetagenerationNotMatch";


### PR DESCRIPTION
This fixes #856. We (I really) incorrectly capitalized MetaGeneration
when Google Cloud Storage treats that as a single word so it should be
Metageneration.

/cc: @houglum 
