### PR TITLE
Split the instance admin endpoint configuration.

### DIFF
--- a/google/cloud/bigtable/client_options.cc
+++ b/google/cloud/bigtable/client_options.cc
@@ -53,7 +53,8 @@ ClientOptions::ClientOptions(std::shared_ptr<grpc::ChannelCredentials> creds)
     : credentials_(std::move(creds)),
       connection_pool_size_(CalculateDefaultConnectionPoolSize()),
       data_endpoint_("bigtable.googleapis.com"),
-      admin_endpoint_("bigtableadmin.googleapis.com") {
+      admin_endpoint_("bigtableadmin.googleapis.com"),
+      instance_admin_endpoint_("bigtableadmin.googleapis.com") {
   static std::string const user_agent_prefix = "cbt-c++/" + version_string();
   channel_arguments_.SetUserAgentPrefix(user_agent_prefix);
 }
@@ -63,6 +64,12 @@ ClientOptions::ClientOptions() : ClientOptions(BigtableDefaultCredentials()) {
   if (emulator != nullptr) {
     data_endpoint_ = emulator;
     admin_endpoint_ = emulator;
+    instance_admin_endpoint_ = emulator;
+  }
+  char const* instance_admin_emulator =
+      std::getenv("BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST");
+  if (instance_admin_emulator != nullptr) {
+    instance_admin_endpoint_ = instance_admin_emulator;
   }
 }
 

--- a/google/cloud/bigtable/client_options.h
+++ b/google/cloud/bigtable/client_options.h
@@ -83,15 +83,6 @@ class ClientOptions {
     return *this;
   }
 
-  /// Return the current endpoint for instance admin RPCs.
-  std::string const& instance_admin_endpoint() const {
-    return instance_admin_endpoint_;
-  }
-  ClientOptions& set_instance_admin_endpoint(std::string endpoint) {
-    instance_admin_endpoint_ = std::move(endpoint);
-    return *this;
-  }
-
   /**
    * Set the name of the connection pool.
    *
@@ -295,6 +286,13 @@ class ClientOptions {
   }
 
  private:
+  /// Return the current endpoint for instance admin RPCs.
+  friend struct InstanceAdminTraits;
+  friend struct ClientOptionsTestTraits;
+  std::string const& instance_admin_endpoint() const {
+    return instance_admin_endpoint_;
+  }
+
   std::shared_ptr<grpc::ChannelCredentials> credentials_;
   grpc::ChannelArguments channel_arguments_;
   std::string connection_pool_name_;

--- a/google/cloud/bigtable/client_options.h
+++ b/google/cloud/bigtable/client_options.h
@@ -83,6 +83,15 @@ class ClientOptions {
     return *this;
   }
 
+  /// Return the current endpoint for instance admin RPCs.
+  std::string const& instance_admin_endpoint() const {
+    return instance_admin_endpoint_;
+  }
+  ClientOptions& set_instance_admin_endpoint(std::string endpoint) {
+    instance_admin_endpoint_ = std::move(endpoint);
+    return *this;
+  }
+
   /**
    * Set the name of the connection pool.
    *
@@ -292,6 +301,7 @@ class ClientOptions {
   std::size_t connection_pool_size_;
   std::string data_endpoint_;
   std::string admin_endpoint_;
+  std::string instance_admin_endpoint_;
 };
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/google/cloud/bigtable/examples/run_examples_utils.sh
+++ b/google/cloud/bigtable/examples/run_examples_utils.sh
@@ -27,11 +27,7 @@ function cleanup_instance {
 
   echo
   echo "Cleaning up test instance projects/${project}/instances/${instance}"
-  local setenv="env"
-  if [ -n "${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST:-}" ]; then
-    setenv="env BIGTABLE_EMULATOR_HOST=${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST}"
-  fi
-  ${setenv} ./bigtable_samples_instance_admin delete-instance "${project}" "${instance}"
+  ./bigtable_samples_instance_admin delete-instance "${project}" "${instance}"
 }
 
 function exit_handler {
@@ -43,21 +39,6 @@ function exit_handler {
     kill_emulators
   else
     cleanup_instance "${project}" "${instance}"
-  fi
-}
-
-# When we finish running a series of examples we want to explicitly cleanup the
-# instance.  We cannot just let the exit handler do it because when running
-# on the emulator the exit handler would kill the emulator.  And when running
-# in production we create a different instance in each group of examples, and
-# there is only one trap at a time.
-function reset_trap {
-  if [ -n "${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST:-}" ]; then
-    # If the test is running against the emulator there is no need to cleanup
-    # the instance, just kill the emulators.
-    trap kill_emulators EXIT
-  else
-    trap - EXIT
   fi
 }
 
@@ -83,7 +64,6 @@ function run_all_instance_admin_examples {
         " against production."
     exit 1
   fi
-  export BIGTABLE_EMULATOR_HOST="${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST}"
 
   # Create a (very likely unique) instance name.
   local -r INSTANCE="in-$(date +%s)"

--- a/google/cloud/bigtable/instance_admin_client.cc
+++ b/google/cloud/bigtable/instance_admin_client.cc
@@ -38,7 +38,7 @@ class DefaultInstanceAdminClient : public bigtable::InstanceAdminClient {
   // the public interface, it should not be part of the public interface.
   struct AdminTraits {
     static std::string const& Endpoint(bigtable::ClientOptions& options) {
-      return options.admin_endpoint();
+      return options.instance_admin_endpoint();
     }
   };
 

--- a/google/cloud/bigtable/instance_admin_client.cc
+++ b/google/cloud/bigtable/instance_admin_client.cc
@@ -20,7 +20,6 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-
 struct InstanceAdminTraits {
   static std::string const& Endpoint(bigtable::ClientOptions& options) {
     return options.instance_admin_endpoint();

--- a/google/cloud/bigtable/instance_admin_client.cc
+++ b/google/cloud/bigtable/instance_admin_client.cc
@@ -16,7 +16,16 @@
 #include "google/cloud/bigtable/internal/common_client.h"
 #include <google/longrunning/operations.grpc.pb.h>
 
-namespace bigtable = google::cloud::bigtable;
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+
+struct InstanceAdminTraits {
+  static std::string const& Endpoint(bigtable::ClientOptions& options) {
+    return options.instance_admin_endpoint();
+  }
+};
 
 namespace {
 /**
@@ -32,24 +41,18 @@ namespace {
  * should only reconnect on those errors that indicate the credentials or
  * connections need refreshing.
  */
-class DefaultInstanceAdminClient : public bigtable::InstanceAdminClient {
+class DefaultInstanceAdminClient : public InstanceAdminClient {
  private:
   // Introduce an early `private:` section because this type is used to define
   // the public interface, it should not be part of the public interface.
-  struct AdminTraits {
-    static std::string const& Endpoint(bigtable::ClientOptions& options) {
-      return options.instance_admin_endpoint();
-    }
-  };
-
-  using Impl = bigtable::internal::CommonClient<
-      AdminTraits, ::google::bigtable::admin::v2::BigtableInstanceAdmin>;
+  using Impl = internal::CommonClient<
+      InstanceAdminTraits,
+      ::google::bigtable::admin::v2::BigtableInstanceAdmin>;
 
  public:
   using AdminStubPtr = Impl::StubPtr;
 
-  DefaultInstanceAdminClient(std::string project,
-                             bigtable::ClientOptions options)
+  DefaultInstanceAdminClient(std::string project, ClientOptions options)
       : project_(std::move(project)), impl_(std::move(options)) {}
 
   std::string const& project() const override { return project_; }
@@ -198,10 +201,6 @@ class DefaultInstanceAdminClient : public bigtable::InstanceAdminClient {
 };
 }  // anonymous namespace
 
-namespace google {
-namespace cloud {
-namespace bigtable {
-inline namespace BIGTABLE_CLIENT_NS {
 std::shared_ptr<InstanceAdminClient> CreateDefaultInstanceAdminClient(
     std::string project, ClientOptions options) {
   return std::make_shared<DefaultInstanceAdminClient>(std::move(project),

--- a/google/cloud/bigtable/tests/run_integration_tests_emulator.sh
+++ b/google/cloud/bigtable/tests/run_integration_tests_emulator.sh
@@ -30,8 +30,7 @@ readonly PROJECT_ID="emulated-${NONCE}"
 
 echo
 echo "Running bigtable::InstanceAdmin integration test."
-  env "BIGTABLE_EMULATOR_HOST=${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST:-}" \
-     ./instance_admin_integration_test "${PROJECT_ID}";
+./instance_admin_integration_test "${PROJECT_ID}";
 
 echo
 echo "Running bigtable::TableAdmin integration test."


### PR DESCRIPTION
The [Cloud Bigtable emulator](https://cloud.google.com/bigtable/docs/emulator) does not support instance admin operations.  When I asked (a while ago), the emulator developers were not interested in adding support for instance operations to it either.  So we wrote our own `instance_admin_emulator` to run integration tests and examples. Note also that we cannot run against production because there is not enough quota.

With this PR, tests and examples that only use the Cloud Bigtable emulator continue to work as before, just set the `BIGTABLE_EMULATOR_HOST` environment variable.

Tests and examples that only use the `instance_admin_emulator` can run using the `BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST` environment variable. We no longer need to temporarily set `BIGTABLE_EMULATOR_HOST` just for that test.

With this PR we can run tests or examples that use both `instance_admin_emulator` and the Cloud Bigtable emulator.  Before such tests or examples could only run against production.


To see how sad our coverage for the examples is look here:

https://codecov.io/gh/coryan/google-cloud-cpp/tree/1fbddfb7f3db9d96fe531a9260bcd548e495950b/google/cloud/bigtable/examples

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1043)
<!-- Reviewable:end -->
