### PR TITLE
Do not use std::iterator.

### DIFF
--- a/google/cloud/bigtable/internal/rowreaderiterator.h
+++ b/google/cloud/bigtable/internal/rowreaderiterator.h
@@ -38,8 +38,17 @@ using OptionalRow = google::cloud::internal::optional<Row>;
 /**
  * The input iterator used to scan the rows in a RowReader.
  */
-class RowReaderIterator : public std::iterator<std::input_iterator_tag, Row> {
+class RowReaderIterator {
  public:
+  //@{
+  /// @name Iterator traits
+  using iterator_category = std::input_iterator_tag;
+  using value_type = Row;
+  using difference_type = std::ptrdiff_t;
+  using pointer = Row*;
+  using reference = Row&;
+  //@}
+
   RowReaderIterator(RowReader* owner, bool is_end) : owner_(owner), row_() {}
 
   RowReaderIterator& operator++();

--- a/google/cloud/bigtable/row_reader.cc
+++ b/google/cloud/bigtable/row_reader.cc
@@ -23,9 +23,20 @@ namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 // RowReader::iterator must satisfy the requirements of an InputIterator.
-static_assert(std::is_base_of<std::iterator<std::input_iterator_tag, Row>,
-                              RowReader::iterator>::value,
-              "RowReader::iterator must be an InputIterator");
+static_assert(
+    std::is_same<std::iterator_traits<RowReader::iterator>::iterator_category,
+                 std::input_iterator_tag>::value,
+    "RowReader::iterator should be an InputIterator");
+static_assert(
+    std::is_same<std::iterator_traits<RowReader::iterator>::value_type,
+                 Row>::value,
+    "RowReader::iterator should be an InputIterator of Row");
+static_assert(std::is_same<std::iterator_traits<RowReader::iterator>::pointer,
+                           Row*>::value,
+              "RowReader::iterator should be an InputIterator of Row");
+static_assert(std::is_same<std::iterator_traits<RowReader::iterator>::reference,
+                           Row&>::value,
+              "RowReader::iterator should be an InputIterator of Row");
 static_assert(std::is_copy_constructible<RowReader::iterator>::value,
               "RowReader::iterator must be CopyConstructible");
 static_assert(std::is_move_constructible<RowReader::iterator>::value,

--- a/google/cloud/storage/list_buckets_reader.cc
+++ b/google/cloud/storage/list_buckets_reader.cc
@@ -21,9 +21,22 @@ inline namespace STORAGE_CLIENT_NS {
 // ListBucketsReader::iterator must satisfy the requirements of an
 // InputIterator.
 static_assert(
-    std::is_base_of<std::iterator<std::input_iterator_tag, BucketMetadata>,
-                    ListBucketsReader::iterator>::value,
-    "ListBucketsReader::iterator must be an InputIterator");
+    std::is_same<
+        std::iterator_traits<ListBucketsReader::iterator>::iterator_category,
+        std::input_iterator_tag>::value,
+    "ListBucketsReader::iterator should be an InputIterator");
+static_assert(
+    std::is_same<std::iterator_traits<ListBucketsReader::iterator>::value_type,
+                 BucketMetadata>::value,
+    "ListBucketsReader::iterator should be an InputIterator of BucketMetadata");
+static_assert(
+    std::is_same<std::iterator_traits<ListBucketsReader::iterator>::pointer,
+                 BucketMetadata*>::value,
+    "ListBucketsReader::iterator should be an InputIterator of BucketMetadata");
+static_assert(
+    std::is_same<std::iterator_traits<ListBucketsReader::iterator>::reference,
+                 BucketMetadata&>::value,
+    "ListBucketsReader::iterator should be an InputIterator of BucketMetadata");
 static_assert(std::is_copy_constructible<ListBucketsReader::iterator>::value,
               "ListBucketsReader::iterator must be CopyConstructible");
 static_assert(std::is_move_constructible<ListBucketsReader::iterator>::value,

--- a/google/cloud/storage/list_buckets_reader.h
+++ b/google/cloud/storage/list_buckets_reader.h
@@ -28,9 +28,17 @@ class ListBucketsReader;
 /**
  * A class meeting C++'s InputIterator requirements for listing buckets.
  */
-class ListBucketsIterator
-    : public std::iterator<std::input_iterator_tag, BucketMetadata> {
+class ListBucketsIterator {
  public:
+  //@{
+  /// @name Iterator traits
+  using iterator_category = std::input_iterator_tag;
+  using value_type = BucketMetadata;
+  using difference_type = std::ptrdiff_t;
+  using pointer = BucketMetadata*;
+  using reference = BucketMetadata&;
+  //@}
+
   ListBucketsIterator() : owner_(nullptr) {}
 
   ListBucketsIterator& operator++();

--- a/google/cloud/storage/list_objects_reader.cc
+++ b/google/cloud/storage/list_objects_reader.cc
@@ -21,9 +21,22 @@ inline namespace STORAGE_CLIENT_NS {
 // ListObjectsReader::iterator must satisfy the requirements of an
 // InputIterator.
 static_assert(
-    std::is_base_of<std::iterator<std::input_iterator_tag, ObjectMetadata>,
-                    ListObjectsReader::iterator>::value,
-    "ListObjectsReader::iterator must be an InputIterator");
+    std::is_same<
+        std::iterator_traits<ListObjectsReader::iterator>::iterator_category,
+        std::input_iterator_tag>::value,
+    "ListObjectsReader::iterator should be an InputIterator");
+static_assert(
+    std::is_same<std::iterator_traits<ListObjectsReader::iterator>::value_type,
+                 ObjectMetadata>::value,
+    "ListObjectsReader::iterator should be an InputIterator of ObjectMetadata");
+static_assert(
+    std::is_same<std::iterator_traits<ListObjectsReader::iterator>::pointer,
+                 ObjectMetadata*>::value,
+    "ListObjectsReader::iterator should be an InputIterator of ObjectMetadata");
+static_assert(
+    std::is_same<std::iterator_traits<ListObjectsReader::iterator>::reference,
+                 ObjectMetadata&>::value,
+    "ListObjectsReader::iterator should be an InputIterator of ObjectMetadata");
 static_assert(std::is_copy_constructible<ListObjectsReader::iterator>::value,
               "ListObjectsReader::iterator must be CopyConstructible");
 static_assert(std::is_move_constructible<ListObjectsReader::iterator>::value,

--- a/google/cloud/storage/list_objects_reader.h
+++ b/google/cloud/storage/list_objects_reader.h
@@ -28,9 +28,17 @@ class ListObjectsReader;
 /**
  * A class meeting C++'s InputIterator requirements for listing objects.
  */
-class ListObjectsIterator
-    : public std::iterator<std::input_iterator_tag, ObjectMetadata> {
+class ListObjectsIterator {
  public:
+  //@{
+  /// @name Iterator traits
+  using iterator_category = std::input_iterator_tag;
+  using value_type = ObjectMetadata;
+  using difference_type = std::ptrdiff_t;
+  using pointer = ObjectMetadata*;
+  using reference = ObjectMetadata&;
+  //@}
+
   ListObjectsIterator() : owner_(nullptr) {}
 
   ListObjectsIterator& operator++();


### PR DESCRIPTION
std::iterator is deprecated in C++17, MSVC is already generating
warnings about using (future) deprecated classes. And while we are not
using C++17 (or C++20 where std::iterator may finally be removed), our
users might be.  It is easier to simply not use the class.

/cc: @houglum

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1066)
<!-- Reviewable:end -->
