### PR TITLE
Move storage::StatusTraits to storage::internal::

### DIFF
--- a/google/cloud/storage/retry_policy.h
+++ b/google/cloud/storage/retry_policy.h
@@ -23,22 +23,28 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+/// Defines what error codes are permanent errors.
 struct StatusTraits {
   static bool IsPermanentFailure(Status const& status) {
     return status.status_code() != 429 and status.status_code() < 500;
   }
 };
+}  // namespace internal
 
 /// The retry policy base class
-using RetryPolicy = google::cloud::internal::RetryPolicy<Status, StatusTraits>;
+using RetryPolicy =
+    google::cloud::internal::RetryPolicy<Status, internal::StatusTraits>;
 
 /// Keep retrying until some time has expired.
 using LimitedTimeRetryPolicy =
-    google::cloud::internal::LimitedTimeRetryPolicy<Status, StatusTraits>;
+    google::cloud::internal::LimitedTimeRetryPolicy<Status,
+                                                    internal::StatusTraits>;
 
 /// Keep retrying until the error count has been exceeded.
 using LimitedErrorCountRetryPolicy =
-    google::cloud::internal::LimitedErrorCountRetryPolicy<Status, StatusTraits>;
+    google::cloud::internal::LimitedErrorCountRetryPolicy<
+        Status, internal::StatusTraits>;
 
 /// The backoff policy base class.
 using BackoffPolicy = google::cloud::internal::BackoffPolicy;

--- a/google/cloud/storage/retry_policy_test.cc
+++ b/google/cloud/storage/retry_policy_test.cc
@@ -19,6 +19,7 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
+namespace internal {
 namespace {
 
 TEST(RetryPolicyTest, PermanentFailure) {
@@ -45,6 +46,7 @@ TEST(RetryPolicyTest, PermanentFailure) {
 }
 
 }  // namespace
+}  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud


### PR DESCRIPTION
This class is an implementation detail, not intended for direct use by
the application developers, needs to be moved to the `internal`
namespace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1134)
<!-- Reviewable:end -->
