### PR TITLE
Implement Client::PatchDefaultObjectAcl().

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -942,6 +942,86 @@ class Client {
     return raw_client_->UpdateDefaultObjectAcl(request).second;
   }
 
+  /**
+   * Patches the value of an existing default object ACL.
+   *
+   * Compute the delta between a previous and new values for a default object
+   * access control, and apply that delta.
+   *
+   * @par Notes
+   * For changing default object access controls the Patch and Update APIs
+   * basically offer the same functionality. The only field that can be modified
+   * by either API is `role`, and it may only be set to a new value (it cannot
+   * be removed). The API is offered for consistency with the other resource
+   * types where Patch and Update APIs have different semantics.
+   *
+   * @param bucket_name the name of the bucket.
+   * @param entity the identifier for the user, group, service account, or
+   *     predefined set of actors holding the permission.
+   * @param original_acl the original ACL value.
+   * @param new_acl the new ACL value. Note that only changes on writeable
+   *     fields will be accepted by the server.
+   * @param options a list of optional query parameters and/or request
+   *     headers. Valid types for this operation include `UserProject`, as well
+   *     as the standard parameters, such as `IfMatchEtag`, and
+   *     `IfNoneMatchEtag`.
+   *
+   * @par Example
+   * @snippet storage_default_object_acl_samples.cc patch default object acl
+   *
+   * @see
+   * https://cloud.google.com/storage/docs/access-control/create-manage-lists#defaultobjects
+   */
+  template <typename... Options>
+  ObjectAccessControl PatchDefaultObjectAcl(
+      std::string const& bucket_name, std::string const& entity,
+      ObjectAccessControl const& original_acl,
+      ObjectAccessControl const& new_acl, Options&&... options) {
+    internal::PatchDefaultObjectAclRequest request(bucket_name, entity,
+                                                   original_acl, new_acl);
+    request.set_multiple_options(std::forward<Options>(options)...);
+    return raw_client_->PatchDefaultObjectAcl(request).second;
+  }
+
+  /**
+   * Patches the value of an existing default object ACL.
+   *
+   * This API allows the application to patch an ObjectAccessControl without
+   * having to read the current value.
+   *
+   * @par Notes
+   * For changing default object access controls the Patch and Update APIs
+   * basically offer the same functionality. The only field that can be modified
+   * by either API is `role`, and it may only be set to a new value (it cannot
+   * be removed). The API is offered for consistency with the other resource
+   * types where Patch and Update APIs have different semantics.
+   *
+   * @param bucket_name the name of the bucket.
+   * @param entity the identifier for the user, group, service account, or
+   *     predefined set of actors holding the permission.
+   * @param builder a builder ready to create the patch.
+   * @param options a list of optional query parameters and/or request
+   *     headers. Valid types for this operation include `UserProject`, as well
+   *     as the standard parameters, such as `IfMatchEtag`, and
+   *     `IfNoneMatchEtag`.
+   *
+   * @par Example
+   * @snippet storage_default_object_acl_samples.cc patch default object acl
+   * no-read
+   *
+   * @see
+   * https://cloud.google.com/storage/docs/access-control/create-manage-lists#defaultobjects
+   */
+  template <typename... Options>
+  ObjectAccessControl PatchDefaultObjectAcl(
+      std::string const& bucket_name, std::string const& entity,
+      ObjectAccessControlPatchBuilder const& builder, Options&&... options) {
+    internal::PatchDefaultObjectAclRequest request(bucket_name, entity,
+                                                   builder);
+    request.set_multiple_options(std::forward<Options>(options)...);
+    return raw_client_->PatchDefaultObjectAcl(request).second;
+  }
+
  private:
   BucketMetadata GetBucketMetadataImpl(
       internal::GetBucketMetadataRequest const& request);

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -112,6 +112,10 @@ run_all_default_object_acl_examples() {
       "${bucket_name}" allAuthenticatedUsers
   run_example ./storage_default_object_acl_samples update-default-object-acl \
       "${bucket_name}" allAuthenticatedUsers OWNER
+  run_example ./storage_default_object_acl_samples patch-default-object-acl \
+      "${bucket_name}" allAuthenticatedUsers READER
+  run_example ./storage_default_object_acl_samples patch-default-object-acl-no-read \
+      "${bucket_name}" allAuthenticatedUsers OWNER
   run_example ./storage_default_object_acl_samples delete-default-object-acl \
       "${bucket_name}" allAuthenticatedUsers
 }
@@ -176,6 +180,8 @@ run_all_object_acl_examples() {
       "${bucket_name}" "${object_name}" allAuthenticatedUsers OWNER
   run_example ./storage_object_acl_samples patch-object-acl \
       "${bucket_name}" "${object_name}" allAuthenticatedUsers READER
+  run_example ./storage_object_acl_samples patch-object-acl \
+      "${bucket_name}" "${object_name}" allAuthenticatedUsers OWNER
   run_example ./storage_object_acl_samples delete-object-acl \
       "${bucket_name}" "${object_name}" allAuthenticatedUsers
 

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -570,6 +570,25 @@ std::pair<Status, ObjectAccessControl> CurlClient::UpdateDefaultObjectAcl(
                         ObjectAccessControl::ParseFromString(payload.payload));
 }
 
+std::pair<Status, ObjectAccessControl> CurlClient::PatchDefaultObjectAcl(
+    PatchDefaultObjectAclRequest const& request) {
+  CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
+                             "/defaultObjectAcl/" + request.entity());
+  builder.SetDebugLogging(options_.enable_http_tracing());
+  builder.AddHeader(options_.credentials()->AuthorizationHeader());
+  request.AddOptionsToHttpRequest(builder);
+  builder.SetMethod("PATCH");
+  builder.AddHeader("Content-Type: application/json");
+  auto payload = builder.BuildRequest(request.payload()).MakeRequest();
+  if (payload.status_code >= 300) {
+    return std::make_pair(
+        Status{payload.status_code, std::move(payload.payload)},
+        ObjectAccessControl{});
+  }
+  return std::make_pair(Status(),
+                        ObjectAccessControl::ParseFromString(payload.payload));
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -102,6 +102,8 @@ class CurlClient : public RawClient {
       GetDefaultObjectAclRequest const&) override;
   std::pair<Status, ObjectAccessControl> UpdateDefaultObjectAcl(
       UpdateDefaultObjectAclRequest const&) override;
+  std::pair<Status, ObjectAccessControl> PatchDefaultObjectAcl(
+      PatchDefaultObjectAclRequest const&) override;
 
  private:
   ClientOptions options_;

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -235,6 +235,12 @@ std::pair<Status, ObjectAccessControl> LoggingClient::UpdateDefaultObjectAcl(
                   __func__);
 }
 
+std::pair<Status, ObjectAccessControl> LoggingClient::PatchDefaultObjectAcl(
+    PatchDefaultObjectAclRequest const& request) {
+  return MakeCall(*client_, &RawClient::PatchDefaultObjectAcl, request,
+                  __func__);
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -94,6 +94,8 @@ class LoggingClient : public RawClient {
       GetDefaultObjectAclRequest const&) override;
   std::pair<Status, ObjectAccessControl> UpdateDefaultObjectAcl(
       UpdateDefaultObjectAclRequest const&) override;
+  std::pair<Status, ObjectAccessControl> PatchDefaultObjectAcl(
+      PatchDefaultObjectAclRequest const&) override;
 
   std::shared_ptr<RawClient> client() const { return client_; }
 

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -121,6 +121,8 @@ class RawClient {
       GetDefaultObjectAclRequest const&) = 0;
   virtual std::pair<Status, ObjectAccessControl> UpdateDefaultObjectAcl(
       UpdateDefaultObjectAclRequest const&) = 0;
+  virtual std::pair<Status, ObjectAccessControl> PatchDefaultObjectAcl(
+      PatchDefaultObjectAclRequest const&) = 0;
   //@}
 };
 

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -344,6 +344,14 @@ std::pair<Status, ObjectAccessControl> RetryClient::UpdateDefaultObjectAcl(
                   &RawClient::UpdateDefaultObjectAcl, request, __func__);
 }
 
+std::pair<Status, ObjectAccessControl> RetryClient::PatchDefaultObjectAcl(
+    PatchDefaultObjectAclRequest const& request) {
+  auto retry_policy = retry_policy_->clone();
+  auto backoff_policy = backoff_policy_->clone();
+  return MakeCall(*retry_policy, *backoff_policy, *client_,
+                  &RawClient::PatchDefaultObjectAcl, request, __func__);
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -109,6 +109,8 @@ class RetryClient : public RawClient {
       GetDefaultObjectAclRequest const&) override;
   std::pair<Status, ObjectAccessControl> UpdateDefaultObjectAcl(
       UpdateDefaultObjectAclRequest const&) override;
+  std::pair<Status, ObjectAccessControl> PatchDefaultObjectAcl(
+      PatchDefaultObjectAclRequest const&) override;
 
   std::shared_ptr<RawClient> client() const { return client_; }
 

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -104,6 +104,9 @@ class MockClient : public google::cloud::storage::internal::RawClient {
   MOCK_METHOD1(UpdateDefaultObjectAcl,
                ResponseWrapper<ObjectAccessControl>(
                    internal::UpdateDefaultObjectAclRequest const&));
+  MOCK_METHOD1(PatchDefaultObjectAcl,
+               ResponseWrapper<ObjectAccessControl>(
+                   internal::PatchDefaultObjectAclRequest const&));
 };
 }  // namespace testing
 }  // namespace storage

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -437,6 +437,13 @@ TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
   get_result = client.GetDefaultObjectAcl(bucket_name, entity_name);
   EXPECT_EQ(get_result, updated_result);
 
+  new_acl = get_result;
+  new_acl.set_role("OWNER");
+  get_result =
+      client.PatchDefaultObjectAcl(bucket_name, entity_name, get_result,
+                                   new_acl, IfMatchEtag(get_result.etag()));
+  EXPECT_EQ(get_result.role(), new_acl.role());
+
   client.DeleteDefaultObjectAcl(bucket_name, entity_name);
   current_acl = client.ListDefaultObjectAcl(bucket_name);
   EXPECT_EQ(0, name_counter(result.entity(), current_acl));

--- a/google/cloud/storage/tests/testbench.py
+++ b/google/cloud/storage/tests/testbench.py
@@ -858,6 +858,19 @@ def bucket_default_object_acl_update(bucket_name, entity):
     return json.dumps(acl)
 
 
+@gcs.route('/b/<bucket_name>/defaultObjectAcl/<entity>', methods=['PATCH'])
+def bucket_default_object_acl_patch(bucket_name, entity):
+    """Implement the 'DefaultObjectAccessControls: patch' API.
+
+      Patch the default access control configuration for a particular entity.
+      """
+    gcs_bucket = GCS_BUCKETS.get(bucket_name)
+    gcs_bucket.check_preconditions(flask.request)
+    payload = json.loads(flask.request.data)
+    acl = gcs_bucket.update_default_object_acl(entity, payload.get('role', ''))
+    return json.dumps(acl)
+
+
 @gcs.route('/b/<bucket_name>/o')
 def objects_list(bucket_name):
     """Implement the 'Objects: list' API: return the objects in a bucket."""


### PR DESCRIPTION
This fixes #837. It implements the API, the usual unit tests, extends
the integration test to use the API, adds examples and runs the examples
as part of the CI build. Some minor tweaks to the testbench also.

/cc: @houglum 