### PR TITLE
Detect mismatched SSL versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
       os: osx
       compiler: clang
       env:
-        CMAKE_FLAGS=-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl
+        CMAKE_FLAGS=-DOPENSSL_ROOT_DIR=/usr/local/opt/libressl
       install:
         - git submodule update --init
         - ci/install-retry.sh ci/travis/install-macosx.sh

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ sudo make install
 #### macOS (using brew)
 
 ```bash
-brew install curl cmake
+brew install curl libressl c-ares
 ```
 
 #### Windows (using vcpkg)
@@ -217,11 +217,28 @@ powershell -exec bypass .\ci\install-windows.ps1
 To build all available libraries and run the tests, run the following commands
 after cloning this repo:
 
-#### Linux and macOS
+#### Linux
 
 ```bash
 git submodule update --init
 cmake -H. -Bbuild-output
+
+# Adjust the number of threads used by modifying parameter for `-j 4`
+cmake --build build-output -- -j 4
+
+# Verify build by running tests
+(cd build-output && ctest --output-on-failure)
+```
+
+You will find compiled binaries in `build-output/` respective to their source paths.
+
+#### macOS
+
+```bash
+git submodule update --init
+export CMAKE_FLAGS=-DOPENSSL_ROOT_DIR=/usr/local/opt/libressl
+cmake -H. -Bbuild-output ${CMAKE_FLAGS}
+
 
 # Adjust the number of threads used by modifying parameter for `-j 4`
 cmake --build build-output -- -j 4

--- a/ci/travis/install-macosx.sh
+++ b/ci/travis/install-macosx.sh
@@ -22,4 +22,4 @@ if [ "${TRAVIS_OS_NAME}" != "osx" ]; then
 fi
 
 brew update
-brew install curl openssl c-ares ccache
+brew install curl libressl c-ares ccache

--- a/google/cloud/storage/link_test.cc
+++ b/google/cloud/storage/link_test.cc
@@ -41,6 +41,11 @@ TEST(LinkTest, CurlVsOpenSSL) {
   std::transform(expected_prefix.begin(), expected_prefix.end(),
                  expected_prefix.begin(),
                  [](char x) { return x == '/' ? ' ' : x; });
+  // LibreSSL seems to be using semantic versioning, so just check the major
+  // version.
+  if (expected_prefix.find("LibreSSL 2") == 0) {
+    expected_prefix = "LibreSSL 2";
+  }
 #ifdef OPENSSL_VERSION
   std::string openssl_v = OpenSSL_version(OPENSSL_VERSION);
 #else

--- a/google/cloud/storage/link_test.cc
+++ b/google/cloud/storage/link_test.cc
@@ -13,14 +13,51 @@
 // limitations under the License.
 
 #include "google/cloud/storage/version.h"
-#include <gtest/gtest.h>
+#include <curl/curl.h>
+#include <gmock/gmock.h>
+#include <openssl/crypto.h>
+#include <openssl/opensslv.h>
 
-namespace storage = google::cloud::storage;
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+using ::testing::StartsWith;
 
 /// @test A trivial test for the Google Cloud Storage C++ Client
 TEST(LinkTest, Simple) {
-  EXPECT_FALSE(storage::version_string().empty());
-  EXPECT_EQ(STORAGE_CLIENT_VERSION_MAJOR, storage::version_major());
-  EXPECT_EQ(STORAGE_CLIENT_VERSION_MINOR, storage::version_minor());
-  EXPECT_EQ(STORAGE_CLIENT_VERSION_PATCH, storage::version_patch());
+  EXPECT_FALSE(version_string().empty());
+  EXPECT_EQ(STORAGE_CLIENT_VERSION_MAJOR, version_major());
+  EXPECT_EQ(STORAGE_CLIENT_VERSION_MINOR, version_minor());
+  EXPECT_EQ(STORAGE_CLIENT_VERSION_PATCH, version_patch());
 }
+
+/// @test Verify that the OpenSSL and CURL libraries linked are compatible.
+TEST(LinkTest, CurlVsOpenSSL) {
+  auto v = curl_version_info(CURLVERSION_NOW);
+  std::string curl_ssl = v->ssl_version;
+  std::string expected_prefix = curl_ssl;
+  std::transform(expected_prefix.begin(), expected_prefix.end(),
+                 expected_prefix.begin(),
+                 [](char x) { return x == '/' ? ' ' : x; });
+#ifdef OPENSSL_VERSION
+  std::string openssl_v = OpenSSL_version(OPENSSL_VERSION);
+#else
+  std::string openssl_v = SSLeay_version(SSLEAY_VERSION);
+#endif  // OPENSSL_VERSION
+  EXPECT_THAT(openssl_v, StartsWith(expected_prefix))
+      << "Mismatched versions of OpenSSL linked in libcurl vs. the version"
+      << " linked by the Google Cloud Storage C++ library.\n"
+      << "libcurl is linked against " << curl_ssl
+      << "\nwhile the google cloud storage library links against " << openssl_v
+      << "\nMismatched versions are not supported.  The Google Cloud Storage"
+      << "\nC++ library needs to configure the OpenSSL library used by libcurl"
+      << "\nand this is not possible if you link different versions.";
+}
+
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
# TESTING NOT READY FOR REVIEW

With this change the unit tests will fail if we manage to compile the library and libcurl against incompatible version of the SSL library.  The typical case is having libcurl compiled against OpenSSL/1.0.2 but compiling the google cloud storage library against OpenSSL/1.1.0, but other combinations are possible and also bad ideas (e.g. OpenSSL with LibreSSL and google cloud storage with OpenSSL).

The problems is that soon we will need to setup global configuration in the SSL library used by libcurl, specifically, the locking strategy so we can use libcurl with multiple threads.  That is not possible if we are configuring a different global state than the state used by libcurl.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1047)
<!-- Reviewable:end -->
