### PR TITLE
Fix component_count type.

### DIFF
--- a/google/cloud/storage/object_metadata.cc
+++ b/google/cloud/storage/object_metadata.cc
@@ -49,7 +49,7 @@ ObjectMetadata ObjectMetadata::ParseFromJson(internal::nl::json const& json) {
 
   result.bucket_ = json.value("bucket", "");
   result.cache_control_ = json.value("cacheControl", "");
-  result.component_count_ = internal::ParseLongField(json, "componentCount");
+  result.component_count_ = internal::ParseIntField(json, "componentCount");
   result.content_disposition_ = json.value("contentDisposition", "");
   result.content_encoding_ = json.value("contentEncoding", "");
   result.content_language_ = json.value("contentLanguage", "");

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -99,7 +99,7 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
     return *this;
   }
 
-  long component_count() const { return component_count_; }
+  std::int32_t component_count() const { return component_count_; }
 
   std::string content_disposition() const { return content_disposition_; }
   ObjectMetadata& set_content_disposition(std::string value) {
@@ -211,7 +211,7 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
   std::vector<ObjectAccessControl> acl_;
   std::string bucket_;
   std::string cache_control_;
-  std::int64_t component_count_;
+  std::int32_t component_count_;
   std::string content_disposition_;
   std::string content_encoding_;
   std::string content_language_;


### PR DESCRIPTION
MSVC was producing warnings about the return type for component_count,
on inspection, the correct type was `std::int32_t`: the type in the JSON
structure is `integer` and we decided to map those to `std::int32_t` in
the surface design doc.

/cc: @houglum

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1067)
<!-- Reviewable:end -->
