### PR TITLE
Implement customer encryption keys

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -152,6 +152,7 @@ add_library(storage_client
             internal/metadata_parser.cc
             internal/nljson.h
             internal/openssl_util.h
+            internal/openssl_util.cc
             internal/object_acl_requests.h
             internal/object_acl_requests.cc
             internal/object_requests.h

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -183,6 +183,7 @@ add_library(storage_client
             version.h
             version.cc
             well_known_headers.h
+            well_known_headers.cc
             well_known_parameters.h)
 target_link_libraries(storage_client
                       PUBLIC google_cloud_cpp_common
@@ -262,7 +263,8 @@ set(storage_client_unit_tests
     retry_policy_test.cc
     storage_class_test.cc
     storage_client_options_test.cc
-    link_test.cc)
+    link_test.cc
+    well_known_headers_test.cc)
 
 foreach (fname ${storage_client_unit_tests})
     string(REPLACE "/"

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -152,11 +152,9 @@ run_all_object_examples() {
       "${bucket_name}" "${object_name}"
 
   local encrypted_object_name="object-$(date +%s)-${RANDOM}.txt"
-  # This is included for demonstration purposes only. You should consult your
-  # security team about best practices to create encryption keys.
-  local key="$(printf "%-32s" "KEY-${RANDOM}-${RANDOM}-${RANDOM}-${RANDOM}" |
-      tr ' ' '=')"
 
+  local key="$(./storage_object_samples generate-encryption-key |
+      grep 'Base64 encoded key' | awk '{print $5}')"
   run_example ./storage_object_samples write-encrypted-object \
       "${bucket_name}" "${encrypted_object_name}" "${key}"
   run_example ./storage_object_samples read-encrypted-object \

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -154,7 +154,8 @@ run_all_object_examples() {
   local encrypted_object_name="object-$(date +%s)-${RANDOM}.txt"
   # This is included for demonstration purposes only. You should consult your
   # security team about best practices to create encryption keys.
-  local key="KEY-${RANDOM}-${RANDOM}-${RANDOM}"
+  local key="$(printf "%-32s" "KEY-${RANDOM}-${RANDOM}-${RANDOM}-${RANDOM}" |
+      tr ' ' '=')"
 
   run_example ./storage_object_samples write-encrypted-object \
       "${bucket_name}" "${encrypted_object_name}" "${key}"

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -150,6 +150,20 @@ run_all_object_examples() {
       "${bucket_name}" "${object_name}" "test-label" "test-value"
   run_example ./storage_object_samples delete-object \
       "${bucket_name}" "${object_name}"
+
+  local encrypted_object_name="object-$(date +%s)-${RANDOM}.txt"
+  # This is included for demonstration purposes only. You should consult your
+  # security team about best practices to create encryption keys.
+  local key="KEY-${RANDOM}-${RANDOM}-${RANDOM}"
+
+  run_example ./storage_object_samples write-encrypted-object \
+      "${bucket_name}" "${encrypted_object_name}" "${key}"
+  run_example ./storage_object_samples read-encrypted-object \
+      "${bucket_name}" "${encrypted_object_name}" "${key}"
+  run_example ./storage_object_samples delete-object \
+      "${bucket_name}" "${encrypted_object_name}"
+
+  run_example ./storage_object_samples generate-encryption-key
 }
 
 ################################################

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -209,13 +209,13 @@ void GenerateEncryptionKey(google::cloud::storage::Client client, int& argc,
   //! [generate encryption key] [START generate_encryption_key_base64]
   // Create a pseudo-random number generator (PRNG), this is included for
   // demonstration purposes only. You should consult your security team about
-  // best practices to initialize PRNG with enough entropy to satisfy the
-  // security policies within your organization. In particular, you should
-  // audit if the C++ library and operating system provide enough entropy for
-  // your purposes.
+  // best practices to initialize PRNG. In particular, you should verify that
+  // the C++ library and operating system provide enough entropy to meet the
+  // security policies in your organization.
 
   // Use the Mersenne-Twister Engine in this example:
   //   https://en.cppreference.com/w/cpp/numeric/random/mersenne_twister_engine
+  // Any C++ PRNG can be used below, the choice is arbitrary.
   using GeneratorType = std::mt19937_64;
 
   // Create the default random device to fetch entropy.
@@ -311,7 +311,7 @@ int main(int argc, char* argv[]) try {
   };
   for (auto&& kv : commands) {
     try {
-      int fake_argc = 1;
+      int fake_argc = 0;
       kv.second(client, fake_argc, argv);
     } catch (Usage const& u) {
       command_usage += "    ";

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -181,6 +181,7 @@ std::pair<Status, std::unique_ptr<ObjectReadStreambuf>> CurlClient::ReadObject(
                              "/o/" + request.object_name());
   builder.SetDebugLogging(options_.enable_http_tracing());
   builder.AddHeader(options_.credentials()->AuthorizationHeader());
+  request.AddOptionsToHttpRequest(builder);
   builder.AddQueryParameter("alt", "media");
   // TODO(#937) - use client options to configure buffer size.
   std::unique_ptr<CurlReadStreambuf> buf(new CurlReadStreambuf(

--- a/google/cloud/storage/internal/curl_request_builder.h
+++ b/google/cloud/storage/internal/curl_request_builder.h
@@ -102,9 +102,9 @@ class CurlRequestBuilder {
   /// Add one of the well-known encryption header groups to the request.
   CurlRequestBuilder& AddOption(EncryptionKey const& p) {
     if (p.has_value()) {
-      AddHeader(std::string(p.prefix()) + "Algorithm: " + p.value().algorithm);
-      AddHeader(std::string(p.prefix()) + "Key: " + p.value().key);
-      AddHeader(std::string(p.prefix()) + "Key-Sha256: " + p.value().sha256);
+      AddHeader(std::string(p.prefix()) + "algorithm: " + p.value().algorithm);
+      AddHeader(std::string(p.prefix()) + "key: " + p.value().key);
+      AddHeader(std::string(p.prefix()) + "key-sha256: " + p.value().sha256);
     }
     return *this;
   }

--- a/google/cloud/storage/internal/curl_request_builder.h
+++ b/google/cloud/storage/internal/curl_request_builder.h
@@ -99,6 +99,26 @@ class CurlRequestBuilder {
     return *this;
   }
 
+  /// Add one of the well-known encryption header groups to the request.
+  CurlRequestBuilder& AddOption(EncryptionKey const& p) {
+    if (p.has_value()) {
+      AddHeader(std::string(p.prefix()) + "Algorithm: " + p.value().algorithm);
+      AddHeader(std::string(p.prefix()) + "Key: " + p.value().key);
+      AddHeader(std::string(p.prefix()) + "Key-Sha256: " + p.value().sha256);
+    }
+    return *this;
+  }
+
+  /// Add one of the well-known encryption header groups to the request.
+  CurlRequestBuilder& AddOption(SourceEncryptionKey const& p) {
+    if (p.has_value()) {
+      AddHeader(std::string(p.prefix()) + "Algorithm: " + p.value().algorithm);
+      AddHeader(std::string(p.prefix()) + "Key: " + p.value().key);
+      AddHeader(std::string(p.prefix()) + "Key-Sha256: " + p.value().sha256);
+    }
+    return *this;
+  }
+
   /// Add a prefix to the user-agent string.
   CurlRequestBuilder& AddUserAgentPrefix(std::string const& prefix);
 

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -83,7 +83,7 @@ std::ostream& operator<<(std::ostream& os, GetObjectMetadataRequest const& r);
  */
 class InsertObjectMediaRequest
     : public GenericObjectRequest<InsertObjectMediaRequest, ContentEncoding,
-                                  ContentType, IfGenerationMatch,
+                                  ContentType, EncryptionKey, IfGenerationMatch,
                                   IfGenerationNotMatch, IfMetagenerationMatch,
                                   IfMetagenerationNotMatch, KmsKeyName,
                                   PredefinedAcl, Projection, UserProject> {
@@ -114,7 +114,7 @@ std::ostream& operator<<(std::ostream& os, InsertObjectMediaRequest const& r);
  */
 class InsertObjectStreamingRequest
     : public GenericObjectRequest<InsertObjectStreamingRequest, ContentEncoding,
-                                  ContentType, IfGenerationMatch,
+                                  ContentType, EncryptionKey, IfGenerationMatch,
                                   IfGenerationNotMatch, IfMetagenerationMatch,
                                   IfMetagenerationNotMatch, KmsKeyName,
                                   PredefinedAcl, Projection, UserProject> {
@@ -129,9 +129,9 @@ std::ostream& operator<<(std::ostream& os,
  * Represents a request to the `Objects: get` API with `alt=media`.
  */
 class ReadObjectRangeRequest
-    : public GenericObjectRequest<ReadObjectRangeRequest, Generation,
-                                  IfGenerationMatch, IfGenerationNotMatch,
-                                  IfMetagenerationMatch,
+    : public GenericObjectRequest<ReadObjectRangeRequest, EncryptionKey,
+                                  Generation, IfGenerationMatch,
+                                  IfGenerationNotMatch, IfMetagenerationMatch,
                                   IfMetagenerationNotMatch, UserProject> {
  public:
   ReadObjectRangeRequest() : GenericObjectRequest(), begin_(0), end_(0) {}

--- a/google/cloud/storage/internal/openssl_util.cc
+++ b/google/cloud/storage/internal/openssl_util.cc
@@ -1,0 +1,80 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/openssl_util.h"
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+
+std::string OpenSslUtils::Base64Decode(std::string const& str) {
+  if (str.empty()) {
+    return std::string{};
+  }
+
+  // We could compute the exact buffer size by looking at the number of padding
+  // characters (=) at the end of str, but we will get the exact length later,
+  // so simply compute a buffer that is big enough.
+  std::string result(str.size() * 3 / 4, ' ');
+
+  using UniqueBioChainPtr = std::unique_ptr<BIO, decltype(&BIO_free_all)>;
+  using UniqueBioPtr = std::unique_ptr<BIO, decltype(&BIO_free)>;
+
+  UniqueBioPtr source(BIO_new_mem_buf(str.data(), static_cast<int>(str.size())),
+                      &BIO_free);
+  if (not source) {
+    std::ostringstream os;
+    os << __func__ << ": cannot create BIO for source string=<" << str << ">";
+    google::cloud::internal::RaiseRuntimeError(os.str());
+  }
+  UniqueBioPtr filter(BIO_new(BIO_f_base64()), &BIO_free);
+  if (not filter) {
+    std::ostringstream os;
+    os << __func__ << ": cannot create BIO for Base64 decoding";
+    google::cloud::internal::RaiseRuntimeError(os.str());
+  }
+
+  UniqueBioChainPtr bio(BIO_push(filter.get(), source.get()), &BIO_free_all);
+  if (not bio) {
+    std::ostringstream os;
+    os << __func__ << ": cannot create BIO chain for Base64 decoding";
+    google::cloud::internal::RaiseRuntimeError(os.str());
+  }
+  // Only after bio is successfully constructed we can release ownership.
+  (void)source.release();
+  (void)filter.release();
+  BIO_set_flags(bio.get(), BIO_FLAGS_BASE64_NO_NL);
+
+  // We do not retry, just make one call because the full stream is blocking.
+  // Note that the number of bytes to read is the number of bytes we fetch from
+  // the *source*, not the number of bytes that we have available in `result`.
+  int len = BIO_read(bio.get(), &result[0], static_cast<int>(str.size()));
+  if (len < 0) {
+    std::ostringstream os;
+    os << "Error parsing Base64 string [" << len << "], string=<" << str
+       << ">";
+    google::cloud::internal::RaiseRuntimeError(os.str());
+  }
+
+  result.resize(static_cast<std::size_t>(len));
+  return result;
+}
+
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/openssl_util.cc
+++ b/google/cloud/storage/internal/openssl_util.cc
@@ -33,7 +33,8 @@ std::string OpenSslUtils::Base64Decode(std::string const& str) {
   using UniqueBioChainPtr = std::unique_ptr<BIO, decltype(&BIO_free_all)>;
   using UniqueBioPtr = std::unique_ptr<BIO, decltype(&BIO_free)>;
 
-  UniqueBioPtr source(BIO_new_mem_buf(str.data(), static_cast<int>(str.size())),
+  UniqueBioPtr source(BIO_new_mem_buf(const_cast<char*>(str.data()),
+                                      static_cast<int>(str.size())),
                       &BIO_free);
   if (not source) {
     std::ostringstream os;

--- a/google/cloud/storage/internal/openssl_util.cc
+++ b/google/cloud/storage/internal/openssl_util.cc
@@ -64,8 +64,7 @@ std::string OpenSslUtils::Base64Decode(std::string const& str) {
   int len = BIO_read(bio.get(), &result[0], static_cast<int>(str.size()));
   if (len < 0) {
     std::ostringstream os;
-    os << "Error parsing Base64 string [" << len << "], string=<" << str
-       << ">";
+    os << "Error parsing Base64 string [" << len << "], string=<" << str << ">";
     google::cloud::internal::RaiseRuntimeError(os.str());
   }
 

--- a/google/cloud/storage/internal/openssl_util.h
+++ b/google/cloud/storage/internal/openssl_util.h
@@ -43,6 +43,11 @@ namespace internal {
 struct OpenSslUtils {
  public:
   /**
+   * Decodes a Base64-encoded string.
+   */
+  static std::string Base64Decode(std::string const& str);
+
+  /**
    * Encodes a string using Base64.
    */
   static std::string Base64Encode(std::string const& str) {

--- a/google/cloud/storage/storage_client.bzl
+++ b/google/cloud/storage/storage_client.bzl
@@ -91,4 +91,5 @@ storage_client_SRCS = [
     "object_metadata.cc",
     "object_stream.cc",
     "version.cc",
+    "well_known_headers.cc",
 ]

--- a/google/cloud/storage/storage_client.bzl
+++ b/google/cloud/storage/storage_client.bzl
@@ -79,6 +79,7 @@ storage_client_SRCS = [
     "internal/http_response.cc",
     "internal/logging_client.cc",
     "internal/metadata_parser.cc",
+    "internal/openssl_util.cc",
     "internal/object_acl_requests.cc",
     "internal/object_requests.cc",
     "internal/object_streambuf.cc",

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -37,4 +37,5 @@ storage_client_unit_tests = [
     "storage_class_test.cc",
     "storage_client_options_test.cc",
     "link_test.cc",
+    "well_known_headers_test.cc",
 ]

--- a/google/cloud/storage/tests/testbench.py
+++ b/google/cloud/storage/tests/testbench.py
@@ -15,9 +15,11 @@
 """A test bench for the Google Cloud Storage C++ Client Library."""
 
 import argparse
+import base64
 import json
 import time
 import flask
+import hashlib
 import httpbin
 import os
 from werkzeug import serving
@@ -127,6 +129,26 @@ def filtered_response(request, response):
     return json.dumps(tmp)
 
 
+def raise_csek_error(code=400):
+    msg = "Missing a SHA256 hash of the encryption key, or it is not base64 encoded, or it does not match the encryption key."
+    link = "https://cloud.google.com/storage/docs/encryption#customer-supplied_encryption_keys"
+    error = {
+        "error": {
+            "errors": [{
+                "domain": "global",
+                "reason": "customerEncryptionKeySha256IsInvalid",
+                "message": msg,
+                "extendedHelp": link,
+            }],
+            "code":
+            code,
+            "message":
+            msg,
+        }
+    }
+    raise ErrorResponse(json.dumps(error), status_code=code)
+
+
 class GcsObjectVersion(object):
     """Represent a single revision of a GCS Object."""
 
@@ -151,6 +173,7 @@ class GcsObjectVersion(object):
             self.media = request.environ.get('wsgi.input').read()
         else:
             self.media = request.data
+
         self.metadata = {
             'timeCreated': timestamp,
             'updated': timestamp,
@@ -165,6 +188,8 @@ class GcsObjectVersion(object):
             self.metadata['contentType'] = request.headers.get('content-type')
         # Update the derived metadata attributes (e.g.: id, kind, selfLink)
         self.update_from_metadata({})
+        # Capture any encryption key headers.
+        self._capture_customer_encryption(request)
         # Insert the well-known values for the ACL.
         self.insert_acl(
             canonical_entity_name('project-owners-123456789'), 'OWNER')
@@ -195,6 +220,46 @@ class GcsObjectVersion(object):
         })
         tmp['metageneration'] = tmp.get('metageneration', 0) + 1
         self.metadata = tmp
+
+    def _capture_customer_encryption(self, request):
+        """Capture the customer-supplied encryption key, if any.
+
+        :param request:flask.Request the http request.
+        :return:NoneType
+        """
+        if request.headers.get('X-Goog-Encryption-Key') is None:
+            return
+        try:
+            keybase64 = request.headers.get('X-Goog-Encryption-Key')
+            key = base64.standard_b64decode(keybase64)
+            algo = request.headers.get('X-Goog-Encryption-Algorithm')
+            if algo is None or algo != 'AES256':
+                raise ErrorResponse(
+                    'Invalid or missing algorithm %s for CSEK' % algo,
+                    status_code=400)
+
+            actual = request.headers.get('X-Goog-Encryption-Key-Sha256')
+            h = hashlib.sha256()
+            h.update(key)
+            expected = base64.standard_b64encode(h.digest())
+            if expected != actual:
+                print(
+                    "\n\n\n MISMATCHED HASH %s != %s\n\n" % (expected, actual))
+                raise_csek_error(400)
+
+            self.metadata['customerEncryption'] = {
+                "encryptionAlgorithm": algo,
+                "keySha256": actual,
+            }
+        except ErrorResponse:
+            # ErrorResponse indicates that the request was invalid, just pass
+            # that exception through.
+            raise
+        except Exception as ex:
+            print("\n\n\n Exception %s\n\n" % ex)
+            # Many of the functions above may raise, convert those to an
+            # ErrorResponse with the right format.
+            raise raise_csek_error()
 
     def insert_acl(self, entity, role):
         """
@@ -249,8 +314,8 @@ class GcsObjectVersion(object):
         for acl in self.metadata.get('acl', []):
             if acl.get('entity', '').lower() == entity:
                 return acl
-        raise ErrorResponse('Entity %s not found in object %s' % (entity,
-                                                                  self.name))
+        raise ErrorResponse(
+            'Entity %s not found in object %s' % (entity, self.name))
 
     def update_acl(self, entity, role):
         """
@@ -565,8 +630,8 @@ class GcsBucket(object):
         for acl in self.metadata.get('acl', []):
             if acl.get('entity', '').lower() == entity:
                 return acl
-        raise ErrorResponse('Entity %s not found in object %s' % (entity,
-                                                                  self.name))
+        raise ErrorResponse(
+            'Entity %s not found in object %s' % (entity, self.name))
 
     def update_acl(self, entity, role):
         """
@@ -628,8 +693,8 @@ class GcsBucket(object):
         for acl in self.metadata.get('defaultObjectAcl', []):
             if acl.get('entity', '').lower() == entity:
                 return acl
-        raise ErrorResponse('Entity %s not found in object %s' % (entity,
-                                                                  self.name))
+        raise ErrorResponse(
+            'Entity %s not found in object %s' % (entity, self.name))
 
     def update_default_object_acl(self, entity, role):
         """
@@ -808,10 +873,10 @@ def bucket_acl_create(bucket_name):
     """
     gcs_bucket = GCS_BUCKETS.get(bucket_name)
     payload = json.loads(flask.request.data)
-    return filtered_response(flask.request,
-                             gcs_bucket.insert_acl(
-                                 payload.get('entity', ''),
-                                 payload.get('role', '')))
+    return filtered_response(
+        flask.request,
+        gcs_bucket.insert_acl(
+            payload.get('entity', ''), payload.get('role', '')))
 
 
 @gcs.route('/b/<bucket_name>/acl/<entity>', methods=['DELETE'])
@@ -887,10 +952,10 @@ def bucket_default_object_acl_create(bucket_name):
     """
     gcs_bucket = GCS_BUCKETS.get(bucket_name)
     payload = json.loads(flask.request.data)
-    return filtered_response(flask.request,
-                             gcs_bucket.insert_default_object_acl(
-                                 payload.get('entity', ''),
-                                 payload.get('role', '')))
+    return filtered_response(
+        flask.request,
+        gcs_bucket.insert_default_object_acl(
+            payload.get('entity', ''), payload.get('role', '')))
 
 
 @gcs.route('/b/<bucket_name>/defaultObjectAcl/<entity>', methods=['DELETE'])
@@ -1037,10 +1102,10 @@ def objects_acl_create(bucket_name, object_name):
     gcs_object.check_preconditions(flask.request)
     revision = gcs_object.get_revision(flask.request)
     payload = json.loads(flask.request.data)
-    return filtered_response(flask.request,
-                             revision.insert_acl(
-                                 payload.get('entity', ''),
-                                 payload.get('role', '')))
+    return filtered_response(
+        flask.request,
+        revision.insert_acl(
+            payload.get('entity', ''), payload.get('role', '')))
 
 
 @gcs.route('/b/<bucket_name>/o/<object_name>/acl/<entity>', methods=['DELETE'])

--- a/google/cloud/storage/tests/testbench.py
+++ b/google/cloud/storage/tests/testbench.py
@@ -227,18 +227,18 @@ class GcsObjectVersion(object):
         :param request:flask.Request the http request.
         :return:NoneType
         """
-        if request.headers.get('X-Goog-Encryption-Key') is None:
+        if request.headers.get('x-goog-encryption-key') is None:
             return
         try:
-            keybase64 = request.headers.get('X-Goog-Encryption-Key')
+            keybase64 = request.headers.get('x-goog-encryption-key')
             key = base64.standard_b64decode(keybase64)
-            algo = request.headers.get('X-Goog-Encryption-Algorithm')
+            algo = request.headers.get('x-goog-encryption-algorithm')
             if algo is None or algo != 'AES256':
                 raise ErrorResponse(
                     'Invalid or missing algorithm %s for CSEK' % algo,
                     status_code=400)
 
-            actual = request.headers.get('X-Goog-Encryption-Key-Sha256')
+            actual = request.headers.get('x-goog-encryption-key-sha256')
             h = hashlib.sha256()
             h.update(key)
             expected = base64.standard_b64encode(h.digest())

--- a/google/cloud/storage/tests/testbench.py
+++ b/google/cloud/storage/tests/testbench.py
@@ -232,6 +232,10 @@ class GcsObjectVersion(object):
         try:
             keybase64 = request.headers.get('x-goog-encryption-key')
             key = base64.standard_b64decode(keybase64)
+            if key is None or len(key) != 256 / 8:
+                print("\n\n%s\nLEN=%d\n\n" % (keybase64, len(key)))
+                raise_csek_error()
+
             algo = request.headers.get('x-goog-encryption-algorithm')
             if algo is None or algo != 'AES256':
                 raise ErrorResponse(
@@ -454,6 +458,8 @@ class GcsObject(object):
                 raise ErrorResponse('Precondition Failed', status_code=412)
         else:
             current = self.revisions.get(self.generation)
+            if current is None:
+                raise ErrorResponse('Object not found', status_code=404)
             metageneration = current.metadata.get('metageneration')
 
             if metageneration_not_match is not None \

--- a/google/cloud/storage/well_known_headers.cc
+++ b/google/cloud/storage/well_known_headers.cc
@@ -48,9 +48,9 @@ EncryptionKey EncryptionKey::FromBinaryKey(std::string const& key) {
 std::ostream& operator<<(std::ostream& os, EncryptionKey const& rhs) {
   char const* prefix = EncryptionKey::prefix();
   if (rhs.has_value()) {
-    return os << prefix << "Algorithm: " << rhs.value().algorithm << "\n"
-              << prefix << "Key: " << rhs.value().key << "\n"
-              << prefix << "Key-Sha256: " << rhs.value().sha256;
+    return os << prefix << "algorithm: " << rhs.value().algorithm << "\n"
+              << prefix << "key: " << rhs.value().key << "\n"
+              << prefix << "key-sha256: " << rhs.value().sha256;
   }
   return os << prefix << "*: <not set>";
 }
@@ -62,9 +62,9 @@ SourceEncryptionKey SourceEncryptionKey::FromBinaryKey(std::string const& key) {
 std::ostream& operator<<(std::ostream& os, SourceEncryptionKey const& rhs) {
   char const* prefix = SourceEncryptionKey::prefix();
   if (rhs.has_value()) {
-    return os << prefix << "Algorithm: " << rhs.value().algorithm << "\n"
-              << prefix << "Key: " << rhs.value().key << "\n"
-              << prefix << "Key-Sha256: " << rhs.value().sha256;
+    return os << prefix << "algorithm: " << rhs.value().algorithm << "\n"
+              << prefix << "key: " << rhs.value().key << "\n"
+              << prefix << "key-sha256: " << rhs.value().sha256;
   }
   return os << prefix << "*: <not set>";
 }

--- a/google/cloud/storage/well_known_headers.cc
+++ b/google/cloud/storage/well_known_headers.cc
@@ -41,8 +41,17 @@ EncryptionKeyData EncryptionDataFromBinaryKey(std::string const& key) {
                            Sha256AsBase64(key)};
 }
 
+EncryptionKeyData EncryptionDataFromBase64Key(std::string const& key) {
+  std::string binary_key = internal::OpenSslUtils::Base64Decode(key);
+  return EncryptionKeyData{"AES256", key, Sha256AsBase64(binary_key)};
+}
+
 EncryptionKey EncryptionKey::FromBinaryKey(std::string const& key) {
   return EncryptionKey(EncryptionDataFromBinaryKey(key));
+}
+
+EncryptionKey EncryptionKey::FromBase64Key(std::string const& key) {
+  return EncryptionKey(EncryptionDataFromBase64Key(key));
 }
 
 std::ostream& operator<<(std::ostream& os, EncryptionKey const& rhs) {
@@ -57,6 +66,10 @@ std::ostream& operator<<(std::ostream& os, EncryptionKey const& rhs) {
 
 SourceEncryptionKey SourceEncryptionKey::FromBinaryKey(std::string const& key) {
   return SourceEncryptionKey(EncryptionDataFromBinaryKey(key));
+}
+
+SourceEncryptionKey SourceEncryptionKey::FromBase64Key(std::string const& key) {
+  return SourceEncryptionKey(EncryptionDataFromBase64Key(key));
 }
 
 std::ostream& operator<<(std::ostream& os, SourceEncryptionKey const& rhs) {

--- a/google/cloud/storage/well_known_headers.cc
+++ b/google/cloud/storage/well_known_headers.cc
@@ -1,0 +1,75 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/well_known_headers.h"
+#include "google/cloud/storage/internal/openssl_util.h"
+#include <openssl/sha.h>
+#include <algorithm>
+#include <iomanip>
+#include <iostream>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+std::string Sha256AsBase64(std::string const& key) {
+  std::string hash(SHA256_DIGEST_LENGTH, ' ');
+
+  SHA256_CTX sha256;
+  SHA256_Init(&sha256);
+  SHA256_Update(&sha256, key.c_str(), key.size());
+  SHA256_Final(reinterpret_cast<unsigned char*>(&hash[0]), &sha256);
+
+  return internal::OpenSslUtils::Base64Encode(hash);
+}
+}  // namespace
+
+EncryptionKeyData EncryptionDataFromBinaryKey(std::string const& key) {
+  return EncryptionKeyData{"AES256", internal::OpenSslUtils::Base64Encode(key),
+                           Sha256AsBase64(key)};
+}
+
+EncryptionKey EncryptionKey::FromBinaryKey(std::string const& key) {
+  return EncryptionKey(EncryptionDataFromBinaryKey(key));
+}
+
+std::ostream& operator<<(std::ostream& os, EncryptionKey const& rhs) {
+  char const* prefix = EncryptionKey::prefix();
+  if (rhs.has_value()) {
+    return os << prefix << "Algorithm: " << rhs.value().algorithm << "\n"
+              << prefix << "Key: " << rhs.value().key << "\n"
+              << prefix << "Key-Sha256: " << rhs.value().sha256;
+  }
+  return os << prefix << "*: <not set>";
+}
+
+SourceEncryptionKey SourceEncryptionKey::FromBinaryKey(std::string const& key) {
+  return SourceEncryptionKey(EncryptionDataFromBinaryKey(key));
+}
+
+std::ostream& operator<<(std::ostream& os, SourceEncryptionKey const& rhs) {
+  char const* prefix = SourceEncryptionKey::prefix();
+  if (rhs.has_value()) {
+    return os << prefix << "Algorithm: " << rhs.value().algorithm << "\n"
+              << prefix << "Key: " << rhs.value().key << "\n"
+              << prefix << "Key-Sha256: " << rhs.value().sha256;
+  }
+  return os << prefix << "*: <not set>";
+}
+
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/well_known_headers.h
+++ b/google/cloud/storage/well_known_headers.h
@@ -77,7 +77,12 @@ struct EncryptionKeyData {
   std::string sha256;
 };
 
-// Compute the encryption data given a (binary) AES256 key.
+/**
+ * Format a (potentially binary) encryption key in the format required by the
+ * Google Cloud Storage API.
+ *
+ * @param key a binary key, must have exactly 32 bytes.
+ */
 EncryptionKeyData EncryptionDataFromBinaryKey(std::string const& key);
 
 struct EncryptionKey
@@ -87,7 +92,7 @@ struct EncryptionKey
   /**
    * Create an encryption key parameter from a binary key.
    *
-   * @param key a binary key, must have exactly 8 bytes.
+   * @param key a binary key, must have exactly 32 bytes.
    */
   static EncryptionKey FromBinaryKey(std::string const& key);
 
@@ -104,7 +109,7 @@ struct SourceEncryptionKey
   /**
    * Create a source encryption key parameter from a binary key.
    *
-   * @param key a binary key, must have exactly 8 bytes.
+   * @param key a binary key, must have exactly 32 bytes.
    */
   static SourceEncryptionKey FromBinaryKey(std::string const& key);
 

--- a/google/cloud/storage/well_known_headers.h
+++ b/google/cloud/storage/well_known_headers.h
@@ -85,6 +85,14 @@ struct EncryptionKeyData {
  */
 EncryptionKeyData EncryptionDataFromBinaryKey(std::string const& key);
 
+/**
+ * Format an encryption key in base64 format to the data structure required by
+ * the Google Cloud Storage API.
+ *
+ * @param key a base64-encoded key, must have exactly 32 bytes when decoded.
+ */
+EncryptionKeyData EncryptionDataFromBase64Key(std::string const& key);
+
 struct EncryptionKey
     : public WellKnownHeader<EncryptionKey, EncryptionKeyData> {
   using WellKnownHeader<EncryptionKey, EncryptionKeyData>::WellKnownHeader;
@@ -95,6 +103,13 @@ struct EncryptionKey
    * @param key a binary key, must have exactly 32 bytes.
    */
   static EncryptionKey FromBinaryKey(std::string const& key);
+
+  /**
+   * Create an encryption key parameter from a key in base64 format.
+   *
+   * @param key a base64-encoded key, must have exactly 32 bytes when decoded.
+   */
+  static EncryptionKey FromBase64Key(std::string const& key);
 
   static char const* prefix() { return "x-goog-encryption-"; }
 };
@@ -112,6 +127,13 @@ struct SourceEncryptionKey
    * @param key a binary key, must have exactly 32 bytes.
    */
   static SourceEncryptionKey FromBinaryKey(std::string const& key);
+
+  /**
+   * Create an encryption key parameter from a key in base64 format.
+   *
+   * @param key a base64-encoded key, must have exactly 32 bytes when decoded.
+   */
+  static SourceEncryptionKey FromBase64Key(std::string const& key);
 
   static char const* prefix() { return "x-goog-copy-source-encryption-"; }
 };

--- a/google/cloud/storage/well_known_headers.h
+++ b/google/cloud/storage/well_known_headers.h
@@ -91,7 +91,7 @@ struct EncryptionKey
    */
   static EncryptionKey FromBinaryKey(std::string const& key);
 
-  static char const* prefix() { return "X-Goog-Encryption-"; }
+  static char const* prefix() { return "x-goog-encryption-"; }
 };
 
 std::ostream& operator<<(std::ostream& os, EncryptionKey const& rhs);
@@ -108,7 +108,7 @@ struct SourceEncryptionKey
    */
   static SourceEncryptionKey FromBinaryKey(std::string const& key);
 
-  static char const* prefix() { return "X-Copy-Source-Goog-Encryption-"; }
+  static char const* prefix() { return "x-goog-copy-source-encryption-"; }
 };
 
 std::ostream& operator<<(std::ostream& os, SourceEncryptionKey const& rhs);

--- a/google/cloud/storage/well_known_headers_test.cc
+++ b/google/cloud/storage/well_known_headers_test.cc
@@ -60,7 +60,8 @@ TEST(WellKnownHeader, EncryptionKeyFromBase64) {
   ASSERT_TRUE(expected.has_value());
   // Generated with:
   //     /bin/echo -n 0123456789-ABCDEFGHIJ-0123456789 | openssl base64
-  EXPECT_EQ("MDEyMzQ1Njc4OS1BQkNERUZHSElKLTAxMjM0NTY3ODk=", expected.value().key);
+  EXPECT_EQ("MDEyMzQ1Njc4OS1BQkNERUZHSElKLTAxMjM0NTY3ODk=",
+            expected.value().key);
   auto actual = EncryptionKey::FromBase64Key(expected.value().key);
   ASSERT_TRUE(actual.has_value());
   EXPECT_EQ(expected.value().algorithm, actual.value().algorithm);

--- a/google/cloud/storage/well_known_headers_test.cc
+++ b/google/cloud/storage/well_known_headers_test.cc
@@ -29,10 +29,10 @@ TEST(WellKnownHeader, EncryptionKey) {
   std::ostringstream os;
   os << header;
   auto actual = os.str();
-  std::string prefix = "X-Goog-Encryption";
-  EXPECT_THAT(actual, HasSubstr(prefix + "-Algorithm: test-algo"));
-  EXPECT_THAT(actual, HasSubstr(prefix + "-Key: test-fake-key"));
-  EXPECT_THAT(actual, HasSubstr(prefix + "-Key-Sha256: test-sha"));
+  std::string prefix = "x-goog-encryption";
+  EXPECT_THAT(actual, HasSubstr(prefix + "-algorithm: test-algo"));
+  EXPECT_THAT(actual, HasSubstr(prefix + "-key: test-fake-key"));
+  EXPECT_THAT(actual, HasSubstr(prefix + "-key-sha256: test-sha"));
 }
 
 /// @test Verify that EncryptionKey::FromBinaryKey works as expected.
@@ -71,10 +71,10 @@ TEST(WellKnownHeader, SourceEncryptionKey) {
   std::ostringstream os;
   os << header;
   auto actual = os.str();
-  std::string prefix = "X-Copy-Source-Goog-Encryption";
-  EXPECT_THAT(actual, HasSubstr(prefix + "-Algorithm: test-algo"));
-  EXPECT_THAT(actual, HasSubstr(prefix + "-Key: test-fake-key"));
-  EXPECT_THAT(actual, HasSubstr(prefix + "-Key-Sha256: test-sha"));
+  std::string prefix = "x-goog-copy-source-encryption";
+  EXPECT_THAT(actual, HasSubstr(prefix + "-algorithm: test-algo"));
+  EXPECT_THAT(actual, HasSubstr(prefix + "-key: test-fake-key"));
+  EXPECT_THAT(actual, HasSubstr(prefix + "-key-sha256: test-sha"));
 }
 
 /// @test Verify that EncryptionKey::FromBinaryKey works as expected.

--- a/google/cloud/storage/well_known_headers_test.cc
+++ b/google/cloud/storage/well_known_headers_test.cc
@@ -1,0 +1,102 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/well_known_headers.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+using ::testing::HasSubstr;
+
+/// @test Verify that EncryptionKey streaming works as expected.
+TEST(WellKnownHeader, EncryptionKey) {
+  EncryptionKey header(
+      EncryptionKeyData{"test-algo", "test-fake-key", "test-sha"});
+  std::ostringstream os;
+  os << header;
+  auto actual = os.str();
+  std::string prefix = "X-Goog-Encryption";
+  EXPECT_THAT(actual, HasSubstr(prefix + "-Algorithm: test-algo"));
+  EXPECT_THAT(actual, HasSubstr(prefix + "-Key: test-fake-key"));
+  EXPECT_THAT(actual, HasSubstr(prefix + "-Key-Sha256: test-sha"));
+}
+
+/// @test Verify that EncryptionKey::FromBinaryKey works as expected.
+TEST(WellKnownHeader, EncryptionKeyFromBinary) {
+  std::string key("01234567");
+  auto header = EncryptionKey::FromBinaryKey(key);
+  ASSERT_TRUE(header.has_value());
+  ASSERT_EQ("AES256", header.value().algorithm);
+  // used:
+  //   /bin/echo -n "01234567" | openssl base64
+  // to get the key value.
+  EXPECT_EQ("MDEyMzQ1Njc=", header.value().key);
+  // used:
+  //   /bin/echo -n "01234567" | sha256sum | awk '{printf("%s", $1);}' |
+  //       xxd -r -p | openssl base64
+  // to get the SHA256 value of the key.
+  EXPECT_EQ("kkWSubED8U+DP6r7Z/SAaR8BmIqkV8AGF2n1jNRzEbw=",
+            header.value().sha256);
+}
+
+/// @test Verify that CreateKeyFromGenerator works as expected.
+TEST(WellKnownHeader, FromGenerator) {
+  internal::DefaultPRNG gen = internal::MakeDefaultPRNG();
+
+  auto header = EncryptionKey(CreateKeyFromGenerator(gen));
+  ASSERT_TRUE(header.has_value());
+  ASSERT_EQ("AES256", header.value().algorithm);
+  ASSERT_FALSE(header.value().key.empty());
+  ASSERT_FALSE(header.value().sha256.empty());
+}
+
+/// @test Verify that EncryptionKey streaming works as expected.
+TEST(WellKnownHeader, SourceEncryptionKey) {
+  SourceEncryptionKey header(
+      EncryptionKeyData{"test-algo", "test-fake-key", "test-sha"});
+  std::ostringstream os;
+  os << header;
+  auto actual = os.str();
+  std::string prefix = "X-Copy-Source-Goog-Encryption";
+  EXPECT_THAT(actual, HasSubstr(prefix + "-Algorithm: test-algo"));
+  EXPECT_THAT(actual, HasSubstr(prefix + "-Key: test-fake-key"));
+  EXPECT_THAT(actual, HasSubstr(prefix + "-Key-Sha256: test-sha"));
+}
+
+/// @test Verify that EncryptionKey::FromBinaryKey works as expected.
+TEST(WellKnownHeader, SourceEncryptionKeyFromBinary) {
+  std::string key("01234567");
+  auto header = SourceEncryptionKey::FromBinaryKey(key);
+  ASSERT_TRUE(header.has_value());
+  ASSERT_EQ("AES256", header.value().algorithm);
+  // used:
+  //   /bin/echo -n "01234567" | openssl base64
+  // to get the key value.
+  EXPECT_EQ("MDEyMzQ1Njc=", header.value().key);
+  // used:
+  //   /bin/echo -n "01234567" | sha256sum | awk '{printf("%s", $1);}' |
+  //       xxd -r -p | openssl base64
+  // to get the SHA256 value of the key.
+  EXPECT_EQ("kkWSubED8U+DP6r7Z/SAaR8BmIqkV8AGF2n1jNRzEbw=",
+            header.value().sha256);
+}
+
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
This fixes #1022. It implements new options for customer supplied
encryption keys.  In addition to supporting the optional headers,
this PR adds some functions to create the header fields from a
binary encryption key, as well as a helper function to create the
encryption key from a pseudo-random number generator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1031)
<!-- Reviewable:end -->
