### PR TITLE
Fix AppVeyor builds.

### DIFF
--- a/ci/appveyor/install-windows.ps1
+++ b/ci/appveyor/install-windows.ps1
@@ -29,6 +29,13 @@ if ($env:PROVIDER -eq "module") {
     return
 }
 
+# BEGIN WORKAROUND
+# As of 2018-08-30 AppVeyor had a broken image, reportedly this is a workaround.
+#     https://github.com/Microsoft/vcpkg/issues/4189#issuecomment-417462822
+Remove-Item C:\OpenSSL-v11-Win32 -Recurse -Force
+Remove-Item C:\OpenSSL-v11-Win64 -Recurse -Force
+# END WORKAROUND
+
 # Update or clone the 'vcpkg' package manager, this is a bit overly complicated,
 # but it works well on your workstation where you may want to run this script
 # multiple times while debugging vcpkg installs.  It also works on AppVeyor


### PR DESCRIPTION
AppVeyor upgraded their images in the last 24 hours:

https://www.appveyor.com/updates/

This update installs OpenSSL in:

C:\OpenSSL-v11-Win64
C:\OpenSSL-v11-Win32

unfortunately that gets picked up by CMake and the build breaks.
Apparently the intention is to remove these directories in the next
image:

https://github.com/appveyor/ci/milestone/95
https://github.com/appveyor/ci/issues/2600
https://github.com/appveyor/ci/issues/2558#issuecomment-417463121

Meanwhile the workaround is to manually delete them:

https://github.com/Microsoft/vcpkg/issues/4189#issuecomment-417462822

For extra joy, the new compiler in this image also requires a new
version of googletest:

https://github.com/google/googletest/pull/1620

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1064)
<!-- Reviewable:end -->
