### PR TITLE
Implement a latency benchmark.

### DIFF
--- a/ci/define-dump-log.sh
+++ b/ci/define-dump-log.sh
@@ -37,9 +37,9 @@ dump_log() {
   if [ "$(wc -l "${logfile}" | awk '{print $1}')" -lt 200 ]; then
     cat "${logfile}"
   else
-    head -100 "${EMULATOR_LOG}"
+    head -100 "${logfile}"
     echo "==== [snip] [snip] [${base}] [snip] [snip] ===="
-    tail -100 "${EMULATOR_LOG}"
+    tail -100 "${logfile}"
   fi
   echo "================ [end ${base}] ================"
 }

--- a/ci/define-example-runner.sh
+++ b/ci/define-example-runner.sh
@@ -70,7 +70,7 @@ run_example() {
     echo    "${COLOR_RED}[    ERROR ]${COLOR_RESET}" \
         " ${program_name} ${example}"
     echo
-    dump_log ${log}
+    dump_log "${log}"
     if [ -f "${EMULATOR_LOG}" ]; then
       dump_log "${EMULATOR_LOG}"
     fi

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -310,6 +310,7 @@ export_list_to_bazel(
 add_subdirectory(tests)
 
 if (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
+    add_subdirectory(benchmarks)
     add_subdirectory(examples)
 endif (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
 

--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -1,0 +1,19 @@
+# ~~~
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+add_executable(storage_latency_benchmark storage_latency_benchmark.cc)
+target_link_libraries(storage_latency_benchmark storage_client
+                      google_cloud_cpp_common_options)

--- a/google/cloud/storage/benchmarks/run_benchmarks_testbench.sh
+++ b/google/cloud/storage/benchmarks/run_benchmarks_testbench.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [ -z "${PROJECT_ROOT+x}" ]; then
+  readonly PROJECT_ROOT="$(cd "$(dirname $0)/../../../.."; pwd)"
+fi
+source "${PROJECT_ROOT}/google/cloud/storage/tools/run_testbench_utils.sh"
+source "${PROJECT_ROOT}/ci/define-example-runner.sh"
+
+echo
+echo "Starting Google Cloud Storage testbench."
+start_testbench
+
+# Define a fake region to run the benchmarks on:
+FAKE_REGION="fake-region-$(date +%s)-${RANDOM}"
+
+# We use the same driver scripts that we use for the examples, the main
+# point here is to run the benchmarks for short periods of time to smoke test
+# them. We are not trying to validate the output is correct, or the performance
+# has not changed.
+export GOOGLE_CLOUD_PROJECT="fake-project-$(date +%s)-${RANDOM}"
+run_example ./storage_latency_benchmark \
+      --duration=5 \
+      --object-count=100 \
+      "${FAKE_REGION}"
+
+if [ "${EXIT_STATUS}" = "0" ]; then
+  TESTBENCH_DUMP_LOG=no
+fi
+exit ${EXIT_STATUS}

--- a/google/cloud/storage/benchmarks/storage_latency_analysis.R
+++ b/google/cloud/storage/benchmarks/storage_latency_analysis.R
@@ -1,0 +1,48 @@
+#!/usr/bin/env Rscript
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require(ggplot2)
+
+args <- commandArgs(trailingOnly=TRUE)
+if (length(args) != 2) {
+    file.arg.name <- "--file="
+    all.args <- commandArgs(trailingOnly=FALSE)
+    cmd <- basename(sub(file.arg.name, "", all.args[grep(file.arg.name, all.args)]))
+    stop(paste("Usage:", cmd, "<benchmark-output-file> <label>"))
+}
+
+arg.filename <- args[1]
+arg.run <- args[2]
+
+load.latency <- function(filename, run) {
+    df <- read.csv(filename, comment.char='#', header=FALSE,
+    col.names=c('op', 'bytes', 'ms'))
+    df$op <- factor(df$op)
+    df$run <- factor(run)
+    df$seconds <- df$ms / 1000.0
+    return(df);
+}
+
+df <- load.latency(arg.filename, arg.run)
+aggregate(ms ~ op, data=df, FUN=summary)
+
+aggregate(ms ~ op, data=df, FUN=function(x) quantile(x, prob=c(0.95, 0.99)))
+
+ggplot(data=df, mapping=aes(x=ms, color=op)) +
+  geom_density() + xlim(0, 600)
+
+ggsave(paste(arg.run, '.png', sep=''))
+
+q(save="no")

--- a/google/cloud/storage/benchmarks/storage_latency_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_latency_benchmark.cc
@@ -1,0 +1,512 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/build_info.h"
+#include "google/cloud/internal/random.h"
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/internal/format_rfc3339.h"
+#include <future>
+#include <iomanip>
+#include <sstream>
+
+/**
+ * @file
+ *
+ * A latency benchmark for the Google Cloud Storage C++ client library.
+ *
+ * This program measures the latency to upload and download small (~1 MiB)
+ * objects to Google Cloud Storage using the C++ client library. The program
+ * repeats the "experiment" of uploading or downloading the file many times,
+ * and reports all the results of this experiment. An external script performs
+ * statistical analysis on the results to estimate likely values for p95 and p99
+ * of the latency.
+ *
+ * The program first creates a Bucket that will contain all the Objects used in
+ * the test.  The Bucket is deleted at the end of the test. The name of the
+ * Bucket is selected at random, that way multiple instances of this test can
+ * run simultaneously. The Bucket uses the `REGIONAL` storage class, in a region
+ * set via the command-line.
+ *
+ * After creating this Bucket the program creates a prescribed number of
+ * objects, selecting random names for all these objects. All the objects have
+ * the same contents, but the contents are generated at random.
+ *
+ * Once the object creation phase is completed, the program starts N threads,
+ * each thread executes a simple loop:
+ * - Pick one of the objects at random, with equal probability for each Object.
+ * - Pick, with equal probably, at action (`read` or `write`) at random.
+ * - If the action was `write` then write a new version of the object.
+ * - If the action was `read` then read the given object.
+ * - Capture the time taken to read and/or write the object.
+ *
+ * The loop runs for a prescribed number of seconds, at the end of the loop the
+ * program prints the captured performance data.
+ *
+ * Then the program remotes all the objects in the bucket, and reports the time
+ * taken to delete each one.
+ *
+ * A helper script in this directory can generate pretty graphs from the report.
+ */
+
+namespace {
+namespace gcs = google::cloud::storage;
+
+constexpr std::chrono::seconds kDefaultDuration(60);
+constexpr long kDefaultObjectCount = 1000;
+constexpr long kBlobSize = 1024 * 1024;
+
+struct Options {
+  std::string region;
+  std::chrono::seconds duration;
+  long object_count;
+  int thread_count;
+  bool enable_connection_pool;
+
+  Options()
+      : duration(kDefaultDuration),
+        object_count(kDefaultObjectCount),
+        enable_connection_pool(true) {
+    thread_count = std::thread::hardware_concurrency();
+    if (thread_count == 0) {
+      thread_count = 1;
+    }
+  }
+
+  void ParseArgs(int& argc, char* argv[]);
+  std::string ConsumeArg(int& argc, char* argv[], char const* arg_name);
+};
+
+std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen);
+std::string MakeRandomData(google::cloud::internal::DefaultPRNG& gen,
+                           std::size_t desired_size);
+std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen);
+
+enum OpType { OP_READ, OP_WRITE, OP_CREATE, OP_DELETE, OP_LAST };
+struct IterationResult {
+  OpType op;
+  bool success;
+  std::chrono::milliseconds elapsed;
+};
+using TestResult = std::vector<IterationResult>;
+
+char const* ToString(OpType type);
+void PrintResult(TestResult const& result);
+
+std::vector<std::string> CreateAllObjects(
+    gcs::Client client, google::cloud::internal::DefaultPRNG& gen,
+    std::string const& bucket_name, Options const& options);
+
+void RunTest(gcs::Client client, std::string const& bucket_name,
+             Options const& options,
+             std::vector<std::string> const& object_names);
+
+void DeleteAllObjects(gcs::Client client, std::string const& bucket_name,
+                      Options const& options,
+                      std::vector<std::string> const& object_names);
+
+}  // namespace
+
+int main(int argc, char* argv[]) try {
+  Options options;
+  options.ParseArgs(argc, argv);
+
+  if (std::getenv("GOOGLE_CLOUD_PROJECT") == nullptr) {
+    std::cerr << "GOOGLE_CLOUD_PROJECT environment variable must be set"
+              << std::endl;
+    return 1;
+  }
+
+  gcs::ClientOptions client_options;
+  if (not options.enable_connection_pool) {
+    client_options.set_connection_pool_size(0);
+  }
+  gcs::Client client(client_options);
+
+  google::cloud::internal::DefaultPRNG generator =
+      google::cloud::internal::MakeDefaultPRNG();
+
+  auto bucket_name = MakeRandomBucketName(generator);
+  auto meta =
+      client.CreateBucket(bucket_name,
+                          gcs::BucketMetadata()
+                              .set_storage_class(gcs::storage_class::Regional())
+                              .set_location(options.region),
+                          gcs::PredefinedAcl("private"),
+                          gcs::PredefinedDefaultObjectAcl("projectPrivate"),
+                          gcs::Projection("full"));
+  std::cout << "# Running test on bucket: " << meta.name() << std::endl;
+  std::string notes = google::cloud::storage::version_string() + ";" +
+                      google::cloud::internal::compiler() + ";" +
+                      google::cloud::internal::compiler_flags();
+  std::transform(notes.begin(), notes.end(), notes.begin(),
+                 [](char c) { return c == '\n' ? ';' : c; });
+  std::cout << "# Start time: "
+            << gcs::internal::FormatRfc3339(std::chrono::system_clock::now())
+            << "\n# Region: " << options.region
+            << "\n# Object Count: " << options.object_count
+            << "\n# Thread Count: " << options.thread_count
+            << "\n# Enable connection pool: " << options.enable_connection_pool
+            << "\n# Build info: " << notes << std::endl;
+
+  std::vector<std::string> object_names =
+      CreateAllObjects(client, generator, bucket_name, options);
+  RunTest(client, bucket_name, options, object_names);
+  DeleteAllObjects(client, bucket_name, options, object_names);
+  std::cout << "# Deleting " << bucket_name << std::endl;
+  client.DeleteBucket(bucket_name);
+
+  return 0;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard exception raised: " << ex.what() << std::endl;
+  return 1;
+}
+
+namespace {
+std::string Basename(std::string const& path) {
+  // Sure would be nice to be using C++17 where std::filesytem is a thing.
+#if _WIN32
+  return path.substr(path.find_last_of('\\') + 1);
+#else
+  return path.substr(path.find_last_of('/') + 1);
+#endif  // _WIN32
+}
+
+std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen) {
+  // The total length of this bucket name must be <= 63 characters,
+  static std::string const prefix = "gcs-cpp-latency-";
+  static std::size_t const kMaxBucketNameLength = 63;
+  std::size_t const max_random_characters =
+      kMaxBucketNameLength - prefix.size();
+  return prefix + google::cloud::internal::Sample(
+                      gen, static_cast<int>(max_random_characters),
+                      "abcdefghijklmnopqrstuvwxyz012456789");
+}
+
+std::string MakeRandomData(google::cloud::internal::DefaultPRNG& gen,
+                           std::size_t desired_size) {
+  std::string result;
+  result.reserve(desired_size);
+
+  // Create lines of 128 characters to start with, we can fill the remaining
+  // characters at the end.
+  constexpr int kLineSize = 128;
+  auto gen_random_line = [&gen](std::size_t count) {
+    return google::cloud::internal::Sample(gen, static_cast<int>(count - 1),
+                                           "abcdefghijklmnopqrstuvwxyz"
+                                           "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                           "012456789"
+                                           " - _ : /") +
+           "\n";
+  };
+  while (result.size() + kLineSize < desired_size) {
+    result += gen_random_line(kLineSize);
+  }
+  if (result.size() < desired_size) {
+    result += gen_random_line(desired_size - result.size());
+  }
+
+  return result;
+}
+
+std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen) {
+  return google::cloud::internal::Sample(gen, 128,
+                                         "abcdefghijklmnopqrstuvwxyz"
+                                         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                         "0123456789");
+}
+
+char const* ToString(OpType type) {
+  static char const* kOpTypeNames[] = {"READ", "WRITE", "CREATE", "DELETE",
+                                       "LAST"};
+  static_assert(OP_LAST + 1 == (sizeof(kOpTypeNames) / sizeof(kOpTypeNames[0])),
+                "Mismatched size for OpType names array");
+  return kOpTypeNames[type];
+}
+
+void PrintResult(TestResult const& result) {
+  for (auto const& r : result) {
+    std::cout << ToString(r.op) << "," << std::boolalpha << r.success << ","
+              << r.elapsed.count() << "\n";
+  }
+}
+
+IterationResult WriteCommon(gcs::Client client, std::string const& bucket_name,
+                            std::string const& object_name,
+                            std::string const& random_data,
+                            Options const& options, OpType op_type) {
+  auto start = std::chrono::steady_clock::now();
+  (void)client.InsertObject(bucket_name, object_name, random_data);
+  auto elapsed = std::chrono::steady_clock::now() - start;
+  using std::chrono::milliseconds;
+  return IterationResult{op_type, true,
+                         std::chrono::duration_cast<milliseconds>(elapsed)};
+}
+
+IterationResult CreateOnce(gcs::Client const& client,
+                           std::string const& bucket_name,
+                           std::string const& object_name,
+                           std::string const& data_chunk,
+                           Options const& options) {
+  return WriteCommon(client, bucket_name, object_name, data_chunk, options,
+                     OP_CREATE);
+}
+
+IterationResult WriteOnce(gcs::Client const& client,
+                          std::string const& bucket_name,
+                          std::string const& object_name,
+                          std::string const& data_chunk,
+                          Options const& options) {
+  return WriteCommon(client, bucket_name, object_name, data_chunk, options,
+                     OP_WRITE);
+}
+
+IterationResult ReadOnce(gcs::Client client, std::string const& bucket_name,
+                         std::string const& object_name,
+                         Options const& options) {
+  auto start = std::chrono::steady_clock::now();
+  gcs::ObjectReadStream stream = client.ReadObject(bucket_name, object_name);
+  std::size_t total_size = 0;
+  while (not stream.eof()) {
+    char buf[4096];
+    stream.read(buf, sizeof(buf));
+    total_size += stream.gcount();
+  }
+  auto elapsed = std::chrono::steady_clock::now() - start;
+  using std::chrono::milliseconds;
+  auto ms = std::chrono::duration_cast<milliseconds>(elapsed);
+  return IterationResult{OP_READ, (total_size == kBlobSize), ms};
+}
+
+TestResult CreateGroup(gcs::Client client, std::string const& bucket_name,
+                       Options const& options, std::vector<std::string> group) {
+  google::cloud::internal::DefaultPRNG generator =
+      google::cloud::internal::MakeDefaultPRNG();
+
+  std::string random_data = MakeRandomData(generator, kBlobSize);
+  TestResult result;
+  for (auto const& object_name : group) {
+    result.emplace_back(
+        CreateOnce(client, bucket_name, object_name, random_data, options));
+  }
+  return result;
+}
+
+std::vector<std::string> CreateAllObjects(
+    gcs::Client client, google::cloud::internal::DefaultPRNG& gen,
+    std::string const& bucket_name, Options const& options) {
+  using std::chrono::duration_cast;
+  using std::chrono::milliseconds;
+
+  auto const max_group_size =
+      std::max(options.object_count / options.thread_count, 1L);
+  std::cout << "# Creating test objects [" << max_group_size << "] "
+            << std::endl;
+
+  // Generate the list of object names.
+  std::vector<std::string> object_names;
+  object_names.reserve(options.object_count);
+  for (long c = 0; c != options.object_count; ++c) {
+    object_names.emplace_back(MakeRandomObjectName(gen));
+  }
+
+  // Split the objects in more or less equally sized groups, launch a thread
+  // to create the objects in each group.
+  auto start = std::chrono::steady_clock::now();
+  std::vector<std::future<TestResult>> tasks;
+  std::vector<std::string> group;
+  group.reserve(max_group_size);
+  for (auto const& o : object_names) {
+    group.push_back(o);
+    if (group.size() >= static_cast<std::size_t>(max_group_size)) {
+      tasks.emplace_back(std::async(std::launch::async, &CreateGroup, client,
+                                    bucket_name, options, std::move(group)));
+      group = {};  // after a move, must assign to guarantee it is valid.
+    }
+  }
+  if (not group.empty()) {
+    tasks.emplace_back(std::async(std::launch::async, &CreateGroup, client,
+                                  bucket_name, options, std::move(group)));
+    group = {};  // after a move, must assign to guarantee it is valid.
+  }
+  // Wait for the threads to finish.
+  for (auto& t : tasks) {
+    PrintResult(t.get());
+  }
+  auto elapsed = std::chrono::steady_clock::now() - start;
+  std::cout << "# Created in " << duration_cast<milliseconds>(elapsed).count()
+            << "ms" << std::endl;
+  return object_names;
+}
+
+TestResult RunTestThread(gcs::Client const& client,
+                         std::string const& bucket_name, Options const& options,
+                         std::vector<std::string> object_names) {
+  google::cloud::internal::DefaultPRNG generator =
+      google::cloud::internal::MakeDefaultPRNG();
+
+  std::string random_data = MakeRandomData(generator, kBlobSize);
+
+  std::uniform_int_distribution<std::size_t> object_number_gen(
+      0, object_names.size() - 1);
+  std::uniform_int_distribution<int> action_gen(0, 99);
+
+  TestResult result;
+  // Reserve memory assuming the iterations take around 200ms. If the assumption
+  // is too small, all that happens is some extra allocations. If the allocation
+  // is too big we may have several MiB of over allocated memory.
+  result.reserve(static_cast<std::size_t>(5 * options.duration.count()));
+  auto deadline = std::chrono::system_clock::now() + options.duration;
+  while (std::chrono::system_clock::now() < deadline) {
+    auto const& object_name = object_names.at(object_number_gen(generator));
+    if (action_gen(generator) < 50) {
+      result.emplace_back(
+          WriteOnce(client, bucket_name, object_name, random_data, options));
+    } else {
+      result.emplace_back(ReadOnce(client, bucket_name, object_name, options));
+    }
+  }
+  return result;
+}
+
+void RunTest(gcs::Client client, std::string const& bucket_name,
+             Options const& options,
+             std::vector<std::string> const& object_names) {
+  std::vector<std::future<TestResult>> tasks;
+  for (int i = 0; i != options.thread_count; ++i) {
+    tasks.emplace_back(std::async(std::launch::async, &RunTestThread, client,
+                                  bucket_name, options, object_names));
+  }
+
+  for (auto& t : tasks) {
+    PrintResult(t.get());
+  }
+}
+
+TestResult DeleteGroup(gcs::Client client,
+                       std::vector<gcs::ObjectMetadata> const& group) {
+  TestResult result;
+  for (auto const& o : group) {
+    auto start = std::chrono::steady_clock::now();
+    client.DeleteObject(o.bucket(), o.name(), gcs::Generation(o.generation()));
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    using std::chrono::milliseconds;
+    auto ms = std::chrono::duration_cast<milliseconds>(elapsed);
+    result.emplace_back(IterationResult{OP_DELETE, true, ms});
+  }
+  return result;
+}
+
+void DeleteAllObjects(gcs::Client client, std::string const& bucket_name,
+                      Options const& options,
+                      std::vector<std::string> const& object_names) {
+  using std::chrono::duration_cast;
+  using std::chrono::milliseconds;
+
+  std::size_t const max_group_size =
+      std::max(object_names.size() / options.thread_count, std::size_t(1));
+
+  std::cout << "# Deleting test objects [" << max_group_size << "]"
+            << std::endl;
+  auto start = std::chrono::steady_clock::now();
+  std::vector<std::future<TestResult>> tasks;
+  std::vector<gcs::ObjectMetadata> group;
+  for (auto const& o : client.ListObjects(bucket_name, gcs::Versions(true))) {
+    group.push_back(o);
+    if (group.size() >= max_group_size) {
+      tasks.emplace_back(std::async(std::launch::async, &DeleteGroup, client,
+                                    std::move(group)));
+      group = {};  // after a move, must assign to guarantee it is valid.
+    }
+  }
+  if (not group.empty()) {
+    tasks.emplace_back(
+        std::async(std::launch::async, &DeleteGroup, client, std::move(group)));
+  }
+  for (auto& t : tasks) {
+    PrintResult(t.get());
+  }
+  auto elapsed = std::chrono::steady_clock::now() - start;
+  std::cout << "# Deleted in " << duration_cast<milliseconds>(elapsed).count()
+            << "ms" << std::endl;
+}
+
+void Options::ParseArgs(int& argc, char* argv[]) {
+  region = ConsumeArg(argc, argv, "region");
+}
+
+std::string Options::ConsumeArg(int& argc, char* argv[], char const* arg_name) {
+  std::string const duration = "--duration=";
+  std::string const object_count = "--object-count=";
+  std::string const thread_count = "--thread-count=";
+  std::string const enable_connection_pool = "--enable-connection-pool=";
+
+  std::string const usage = R""(
+[options] <region>
+The options are:
+    --help: produce this message.
+    --duration (in seconds): for how long should the test run.
+    --object-count: the number of objects to use in the benchmark.
+    --thread-count: the number of threads to use in the benchmark.
+    --enable-connection-pool: reuse connections across requests.
+
+    region: a Google Cloud Storage region where all the objects used in this
+       test will be located.
+)"";
+
+  std::string error;
+  while (argc >= 2) {
+    std::string argument(argv[1]);
+    std::copy(argv + 2, argv + argc, argv + 1);
+    argc--;
+    if (argument == "--help") {
+    } else if (0 == argument.rfind(duration, 0)) {
+      std::string val = argument.substr(duration.size());
+      this->duration = std::chrono::seconds(std::stoi(val));
+    } else if (0 == argument.rfind(object_count, 0)) {
+      auto arg = argument.substr(object_count.size());
+      auto val = std::stol(arg);
+      if (val <= 0) {
+        error = "Invalid object-count argument (" + arg + ")";
+        break;
+      }
+      this->object_count = val;
+    } else if (0 == argument.rfind(thread_count, 0)) {
+      auto arg = argument.substr(object_count.size());
+      auto val = std::stoi(arg);
+      if (val <= 0) {
+        error = "Invalid thread-count argument (" + arg + ")";
+        break;
+      }
+      this->thread_count = val;
+    } else if (0 == argument.rfind(enable_connection_pool, 0)) {
+      auto arg = argument.substr(enable_connection_pool.size());
+      if (arg == "true" or arg == "yes" or arg == "1") {
+        this->enable_connection_pool = true;
+      } else if (arg == "false" or arg == "no" or arg == "0") {
+        this->enable_connection_pool = false;
+      } else {
+        error = "Invalid enable-connection-pool argument (" + arg + ")";
+        break;
+      }
+    } else {
+      return argument;
+    }
+  }
+  std::ostringstream os;
+  os << "Missing argument " << arg_name << "\n";
+  os << "Usage: " << Basename(argv[0]) << usage << std::endl;
+  throw std::runtime_error(os.str());
+}
+
+}  // namespace

--- a/google/cloud/storage/benchmarks/storage_latency_benchmark_go.go
+++ b/google/cloud/storage/benchmarks/storage_latency_benchmark_go.go
@@ -1,0 +1,279 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"os"
+	"runtime"
+	"strconv"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
+)
+
+const (
+	kDefaultDurationSeconds = 60
+	kDefaultObjectCount     = 10000
+)
+
+type IterationResult struct {
+	op      string
+	success bool
+	elapsed time.Duration
+}
+
+type TestResult []IterationResult
+
+func main() {
+	duration := kDefaultDurationSeconds
+	objectCount := kDefaultObjectCount
+	threadCount := runtime.NumCPU()
+
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: endurance_test_go <location>"+
+			" [duration-in-seconds (%d)] [object-count (%d)] [thread-count (%d)]\n",
+			duration, objectCount, threadCount)
+		os.Exit(1)
+	}
+	location := os.Args[1]
+
+	if len(os.Args) > 2 {
+		v, err := strconv.Atoi(os.Args[2])
+		if err != nil {
+			log.Fatal("%v while parsing duration argument (%s)", err, os.Args[2])
+		}
+		duration = v
+	}
+	if len(os.Args) > 3 {
+		v, err := strconv.Atoi(os.Args[3])
+		if err != nil {
+			log.Fatal("%v while parsing object-count argument (%s)", err, os.Args[3])
+		}
+		objectCount = v
+	}
+	if len(os.Args) > 4 {
+		v, err := strconv.Atoi(os.Args[4])
+		if err != nil {
+			log.Fatal("%v while parsing thread-count argument (%s)", err, os.Args[4])
+		}
+		threadCount = v
+	}
+
+	ctx := context.Background()
+
+	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
+	if projectID == "" {
+		fmt.Fprintf(os.Stderr, "GOOGLE_CLOUD_PROJECT environment variable must be set.\n")
+		os.Exit(1)
+	}
+
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Initialize the default PRNG so that different runs do not generate the
+	// same sequence.
+	rand.Seed(time.Now().UnixNano())
+
+	bucketName := MakeRandomBucketName()
+	bucket := client.Bucket(bucketName)
+	if err := bucket.Create(ctx, projectID, &storage.BucketAttrs{
+		StorageClass:               "REGIONAL",
+		Location:                   location,
+		PredefinedACL:              "private",
+		PredefinedDefaultObjectACL: "projectPrivate",
+	}); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("# Running test on bucket: %v\n", bucketName)
+	fmt.Printf("# Start time: %s\n", time.Now().Format(time.RFC3339))
+	fmt.Printf("# Location: %s\n", location)
+	fmt.Printf("# Object Count: %d\n", objectCount)
+	fmt.Printf("# Thread Count: %d\n", threadCount)
+	fmt.Printf("# Build info: %s\n", runtime.Version())
+
+	objectNames := CreateAllObjects(bucket, ctx, objectCount)
+
+	ch := make(chan TestResult, threadCount)
+	for i := 0; i < threadCount; i++ {
+		go RunTest(bucket, ctx, objectNames, duration, ch)
+	}
+	for i := 0; i < threadCount; i++ {
+		result := <-ch
+		PrintResult(result)
+	}
+
+	DeleteAllObjects(bucket, ctx, objectCount)
+
+	fmt.Printf("# Deleting %v\n", bucketName)
+	if err := bucket.Delete(ctx); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func sample(letters []rune, n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func MakeRandomBucketName() string {
+	letters := []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+	prefix := "gcs-go-latency-"
+	const maxBucketNameLength = 63
+
+	return prefix + sample(letters, maxBucketNameLength-len(prefix))
+}
+
+func MakeRandomObjectName() string {
+	letters := []rune("abcdefghijklmnopqrstuvwxyz" + "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+		"0123456789")
+	return sample(letters, 128)
+}
+
+func PrintResult(result TestResult) {
+	for _, r := range result {
+		fmt.Printf("%s,%t,%d\n", r.op, r.success, r.elapsed.Nanoseconds()/1000000)
+	}
+}
+
+func MakeRandomData(desiredSize int) string {
+	chars := []rune("abcdefghijklmnopqrstuvwxyz" + "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+		"0123456789" + " - _ : /")
+	const (
+		kLineSize = 128
+	)
+	result := ""
+	for len(result)+kLineSize < desiredSize {
+		result = result + sample(chars, kLineSize-1) + "\n"
+	}
+	if len(result) < desiredSize {
+		result = sample(chars, desiredSize-len(result))
+	}
+	return result
+}
+
+func CreateOneObject(bucket *storage.BucketHandle, ctx context.Context, objectName string, data string) {
+	start := time.Now()
+	w := bucket.Object(objectName).NewWriter(ctx)
+	if _, err := w.Write([]byte(data)); err != nil {
+		elapsed := time.Since(start)
+		fmt.Printf("CREATE,false,%d\n", elapsed.Nanoseconds()/1000000)
+	}
+	if err := w.Close(); err != nil {
+		elapsed := time.Since(start)
+		fmt.Printf("CREATE,false,%d\n", elapsed.Nanoseconds()/1000000)
+	}
+	elapsed := time.Since(start)
+	fmt.Printf("CREATE,true,%d\n", elapsed.Nanoseconds()/1000000)
+}
+
+func CreateAllObjects(bucket *storage.BucketHandle, ctx context.Context, objectCount int) []string {
+	names := make([]string, 0, objectCount)
+	for i := 0; i < objectCount; i++ {
+		names = append(names, MakeRandomObjectName())
+	}
+
+	data := MakeRandomData(1024 * 1024)
+	fmt.Printf("# Creating test objects [N/A]\n")
+	start := time.Now()
+	for _, name := range names {
+		CreateOneObject(bucket, ctx, name, data)
+	}
+	elapsed := time.Since(start)
+	fmt.Printf("# Created in %dms\n", elapsed.Nanoseconds()/1000000)
+	return names
+}
+
+func WriteOnce(bucket *storage.BucketHandle, ctx context.Context, objectName string, data string) IterationResult {
+	start := time.Now()
+	w := bucket.Object(objectName).NewWriter(ctx)
+	if _, err := w.Write([]byte(data)); err != nil {
+		return IterationResult{op: "WRITE", success: false, elapsed: time.Since(start)}
+	}
+	if err := w.Close(); err != nil {
+		return IterationResult{op: "WRITE", success: false, elapsed: time.Since(start)}
+	}
+	return IterationResult{op: "WRITE", success: true, elapsed: time.Since(start)}
+}
+
+func ReadOnce(bucket *storage.BucketHandle, ctx context.Context, objectName string) IterationResult {
+	start := time.Now()
+	rd, err := bucket.Object(objectName).NewReader(ctx)
+	if err != nil {
+		return IterationResult{op: "READ", success: false, elapsed: time.Since(start)}
+	}
+	_, err = ioutil.ReadAll(rd)
+	rd.Close()
+	if err != nil {
+		return IterationResult{op: "READ", success: false, elapsed: time.Since(start)}
+	}
+	return IterationResult{op: "READ", success: true, elapsed: time.Since(start)}
+}
+
+func RunTest(bucket *storage.BucketHandle, ctx context.Context, objectNames []string,
+	duration int,
+	ch chan TestResult) {
+	data := MakeRandomData(1024 * 1024)
+	result := make([]IterationResult, 0, 5*duration)
+	deadline := time.Now().Add(time.Duration(duration) * time.Second)
+	for time.Now().Before(deadline) {
+		name := objectNames[rand.Intn(len(objectNames))]
+		if rand.Intn(100) < 50 {
+			result = append(result, WriteOnce(bucket, ctx, name, data))
+		} else {
+			result = append(result, ReadOnce(bucket, ctx, name))
+		}
+	}
+	ch <- result
+}
+
+func DeleteObject(bucket *storage.BucketHandle, ctx context.Context, objectName string) {
+	start := time.Now()
+	bucket.Object(objectName).Delete(ctx)
+	elapsed := time.Since(start)
+	fmt.Printf("DELETE,true,%d\n", elapsed.Nanoseconds()/1000000)
+}
+
+func DeleteAllObjects(bucket *storage.BucketHandle, ctx context.Context, objectCount int) {
+	fmt.Printf("# Deleting test objects [N/A]\n")
+	start := time.Now()
+	names := make([]string, 0, objectCount)
+	it := bucket.Objects(ctx, nil)
+	for {
+		objAttrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			log.Fatal("%v while getting object list", err)
+		}
+		names = append(names, objAttrs.Name)
+	}
+	for _, name := range names {
+		DeleteObject(bucket, ctx, name)
+	}
+	elapsed := time.Since(start)
+	fmt.Printf("# Deleted in %dms\n", elapsed.Nanoseconds()/1000000)
+}

--- a/google/cloud/storage/benchmarks/storage_latency_compare.R
+++ b/google/cloud/storage/benchmarks/storage_latency_compare.R
@@ -1,0 +1,58 @@
+#!/usr/bin/env Rscript
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require(ggplot2)
+
+args <- commandArgs(trailingOnly=TRUE)
+if (length(args) != 4) {
+    file.arg.name <- "--file="
+    all.args <- commandArgs(trailingOnly=FALSE)
+    cmd <- basename(sub(file.arg.name, "", all.args[grep(file.arg.name, all.args)]))
+    stop(paste("Usage:", cmd, "<a-file> <a-name> <b-file> <b-name>"))
+}
+
+a.filename <- args[1]
+a.run <- args[2]
+b.filename <- args[3]
+b.run <- args[4]
+
+load.latency <- function(filename, run) {
+    df <- read.csv(filename, comment.char='#', header=FALSE,
+    col.names=c('op', 'bytes', 'ms'))
+    df$op <- factor(df$op)
+    df$run <- factor(run)
+    df$seconds <- df$ms / 1000.0
+    return(df);
+}
+
+df.a <- load.latency(a.filename, a.run)
+df.b <- load.latency(b.filename, b.run)
+df <- rbind(df.a, df.b)
+aggregate(ms ~ run + op, data=df, FUN=summary)
+
+aggregate(ms ~ run + op, data=df, FUN=function(x) quantile(x, prob=c(0.95, 0.99)))
+
+ggplot(data=df, mapping=aes(x=ms, color=run)) + facet_grid(op ~ .) +
+  geom_density() + xlim(0, 600)
+
+fig.height <- function(width) {
+    phi <- (1 + sqrt(5.0)) / 2
+    return(width / phi)
+}
+
+ggsave(paste('compare-latency-', a.run, '-', b.run, '.png', sep=''),
+    width=8.5, height=fig.height(8.5))
+
+q(save="no")

--- a/google/cloud/storage/ci/run_integration_tests.sh
+++ b/google/cloud/storage/ci/run_integration_tests.sh
@@ -24,14 +24,22 @@ source "${PROJECT_ROOT}/ci/colors.sh"
 # This script should is called from the build directory, and it finds other
 # scripts in the source directory using its own path.
 readonly BINDIR="$(dirname $0)"
+readonly GCSDIR="${PROJECT_ROOT}/google/cloud/storage"
 (cd google/cloud/storage/tests && \
-    "${BINDIR}/../tests/run_integration_tests_testbench.sh")
+    "${GCSDIR}/tests/run_integration_tests_testbench.sh")
 
 # In the no-exceptions build this directory does not exist. Note that the script
 # typically runs in ${CMAKE_PROJECT_BINARY_DIR}.
 if [ -d google/cloud/storage/examples ]; then
   (cd google/cloud/storage/examples && \
-      "${BINDIR}/../examples/run_examples_testbench.sh")
+      "${GCSDIR}/examples/run_examples_testbench.sh")
 else
   echo "${COLOR_YELLOW}Skipping google/cloud/storage/examples.${COLOR_RESET}"
+fi
+
+if [ -d google/cloud/storage/benchmarks ]; then
+  (cd google/cloud/storage/benchmarks && \
+      "${GCSDIR}/benchmarks/run_benchmarks_testbench.sh")
+else
+  echo "${COLOR_YELLOW}Skipping google/cloud/storage/benchmarks.${COLOR_RESET}"
 fi


### PR DESCRIPTION
Measures the latency to create, read, write, and delete objects in the
1MiB range. Part of the work for #572.

Improve the testbench to not keep multiple versions of each object
is versioning is disabled in the Bucket, makes it possible to run
this benchmark against the testbench. In addition, the tesbench should
not perform I/O in the middle of changing its state, as that can create
race conditions with gevent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1132)
<!-- Reviewable:end -->
