### PR TITLE
Implement the ContentType optional header.

### DIFF
--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -137,10 +137,14 @@ std::pair<Status, ObjectMetadata> CurlClient::InsertObjectMedia(
                              "/o");
   builder.SetDebugLogging(options_.enable_http_tracing());
   builder.AddHeader(options_.credentials()->AuthorizationHeader());
+  // Set the content type of a sensible value, the application can override this
+  // in the options for the request.
+  if (not request.HasOption<ContentType>()) {
+    builder.AddHeader("content-type: application/octet-stream");
+  }
   request.AddOptionsToHttpRequest(builder);
   builder.AddQueryParameter("uploadType", "media");
   builder.AddQueryParameter("name", request.object_name());
-  builder.AddHeader("Content-Type: application/octet-stream");
   builder.AddHeader("Content-Length: " +
                     std::to_string(request.contents().size()));
   auto payload = builder.BuildRequest(request.contents()).MakeRequest();
@@ -191,10 +195,14 @@ CurlClient::WriteObject(InsertObjectStreamingRequest const& request) {
   CurlRequestBuilder builder(url);
   builder.SetDebugLogging(options_.enable_http_tracing());
   builder.AddHeader(options_.credentials()->AuthorizationHeader());
+  // Set the content type of a sensible value, the application can override this
+  // in the options for the request.
+  if (not request.HasOption<ContentType>()) {
+    builder.AddHeader("content-type: application/octet-stream");
+  }
   request.AddOptionsToHttpRequest(builder);
   builder.AddQueryParameter("uploadType", "media");
   builder.AddQueryParameter("name", request.object_name());
-  builder.AddHeader("Content-Type: application/octet-stream");
   // TODO(#937) - use client options to configure buffer size.
   std::unique_ptr<internal::CurlStreambuf> buf(
       new internal::CurlStreambuf(builder.BuildUpload(), 128 * 1024));

--- a/google/cloud/storage/internal/generic_request.h
+++ b/google/cloud/storage/internal/generic_request.h
@@ -58,6 +58,14 @@ class GenericRequestBase<Derived, Option> {
     }
   }
 
+  template <typename O>
+  bool HasOption() const {
+    if (std::is_same<O, Option>::value) {
+      return option_.has_value();
+    }
+    return false;
+  }
+
  private:
   Option option_;
 };
@@ -91,6 +99,14 @@ class GenericRequestBase : public GenericRequestBase<Derived, Options...> {
     } else {
       GenericRequestBase<Derived, Options...>::DumpOptions(os, sep);
     }
+  }
+
+  template <typename O>
+  bool HasOption() const {
+    if (std::is_same<O, Option>::value) {
+      return option_.has_value();
+    }
+    return GenericRequestBase<Derived, Options...>::template HasOption<O>();
   }
 
  private:
@@ -155,6 +171,11 @@ class GenericRequest
   }
 
   Derived& set_multiple_options() { return *static_cast<Derived*>(this); }
+
+  template <typename Option>
+  bool HasOption() const {
+    return Super::template HasOption<Option>();
+  }
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -82,10 +82,11 @@ std::ostream& operator<<(std::ostream& os, GetObjectMetadataRequest const& r);
  * objects.
  */
 class InsertObjectMediaRequest
-    : public GenericObjectRequest<
-          InsertObjectMediaRequest, ContentEncoding, IfGenerationMatch,
-          IfGenerationNotMatch, IfMetagenerationMatch, IfMetagenerationNotMatch,
-          KmsKeyName, PredefinedAcl, Projection, UserProject> {
+    : public GenericObjectRequest<InsertObjectMediaRequest, ContentEncoding,
+                                  ContentType, IfGenerationMatch,
+                                  IfGenerationNotMatch, IfMetagenerationMatch,
+                                  IfMetagenerationNotMatch, KmsKeyName,
+                                  PredefinedAcl, Projection, UserProject> {
  public:
   InsertObjectMediaRequest() : GenericObjectRequest(), contents_() {}
 
@@ -112,10 +113,11 @@ std::ostream& operator<<(std::ostream& os, InsertObjectMediaRequest const& r);
  * application.
  */
 class InsertObjectStreamingRequest
-    : public GenericObjectRequest<
-          InsertObjectStreamingRequest, ContentEncoding, IfGenerationMatch,
-          IfGenerationNotMatch, IfMetagenerationMatch, IfMetagenerationNotMatch,
-          KmsKeyName, PredefinedAcl, Projection, UserProject> {
+    : public GenericObjectRequest<InsertObjectStreamingRequest, ContentEncoding,
+                                  ContentType, IfGenerationMatch,
+                                  IfGenerationNotMatch, IfMetagenerationMatch,
+                                  IfMetagenerationNotMatch, KmsKeyName,
+                                  PredefinedAcl, Projection, UserProject> {
  public:
   using GenericObjectRequest::GenericObjectRequest;
 };

--- a/google/cloud/storage/tests/testbench.py
+++ b/google/cloud/storage/tests/testbench.py
@@ -166,6 +166,8 @@ class GcsObjectVersion(object):
             'size': len(self.media),
             'etag': 'XYZ='
         }
+        if request.headers.get('content-type') is not None:
+            self.metadata['contentType'] = request.headers.get('content-type')
         self.insert_acl(
             canonical_entity_name('project-owners-123456789'), 'OWNER')
         self.insert_acl(

--- a/google/cloud/storage/well_known_headers.h
+++ b/google/cloud/storage/well_known_headers.h
@@ -52,6 +52,11 @@ std::ostream& operator<<(std::ostream& os, WellKnownHeader<H, T> const& rhs) {
   return os << rhs.header_name() << ": <not set>";
 }
 
+struct ContentType : public WellKnownHeader<ContentType, std::string> {
+  using WellKnownHeader<ContentType, std::string>::WellKnownHeader;
+  static char const* header_name() { return "content-type"; }
+};
+
 struct IfMatchEtag : public WellKnownHeader<IfMatchEtag, std::string> {
   using WellKnownHeader<IfMatchEtag, std::string>::WellKnownHeader;
   static char const* header_name() { return "If-Match"; }


### PR DESCRIPTION
This fixes #1020. It implements the parameter, adds it
Client::InsertObject and Client::WriteObject, fixes the testbench to
capture the header in the contentType metadata, and includes integration
tests that use the parameter.  By default the header is set to
application/octet-stream, because the libcurl default is plain awful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1041)
<!-- Reviewable:end -->
