### PR TITLE
Implement Client::CopyObject().

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -326,6 +326,57 @@ class Client {
   }
 
   /**
+   * Copies an existing object.
+   *
+   * Use `CopyObject` to copy between objects in the same location and storage
+   * class.  Copying objects across locations or storage classes can fail for
+   * large objects and retrying the operation will not succeed.
+   *
+   * @see https://cloud.google.com/storage/docs/json_api/v1/objects/copy for
+   *   a full description of the advantages of `RewriteObject` over
+   *   `CopyObject`.
+   *
+   * @param source_bucket_name the name of the bucket that contains the object
+   *     to be copied.
+   * @param source_object_name the name of the object to copy.
+   * @param destination_bucket_name the name of the bucket that will contain the
+   *     new object.
+   * @param destination_object_name the name of the new object.
+   * @param metadata additional metadata attributes that you want to set in the
+   *     new object.
+   * @param options a list of optional query parameters and/or request headers.
+   *     Valid types for this operation include `DestinationPredefinedAcl`,
+   *     `EncryptionKey`, `IfGenerationMatch`, `IfGenerationNotMatch`,
+   *     `IfMetagenerationMatch`, `IfMetagenerationNotMatch`,
+   *     `IfSourceGenerationMatch`, `IfSourceGenerationNotMatch`,
+   *     `IfSourceMetagenerationMatch`, `IfSourceMetagenerationNotMatch`,
+   *     `Projection`, `SourceGeneration`, and `UserProject`.
+   *
+   * @throw std::runtime_error if the operation cannot be completed using the
+   *   current policies.
+   *
+   * @par Examples
+   *
+   * @snippet storage_object_samples.cc copy object
+   *
+   * @snippet storage_object_samples.cc copy encrypted object
+   */
+  template <typename... Options>
+  ObjectMetadata CopyObject(std::string source_bucket_name,
+                            std::string source_object_name,
+                            std::string destination_bucket_name,
+                            std::string destination_object_name,
+                            ObjectMetadata const& metadata,
+                            Options&&... options) {
+    internal::CopyObjectRequest request(
+        std::move(source_bucket_name), std::move(source_object_name),
+        std::move(destination_bucket_name), std::move(destination_object_name),
+        metadata);
+    request.set_multiple_options(std::forward<Options>(options)...);
+    return raw_client_->CopyObject(request).second;
+  }
+
+  /**
    * Fetches the object metadata.
    *
    * @param bucket_name the bucket containing the object.
@@ -479,8 +530,8 @@ class Client {
    * @param updated the updated value for the object metadata.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `Generation`,
-   *     `IfGenerationMatch`, `IfGenerationNotMatch`, `IfMetaGenerationMatch`,
-   *     `IfMetaGenerationNotMatch`, `PredefinedAcl`,
+   *     `IfGenerationMatch`, `IfGenerationNotMatch`, `IfMetagenerationMatch`,
+   *     `IfMetagenerationNotMatch`, `PredefinedAcl`,
    *     `Projection`, and `UserProject`.
    *
    * @throw std::runtime_error if the metadata cannot be fetched using the
@@ -513,8 +564,8 @@ class Client {
    * @param builder the set of updates to perform in the Object metadata.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `Generation`,
-   *     `IfGenerationMatch`, `IfGenerationNotMatch`, `IfMetaGenerationMatch`,
-   *     `IfMetaGenerationNotMatch`, `PredefinedAcl`,
+   *     `IfGenerationMatch`, `IfGenerationNotMatch`, `IfMetagenerationMatch`,
+   *     `IfMetagenerationNotMatch`, `PredefinedAcl`,
    *     `Projection`, and `UserProject`.
    *
    * @throw std::runtime_error if the metadata cannot be fetched using the

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -333,8 +333,10 @@ class Client {
    * large objects and retrying the operation will not succeed.
    *
    * @see https://cloud.google.com/storage/docs/json_api/v1/objects/copy for
-   *   a full description of the advantages of `RewriteObject` over
-   *   `CopyObject`.
+   *   a full description of the advantages of `Objects: rewrite` over
+   *   `Objects: copy`.
+   *
+   * TODO(#816) - reference the RewriteObject() member function here.
    *
    * @param source_bucket_name the name of the bucket that contains the object
    *     to be copied.

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -151,6 +151,7 @@ run_all_object_examples() {
 
   local object_name="object-$(date +%s)-${RANDOM}.txt"
   local composed_object_name="composed-object-$(date +%s)-${RANDOM}.txt"
+  local copied_object_name="copied-object-$(date +%s)-${RANDOM}.txt"
 
   run_example ./storage_object_samples insert-object \
       "${bucket_name}" "${object_name}" "a-string-to-serve-as-object-media"
@@ -173,11 +174,17 @@ run_all_object_examples() {
       "${object_name}"
   run_example ./storage_object_samples delete-object \
       "${bucket_name}" "${composed_object_name}"
+  run_example ./storage_object_samples copy-object \
+      "${bucket_name}" "${object_name}" \
+      "${bucket_name}" "${copied_object_name}"
+  run_example ./storage_object_samples delete-object \
+      "${bucket_name}" "${copied_object_name}"
   run_example ./storage_object_samples delete-object \
       "${bucket_name}" "${object_name}"
 
-  local encrypted_object_name="object-$(date +%s)-${RANDOM}.txt"
-  local encrypted_composed_object_name="composed-object-$(date +%s)-${RANDOM}.txt"
+  local encrypted_object_name="enc-obj-$(date +%s)-${RANDOM}.txt"
+  local encrypted_composed_object_name="composed-enc-obj-$(date +%s)-${RANDOM}.txt"
+  local encrypted_copied_object_name="copied-enc-obj-$(date +%s)-${RANDOM}.txt"
 
   local key="$(./storage_object_samples generate-encryption-key |
       grep 'Base64 encoded key' | awk '{print $5}')"
@@ -188,6 +195,15 @@ run_all_object_examples() {
   run_example ./storage_object_samples compose-object-from-encrypted-objects \
       "${bucket_name}" "${encrypted_composed_object_name}" "${key}" "${key}" \
       "${encrypted_object_name}" "${encrypted_object_name}"
+  run_example ./storage_object_samples read-encrypted-object \
+      "${bucket_name}" "${encrypted_composed_object_name}" "${key}"
+  run_example ./storage_object_samples copy-encrypted-object \
+      "${bucket_name}" "${encrypted_object_name}" \
+      "${bucket_name}" "${encrypted_copied_object_name}" "${key}"
+  run_example ./storage_object_samples read-encrypted-object \
+      "${bucket_name}" "${encrypted_copied_object_name}" "${key}"
+  run_example ./storage_object_samples delete-object \
+      "${bucket_name}" "${encrypted_copied_object_name}"
   run_example ./storage_object_samples delete-object \
       "${bucket_name}" "${encrypted_object_name}"
 

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -84,6 +84,65 @@ void InsertObject(google::cloud::storage::Client client, int& argc,
   (std::move(client), bucket_name, object_name, contents);
 }
 
+void CopyObject(google::cloud::storage::Client client, int& argc,
+                char* argv[]) {
+  if (argc != 5) {
+    throw Usage{
+        "copy-object <source-bucket-name> <source-object-name>"
+        " <destination-bucket-name> <destination-object-name>"};
+  }
+  auto source_bucket_name = ConsumeArg(argc, argv);
+  auto source_object_name = ConsumeArg(argc, argv);
+  auto destination_bucket_name = ConsumeArg(argc, argv);
+  auto destination_object_name = ConsumeArg(argc, argv);
+  //! [copy object]
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string source_bucket_name,
+     std::string source_object_name, std::string destination_bucket_name,
+     std::string destination_object_name) {
+    gcs::ObjectMetadata copy = client.CopyObject(
+        source_bucket_name, source_object_name, destination_bucket_name,
+        destination_object_name, gcs::ObjectMetadata());
+    std::cout << "Object copy. The full metadata after the copy is: " << copy
+              << std::endl;
+  }
+  //! [copy object]
+  (std::move(client), source_bucket_name, source_object_name,
+   destination_bucket_name, destination_object_name);
+}
+
+void CopyEncryptedObject(google::cloud::storage::Client client, int& argc,
+                         char* argv[]) {
+  if (argc != 6) {
+    throw Usage{
+        "copy-encrypted-object <source-bucket-name> <source-object-name>"
+        " <destination-bucket-name>"
+        " <destination-object-name> <destination-object-key>"};
+  }
+  auto source_bucket_name = ConsumeArg(argc, argv);
+  auto source_object_name = ConsumeArg(argc, argv);
+  auto destination_bucket_name = ConsumeArg(argc, argv);
+  auto destination_object_name = ConsumeArg(argc, argv);
+  auto key = ConsumeArg(argc, argv);
+  //! [copy encrypted object]
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string source_bucket_name,
+     std::string source_object_name,
+     std::string destination_bucket_name,
+     std::string destination_object_name, std::string key_base64) {
+    gcs::ObjectMetadata copy = client.CopyObject(
+        source_bucket_name, source_object_name, destination_bucket_name,
+        destination_object_name,
+        gcs::ObjectMetadata(),
+        gcs::EncryptionKey::FromBase64Key(key_base64));
+    std::cout << "Object copy. The full metadata after the copy is: " << copy
+              << std::endl;
+  }
+  //! [copy encrypted object]
+  (std::move(client), source_bucket_name, source_object_name,
+   destination_bucket_name, destination_object_name, key);
+}
+
 void GetObjectMetadata(google::cloud::storage::Client client, int& argc,
                        char* argv[]) {
   if (argc < 3) {
@@ -419,6 +478,8 @@ int main(int argc, char* argv[]) try {
   std::map<std::string, CommandType> commands = {
       {"list-objects", &ListObjects},
       {"insert-object", &InsertObject},
+      {"copy-object", &CopyObject},
+      {"copy-encrypted-object", &CopyEncryptedObject},
       {"get-object-metadata", &GetObjectMetadata},
       {"read-object", &ReadObject},
       {"delete-object", &DeleteObject},

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -100,11 +100,11 @@ void CopyObject(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string source_bucket_name,
      std::string source_object_name, std::string destination_bucket_name,
      std::string destination_object_name) {
-    gcs::ObjectMetadata copy = client.CopyObject(
+    gcs::ObjectMetadata new_copy_meta = client.CopyObject(
         source_bucket_name, source_object_name, destination_bucket_name,
         destination_object_name, gcs::ObjectMetadata());
-    std::cout << "Object copy. The full metadata after the copy is: " << copy
-              << std::endl;
+    std::cout << "Object copied. The full metadata after the copy is: "
+              << new_copy_meta << std::endl;
   }
   //! [copy object]
   (std::move(client), source_bucket_name, source_object_name,
@@ -116,8 +116,8 @@ void CopyEncryptedObject(google::cloud::storage::Client client, int& argc,
   if (argc != 6) {
     throw Usage{
         "copy-encrypted-object <source-bucket-name> <source-object-name>"
-        " <destination-bucket-name>"
-        " <destination-object-name> <destination-object-key>"};
+        " <destination-bucket-name> <destination-object-name>"
+        " <encryption-key-base64>"};
   }
   auto source_bucket_name = ConsumeArg(argc, argv);
   auto source_object_name = ConsumeArg(argc, argv);
@@ -127,16 +127,14 @@ void CopyEncryptedObject(google::cloud::storage::Client client, int& argc,
   //! [copy encrypted object]
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string source_bucket_name,
-     std::string source_object_name,
-     std::string destination_bucket_name,
+     std::string source_object_name, std::string destination_bucket_name,
      std::string destination_object_name, std::string key_base64) {
-    gcs::ObjectMetadata copy = client.CopyObject(
+    gcs::ObjectMetadata new_copy_meta = client.CopyObject(
         source_bucket_name, source_object_name, destination_bucket_name,
-        destination_object_name,
-        gcs::ObjectMetadata(),
+        destination_object_name, gcs::ObjectMetadata(),
         gcs::EncryptionKey::FromBase64Key(key_base64));
-    std::cout << "Object copy. The full metadata after the copy is: " << copy
-              << std::endl;
+    std::cout << "Object copied. The full metadata after the copy is: "
+    << new_copy_meta << std::endl;
   }
   //! [copy encrypted object]
   (std::move(client), source_bucket_name, source_object_name,

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -188,6 +188,25 @@ std::pair<Status, ObjectMetadata> CurlClient::InsertObjectMedia(
                         ObjectMetadata::ParseFromString(payload.payload));
 }
 
+std::pair<Status, ObjectMetadata> CurlClient::CopyObject(
+    CopyObjectRequest const& request) {
+  CurlRequestBuilder builder(
+      storage_endpoint_ + "/b/" + request.source_bucket() + "/o/" +
+          request.source_object() + "/copyTo/b/" +
+          request.destination_bucket() + "/o/" + request.destination_object(),
+      storage_factory_);
+  SetupBuilder(builder, request, "POST");
+  builder.AddHeader("Content-Type: application/json");
+  auto payload = builder.BuildRequest(request.json_payload()).MakeRequest();
+  if (payload.status_code >= 300) {
+    return std::make_pair(
+        Status{payload.status_code, std::move(payload.payload)},
+        ObjectMetadata{});
+  }
+  return std::make_pair(Status(),
+                        ObjectMetadata::ParseFromString(payload.payload));
+}
+
 std::pair<Status, ObjectMetadata> CurlClient::GetObjectMetadata(
     GetObjectMetadataRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -83,6 +83,8 @@ class CurlClient : public RawClient {
 
   std::pair<Status, ListBucketAclResponse> ListBucketAcl(
       ListBucketAclRequest const& request) override;
+  std::pair<Status, ObjectMetadata> CopyObject(
+      CopyObjectRequest const& request) override;
   std::pair<Status, BucketAccessControl> CreateBucketAcl(
       CreateBucketAclRequest const&) override;
   std::pair<Status, BucketAccessControl> GetBucketAcl(

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -118,6 +118,11 @@ std::pair<Status, ObjectMetadata> LoggingClient::InsertObjectMedia(
   return MakeCall(*client_, &RawClient::InsertObjectMedia, request, __func__);
 }
 
+std::pair<Status, ObjectMetadata> LoggingClient::CopyObject(
+    CopyObjectRequest const& request) {
+  return MakeCall(*client_, &RawClient::CopyObject, request, __func__);
+}
+
 std::pair<Status, ObjectMetadata> LoggingClient::GetObjectMetadata(
     GetObjectMetadataRequest const& request) {
   return MakeCall(*client_, &RawClient::GetObjectMetadata, request, __func__);

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -47,6 +47,8 @@ class LoggingClient : public RawClient {
 
   std::pair<Status, ObjectMetadata> InsertObjectMedia(
       InsertObjectMediaRequest const& request) override;
+  std::pair<Status, ObjectMetadata> CopyObject(
+      CopyObjectRequest const& request) override;
   std::pair<Status, ObjectMetadata> GetObjectMetadata(
       GetObjectMetadataRequest const& request) override;
   std::pair<Status, std::unique_ptr<ObjectReadStreambuf>> ReadObject(

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -130,11 +130,12 @@ std::ostream& operator<<(std::ostream& os,
  */
 class CopyObjectRequest
     : public GenericRequest<
-          CopyObjectRequest, DestinationPredefinedAcl, IfGenerationMatch,
-          IfGenerationNotMatch, IfMetagenerationMatch, IfMetagenerationNotMatch,
-          IfSourceGenerationMatch, IfSourceGenerationNotMatch,
-          IfSourceMetagenerationMatch, IfSourceMetagenerationNotMatch,
-          Projection, SourceGeneration, UserProject> {
+          CopyObjectRequest, DestinationPredefinedAcl, EncryptionKey,
+          IfGenerationMatch, IfGenerationNotMatch, IfMetagenerationMatch,
+          IfMetagenerationNotMatch, IfSourceGenerationMatch,
+          IfSourceGenerationNotMatch, IfSourceMetagenerationMatch,
+          IfSourceMetagenerationNotMatch, Projection, SourceGeneration,
+          UserProject> {
  public:
   CopyObjectRequest() = default;
   CopyObjectRequest(std::string source_bucket, std::string source_object,

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -65,6 +65,8 @@ class RawClient {
   /// @name Object resource operations
   virtual std::pair<Status, ObjectMetadata> InsertObjectMedia(
       InsertObjectMediaRequest const&) = 0;
+  virtual std::pair<Status, ObjectMetadata> CopyObject(
+      CopyObjectRequest const&) = 0;
   virtual std::pair<Status, ObjectMetadata> GetObjectMetadata(
       GetObjectMetadataRequest const& request) = 0;
   virtual std::pair<Status, std::unique_ptr<ObjectReadStreambuf>> ReadObject(

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -167,6 +167,14 @@ std::pair<Status, ObjectMetadata> RetryClient::InsertObjectMedia(
                   &RawClient::InsertObjectMedia, request, __func__);
 }
 
+std::pair<Status, ObjectMetadata> RetryClient::CopyObject(
+    CopyObjectRequest const& request) {
+  auto retry_policy = retry_policy_->clone();
+  auto backoff_policy = backoff_policy_->clone();
+  return MakeCall(*retry_policy, *backoff_policy, *client_,
+                  &RawClient::CopyObject, request, __func__);
+}
+
 std::pair<Status, ObjectMetadata> RetryClient::GetObjectMetadata(
     GetObjectMetadataRequest const& request) {
   auto retry_policy = retry_policy_->clone();

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -58,6 +58,8 @@ class RetryClient : public RawClient {
 
   std::pair<Status, ObjectMetadata> InsertObjectMedia(
       InsertObjectMediaRequest const& request) override;
+  std::pair<Status, ObjectMetadata> CopyObject(
+      CopyObjectRequest const& request) override;
   std::pair<Status, ObjectMetadata> GetObjectMetadata(
       GetObjectMetadataRequest const& request) override;
   std::pair<Status, std::unique_ptr<ObjectReadStreambuf>> ReadObject(

--- a/google/cloud/storage/object_metadata.cc
+++ b/google/cloud/storage/object_metadata.cc
@@ -96,7 +96,7 @@ ObjectMetadata ObjectMetadata::ParseFromString(std::string const& payload) {
 
 std::string ObjectMetadata::JsonPayloadForUpdate() const {
   auto json = JsonForUpdate();
-  return json.dump();
+  return json.empty() ? "{}" : json.dump();
 }
 
 std::string ObjectMetadata::JsonPayloadForCopy() const {
@@ -106,7 +106,7 @@ std::string ObjectMetadata::JsonPayloadForCopy() const {
   // copy but are not included in an update.  The server has the checksums for
   // a copy though, so it does not seem necessary to send them. When we
   // implement #564 we should revisit this decision.
-  return json.dump();
+  return json.empty() ? "{}" : json.dump();
 }
 
 internal::nl::json ObjectMetadata::JsonForUpdate() const {

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -49,6 +49,8 @@ class MockClient : public google::cloud::storage::internal::RawClient {
   MOCK_METHOD1(InsertObjectMedia,
                ResponseWrapper<storage::ObjectMetadata>(
                    internal::InsertObjectMediaRequest const&));
+  MOCK_METHOD1(CopyObject, ResponseWrapper<storage::ObjectMetadata>(
+                               internal::CopyObjectRequest const&));
   MOCK_METHOD1(GetObjectMetadata,
                ResponseWrapper<storage::ObjectMetadata>(
                    internal::GetObjectMetadataRequest const&));

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -361,6 +361,34 @@ TEST_F(ObjectIntegrationTest, ReadNotFound) {
   EXPECT_FALSE(stream.IsOpen());
 }
 
+TEST_F(ObjectIntegrationTest, Copy) {
+  Client client;
+  auto bucket_name = ObjectTestEnvironment::bucket_name();
+  auto source_object_name = MakeRandomObjectName();
+  auto destination_object_name = MakeRandomObjectName();
+
+  std::string expected = LoremIpsum();
+
+  ObjectMetadata source_meta = client.InsertObject(
+      bucket_name, source_object_name, expected, IfGenerationMatch(0));
+  EXPECT_EQ(source_object_name, source_meta.name());
+  EXPECT_EQ(bucket_name, source_meta.bucket());
+
+  ObjectMetadata meta = client.CopyObject(
+      bucket_name, source_object_name, bucket_name, destination_object_name,
+      ObjectMetadata().set_content_type("text/plain"));
+  EXPECT_EQ(destination_object_name, meta.name());
+  EXPECT_EQ(bucket_name, meta.bucket());
+  EXPECT_EQ("text/plain", meta.content_type());
+
+  auto stream = client.ReadObject(bucket_name, destination_object_name);
+  std::string actual(std::istreambuf_iterator<char>{stream}, {});
+  EXPECT_EQ(expected, actual);
+
+  client.DeleteObject(bucket_name, destination_object_name);
+  client.DeleteObject(bucket_name, source_object_name);
+}
+
 TEST_F(ObjectIntegrationTest, StreamingWrite) {
   Client client;
   auto bucket_name = ObjectTestEnvironment::bucket_name();


### PR DESCRIPTION
This fixes #812. It implements the API, the usual unit tests, adds a
new test case in the integration tests, adds the example, and runs
the example as part of the CI build.

The testbench has a number of changes to validate the encryption keys,
we do not encrypt the data, but verify that reads use the same keys that
were passed on the write operation.

Note that `Objects: copy` only uses the `x-goog-encryption-*` headers,
trying to use different encryption keys for the source and destination
does not work against production, though the documentation is unclear.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1101)
<!-- Reviewable:end -->
