### PR TITLE
Check callback parameters for asynchronous calls.

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(google_cloud_cpp_common
             internal/port_platform.h
             internal/random.h
             internal/random.cc
+            internal/invoke_result.h
             internal/retry_policy.h
             internal/setenv.h
             internal/setenv.cc
@@ -118,6 +119,7 @@ set(google_cloud_cpp_common_unit_tests
     internal/backoff_policy_test.cc
     internal/optional_test.cc
     internal/random_test.cc
+    internal/invoke_result_test.cc
     internal/retry_policy_test.cc
     internal/throw_delegate_test.cc
     log_test.cc)

--- a/google/cloud/bigtable/internal/table.h
+++ b/google/cloud/bigtable/internal/table.h
@@ -137,7 +137,12 @@ class Table {
    * @return A handle to the asynchronous operation, applications can request
    *   the operation to be canceled.
    */
-  template <typename Functor>
+  template <typename Functor,
+            typename std::enable_if<
+                google::cloud::internal::is_invocable<
+                    Functor, google::bigtable::v2::MutateRowResponse&,
+                    grpc::Status&>::value,
+                int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncApply(SingleRowMutation&& mut,
                                              CompletionQueue& cq,
                                              Functor&& callback) {

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -9,6 +9,7 @@ google_cloud_cpp_common_HDRS = [
     "internal/optional.h",
     "internal/port_platform.h",
     "internal/random.h",
+    "internal/invoke_result.h",
     "internal/retry_policy.h",
     "internal/setenv.h",
     "internal/throw_delegate.h",

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -4,6 +4,7 @@ google_cloud_cpp_common_unit_tests = [
     "internal/backoff_policy_test.cc",
     "internal/optional_test.cc",
     "internal/random_test.cc",
+    "internal/invoke_result_test.cc",
     "internal/retry_policy_test.cc",
     "internal/throw_delegate_test.cc",
     "log_test.cc",

--- a/google/cloud/internal/invoke_result.h
+++ b/google/cloud/internal/invoke_result.h
@@ -1,0 +1,180 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_INVOKE_RESULT_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_INVOKE_RESULT_H_
+
+#include "google/cloud/version.h"
+#include <type_traits>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+/**
+ * A helper to detect if expressions are valid and use SFINAE.
+ *
+ * This class will be introduced in C++17, it makes it easier to write SFINAE
+ * expressions, basically you use `void_t< some expression here >` in the SFINAE
+ * branch that is trying to test if `some expression here` is valid. If the
+ * expression is valid it expands to `void` and your branch continues, if it is
+ * invalid it fails and the default SFINAE branch is used.
+ *
+ * @see https://en.cppreference.com/w/cpp/types/void_t for more details about
+ *   this class.
+ */
+template <typename...>
+using void_t = void;
+
+/**
+ * A helper class to determine the result type of a function-like object.
+ *
+ * We want to define a class similar to `std::invoke_result<>` from C++17, to do
+ * so we need to know the result type of calling the function-like `F` with some
+ * parameters. But knowing how to call it depends on what `F` is:
+ *
+ * For function-like objects you would want to test the expression `f(a...)`,
+ * where `f` is of type `F` and `a...` are the arguments
+ *
+ * For pointer to member-like objects you would want to test the expression
+ * `a->f(b...)` where a is the first parameter (if a pointer) and `b...` are the
+ * remaining parameters.
+ *
+ * This of course gets more complicated with references (`a.f(b...)`), derived
+ * classes, etc.
+ *
+ * Fortunately, we just need to implement the easy case (function-like things)
+ * in the library:
+ *
+ * @tparam T the decayed (via `std::decay`) type of F.
+ */
+template <typename T>
+struct invoke_impl {
+  /**
+   * Determine the result type of calling `f(ArgTypes...)`
+   *
+   * @param f the function-like object to call.
+   * @param a the parameters to call @p f with.
+   * @tparam F the type of the function-like object, note that in some cases the
+   *     function-like object may have multiple overloaded `operator()`, with
+   *     different return types for each.
+   * @tparam ArgTypes the types of the parameters.
+   * @return the result of `f(a...)`;
+   */
+  template <typename F, typename... ArgTypes>
+  static auto call(F&& f, ArgTypes&&... a)
+      -> decltype(std::forward<F>(f)(std::forward<ArgTypes>(a)...)) {
+    return std::forward<F>(f)(std::forward<ArgTypes>(a)...);
+  }
+};
+
+/**
+ * Discover the result type of `INVOKE(f, a...)`.
+ *
+ * Recall that C++11 defines *invoking* a function-like object with given
+ * parameters in as calling `F` with the given arguments, where `F` can be a
+ * lambda type, a class with (potentially multiple) `operator()` defined, a
+ * pointer to function, a pointer to member function, etc.
+ *
+ * @param f a function-like object to be called.
+ * @param a the arguments to call @p `f` with.
+ * @tparam F the type of the function-like object.
+ * @tparam ArgTypes
+ * @tparam Fd the decayed (via std::decay<>) of F.
+ * @return
+ *
+ * @see https://en.cppreference.com/w/cpp/utility/functional/invoke for a longer
+ *     discussion about invoking functions in C++.
+ *
+ * @see https://en.cppreference.com/w/cpp/types/decay for a discussion of
+ *     decaying function types.
+ */
+template <class F, class... ArgTypes, class Fd = typename std::decay<F>::type>
+auto invoker_function(F&& f, ArgTypes&&... a)
+    -> decltype(invoke_impl<Fd>::call(std::forward<F>(f),
+                                      std::forward<ArgTypes>(a)...));
+
+// The default (failure) SFINAE branch for `invoke_result_impl`.
+template <typename AlwaysVoid, typename, typename...>
+struct invoke_result_impl {};
+
+/**
+ * The implementation details for `invoke_result<>`.
+ *
+ * This meta function discovers if `F` can be invoked with `ArgTypes`, and if
+ * so, captures the return type in the `type` trait.
+ *
+ * @tparam F the type of the function-like object.
+ * @tparam ArgTypes the types of the arguments.
+ */
+template <typename F, typename... ArgTypes>
+struct invoke_result_impl<decltype(void(invoker_function(
+                              std::declval<F>(), std::declval<ArgTypes>()...))),
+                          F, ArgTypes...> {
+  using type = decltype(
+      invoker_function(std::declval<F>(), std::declval<ArgTypes>()...));
+};
+
+/**
+ * Implement `std::invoke_result<>` from C++17.
+ *
+ * `std::invoke_result<>` is a meta-function to discover (a) if
+ * `std::invoke(F&&, ArgTypes&&...)` is valid (roughly: if one can call a
+ * function-like object of type `F` with parameters `ArgTypes&&`), and (b) what
+ * is the return type of `std::invoke(...)` if that is the case.
+ *
+ * C++11 provides a similar meta-function: `std::result_of<>`, but unfortunately
+ * it is undefined behavior to use it with an invalid expression.
+ *
+ * @tparam F the type of the function-like object.
+ * @tparam ArgTypes the type of the arguments.
+ *
+ * @see https://en.cppreference.com/w/cpp/types/result_of for more information
+ *     about `std::invoke_result` and `std::result_of` (deprecated in C++17).
+ */
+template <typename F, typename... ArgTypes>
+struct invoke_result : public invoke_result_impl<void, F, ArgTypes...> {};
+
+/// Implement the C++17 `std::invoke_result_t<>` meta-function.
+template <typename F, typename... ArgTypes>
+using invoke_result_t = typename invoke_result<F, ArgTypes...>::type;
+
+// The default (failure) SFINAE branch for `is_invocable_impl`.
+template <typename AlwaysVoid, typename, typename...>
+struct is_invocable_impl : public std::false_type {};
+
+template <typename F, typename... ArgTypes>
+struct is_invocable_impl<decltype(void(invoker_function(
+                             std::declval<F>(), std::declval<ArgTypes>()...))),
+                         F, ArgTypes...> : public std::true_type {};
+
+/**
+ * Implement `std::is_invocable<>` from C++17.
+ *
+ * `std::is_invocable<>` is a meta-function top discover if
+ * `std::invoke(F&&, ArgTypes&&...)` is valid (roughly: if one can call a
+ * function-like object of type `F` with parameters `ArgTypes&&`).
+ *
+ * @tparam F the type of the function-like object.
+ * @tparam ArgTypes the type of the arguments.
+ */
+template <typename F, typename... ArgTypes>
+struct is_invocable : public is_invocable_impl<void, F, ArgTypes...> {};
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_INVOKE_RESULT_H_

--- a/google/cloud/internal/invoke_result.h
+++ b/google/cloud/internal/invoke_result.h
@@ -57,7 +57,10 @@ using void_t = void;
  * Fortunately, we just need to implement the easy case (function-like things)
  * in the library:
  *
- * @tparam T the decayed (via `std::decay`) type of F.
+ * @tparam T the decayed (via `std::decay`) type of F. Currently unused, but if
+ *     we ever specialize this class to work with pointers to member functions
+ *     and other more complex function-like things it would be used to pick the
+ *     specialization.
  */
 template <typename T>
 struct invoke_impl {
@@ -162,7 +165,7 @@ struct is_invocable_impl<decltype(void(invoker_function(
 /**
  * Implement `std::is_invocable<>` from C++17.
  *
- * `std::is_invocable<>` is a meta-function top discover if
+ * `std::is_invocable<>` is a meta-function to discover if
  * `std::invoke(F&&, ArgTypes&&...)` is valid (roughly: if one can call a
  * function-like object of type `F` with parameters `ArgTypes&&`).
  *

--- a/google/cloud/internal/invoke_result_test.cc
+++ b/google/cloud/internal/invoke_result_test.cc
@@ -42,24 +42,24 @@ TEST(ResultOfTest, Function) {
 
   using R1 = decltype(invoker_function(test_function, 7, std::string{}));
   static_assert(std::is_same<R1, std::string>::value,
-                "expected `std::string` in decltype(invoker_function())");
+                "expected `std::string` in R1==decltype(invoker_function())");
 
   using R2 = decltype(invoker_function(test_function, std::declval<int>(),
                                        std::declval<std::string const&>()));
   static_assert(std::is_same<R2, std::string>::value,
-                "expected `std::string` in decltype(invoker_function())");
+                "expected `std::string` in R2==decltype(invoker_function())");
   EXPECT_TRUE((std::is_same<R2, std::string>::value));
 
   using F = decltype(test_function);
   using R3 = decltype(invoker_function(std::declval<F>(), std::declval<int>(),
                                        std::declval<std::string const&>()));
   static_assert(std::is_same<R3, std::string>::value,
-                "expected `std::string` in decltype(invoker_function())");
+                "expected `std::string` in R3==decltype(invoker_function())");
   EXPECT_TRUE((std::is_same<R3, std::string>::value));
 
   using R4 = invoke_result<F, int, std::string const&>;
   static_assert(std::is_same<R4::type, std::string>::value,
-                "expected `std::string` in invoke_result_t<>");
+                "expected `std::string` in R4==invoke_result_t<>");
 
   static_assert(
       is_invocable<F, int, std::string const&>::value,

--- a/google/cloud/internal/invoke_result_test.cc
+++ b/google/cloud/internal/invoke_result_test.cc
@@ -1,0 +1,88 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/invoke_result.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+namespace {
+TEST(ResultOfTest, Lambda) {
+  // This test mostly uses static assertions because the result_of classes are
+  // largely meta-functions.
+
+  auto l = [](long, int) -> int { return 7; };
+
+  using F = decltype(l);
+
+  using R = invoke_result<F, long, int>::type;
+
+  static_assert(std::is_same<R, int>::value,
+                "expected `int` in invoke_result_t<>");
+}
+
+std::string test_function(int, std::string const&) { return "42"; }
+
+TEST(ResultOfTest, Function) {
+  // This test mostly uses static assertions because the result_of classes are
+  // largely meta-functions.
+
+  using R1 = decltype(invoker_function(test_function, 7, std::string{}));
+  static_assert(std::is_same<R1, std::string>::value,
+                "expected `std::string` in decltype(invoker_function())");
+
+  using R2 = decltype(invoker_function(test_function, std::declval<int>(),
+                                       std::declval<std::string const&>()));
+  static_assert(std::is_same<R2, std::string>::value,
+                "expected `std::string` in decltype(invoker_function())");
+  EXPECT_TRUE((std::is_same<R2, std::string>::value));
+
+  using F = decltype(test_function);
+  using R3 = decltype(invoker_function(std::declval<F>(), std::declval<int>(),
+                                       std::declval<std::string const&>()));
+  static_assert(std::is_same<R3, std::string>::value,
+                "expected `std::string` in decltype(invoker_function())");
+  EXPECT_TRUE((std::is_same<R3, std::string>::value));
+
+  using R4 = invoke_result<F, int, std::string const&>;
+  static_assert(std::is_same<R4::type, std::string>::value,
+                "expected `std::string` in invoke_result_t<>");
+
+  static_assert(
+      is_invocable<F, int, std::string const&>::value,
+      "expected `is_invocable<F, int, std::string const&>` to be true");
+
+  static_assert(is_invocable<F, int, std::string>::value,
+                "expected `is_invocable<F, int, std::string>` to be true");
+
+  static_assert(is_invocable<F, int, std::string&>::value,
+                "expected `is_invocable<F, int, std::string&>` to be true");
+
+  static_assert(not is_invocable<F, std::string>::value,
+                "expected `is_invocable<F, std::string>` to be false");
+
+  static_assert(not is_invocable<F>::value,
+                "expected `is_invocable<F>` to be false");
+
+  // Some compilers create warnings/errors if the function is not used, even
+  // though in this test we are mostly interested in its type.
+  EXPECT_EQ("42", test_function(7, "7"));
+}
+}  // namespace
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
This is part of the work for #1002.  The callback parameters must meet
specific requirements. With this change each asynchronous function
enforces those parameters via `std::enable_if<>`, which (generally) produces
more readable error messages than just letting the compiler figure it out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1113)
<!-- Reviewable:end -->
