### PR TITLE
Fixed upload of code coverage stats.

### DIFF
--- a/ci/travis/upload-codecov.sh
+++ b/ci/travis/upload-codecov.sh
@@ -22,7 +22,7 @@ if [ "${BUILD_TYPE:-Release}" != "Coverage" ]; then
 fi
 
 if [ -z "${PROJECT_ROOT+x}" ]; then
-  readonly PROJECT_ROOT="$(cd "$(dirname $0)/.."; pwd)"
+  readonly PROJECT_ROOT="$(cd "$(dirname $0)/../.."; pwd)"
 fi
 source "${PROJECT_ROOT}/ci/define-dump-log.sh"
 
@@ -34,4 +34,4 @@ sudo docker run $CI_ENV \
     --volume $PWD:/v --workdir /v \
     "${IMAGE}:tip" /bin/bash -c "/bin/bash <(curl -s https://codecov.io/bash)"
 
-ci_dump_log codecov.log
+dump_log codecov.log


### PR DESCRIPTION
Ooops, the name of the function to dump the log was wrong, and the path
to discover where that function is defined was also wrong. The result
was no code coverage uploads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1137)
<!-- Reviewable:end -->
