### PR TITLE
Cleanup CMAKE_FLAGS hack.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,7 +131,6 @@ matrix:
       os: linux
       compiler: gcc
       env:
-        CMAKE_FLAGS=-DBUILD_SHARED_LIBS=yes
         DISTRO=fedora
         DISTRO_VERSION=27
       if: repo =~ ^GoogleCloudPlatform/ or head_repo =~ ^GoogleCloudPlatform/

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
       os: osx
       compiler: clang
       env:
-        CMAKE_FLAGS=-DOPENSSL_ROOT_DIR=/usr/local/opt/libressl
+        OPENSSL_ROOT_DIR=/usr/local/opt/libressl
       install:
         - git submodule update --init
         - ci/install-retry.sh ci/travis/install-macosx.sh
@@ -131,6 +131,7 @@ matrix:
       os: linux
       compiler: gcc
       env:
+        CMAKE_FLAGS=-DBUILD_SHARED_LIBS=yes
         DISTRO=fedora
         DISTRO_VERSION=27
       if: repo =~ ^GoogleCloudPlatform/ or head_repo =~ ^GoogleCloudPlatform/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,22 +44,29 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     endif ()
 endif ()
 
+option(GOOGLE_CLOUD_CPP_ENABLE_MACOS_OPENSSL_CHECK
+       "If enabled, check that the user has defined OPENSSL_ROOT_DIR on macOS"
+       ON)
 if (APPLE)
     # This is an easy mistake to make, and the error messages are very
     # confusing. Help our users by giving them some guidance.
-    if (NOT DEFINED ENV{CMAKE_FLAGS})
-        message(
-            FATAL_ERROR
-                "The google-cloud-cpp CMake files use the CMAKE_FLAGS"
-                " environment variable to configure external projects. In most"
-                " macOS systems, this environment variable should contain any"
-                " definitions required to find the OpenSSL libraries, e.g.,"
-                "     `-DOPENSSL_ROOT_DIR=/usr/local/opt/libressl`."
-                " You have not set this environment variable. Most likely, this"
-                " will result in a broken build with fairly obscure error"
-                " messages. Set CMAKE_FLAGS to an empty string to silence this"
-                " error if your environment does not require additional"
-                " settings to find the OpenSSL libraries.")
+    if ("${GOOGLE_CLOUD_CPP_ENABLE_MACOS_OPENSSL_CHECK}"
+        AND
+        NOT DEFINED ENV{OPENSSL_ROOT_DIR})
+        message(FATAL_ERROR [===[
+The Google Cloud C++ client libraries use the native OpenSSL library. In most
+macOS systems, you need to set the OPENSSL_ROOT_DIR environment variable to find
+this dependency, for example:
+
+export OPENSSL_ROOT_DIR=/usr/local/opt/libressl
+
+You have not set this environment variable. Most likely, this will result in a
+broken build with fairly obscure error messages. If your environment does not
+require setting OPENSSL_ROOT_DIR, you can disable this check using:
+
+cmake -DGOOGLE_CLOUD_CPP_ENABLE_MACOS_OPENSSL_CHECK=OFF ...
+
+]===])
     endif ()
 endif (APPLE)
 

--- a/README.md
+++ b/README.md
@@ -236,8 +236,8 @@ You will find compiled binaries in `build-output/` respective to their source pa
 
 ```bash
 git submodule update --init
-export CMAKE_FLAGS=-DOPENSSL_ROOT_DIR=/usr/local/opt/libressl
-cmake -H. -Bbuild-output ${CMAKE_FLAGS?}
+export OPENSSL_ROOT_DIR=/usr/local/opt/libressl
+cmake -H. -Bbuild-output
 
 # Adjust the number of threads used by modifying parameter for `-j 4`
 cmake --build build-output -- -j 4

--- a/ci/travis/build-macosx.sh
+++ b/ci/travis/build-macosx.sh
@@ -23,8 +23,6 @@ fi
 
 export PATH="/usr/local/opt/ccache/libexec:$PATH"
 
-cmake -H. -B.build \
-  -DCMAKE_BUILD_TYPE="${BUILD_TYPE:-Release}" \
-  ${CMAKE_FLAGS}
+cmake -H. -B.build -DCMAKE_BUILD_TYPE="${BUILD_TYPE:-Release}"
 cmake --build .build -- -j "${NCPU:-2}"
 (cd .build && ctest --output-on-failure)

--- a/cmake/external/c-ares.cmake
+++ b/cmake/external/c-ares.cmake
@@ -34,9 +34,9 @@ if (NOT TARGET c_ares_project)
         URL_HASH
             SHA256=62dd12f0557918f89ad6f5b759f0bf4727174ae9979499f5452c02be38d9d3e8
         CONFIGURE_COMMAND ${CMAKE_COMMAND}
-                          $ENV{CMAKE_FLAGS}
                           ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
                           -DCMAKE_BUILD_TYPE=Release
+                          -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                           -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                           -H<SOURCE_DIR>
                           -B<BINARY_DIR>/Release

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -38,9 +38,9 @@ if (NOT TARGET gprc_project)
         URL_HASH
             SHA256=16f22430210abf92e06626a5a116e114591075e5854ac78f1be8564171658b70
         CONFIGURE_COMMAND ${CMAKE_COMMAND}
-                          $ENV{CMAKE_FLAGS}
                           ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
                           -DCMAKE_BUILD_TYPE=Release
+                          -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                           -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                           -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
                           -DgRPC_BUILD_TESTS=OFF

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -37,17 +37,18 @@ if (NOT TARGET protobuf_project)
         URL_HASH
             SHA256=4ffd420f39f226e96aebc3554f9c66a912f6cad6261f39f194f16af8a1f6dab2
         CONFIGURE_COMMAND ${CMAKE_COMMAND}
-                          $ENV{CMAKE_FLAGS}
                           ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
                           -DCMAKE_BUILD_TYPE=Debug
+                          -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                           -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                           -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
                           -Dprotobuf_BUILD_TESTS=OFF
                           -H<SOURCE_DIR>/cmake
                           -B<BINARY_DIR>/Debug
-        COMMAND ${CMAKE_COMMAND} $ENV{CMAKE_FLAGS}
-                ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
-                -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        COMMAND ${CMAKE_COMMAND} ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+                -DCMAKE_BUILD_TYPE=Release
+                -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+                -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                 -DCMAKE_PREFIX_PATH=<INSTALL_DIR> -Dprotobuf_BUILD_TESTS=OFF
                 -H<SOURCE_DIR>/cmake -B<BINARY_DIR>/Release
         BUILD_COMMAND ${CMAKE_COMMAND}

--- a/cmake/external/zlib.cmake
+++ b/cmake/external/zlib.cmake
@@ -34,9 +34,9 @@ if (NOT TARGET zlib_project)
         URL_HASH
             SHA256=629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff
         CONFIGURE_COMMAND ${CMAKE_COMMAND}
-                          $ENV{CMAKE_FLAGS}
                           ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
                           -DCMAKE_BUILD_TYPE=Release
+                          -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                           -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                           -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
                           -H<SOURCE_DIR>


### PR DESCRIPTION
I was abusing CMAKE_FLAGS to pass information down to the external
projects. Instead we should rely (when needed), on existing environment
variables (for example OPENSSL_ROOT_DIR) if the platform requires
special settings. Standard variables, like BUILD_SHARED_LIBS, should
be passed down using -DVAR=${VAR}.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1078)
<!-- Reviewable:end -->
