### PR TITLE
Initialize SSL thread callbacks when needed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
       os: osx
       compiler: clang
       env:
-        CMAKE_FLAGS=-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl
+        CMAKE_FLAGS=-DOPENSSL_ROOT_DIR=/usr/local/opt/libressl
       install:
         - git submodule update --init
         - ci/install-retry.sh ci/travis/install-macosx.sh

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ sudo make install
 #### macOS (using brew)
 
 ```bash
-brew install curl libressl c-ares
+brew install curl cmake libressl c-ares
 ```
 
 #### Windows (using vcpkg)

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ sudo make install
 #### macOS (using brew)
 
 ```bash
-brew install curl cmake
+brew install curl libressl c-ares
 ```
 
 #### Windows (using vcpkg)
@@ -217,11 +217,28 @@ powershell -exec bypass .\ci\install-windows.ps1
 To build all available libraries and run the tests, run the following commands
 after cloning this repo:
 
-#### Linux and macOS
+#### Linux
 
 ```bash
 git submodule update --init
 cmake -H. -Bbuild-output
+
+# Adjust the number of threads used by modifying parameter for `-j 4`
+cmake --build build-output -- -j 4
+
+# Verify build by running tests
+(cd build-output && ctest --output-on-failure)
+```
+
+You will find compiled binaries in `build-output/` respective to their source paths.
+
+#### macOS
+
+```bash
+git submodule update --init
+export CMAKE_FLAGS=-DOPENSSL_ROOT_DIR=/usr/local/opt/libressl
+cmake -H. -Bbuild-output ${CMAKE_FLAGS}
+
 
 # Adjust the number of threads used by modifying parameter for `-j 4`
 cmake --build build-output -- -j 4

--- a/ci/travis/install-macosx.sh
+++ b/ci/travis/install-macosx.sh
@@ -22,4 +22,4 @@ if [ "${TRAVIS_OS_NAME}" != "osx" ]; then
 fi
 
 brew update
-brew install curl openssl c-ares ccache
+brew install curl libressl c-ares ccache

--- a/google/cloud/storage/internal/curl_wrappers.cc
+++ b/google/cloud/storage/internal/curl_wrappers.cc
@@ -56,8 +56,8 @@ bool SslLibraryNeedsLocking(std::string const& curl_ssl_id) {
   //    https://curl.haxx.se/libcurl/c/threadsafe.html
   // Only these library prefixes require special configuration for using safely
   // with multiple threads.
-  return (curl_ssl_id.find("OpenSSL/1.0") == 0 or
-          curl_ssl_id.find("LibreSSL/2") == 0);
+  return (curl_ssl_id.rfind("OpenSSL/1.0", 0) == 0 or
+          curl_ssl_id.rfind("LibreSSL/2", 0) == 0);
 }
 
 void InitializeSslLocking() {
@@ -80,7 +80,7 @@ void InitializeSslLocking() {
                  [](char x) { return x == '/' ? ' ' : x; });
   // LibreSSL seems to be using semantic versioning, so just check the major
   // version.
-  if (expected_prefix.find("LibreSSL 2") == 0) {
+  if (expected_prefix.rfind("LibreSSL 2", 0) == 0) {
     expected_prefix = "LibreSSL 2";
   }
 #ifdef OPENSSL_VERSION
@@ -92,7 +92,7 @@ void InitializeSslLocking() {
   // that the major version matches (e.g. LibreSSL), and (b) because the
   // `openssl_v` string sometimes reads `OpenSSL 1.1.0 May 2018` while the
   // string reported by libcurl would be `OpenSSL/1.1.0`, sigh...
-  if (openssl_v.find(expected_prefix) != 0) {
+  if (openssl_v.rfind(expected_prefix, 0) != 0) {
     std::ostringstream os;
     os << "Mismatched versions of OpenSSL linked in libcurl vs. the version"
        << " linked by the Google Cloud Storage C++ library.\n"

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -20,7 +20,8 @@ set(storage_client_integration_tests
     curl_download_request_integration_test.cc
     curl_request_integration_test.cc
     curl_streambuf_integration_test.cc
-    object_integration_test.cc)
+    object_integration_test.cc
+    thread_integration_test.cc)
 
 foreach (fname ${storage_client_integration_tests})
     string(REPLACE "/"

--- a/google/cloud/storage/tests/run_integration_tests_testbench.sh
+++ b/google/cloud/storage/tests/run_integration_tests_testbench.sh
@@ -26,6 +26,7 @@ source "${PROJECT_ROOT}/google/cloud/storage/tools/run_testbench_utils.sh"
 # can use the same testbench.
 export PROJECT_ID="fake-project-$(date +%s)"
 export BUCKET_NAME="fake-bucket-$(date +%s)"
+export LOCATION="fake-region1"
 
 echo
 echo "Running Storage integration tests against local servers."
@@ -56,8 +57,8 @@ echo "Running GCS Object APIs integration tests."
 ./object_integration_test "${PROJECT_ID}" "${BUCKET_NAME}"
 
 echo
-echo "Running storage::internal::CurlRequest integration test."
-./curl_request_integration_test
+echo "Running GCS multi-threaded integration test."
+./thread_integration_test "${PROJECT_ID}" "${LOCATION}"
 
 # The tests were successful, so disable dumping of test bench log during
 # shutdown.

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -6,4 +6,5 @@ storage_client_integration_tests = [
     "curl_request_integration_test.cc",
     "curl_streambuf_integration_test.cc",
     "object_integration_test.cc",
+    "thread_integration_test.cc",
 ]

--- a/google/cloud/storage/tests/thread_integration_test.cc
+++ b/google/cloud/storage/tests/thread_integration_test.cc
@@ -1,0 +1,216 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/random.h"
+#include "google/cloud/storage/client.h"
+#include "google/cloud/testing_util/init_google_mock.h"
+#include <gmock/gmock.h>
+#include <future>
+#include <thread>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+/// Store the project and instance captured from the command-line arguments.
+class ThreadTestEnvironment : public ::testing::Environment {
+ public:
+  ThreadTestEnvironment(std::string project, std::string location) {
+    project_id_ = std::move(project);
+    location_ = std::move(location);
+  }
+
+  static std::string const& project_id() { return project_id_; }
+  static std::string const& location() { return location_; }
+
+ private:
+  static std::string project_id_;
+  static std::string location_;
+};
+
+std::string ThreadTestEnvironment::project_id_;
+std::string ThreadTestEnvironment::location_;
+
+class ThreadIntegrationTest : public ::testing::Test {
+ protected:
+  std::string MakeRandomBucketName() {
+    // The total length of this bucket name must be <= 63 characters,
+    static std::string const prefix = "gcs-cpp-test-bucket-";
+    static std::size_t const kMaxBucketNameLength = 63;
+    std::size_t const max_random_characters =
+        kMaxBucketNameLength - prefix.size();
+    return prefix + google::cloud::internal::Sample(
+                        generator_, static_cast<int>(max_random_characters),
+                        "abcdefghijklmnopqrstuvwxyz012456789");
+  }
+
+  std::string MakeRandomObjectName() {
+    return google::cloud::internal::Sample(generator_, 24,
+                                           "abcdefghijklmnopqrstuvwxyz"
+                                           "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                           "012456789") +
+           ".txt";
+  }
+
+  std::string MakeEntityName() {
+    // We always use the viewers for the project because it is known to exist.
+    return "project-viewers-" + ThreadTestEnvironment::project_id();
+  }
+
+ protected:
+  google::cloud::internal::DefaultPRNG generator_ =
+      google::cloud::internal::MakeDefaultPRNG();
+};
+
+std::string LoremIpsum() {
+  return R"""(Lorem ipsum dolor sit amet, consectetur adipiscing
+elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit
+esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+})""";
+}
+
+using ObjectNameList = std::vector<std::string>;
+
+/**
+ * Divide @p source in to @p count groups of approximately equal size.
+ */
+std::vector<ObjectNameList> DivideIntoEqualSizedGroups(
+    ObjectNameList const& source, int count) {
+  std::vector<ObjectNameList> groups;
+  groups.reserve(count);
+  auto div = source.size() / count;
+  auto rem = source.size() % count;
+  // begin points to the beginning of the next chunk, it is incremented inside
+  // the loop by the number of elements.
+  std::size_t size;
+  for (auto begin = source.begin(); begin != source.end(); begin += size) {
+    size = div;
+    if (rem != 0) {
+      size++;
+      rem--;
+    }
+    auto remaining =
+        static_cast<std::size_t>(std::distance(begin, source.end()));
+    if (remaining < size) {
+      size = remaining;
+    }
+    auto end = begin;
+    std::advance(end, size);
+    groups.emplace_back(ObjectNameList(begin, end));
+  }
+  return groups;
+}
+
+void CreateObjects(std::string const& bucket_name, ObjectNameList group) {
+  // Create our own client so no state is shared with the other threads.
+  Client client;
+  for (auto const& object_name : group) {
+    (void)client.InsertObject(bucket_name, object_name, LoremIpsum(),
+                              IfGenerationMatch(0));
+  }
+}
+
+void DeleteObjects(std::string const& bucket_name, ObjectNameList group) {
+  // Create our own client so no state is shared with the other threads.
+  Client client;
+  for (auto const& object_name : group) {
+    (void)client.DeleteObject(bucket_name, object_name);
+  }
+}
+}  // anonymous namespace
+
+TEST_F(ThreadIntegrationTest, Unshared) {
+  auto project_id = ThreadTestEnvironment::project_id();
+  std::string bucket_name = MakeRandomBucketName();
+  Client client;
+
+  auto bucket = client.CreateBucketForProject(
+      bucket_name, project_id,
+      BucketMetadata()
+          .set_storage_class(storage_class::Regional())
+          .set_location(ThreadTestEnvironment::location())
+          .disable_versioning(),
+      PredefinedAcl("private"), PredefinedDefaultObjectAcl("projectPrivate"),
+      Projection("full"));
+  EXPECT_EQ(bucket_name, bucket.name());
+
+  constexpr int kObjectCount = 10000;
+  std::vector<std::string> objects;
+  objects.reserve(kObjectCount);
+  std::generate_n(std::back_inserter(objects), kObjectCount,
+                  [this] { return MakeRandomObjectName(); });
+
+  unsigned int thread_count = std::thread::hardware_concurrency();
+  if (thread_count == 0) {
+    thread_count = 4;
+  }
+
+  std::cout << "Creating " << kObjectCount << " objects " << std::flush;
+  auto groups = DivideIntoEqualSizedGroups(objects, thread_count);
+  std::vector<std::future<void>> tasks;
+  for (auto const& g : groups) {
+    tasks.emplace_back(
+        std::async(std::launch::async, &CreateObjects, bucket_name, g));
+  }
+  for (auto& t : tasks) {
+    t.get();
+    std::cout << '.' << std::flush;
+  }
+  std::cout << " DONE" << std::endl;
+
+  std::cout << "Deleting " << kObjectCount << " objects " << std::flush;
+  tasks.clear();
+  for (auto const& g : groups) {
+    tasks.emplace_back(
+        std::async(std::launch::async, &DeleteObjects, bucket_name, g));
+  }
+  for (auto& t : tasks) {
+    t.get();
+    std::cout << '.' << std::flush;
+  }
+  std::cout << " DONE" << std::endl;
+
+  std::cout << "Deleting " << bucket_name << std::endl;
+  client.DeleteBucket(bucket_name);
+}
+
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+int main(int argc, char* argv[]) {
+  google::cloud::testing_util::InitGoogleMock(argc, argv);
+
+  // Make sure the arguments are valid.
+  if (argc != 3) {
+    std::string const cmd = argv[0];
+    auto last_slash = std::string(argv[0]).find_last_of('/');
+    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
+              << " <project-id> <location (GCP region, e.g us-east1)>"
+              << std::endl;
+    return 1;
+  }
+
+  std::string const project_id = argv[1];
+  std::string const location = argv[2];
+  (void)::testing::AddGlobalTestEnvironment(
+      new google::cloud::storage::ThreadTestEnvironment(project_id, location));
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This fixes #1048.

OpenSSL 1.0.2 (which is still widely deployed) does not perform any
internal locking. Instead, we must provide callbacks to lock and
unlock the OpenSSL data structures. Because we use OpenSSL via
libcurl, we must perform this configuration only if libcurl is
linked against OpenSSL<=1.0.2.

In some environments multiple versions of OpenSSL are available, if we
manage to link the library against a different version than the one used
by libcurl, the callback configurations would not work.  So we
explicitly check the library versions once, and fail to initialize the
library if this is the case.

On macOS libcurl is linked against the LibreSSL library, we need to
link the same library in our code or we cannot safely use it with
multiple threads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1050)
<!-- Reviewable:end -->
