### PR TITLE
Improve errors if the user does not set CMAKE_FLAGS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,16 +50,16 @@ if (APPLE)
     if (NOT DEFINED ENV{CMAKE_FLAGS})
         message(
             FATAL_ERROR
-                "The google-cloud-cpp CMake files use the CMAKE_FLAGS environment"
-                " variable to configure external projects. In most macOS systems"
-                " this environment variable should contain any definitions required"
-                " to find the OpenSSL libraries, e.g. "
+                "The google-cloud-cpp CMake files use the CMAKE_FLAGS"
+                " environment variable to configure external projects. In most"
+                " macOS systems, this environment variable should contain any"
+                " definitions required to find the OpenSSL libraries, e.g.,"
                 "     `-DOPENSSL_ROOT_DIR=/usr/local/opt/libressl`."
-                " You have not set this environment variable. Most likely this"
-                " will result in a broken build with fairly obscure error messages."
-                " Set CMAKE_FLAGS to an empty string to silence this error if your"
-                " environment does not require additional settings to find the"
-                " OpenSSL libraries.")
+                " You have not set this environment variable. Most likely, this"
+                " will result in a broken build with fairly obscure error"
+                " messages. Set CMAKE_FLAGS to an empty string to silence this"
+                " error if your environment does not require additional"
+                " settings to find the OpenSSL libraries.")
     endif ()
 endif (APPLE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,25 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     endif ()
 endif ()
 
+if (APPLE)
+    # This is an easy mistake to make, and the error messages are very
+    # confusing. Help our users by giving them some guidance.
+    if (NOT DEFINED ENV{CMAKE_FLAGS})
+        message(
+            FATAL_ERROR
+                "The google-cloud-cpp CMake files use the CMAKE_FLAGS environment"
+                " variable to configure external projects. In most macOS systems"
+                " this environment variable should contain any definitions required"
+                " to find the OpenSSL libraries, e.g. "
+                "     `-DOPENSSL_ROOT_DIR=/usr/local/opt/libressl`."
+                " You have not set this environment variable. Most likely this"
+                " will result in a broken build with fairly obscure error messages."
+                " Set CMAKE_FLAGS to an empty string to silence this error if your"
+                " environment does not require additional settings to find the"
+                " OpenSSL libraries.")
+    endif ()
+endif (APPLE)
+
 # If ccache is installed use it for the build. This makes the Travis
 # configuration agnostic as to wether ccache is installed or not.
 option(

--- a/README.md
+++ b/README.md
@@ -237,8 +237,7 @@ You will find compiled binaries in `build-output/` respective to their source pa
 ```bash
 git submodule update --init
 export CMAKE_FLAGS=-DOPENSSL_ROOT_DIR=/usr/local/opt/libressl
-cmake -H. -Bbuild-output ${CMAKE_FLAGS}
-
+cmake -H. -Bbuild-output ${CMAKE_FLAGS?}
 
 # Adjust the number of threads used by modifying parameter for `-j 4`
 cmake --build build-output -- -j 4


### PR DESCRIPTION
Forgetting to set CMAKE_FLAGS is an easy mistake to make. Changed the
README.md file to fail if the user does not set the environment
variable. If the user types `${CMAKE_FLAGS}` without the ending `?`
we also generate an error in the CMake file that explains what is
going on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1069)
<!-- Reviewable:end -->
