### PR TITLE
Trim log file output in CI builds.

### DIFF
--- a/ci/define-dump-log.sh
+++ b/ci/define-dump-log.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+################################################
+# Dump a log file to the console without going over CI system limits.
+# Globals:
+#   None
+# Arguments:
+#   logfile: the name of the logfile to print out.
+# Returns:
+#   None
+################################################
+dump_log() {
+  local -r logfile=$1
+  shift
+  local -r base="$(basename "${logfile}")"
+
+  if [ ! -r "${logfile}" ]; then
+    return
+  fi
+
+  echo "================ [begin ${base}] ================"
+  # Travis has a limit of ~10,000 lines, if the file is around 1,000 just print
+  # the full file.
+  if [ "$(wc -l "${logfile}" | awk '{print $1}')" -lt 200 ]; then
+    cat "${logfile}"
+  else
+    head -100 "${EMULATOR_LOG}"
+    echo "==== [snip] [snip] [${base}] [snip] [snip] ===="
+    tail -100 "${EMULATOR_LOG}"
+  fi
+  echo "================ [end ${base}] ================"
+}

--- a/ci/define-example-runner.sh
+++ b/ci/define-example-runner.sh
@@ -16,6 +16,7 @@
 if [ -z "${PROJECT_ROOT+x}" ]; then
   readonly PROJECT_ROOT="$(cd "$(dirname $0)/.."; pwd)"
 fi
+source "${PROJECT_ROOT}/ci/define-dump-log.sh"
 source "${PROJECT_ROOT}/ci/colors.sh"
 
 # If an example fails, this is set to 1 and the program exits with failure.
@@ -69,13 +70,9 @@ run_example() {
     echo    "${COLOR_RED}[    ERROR ]${COLOR_RESET}" \
         " ${program_name} ${example}"
     echo
-    echo "================ [begin ${log}] ================"
-    cat "${log}"
-    echo "================ [end ${log}] ================"
+    dump_log ${log}
     if [ -f "${EMULATOR_LOG}" ]; then
-      echo "================ [begin ${EMULATOR_LOG} ================"
-      cat "${EMULATOR_LOG}"
-      echo "================ [end ${EMULATOR_LOG} ================"
+      dump_log "${EMULATOR_LOG}"
     fi
   fi
   set -e
@@ -122,13 +119,9 @@ run_example_usage() {
     echo    "${COLOR_RED}[    ERROR ]${COLOR_RESET}" \
         " ${program_name}"
     echo
-    echo "================ [begin ${log}] ================"
-    cat "${log}"
-    echo "================ [end ${log}] ================"
+    dump_log ${log}
     if [ -f "${EMULATOR_LOG}" ]; then
-      echo "================ [begin ${EMULATOR_LOG} ================"
-      cat "${EMULATOR_LOG}"
-      echo "================ [end ${EMULATOR_LOG} ================"
+      dump_log "${EMULATOR_LOG}"
     fi
   fi
   set -e

--- a/ci/travis/dump-logs.sh
+++ b/ci/travis/dump-logs.sh
@@ -16,14 +16,16 @@
 
 set -eu
 
+if [ -z "${PROJECT_ROOT+x}" ]; then
+  readonly PROJECT_ROOT="$(cd "$(dirname $0)/../.."; pwd)"
+fi
+source "${PROJECT_ROOT}/ci/define-dump-log.sh"
+
 readonly BUILD_OUTPUT="build-output/cached-${DISTRO}-${DISTRO_VERSION}"
 # Dump the emulator log file. Tests run in the google/cloud/bigtable/tests directory.
 echo
-echo "================ emulator.log ================"
-cat "${BUILD_OUTPUT}/google/cloud/bigtable/tests/emulator.log" >&2 || true
-echo
-echo "================ instance-admin-emulator.log ================"
-cat "${BUILD_OUTPUT}/google/cloud/bigtable/tests/instance-admin-emulator.log" >&2 || true
+dump_log "${BUILD_OUTPUT}/google/cloud/bigtable/tests/emulator.log"
+dump_log "${BUILD_OUTPUT}/google/cloud/bigtable/tests/instance-admin-emulator.log"
 
 # This script runs on macOS and Linux, there are no analysis steps executed by
 # the macOS builds, so we can safely exit here unless we are running Linux.

--- a/ci/travis/upload-codecov.sh
+++ b/ci/travis/upload-codecov.sh
@@ -21,6 +21,11 @@ if [ "${BUILD_TYPE:-Release}" != "Coverage" ]; then
     exit 0
 fi
 
+if [ -z "${PROJECT_ROOT+x}" ]; then
+  readonly PROJECT_ROOT="$(cd "$(dirname $0)/.."; pwd)"
+fi
+source "${PROJECT_ROOT}/ci/define-dump-log.sh"
+
 # Upload the results using the script from codecov.io
 # Save the log to a file because it exceeds the 4MB limit in Travis.
 readonly CI_ENV=$(bash <(curl -s https://codecov.io/env))
@@ -29,8 +34,4 @@ sudo docker run $CI_ENV \
     --volume $PWD:/v --workdir /v \
     "${IMAGE}:tip" /bin/bash -c "/bin/bash <(curl -s https://codecov.io/bash)"
 
-echo "================================================================"
-head -1000 codecov.log
-echo "================================================================"
-tail -1000 codecov.log
-echo "================================================================"
+ci_dump_log codecov.log

--- a/google/cloud/storage/tools/run_testbench_utils.sh
+++ b/google/cloud/storage/tools/run_testbench_utils.sh
@@ -38,13 +38,20 @@ TESTBENCH_DUMP_LOG=yes
 kill_testbench() {
   echo "${COLOR_GREEN}[ -------- ]${COLOR_RESET} Integration test environment tear-down."
   echo -n "Killing testbench server [${TESTBENCH_PID}] ... "
-  curl -d "please shutdown" "${SHUTDOWN_ENDPOINT}"
   kill "${TESTBENCH_PID}"
   wait >/dev/null 2>&1
   echo "done."
-  if [ "${TESTBENCH_DUMP_LOG}" = "yes" ]; then
+  if [ "${TESTBENCH_DUMP_LOG}" = "yes" -a "testbench.log" ]; then
     echo "================ [begin testbench.log] ================"
-    cat "testbench.log"
+    # Travis has a limit of ~10,000 lines, and sometimes the
+    # emulator log gets too long, just print the interesting bits:
+    if [ "$(wc -l "testbench.log" | awk '{print $1}')" -lt 1000 ]; then
+      cat "testbench.log"
+    else
+      head -500 "testbench.log"
+      echo "        [snip snip snip]        "
+      tail -500 "testbench.log"
+    fi
     echo "================ [end testbench.log] ================"
   fi
   echo "${COLOR_GREEN}[ ======== ]${COLOR_RESET} Integration test environment tear-down."


### PR DESCRIPTION
Sometimes we get super large log files, and the CI builds fail
because we printed too much. The common solution is to just print
the top and bottom portions of the log, because the rest is typically
repetitive. This change refactors a few places where we did the trimming
in different ways.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1073)
<!-- Reviewable:end -->
