### PR TITLE
Issue #1055 adding sample snippet for TableAdmin::GetSnapshot

### DIFF
--- a/google/cloud/bigtable/examples/bigtable_samples.cc
+++ b/google/cloud/bigtable/examples/bigtable_samples.cc
@@ -302,6 +302,17 @@ void WaitForConsistencyCheck(google::cloud::bigtable::TableAdmin admin,
 }
 //! [wait for consistency check]
 
+//! [get snapshot]
+void GetSnapshot(google::cloud::bigtable::TableAdmin admin,
+                 std::string const& cluster_id_str,
+                 std::string const& snapshot_id_str) {
+  google::cloud::bigtable::ClusterId cluster_id(cluster_id_str);
+  google::cloud::bigtable::SnapshotId snapshot_id(snapshot_id_str);
+  auto snapshot = admin.GetSnapshot(cluster_id, snapshot_id);
+  std::cout << "GetSnapshot name : " << snapshot.name() << std::endl;
+}
+//! [get snapshot]
+
 //! [sample row keys]
 void SampleRows(google::cloud::bigtable::Table table) {
   auto samples = table.SampleRows<>();

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -292,6 +292,9 @@ class TableAdmin {
    * @return the information about the snapshot.
    * @throws std::exception if the information could not be obtained before the
    *     RPC policies in effect gave up.
+   *
+   * @par Example
+   * @snippet bigtable_samples.cc get snapshot
    */
   google::bigtable::admin::v2::Snapshot GetSnapshot(
       bigtable::ClusterId const& cluster_id,


### PR DESCRIPTION
Here adding Snippet for GetSnapshot, but following thing  I have left, due to not clear idea
1. calling GetSnapshot snippet, In main function in bigtable_samples.cc ( because it require snapshot_id and cluster_id but except snapshot nippets other doesn't require)
2. call for GetSnapshot in run_examples_utils.sh ( as we are not running agaist emulator as of now)

Fixes issue #1055.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1103)
<!-- Reviewable:end -->
