### PR TITLE
Implement request classes for {Get,Set,Test}BucketIam*.

### DIFF
--- a/google/cloud/iam_bindings.h
+++ b/google/cloud/iam_bindings.h
@@ -52,13 +52,13 @@ class IamBindings {
    * Returns an iterator referring to the first element in IamBindings
    * container.
    */
-  iterator begin() { return bindings_.begin(); }
+  iterator begin() const { return bindings_.begin(); }
 
   /**
    * Returns an iterator referring to the past-the-end element in IamBindings
    * container.
    */
-  iterator end() { return bindings_.end(); }
+  iterator end() const { return bindings_.end(); }
 
   /**
    * Returns whether the Bindings container is empty.

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/bucket_requests.h"
+#include "google/cloud/storage/internal/nljson.h"
 #include <iostream>
 
 namespace google {
@@ -187,6 +188,55 @@ std::ostream& operator<<(std::ostream& os, PatchBucketRequest const& r) {
   os << "PatchBucketRequest={bucket_name=" << r.bucket();
   r.DumpOptions(os, ", ");
   return os << ", payload=" << r.payload() << "}";
+}
+
+std::ostream& operator<<(std::ostream& os, GetBucketIamPolicyRequest const& r) {
+  os << "GetBucketIamPolicyRequest={bucket_name=" << r.bucket_name();
+  r.DumpOptions(os, ", ");
+  return os << "}";
+}
+
+SetBucketIamPolicyRequest::SetBucketIamPolicyRequest(
+    std::string bucket_name, google::cloud::IamPolicy const& policy)
+    : bucket_name_(std::move(bucket_name)) {
+  internal::nl::json iam{
+      {"kind", "storage#policy"},
+      {"etag", policy.etag},
+  };
+  internal::nl::json bindings;
+  for (auto const& binding : policy.bindings) {
+    internal::nl::json b{
+        {"role", binding.first},
+    };
+    internal::nl::json m;
+    for (auto const& member : binding.second) {
+      m.emplace_back(member);
+    }
+    b["members"] = std::move(m);
+    bindings.emplace_back(std::move(b));
+  }
+  iam["bindings"] = std::move(bindings);
+  json_payload_ = iam.dump();
+}
+
+std::ostream& operator<<(std::ostream& os, SetBucketIamPolicyRequest const& r) {
+  os << "GetBucketIamPolicyRequest={bucket_name=" << r.bucket_name();
+  r.DumpOptions(os, ", ");
+  return os << ", json_payload=" << r.json_payload() << "}";
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         TestBucketIamPermissionsRequest const& r) {
+  os << "TestBucketIamPermissionsREquest={bucket_name=" << r.bucket_name()
+     << ", permissions=[";
+  char const* sep = "";
+  for (auto const& p : r.permissions()) {
+    os << sep << p;
+    sep = ", ";
+  }
+  os << "]";
+  r.DumpOptions(os, ", ");
+  return os << "}";
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/bucket_requests.h
+++ b/google/cloud/storage/internal/bucket_requests.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_BUCKET_REQUESTS_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_BUCKET_REQUESTS_H_
 
+#include "google/cloud/iam_policy.h"
 #include "google/cloud/storage/bucket_metadata.h"
 #include "google/cloud/storage/internal/generic_request.h"
 #include "google/cloud/storage/internal/http_response.h"
@@ -179,6 +180,68 @@ class PatchBucketRequest
 };
 
 std::ostream& operator<<(std::ostream& os, PatchBucketRequest const& r);
+
+/**
+ * Represents a request to the `Buckets: getIamPolicy` API.
+ */
+class GetBucketIamPolicyRequest
+    : public GenericRequest<GetBucketIamPolicyRequest, UserProject> {
+ public:
+  GetBucketIamPolicyRequest() = default;
+  explicit GetBucketIamPolicyRequest(std::string bucket_name)
+      : bucket_name_(std::move(bucket_name)) {}
+
+  std::string const& bucket_name() const { return bucket_name_; }
+
+ private:
+  std::string bucket_name_;
+};
+
+std::ostream& operator<<(std::ostream& os, GetBucketIamPolicyRequest const& r);
+
+/**
+ * Represents a request to the `Buckets: getIamPolicy` API.
+ */
+class SetBucketIamPolicyRequest
+    : public GenericRequest<SetBucketIamPolicyRequest, UserProject> {
+ public:
+  SetBucketIamPolicyRequest() = default;
+  explicit SetBucketIamPolicyRequest(std::string bucket_name,
+                                     google::cloud::IamPolicy const& policy);
+
+  std::string const& bucket_name() const { return bucket_name_; }
+  std::string const& json_payload() const { return json_payload_; }
+
+ private:
+  std::string bucket_name_;
+  std::string json_payload_;
+};
+
+std::ostream& operator<<(std::ostream& os, SetBucketIamPolicyRequest const& r);
+
+/**
+ * Represents a request to the `Buckets: testIamPolicyPermissions` API.
+ */
+class TestBucketIamPermissionsRequest
+    : public GenericRequest<TestBucketIamPermissionsRequest, UserProject> {
+ public:
+  TestBucketIamPermissionsRequest() = default;
+  explicit TestBucketIamPermissionsRequest(std::string bucket_name,
+                                           std::vector<std::string> permissions)
+      : bucket_name_(std::move(bucket_name)),
+        permissions_(std::move(permissions)) {}
+
+  std::string const& bucket_name() const { return bucket_name_; }
+  std::vector<std::string> const& permissions() const { return permissions_; }
+
+ private:
+  std::string bucket_name_;
+  std::vector<std::string> permissions_;
+};
+
+std::ostream& operator<<(std::ostream& os,
+                         TestBucketIamPermissionsRequest const& r);
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -15,10 +15,6 @@
 #include "google/cloud/storage/internal/bucket_requests.h"
 #include <gmock/gmock.h>
 
-namespace google_cloud_storage_internal_nlohmann_3_1_2 {
-inline void PrintTo(json const& json, std::ostream* os) { *os << json.dump(); }
-}  // namespace google_cloud_storage_internal_nlohmann_3_1_2
-
 namespace google {
 namespace cloud {
 namespace storage {

--- a/google/cloud/storage/internal/nljson.h
+++ b/google/cloud/storage/internal/nljson.h
@@ -34,6 +34,21 @@
 
 #define nlohmann google_cloud_storage_internal_nlohmann_3_1_2
 #include <nlohmann/json.hpp>
+
+namespace nlohmann {
+//
+// Google Test uses PrintTo (with many overloads) to print the results of failed
+// comparisons. Most of the time the default overloads for PrintTo() provided
+// by Google Test magically do the job picking a good way to print things, but
+// in this case there is a bug:
+//     https://github.com/nlohmann/json/issues/709
+// explicitly defining an overload, which must be in the namespace of the class,
+// works around the problem, see ADL for why it must be in the right namespace:
+//     https://en.wikipedia.org/wiki/Argument-dependent_name_lookup
+//
+/// Prints json objects to output streams from within Google Test.
+inline void PrintTo(json const& j, std::ostream* os) { *os << j.dump(); }
+}  // namespace nlohmann
 #undef nlohmann
 
 namespace google {


### PR DESCRIPTION
This is part of the work for #846, #847, and #848. It implements the
request classes for GetBucketIamPolicy, SetBucketIamPolicy, and
TestBucketIamPermissions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1110)
<!-- Reviewable:end -->
