### PR TITLE
Cleanup well-known parameters.

### DIFF
--- a/google/cloud/storage/testing/mock_http_request.h
+++ b/google/cloud/storage/testing/mock_http_request.h
@@ -66,21 +66,23 @@ class MockHttpRequestBuilder {
   using RequestType = MockHttpRequest;
 
   template <typename P>
-  void AddWellKnownParameter(WellKnownParameter<P, std::string> const& p) {
+  void AddWellKnownParameter(
+      internal::WellKnownParameter<P, std::string> const& p) {
     if (p.has_value()) {
       mock->AddQueryParameter(p.parameter_name(), p.value());
     }
   }
 
   template <typename P>
-  void AddWellKnownParameter(WellKnownParameter<P, std::int64_t> const& p) {
+  void AddWellKnownParameter(
+      internal::WellKnownParameter<P, std::int64_t> const& p) {
     if (p.has_value()) {
       mock->AddQueryParameter(p.parameter_name(), std::to_string(p.value()));
     }
   }
 
   template <typename P>
-  void AddWellKnownParameter(WellKnownParameter<P, bool> const& p) {
+  void AddWellKnownParameter(internal::WellKnownParameter<P, bool> const& p) {
     if (not p.has_value()) {
       return;
     }

--- a/google/cloud/storage/well_known_parameters.h
+++ b/google/cloud/storage/well_known_parameters.h
@@ -24,6 +24,7 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
+namespace internal {
 /**
  * Defines well-known request headers using the CRTP.
  *
@@ -52,9 +53,16 @@ std::ostream& operator<<(std::ostream& os,
   }
   return os << rhs.parameter_name() << "=<not set>";
 }
+}  // namespace internal
 
+/**
+ * Sets the contentEncoding option for object uploads.
+ *
+ * The contentEncoding option allows applications to describe how is the data
+ * encoded (binary or ASCII) in upload requests.
+ */
 struct ContentEncoding
-    : public WellKnownParameter<ContentEncoding, std::string> {
+    : public internal::WellKnownParameter<ContentEncoding, std::string> {
   using WellKnownParameter<ContentEncoding, std::string>::WellKnownParameter;
   static char const* well_known_parameter_name() { return "contentEncoding"; }
 };
@@ -70,24 +78,47 @@ struct ContentEncoding
  * https://cloud.google.com/storage/docs/json_api/v1/how-tos/performance#partial-response
  *     for general documentation on how to use this parameter.
  */
-struct Fields : public WellKnownParameter<Fields, std::string> {
+struct Fields : public internal::WellKnownParameter<Fields, std::string> {
   using WellKnownParameter<Fields, std::string>::WellKnownParameter;
   static char const* well_known_parameter_name() { return "fields"; }
 };
 
-struct Generation : public WellKnownParameter<Generation, std::int64_t> {
+/**
+ * Set the version of an object to operate on.
+ *
+ * For objects in Buckets with `versioning` enabled, the application sometimes
+ * needs to specify which version of the object should the request target. This
+ * is an optional query parameter to control the version.
+ *
+ * @see https://cloud.google.com/storage/docs/object-versioning for more
+ *     information on GCS Object versioning.
+ */
+struct Generation
+    : public internal::WellKnownParameter<Generation, std::int64_t> {
   using WellKnownParameter<Generation, std::int64_t>::WellKnownParameter;
   static char const* well_known_parameter_name() { return "generation"; }
 };
 
+/**
+ * A pre-condition: the request succeeds only if the object generation matches.
+ *
+ * @note Setting this to 0 makes the pre-condition succeed only if there are no
+ *     live versions of the object.
+ */
 struct IfGenerationMatch
-    : public WellKnownParameter<IfGenerationMatch, std::int64_t> {
+    : public internal::WellKnownParameter<IfGenerationMatch, std::int64_t> {
   using WellKnownParameter<IfGenerationMatch, std::int64_t>::WellKnownParameter;
   static char const* well_known_parameter_name() { return "ifGenerationMatch"; }
 };
 
+/**
+ * A pre-condition: the request succeeds unless the object generation matches.
+ *
+ * @note When set to 0 the pre-condition succeeds only if there are live
+ *    versions of the object.
+ */
 struct IfGenerationNotMatch
-    : public WellKnownParameter<IfGenerationNotMatch, std::int64_t> {
+    : public internal::WellKnownParameter<IfGenerationNotMatch, std::int64_t> {
   using WellKnownParameter<IfGenerationNotMatch,
                            std::int64_t>::WellKnownParameter;
   static char const* well_known_parameter_name() {
@@ -95,8 +126,11 @@ struct IfGenerationNotMatch
   }
 };
 
+/**
+ * A pre-condition: the request succeeds if the metadata generation matches.
+ */
 struct IfMetagenerationMatch
-    : public WellKnownParameter<IfMetagenerationMatch, std::int64_t> {
+    : public internal::WellKnownParameter<IfMetagenerationMatch, std::int64_t> {
   using WellKnownParameter<IfMetagenerationMatch,
                            std::int64_t>::WellKnownParameter;
   static char const* well_known_parameter_name() {
@@ -104,8 +138,12 @@ struct IfMetagenerationMatch
   }
 };
 
+/**
+ * A pre-condition: the request succeeds unless the metadata generation matches.
+ */
 struct IfMetagenerationNotMatch
-    : public WellKnownParameter<IfMetagenerationNotMatch, std::int64_t> {
+    : public internal::WellKnownParameter<IfMetagenerationNotMatch,
+                                          std::int64_t> {
   using WellKnownParameter<IfMetagenerationNotMatch,
                            std::int64_t>::WellKnownParameter;
   static char const* well_known_parameter_name() {
@@ -113,8 +151,15 @@ struct IfMetagenerationNotMatch
   }
 };
 
+/**
+ * A pre-condition: the request succeeds if the source object generation
+ * matches.
+ *
+ * This is only used in CopyObject and RewriteObject operations.
+ */
 struct IfSourceGenerationMatch
-    : public WellKnownParameter<IfSourceGenerationMatch, std::int64_t> {
+    : public internal::WellKnownParameter<IfSourceGenerationMatch,
+                                          std::int64_t> {
   using WellKnownParameter<IfSourceGenerationMatch,
                            std::int64_t>::WellKnownParameter;
   static char const* well_known_parameter_name() {
@@ -122,8 +167,13 @@ struct IfSourceGenerationMatch
   }
 };
 
+/**
+ * A pre-condition: the request succeeds unless the source object generation
+ * matches.
+ */
 struct IfSourceGenerationNotMatch
-    : public WellKnownParameter<IfSourceGenerationNotMatch, std::int64_t> {
+    : public internal::WellKnownParameter<IfSourceGenerationNotMatch,
+                                          std::int64_t> {
   using WellKnownParameter<IfSourceGenerationNotMatch,
                            std::int64_t>::WellKnownParameter;
   static char const* well_known_parameter_name() {
@@ -131,8 +181,13 @@ struct IfSourceGenerationNotMatch
   }
 };
 
+/**
+ * A pre-condition: the request succeeds if the source object metadata
+ * generation matches.
+ */
 struct IfSourceMetagenerationMatch
-    : public WellKnownParameter<IfSourceMetagenerationMatch, std::int64_t> {
+    : public internal::WellKnownParameter<IfSourceMetagenerationMatch,
+                                          std::int64_t> {
   using WellKnownParameter<IfSourceMetagenerationMatch,
                            std::int64_t>::WellKnownParameter;
   static char const* well_known_parameter_name() {
@@ -140,8 +195,13 @@ struct IfSourceMetagenerationMatch
   }
 };
 
+/**
+ * A pre-condition: the request succeeds unless the source object metadata
+ * generation matches.
+ */
 struct IfSourceMetagenerationNotMatch
-    : public WellKnownParameter<IfSourceMetagenerationNotMatch, std::int64_t> {
+    : public internal::WellKnownParameter<IfSourceMetagenerationNotMatch,
+                                          std::int64_t> {
   using WellKnownParameter<IfSourceMetagenerationNotMatch,
                            std::int64_t>::WellKnownParameter;
   static char const* well_known_parameter_name() {
@@ -149,23 +209,63 @@ struct IfSourceMetagenerationNotMatch
   }
 };
 
-struct KmsKeyName : public WellKnownParameter<KmsKeyName, std::string> {
+/**
+ * Configure the Customer-Managed Encryption Key (CMEK) for an upload.
+ *
+ * With Customer-Managed Encryption Keys you can use keys generated by Google
+ * Cloud's Key Management Service.
+ *
+ * @see https://cloud.google.com/storage/docs/encryption/customer-managed-keys
+ *     for a general introduction to CMEK in GCS.
+ */
+struct KmsKeyName
+    : public internal::WellKnownParameter<KmsKeyName, std::string> {
   using WellKnownParameter<KmsKeyName, std::string>::WellKnownParameter;
   static char const* well_known_parameter_name() { return "kmsKeyName"; }
 };
 
-struct MaxResults : public WellKnownParameter<MaxResults, std::int64_t> {
+/**
+ * Limit the number of results per page when listing Buckets and Objects.
+ *
+ * Applications may reduce the memory requirements of the Bucket and Object
+ * iterators by using smaller page sizes. The downside is that more requests
+ * may be needed to iterate over the full range of Buckets and/or Objects.
+ */
+struct MaxResults
+    : public internal::WellKnownParameter<MaxResults, std::int64_t> {
   using WellKnownParameter<MaxResults, std::int64_t>::WellKnownParameter;
   static char const* well_known_parameter_name() { return "maxResults"; }
 };
 
-struct PredefinedAcl : public WellKnownParameter<PredefinedAcl, std::string> {
+/**
+ * Set the ACL to predefined values when creating Buckets or Objects.
+ *
+ * A predefined ACL is an alias for a set of specific ACL entries that you can
+ * use to quickly apply many ACL entries at once to a bucket or object.
+ *
+ * @see
+ * https://cloud.google.com/storage/docs/access-control/lists#predefined-acl for
+ * a more detailed description of Predefined ACLs in GCS.
+ */
+struct PredefinedAcl
+    : public internal::WellKnownParameter<PredefinedAcl, std::string> {
   using WellKnownParameter<PredefinedAcl, std::string>::WellKnownParameter;
   static char const* well_known_parameter_name() { return "predefinedAcl"; }
 };
 
+/**
+ * Set the ACL to a predefined value when copying Objects.
+ *
+ * A predefined ACL is an alias for a set of specific ACL entries that you can
+ * use to quickly apply many ACL entries at once to a bucket or object.
+ *
+ * @see
+ * https://cloud.google.com/storage/docs/access-control/lists#predefined-acl for
+ * a more detailed description of Predefined ACLs in GCS.
+ */
 struct DestinationPredefinedAcl
-    : public WellKnownParameter<DestinationPredefinedAcl, std::string> {
+    : public internal::WellKnownParameter<DestinationPredefinedAcl,
+                                          std::string> {
   using WellKnownParameter<DestinationPredefinedAcl,
                            std::string>::WellKnownParameter;
   static char const* well_known_parameter_name() {
@@ -173,8 +273,25 @@ struct DestinationPredefinedAcl
   }
 };
 
+/**
+ * Set the default object ACL to a predefined value in a Bucket.
+ *
+ * Every bucket has a default object ACL, and this ACL is applied to all objects
+ * uploaded to that bucket without a predefined ACL or an ACL specified in the
+ * request.  When creating Buckets it is sometimes convenient to define the
+ * default object ACL to one of the predefined values.
+ *
+ * @see
+ * https://cloud.google.com/storage/docs/access-control/lists#defaultobjects for
+ * a mode detailed description of default object ACLs.
+ *
+ * @see
+ * https://cloud.google.com/storage/docs/access-control/lists#predefined-acl for
+ * a more detailed description of Predefined ACLs in GCS.
+ */
 struct PredefinedDefaultObjectAcl
-    : public WellKnownParameter<PredefinedDefaultObjectAcl, std::string> {
+    : public internal::WellKnownParameter<PredefinedDefaultObjectAcl,
+                                          std::string> {
   using WellKnownParameter<PredefinedDefaultObjectAcl,
                            std::string>::WellKnownParameter;
   static char const* well_known_parameter_name() {
@@ -182,38 +299,95 @@ struct PredefinedDefaultObjectAcl
   }
 };
 
-struct Prefix : public WellKnownParameter<Prefix, std::string> {
+/**
+ * Restrict list operations to entries starting with this value.
+ *
+ * This optional parameter applies to both the request to list objects and to
+ * the request that lists buckets.  Setting a value for this option returns
+ * only the entries that start with the given prefix.
+ */
+struct Prefix : public internal::WellKnownParameter<Prefix, std::string> {
   using WellKnownParameter<Prefix, std::string>::WellKnownParameter;
   static char const* well_known_parameter_name() { return "prefix"; }
 };
 
-struct Projection : public WellKnownParameter<Projection, std::string> {
+/**
+ * Controls what metadata fields are included in the response.
+ *
+ * For those operations that return the metadata of an Object or Bucket, this
+ * option controls if all the fields are returned (using `full`) or if the ACL
+ * fields (which can be long) are to be excluded (using `noACL`).
+ *
+ * Use the `Fields` option for more fine-grained control over the returned
+ * fields.
+ */
+struct Projection
+    : public internal::WellKnownParameter<Projection, std::string> {
   using WellKnownParameter<Projection, std::string>::WellKnownParameter;
   static char const* well_known_parameter_name() { return "projection"; }
 };
 
-struct QuotaUser : public WellKnownParameter<QuotaUser, std::string> {
+/**
+ * Sets the user for this operation for quota enforcement purposes.
+ *
+ * Google Cloud Platform allows you to set an arbitrary string, up to 40
+ * characters long, that identifies a "user" for quota enforcement purposes.
+ *
+ * @see https://cloud.google.com/apis/docs/capping-api-usage for an introduction
+ *     to quotas in Google Cloud Platform.
+ */
+struct QuotaUser : public internal::WellKnownParameter<QuotaUser, std::string> {
   using WellKnownParameter<QuotaUser, std::string>::WellKnownParameter;
   static char const* well_known_parameter_name() { return "quotaUser"; }
 };
 
+/**
+ * Set the generation for the source object in copy operations.
+ *
+ * For objects in Buckets with `versioning` enabled, the application sometimes
+ * needs to specify which version of the object should the request target. This
+ * is an optional query parameter to control the version of the source object
+ * in copy operations.
+ *
+ * @see https://cloud.google.com/storage/docs/object-versioning for more
+ *     information on GCS Object versioning.
+ */
 struct SourceGeneration
-    : public WellKnownParameter<SourceGeneration, std::int64_t> {
+    : public internal::WellKnownParameter<SourceGeneration, std::int64_t> {
   using WellKnownParameter<SourceGeneration, std::int64_t>::WellKnownParameter;
   static char const* well_known_parameter_name() { return "sourceGeneration"; }
 };
 
-struct UploadType : public WellKnownParameter<UploadType, std::string> {
-  using WellKnownParameter<UploadType, std::string>::WellKnownParameter;
-  static char const* well_known_parameter_name() { return "uploadType"; }
-};
-
-struct UserProject : public WellKnownParameter<UserProject, std::string> {
+/**
+ * Set the project used for billing in "requester pays" Buckets.
+ *
+ * GCS Buckets can be configured to charge the requester of an operation for all
+ * charges, as opposed to the project that owns the Bucket. Use this parameter
+ * when accessing such Buckets to control which project is charged. Note that
+ * the caller must have the right permissions in the billed project or the
+ * operation would fail.
+ *
+ * @see https://cloud.google.com/storage/docs/requester-pays for a detailed
+ *     description of the requester pays features, which charges are incurred by
+ *     the requester, and the exact permissions that you must have to make
+ *     such a request.
+ */
+struct UserProject
+    : public internal::WellKnownParameter<UserProject, std::string> {
   using WellKnownParameter<UserProject, std::string>::WellKnownParameter;
   static char const* well_known_parameter_name() { return "userProject"; }
 };
 
-struct Versions : public WellKnownParameter<Versions, bool> {
+/**
+ * Control if all versions of an object should be included when listing objects.
+ *
+ * By default requests listing objects only included the latest (live) version
+ * of each object, set this option to `true` to get all the previous versions.
+ *
+ * @see https://cloud.google.com/storage/docs/object-versioning for more
+ *     information on GCS Object versioning.
+ */
+struct Versions : public internal::WellKnownParameter<Versions, bool> {
   using WellKnownParameter<Versions, bool>::WellKnownParameter;
   static char const* well_known_parameter_name() { return "versions"; }
 };


### PR DESCRIPTION
This is a pass over well_known_parameters.h cleaning a few things:

- First, moved the `WellKnownParameter<>` template class to the `internal`
  namespace. This class is not intended as part of the public API.
  This fixes #1122.
- Second, add documentation to each class, they are public types, they
  should be documented.
- Finally, removed an unused type (`UpdloadType`), we will never use
  that and documenting it was more work than removing it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1125)
<!-- Reviewable:end -->
