### PR TITLE
Upgrade to Fedora 28.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,7 @@ matrix:
       compiler: gcc
       env:
         DISTRO=fedora
-        DISTRO_VERSION=27
+        DISTRO_VERSION=28
       if: repo =~ ^GoogleCloudPlatform/ or head_repo =~ ^GoogleCloudPlatform/
     - # Compile on CentOS.
       os: linux

--- a/ci/travis/Dockerfile.fedora
+++ b/ci/travis/Dockerfile.fedora
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=27
+ARG DISTRO_VERSION=28
 FROM fedora:${DISTRO_VERSION}
 MAINTAINER "Carlos O'Ryan <coryan@google.com>"
 


### PR DESCRIPTION
Fedora 27 will go EOL in a couple of months (~2018-11), and 28 has been
around for a while (since ~2018-05). Better to test with 28 since we
have limited cycles and we cannot test with both.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1081)
<!-- Reviewable:end -->
