### PR TITLE
Implement a throughput benchmark.

### DIFF
--- a/google/cloud/storage/benchmarks/BUILD
+++ b/google/cloud/storage/benchmarks/BUILD
@@ -1,5 +1,4 @@
-# ~~~
-# Copyright 2018 Google Inc.
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ~~~
 
-add_executable(storage_latency_benchmark storage_latency_benchmark.cc)
-target_link_libraries(storage_latency_benchmark storage_client
-                      google_cloud_cpp_common_options)
+package(default_visibility = ["//visibility:public"])
 
-add_executable(storage_throughput_benchmark storage_throughput_benchmark.cc)
-target_link_libraries(storage_throughput_benchmark storage_client
-                      google_cloud_cpp_common_options)
+licenses(["notice"])  # Apache 2.0
+
+cc_binary(
+    name = "storage_latency_benchmark",
+    srcs = ["storage_latency_benchmark.cc"],
+    deps = ["//google/cloud/storage:storage_client"],
+)
+
+cc_binary(
+    name = "storage_throughput_benchmark",
+    srcs = ["storage_throughput_benchmark.cc"],
+    deps = ["//google/cloud/storage:storage_client"],
+)

--- a/google/cloud/storage/benchmarks/run_benchmarks_testbench.sh
+++ b/google/cloud/storage/benchmarks/run_benchmarks_testbench.sh
@@ -39,6 +39,12 @@ run_example ./storage_latency_benchmark \
       --object-count=100 \
       "${FAKE_REGION}"
 
+run_example ./storage_throughput_benchmark \
+      --duration=5 \
+      --object-count=8 \
+      --object-chunk-count=20 \
+      "${FAKE_REGION}"
+
 if [ "${EXIT_STATUS}" = "0" ]; then
   TESTBENCH_DUMP_LOG=no
 fi

--- a/google/cloud/storage/benchmarks/storage_throughput_analysis.R
+++ b/google/cloud/storage/benchmarks/storage_throughput_analysis.R
@@ -1,0 +1,57 @@
+#!/usr/bin/env Rscript
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require(ggplot2)
+
+args <- commandArgs(trailingOnly=TRUE)
+if (length(args) != 2) {
+    file.arg.name <- "--file="
+    all.args <- commandArgs(trailingOnly=FALSE)
+    cmd <- basename(sub(file.arg.name, "", all.args[grep(file.arg.name, all.args)]))
+    stop(paste("Usage:", cmd, "<benchmark-output-file> <label>"))
+}
+
+arg.filename <- args[1]
+arg.run <- args[2]
+
+load.throughput <- function(filename, run) {
+    df <- read.csv(filename, comment.char='#', header=FALSE,
+    col.names=c('op', 'bytes', 'ms'))
+    df$op <- factor(df$op)
+    df$run <- factor(run)
+    df$seconds <- df$ms / 1000.0
+    df$bits <- 8 * df$bytes
+    df$MiB <- df$bytes / (1024 * 1024.0)
+    df$Mbits <- df$bits / 10000000.0
+    df$Mbps <- df$Mbits / df$seconds
+    return(df);
+}
+
+df <- load.throughput(arg.filename, arg.run)
+MiB.max <- max(df$MiB)
+aggregate(Mbps ~ MiB + op, data=subset(df, MiB == MiB.max), FUN=summary)
+
+# Skip the DELETE operations in this graph because they have "0" throughput.
+ggplot(data=df, mapping=aes(x=MiB, y=Mbps, color=op)) +
+    geom_smooth()
+
+fig.height <- function(width) {
+    phi <- (1 + sqrt(5.0)) / 2
+    return(width / phi)
+}
+
+ggsave(paste(arg.run, '.png', sep=''), width=8.5, height=fig.height(8.5))
+
+q(save="no")

--- a/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
@@ -1,0 +1,554 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/build_info.h"
+#include "google/cloud/internal/random.h"
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/internal/format_rfc3339.h"
+#include <future>
+#include <iomanip>
+#include <sstream>
+
+/**
+ * @file
+ *
+ * A thoughput benchmark for the Google Cloud Storage C++ client library.
+ *
+ * This program first creates a Bucket that will contain all the Objects used in
+ * the test.  The Bucket is deleted at the end of the test. The name of the
+ * Bucket is selected at random, that way multiple instances of this test can
+ * run simultaneously. The Bucket uses the `REGIONAL` storage class, in a region
+ * set via the command-line.
+ *
+ * After creating this Bucket the program creates a number of objects, all the
+ * objects have the same contents, but the contents are generated at random.
+ *
+ * The size of the objects can be configured in the command-line, but they are
+ * typically 250MiB is size.  The program reports the time it takes to upload
+ * the first 10 MiB, the first 20 MiB, the first 30 MiB, and so forth until the
+ * total size of the object is uploaded.
+ *
+ * Once the object creation phase is completed, the program starts N threads,
+ * each thread executes a simple loop:
+ * - Pick one of the objects at random, with equal probability for each Object.
+ * - Pick, with equal probably, at action (`read` or `write`) at random.
+ * - If the action was `write` then write to the object. Capturing throughput
+ *   information (to be reported at the end of the thread).
+ * - If the action was `read` then read the object. Capture the time taken to
+ *   read the first 10 MiB, the first 20 MiB, and so forth until the full
+ *   object is read.
+ *
+ * The loop runs for a prescribed number of seconds, at the end of the loop the
+ * program prints the captured performance data.
+ *
+ * Then the program removes all the objects in the bucket, and reports the time
+ * taken to delete each one.
+ *
+ * A helper script in this directory can generate pretty graphs from the report.
+ */
+
+namespace {
+namespace gcs = google::cloud::storage;
+
+constexpr std::chrono::seconds kDefaultDuration(60);
+constexpr unsigned long kDefaultObjectCount = 1000;
+constexpr long kMiB = 1024 * 1024;
+constexpr unsigned long kChunkSize = 1 * kMiB;
+constexpr int kDefaultObjectChunkCount = 250;
+constexpr int kThroughputReportIntervalInChunks = 10;
+
+struct Options {
+  std::string region;
+  std::chrono::seconds duration;
+  long object_count;
+  int thread_count;
+  int object_chunk_count;
+  bool enable_connection_pool;
+
+  Options()
+      : duration(kDefaultDuration),
+        object_count(kDefaultObjectCount),
+        thread_count(1),
+        object_chunk_count(kDefaultObjectChunkCount),
+        enable_connection_pool(true) {}
+
+  void ParseArgs(int& argc, char* argv[]);
+  std::string ConsumeArg(int& argc, char* argv[], char const* arg_name);
+};
+
+std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen);
+std::string MakeRandomData(google::cloud::internal::DefaultPRNG& gen,
+                           std::size_t desired_size);
+std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen);
+
+enum OpType { OP_READ, OP_WRITE, OP_CREATE, OP_DELETE, OP_LAST };
+struct IterationResult {
+  OpType op;
+  std::size_t bytes;
+  std::chrono::milliseconds elapsed;
+};
+using TestResult = std::vector<IterationResult>;
+
+char const* ToString(OpType type);
+void PrintResult(TestResult const& result);
+
+std::vector<std::string> CreateAllObjects(
+    gcs::Client client, google::cloud::internal::DefaultPRNG& gen,
+    std::string const& bucket_name, Options const& options);
+
+void RunTest(gcs::Client client, std::string const& bucket_name,
+             Options const& options,
+             std::vector<std::string> const& object_names);
+
+void DeleteAllObjects(gcs::Client client, std::string const& bucket_name,
+                      Options const& options,
+                      std::vector<std::string> const& object_names);
+
+}  // namespace
+
+int main(int argc, char* argv[]) try {
+  Options options;
+  options.ParseArgs(argc, argv);
+
+  if (std::getenv("GOOGLE_CLOUD_PROJECT") == nullptr) {
+    std::cerr << "GOOGLE_CLOUD_PROJECT environment variable must be set"
+              << std::endl;
+    return 1;
+  }
+
+  gcs::ClientOptions client_options;
+  if (not options.enable_connection_pool) {
+    client_options.set_connection_pool_size(0);
+  }
+  gcs::Client client(client_options);
+
+  google::cloud::internal::DefaultPRNG generator =
+      google::cloud::internal::MakeDefaultPRNG();
+
+  auto bucket_name = MakeRandomBucketName(generator);
+  auto meta =
+      client.CreateBucket(bucket_name,
+                          gcs::BucketMetadata()
+                              .set_storage_class(gcs::storage_class::Regional())
+                              .set_location(options.region),
+                          gcs::PredefinedAcl("private"),
+                          gcs::PredefinedDefaultObjectAcl("projectPrivate"),
+                          gcs::Projection("full"));
+  std::cout << "# Running test on bucket: " << meta.name() << std::endl;
+  std::string notes = google::cloud::storage::version_string() + ";" +
+                      google::cloud::internal::compiler() + ";" +
+                      google::cloud::internal::compiler_flags();
+  std::transform(notes.begin(), notes.end(), notes.begin(),
+                 [](char c) { return c == '\n' ? ';' : c; });
+  std::cout << "# Start time: "
+            << gcs::internal::FormatRfc3339(std::chrono::system_clock::now())
+            << "\n# Region: " << options.region
+            << "\n# Object Count: " << options.object_count
+            << "\n# Object Chunk Count: " << options.object_chunk_count
+            << "\n# Thread Count: " << options.thread_count
+            << "\n# Enable connection pool: " << options.enable_connection_pool
+            << "\n# Build info: " << notes << std::endl;
+
+  std::vector<std::string> object_names =
+      CreateAllObjects(client, generator, bucket_name, options);
+  RunTest(client, bucket_name, options, object_names);
+  DeleteAllObjects(client, bucket_name, options, object_names);
+
+  std::cout << "# Deleting " << bucket_name << std::endl;
+  client.DeleteBucket(bucket_name);
+
+  return 0;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard exception raised: " << ex.what() << std::endl;
+  return 1;
+}
+
+namespace {
+std::string Basename(std::string const& path) {
+  // Sure would be nice to be using C++17 where std::filesytem is a thing.
+#if _WIN32
+  return path.substr(path.find_last_of('\\') + 1);
+#else
+  return path.substr(path.find_last_of('/') + 1);
+#endif  // _WIN32
+}
+
+std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen) {
+  // The total length of this bucket name must be <= 63 characters,
+  static std::string const prefix = "gcs-cpp-thoughput-";
+  static std::size_t const kMaxBucketNameLength = 63;
+  std::size_t const max_random_characters =
+      kMaxBucketNameLength - prefix.size();
+  return prefix + google::cloud::internal::Sample(
+                      gen, static_cast<int>(max_random_characters),
+                      "abcdefghijklmnopqrstuvwxyz012456789");
+}
+
+std::string MakeRandomData(google::cloud::internal::DefaultPRNG& gen,
+                           std::size_t desired_size) {
+  std::string result;
+  result.reserve(desired_size);
+
+  // Create lines of 128 characters to start with, we can fill the remaining
+  // characters at the end.
+  constexpr int kLineSize = 128;
+  auto gen_random_line = [&gen](std::size_t count) {
+    return google::cloud::internal::Sample(gen, static_cast<int>(count - 1),
+                                           "abcdefghijklmnopqrstuvwxyz"
+                                           "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                           "012456789"
+                                           " - _ : /") +
+           "\n";
+  };
+  while (result.size() + kLineSize < desired_size) {
+    result += gen_random_line(kLineSize);
+  }
+  if (result.size() < desired_size) {
+    result += gen_random_line(desired_size - result.size());
+  }
+
+  return result;
+}
+
+std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen) {
+  return google::cloud::internal::Sample(gen, 128,
+                                         "abcdefghijklmnopqrstuvwxyz"
+                                         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                         "0123456789");
+}
+
+char const* ToString(OpType type) {
+  static char const* kOpTypeNames[] = {"READ", "WRITE", "CREATE", "DELETE",
+                                       "LAST"};
+  static_assert(OP_LAST + 1 == (sizeof(kOpTypeNames) / sizeof(kOpTypeNames[0])),
+                "Mismatched size for OpType names array");
+  return kOpTypeNames[type];
+}
+
+void PrintResult(TestResult const& result) {
+  for (auto const& r : result) {
+    std::cout << ToString(r.op) << "," << r.bytes << "," << r.elapsed.count()
+              << "\n";
+  }
+}
+
+TestResult WriteCommon(gcs::Client client, std::string const& bucket_name,
+                       std::string const& object_name,
+                       std::string const& data_chunk, Options const& options,
+                       OpType op_type = OP_WRITE) {
+  using std::chrono::milliseconds;
+  auto start = std::chrono::steady_clock::now();
+
+  TestResult result;
+  result.reserve(options.object_chunk_count /
+                 kThroughputReportIntervalInChunks);
+  gcs::ObjectWriteStream stream = client.WriteObject(bucket_name, object_name);
+  for (int i = 0; i < options.object_chunk_count; ++i) {
+    stream.write(data_chunk.data(), data_chunk.size());
+    if (i != 0 and i % kThroughputReportIntervalInChunks == 0) {
+      auto elapsed = std::chrono::steady_clock::now() - start;
+      result.emplace_back(
+          IterationResult{op_type, i * kChunkSize,
+                          std::chrono::duration_cast<milliseconds>(elapsed)});
+    }
+  }
+  try {
+    stream.Close();
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    result.emplace_back(
+        IterationResult{op_type, options.object_chunk_count * kChunkSize,
+                        std::chrono::duration_cast<milliseconds>(elapsed)});
+  } catch (std::exception const& ex) {
+    std::cerr << ex.what() << std::endl;
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    result.emplace_back(IterationResult{
+        op_type, 0, std::chrono::duration_cast<milliseconds>(elapsed)});
+  }
+  return result;
+}
+
+TestResult CreateOnce(gcs::Client client, std::string const& bucket_name,
+                      std::string const& object_name,
+                      std::string const& data_chunk, Options const& options) {
+  return WriteCommon(client, bucket_name, object_name, data_chunk, options,
+                     OP_CREATE);
+}
+
+TestResult WriteOnce(gcs::Client client, std::string const& bucket_name,
+                     std::string const& object_name,
+                     std::string const& data_chunk, Options const& options) {
+  return WriteCommon(client, bucket_name, object_name, data_chunk, options,
+                     OP_WRITE);
+}
+
+TestResult ReadOnce(gcs::Client client, std::string const& bucket_name,
+                    std::string const& object_name, Options const& options) {
+  using std::chrono::milliseconds;
+  auto start = std::chrono::steady_clock::now();
+  TestResult result;
+  result.reserve(kDefaultObjectChunkCount);
+
+  gcs::ObjectReadStream stream = client.ReadObject(bucket_name, object_name);
+  std::size_t total_size = 0;
+  constexpr auto report = kThroughputReportIntervalInChunks * kChunkSize;
+  while (not stream.eof()) {
+    char buf[4096];
+    stream.read(buf, sizeof(buf));
+    total_size += stream.gcount();
+    if (total_size != 0 and total_size % report == 0) {
+      auto elapsed = std::chrono::steady_clock::now() - start;
+      result.emplace_back(
+          IterationResult{OP_READ, total_size,
+                          std::chrono::duration_cast<milliseconds>(elapsed)});
+    }
+  }
+  auto elapsed = std::chrono::steady_clock::now() - start;
+  result.emplace_back(IterationResult{
+      OP_READ, total_size, std::chrono::duration_cast<milliseconds>(elapsed)});
+  return result;
+}
+
+TestResult CreateGroup(gcs::Client client, std::string const& bucket_name,
+                       Options const& options, std::vector<std::string> group) {
+  google::cloud::internal::DefaultPRNG generator =
+      google::cloud::internal::MakeDefaultPRNG();
+
+  std::string random_data = MakeRandomData(generator, kChunkSize);
+  TestResult result;
+  for (auto const& object_name : group) {
+    auto tmp =
+        CreateOnce(client, bucket_name, object_name, random_data, options);
+    result.insert(result.end(), tmp.begin(), tmp.end());
+  }
+  return result;
+}
+
+std::vector<std::string> CreateAllObjects(
+    gcs::Client client, google::cloud::internal::DefaultPRNG& gen,
+    std::string const& bucket_name, Options const& options) {
+  using std::chrono::duration_cast;
+  using std::chrono::milliseconds;
+
+  std::size_t const max_group_size =
+      std::max(options.object_count / options.thread_count, 1L);
+  std::cout << "# Creating test objects [" << max_group_size << "] "
+            << std::endl;
+
+  // Generate the list of object names.
+  std::vector<std::string> object_names;
+  object_names.reserve(options.object_count);
+  for (long c = 0; c != options.object_count; ++c) {
+    object_names.emplace_back(MakeRandomObjectName(gen));
+  }
+
+  // Split the objects in more or less equally sized groups, launch a thread
+  // to create the objects in each group.
+  auto start = std::chrono::steady_clock::now();
+  std::vector<std::future<TestResult>> tasks;
+  std::vector<std::string> group;
+  for (auto const& o : object_names) {
+    group.push_back(o);
+    if (group.size() >= max_group_size) {
+      tasks.emplace_back(std::async(std::launch::async, &CreateGroup, client,
+                                    bucket_name, options, std::move(group)));
+      group = {};  // after a move, must assign to guarantee it is valid.
+    }
+  }
+  if (not group.empty()) {
+    tasks.emplace_back(std::async(std::launch::async, &CreateGroup, client,
+                                  bucket_name, options, std::move(group)));
+    group = {};  // after a move, must assign to guarantee it is valid.
+  }
+  // Wait for the threads to finish.
+  for (auto& t : tasks) {
+    PrintResult(t.get());
+  }
+  auto elapsed = std::chrono::steady_clock::now() - start;
+  std::cout << "# Created in " << duration_cast<milliseconds>(elapsed).count()
+            << "ms" << std::endl;
+  return object_names;
+}
+
+TestResult RunTestThread(gcs::Client client, std::string const& bucket_name,
+                         Options const& options,
+                         std::vector<std::string> const& object_names) {
+  google::cloud::internal::DefaultPRNG generator =
+      google::cloud::internal::MakeDefaultPRNG();
+
+  std::string random_data = MakeRandomData(generator, kChunkSize);
+
+  std::uniform_int_distribution<std::size_t> object_number_gen(
+      0, object_names.size() - 1);
+  std::uniform_int_distribution<int> action_gen(0, 99);
+
+  TestResult result;
+  result.reserve(static_cast<std::size_t>(options.duration.count()));
+  auto deadline = std::chrono::system_clock::now() + options.duration;
+  while (std::chrono::system_clock::now() < deadline) {
+    auto const& object_name = object_names.at(object_number_gen(generator));
+    if (action_gen(generator) < 50) {
+      TestResult tmp =
+          WriteOnce(client, bucket_name, object_name, random_data, options);
+      result.insert(result.end(), tmp.begin(), tmp.end());
+    } else {
+      TestResult tmp = ReadOnce(client, bucket_name, object_name, options);
+      result.insert(result.end(), tmp.begin(), tmp.end());
+    }
+  }
+  return result;
+}
+
+void RunTest(gcs::Client client, std::string const& bucket_name,
+             Options const& options,
+             std::vector<std::string> const& object_names) {
+  std::vector<std::future<TestResult>> tasks;
+  for (int i = 0; i != options.thread_count; ++i) {
+    tasks.emplace_back(std::async(std::launch::async, &RunTestThread, client,
+                                  bucket_name, options, object_names));
+  }
+
+  for (auto& t : tasks) {
+    PrintResult(t.get());
+  }
+}
+
+TestResult DeleteGroup(gcs::Client client,
+                       std::vector<gcs::ObjectMetadata> group) {
+  TestResult result;
+  for (auto const& o : group) {
+    auto start = std::chrono::steady_clock::now();
+    client.DeleteObject(o.bucket(), o.name(), gcs::Generation(o.generation()));
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    using std::chrono::milliseconds;
+    auto ms = std::chrono::duration_cast<milliseconds>(elapsed);
+    result.emplace_back(IterationResult{OP_DELETE, 0, ms});
+  }
+  return result;
+}
+
+void DeleteAllObjects(gcs::Client client, std::string const& bucket_name,
+                      Options const& options,
+                      std::vector<std::string> const& object_names) {
+  using std::chrono::duration_cast;
+  using std::chrono::milliseconds;
+
+  auto const max_group_size =
+      std::max(options.object_count / options.thread_count, 1L);
+
+  std::cout << "# Deleting test objects [" << max_group_size << "]"
+            << std::endl;
+  auto start = std::chrono::steady_clock::now();
+  std::vector<std::future<TestResult>> tasks;
+  std::vector<gcs::ObjectMetadata> group;
+  for (auto const& o : client.ListObjects(bucket_name, gcs::Versions(true))) {
+    group.push_back(o);
+    if (group.size() >= static_cast<std::size_t>(max_group_size)) {
+      tasks.emplace_back(std::async(std::launch::async, &DeleteGroup, client,
+                                    std::move(group)));
+      group = {};  // after a move, must assign to guarantee it is valid.
+    }
+  }
+  if (not group.empty()) {
+    tasks.emplace_back(
+        std::async(std::launch::async, &DeleteGroup, client, std::move(group)));
+  }
+  // We do not print the latency to delete the objects because we have another
+  // benchmark to measure that.
+  auto elapsed = std::chrono::steady_clock::now() - start;
+  std::cout << "# Deleted in " << duration_cast<milliseconds>(elapsed).count()
+            << "ms" << std::endl;
+}
+
+void Options::ParseArgs(int& argc, char* argv[]) {
+  region = ConsumeArg(argc, argv, "region");
+}
+
+std::string Options::ConsumeArg(int& argc, char* argv[], char const* arg_name) {
+  std::string const duration = "--duration=";
+  std::string const object_count = "--object-count=";
+  std::string const object_chunk_count = "--object-chunk-count=";
+  std::string const thread_count = "--thread-count=";
+  std::string const enable_connection_pool = "--enable-connection-pool=";
+  std::string const enable_xml_api = "--enable-xml-api=";
+
+  std::string const usage = R""(
+[options] <region>
+The options are:
+    --help: produce this message.
+    --duration (in seconds): for how long should the test run.
+    --object-count: the number of objects to use in the benchmark.
+    --object-chunk-count: the number of chunks (1 MiB blocks) in each object.
+    --thread-count: the number of threads to use in the benchmark.
+    --enable-connection-pool: reuse connections across requests.
+    --enable-xml-api: configure read+write operations to use XML API.
+
+    region: a Google Cloud Storage region where all the objects used in this
+       test will be located.
+)"";
+
+  std::string error = "Missing argument ";
+  error += arg_name;
+  while (argc >= 2) {
+    std::string argument(argv[1]);
+    std::copy(argv + 2, argv + argc, argv + 1);
+    argc--;
+    if (argument == "--help") {
+    } else if (0 == argument.rfind(duration, 0)) {
+      std::string val = argument.substr(duration.size());
+      this->duration = std::chrono::seconds(std::stoi(val));
+    } else if (0 == argument.rfind(object_count, 0)) {
+      auto arg = argument.substr(object_count.size());
+      auto val = std::stol(arg);
+      if (val <= 0) {
+        error = "Invalid object-count argument (" + arg + ")";
+        break;
+      }
+      this->object_count = val;
+    } else if (0 == argument.rfind(object_chunk_count, 0)) {
+      auto arg = argument.substr(object_chunk_count.size());
+      auto val = std::stol(arg);
+      if (val <= 0) {
+        error = "Invalid object-chunk-count argument (" + arg + ")";
+        break;
+      }
+      this->object_chunk_count = val;
+    } else if (0 == argument.rfind(thread_count, 0)) {
+      auto arg = argument.substr(object_count.size());
+      auto val = std::stoi(arg);
+      if (val <= 0) {
+        error = "Invalid thread-count argument (" + arg + ")";
+        break;
+      }
+      this->thread_count = val;
+    } else if (0 == argument.rfind(enable_connection_pool, 0)) {
+      auto arg = argument.substr(enable_connection_pool.size());
+      if (arg == "true" or arg == "yes" or arg == "1") {
+        this->enable_connection_pool = true;
+      } else if (arg == "false" or arg == "no" or arg == "0") {
+        this->enable_connection_pool = false;
+      } else {
+        error = "Invalid enable-connection-pool argument (" + arg + ")";
+        break;
+      }
+    } else {
+      return argument;
+    }
+  }
+  std::ostringstream os;
+  os << error << "\n";
+  os << "Usage: " << Basename(argv[0]) << usage << std::endl;
+  throw std::runtime_error(os.str());
+}
+
+}  // namespace

--- a/google/cloud/storage/benchmarks/storage_throughput_benchmark_go.go
+++ b/google/cloud/storage/benchmarks/storage_throughput_benchmark_go.go
@@ -1,0 +1,314 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"os"
+	"path"
+	"runtime"
+	"strconv"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
+)
+
+const (
+	kDefaultDurationSeconds           = 60
+	kDefaultObjectCount               = 1000
+	kChunkSize                        = 1024 * 1024
+	kDefaultObjectChunkCount          = 250
+	kThroughputReportIntervalInChunks = 10
+)
+
+type IterationResult struct {
+	op      string
+	bytes   int
+	elapsed time.Duration
+}
+
+type TestResult []IterationResult
+
+func main() {
+	duration := kDefaultDurationSeconds
+	objectCount := kDefaultObjectCount
+	objectChunkCount := kDefaultObjectChunkCount
+	threadCount := 1
+
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <location>"+
+			" [duration-in-seconds (%d)] [object-count (%d)] [object-size-in-chunks (%d)] [thread-count (%d)]\n",
+			path.Base(os.Args[0]), duration, objectCount, objectChunkCount, threadCount)
+		os.Exit(1)
+	}
+	location := os.Args[1]
+
+	if len(os.Args) > 2 {
+		v, err := strconv.Atoi(os.Args[2])
+		if err != nil {
+			log.Fatal("%v while parsing duration argument (%s)", err, os.Args[2])
+		}
+		duration = v
+	}
+	if len(os.Args) > 3 {
+		v, err := strconv.Atoi(os.Args[3])
+		if err != nil {
+			log.Fatal("%v while parsing object-count argument (%s)", err, os.Args[3])
+		}
+		objectCount = v
+	}
+	if len(os.Args) > 4 {
+		v, err := strconv.Atoi(os.Args[4])
+		if err != nil {
+			log.Fatal("%v while parsing object-chunk-count argument (%s)", err, os.Args[4])
+		}
+		objectChunkCount = v
+	}
+	if len(os.Args) > 5 {
+		v, err := strconv.Atoi(os.Args[5])
+		if err != nil {
+			log.Fatal("%v while parsing thread-count argument (%s)", err, os.Args[4])
+		}
+		threadCount = v
+	}
+
+	ctx := context.Background()
+
+	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
+	if projectID == "" {
+		fmt.Fprintf(os.Stderr, "GOOGLE_CLOUD_PROJECT environment variable must be set.\n")
+		os.Exit(1)
+	}
+
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Initialize the default PRNG so that different runs do not generate the
+	// same sequence.
+	rand.Seed(time.Now().UnixNano())
+
+	bucketName := MakeRandomBucketName()
+	bucket := client.Bucket(bucketName)
+	if err := bucket.Create(ctx, projectID, &storage.BucketAttrs{
+		StorageClass:               "REGIONAL",
+		Location:                   location,
+		PredefinedACL:              "private",
+		PredefinedDefaultObjectACL: "projectPrivate",
+	}); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("# Running test on bucket: %v\n", bucketName)
+	fmt.Printf("# Start time: %s\n", time.Now().Format(time.RFC3339))
+	fmt.Printf("# Location: %s\n", location)
+	fmt.Printf("# Object Count: %d\n", objectCount)
+	fmt.Printf("# Object Chunk Count: %d\n", objectChunkCount)
+	fmt.Printf("# Thread Count: %d\n", threadCount)
+	fmt.Printf("# Build info: %s\n", runtime.Version())
+
+	objectNames := CreateAllObjects(bucket, ctx, objectCount, objectChunkCount, threadCount)
+	RunTest(bucket, ctx, duration, objectNames, objectChunkCount, threadCount)
+	DeleteAllObjects(bucket, ctx, objectCount)
+
+	fmt.Printf("# Deleting %v\n", bucketName)
+	if err := bucket.Delete(ctx); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func sample(letters []rune, n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func MakeRandomBucketName() string {
+	letters := []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+	prefix := "gcs-go-throughput-test-"
+	const maxBucketNameLength = 63
+
+	return prefix + sample(letters, maxBucketNameLength-len(prefix))
+}
+
+func MakeRandomObjectName() string {
+	letters := []rune("abcdefghijklmnopqrstuvwxyz" + "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+		"0123456789")
+	return sample(letters, 128)
+}
+
+func PrintResult(result TestResult) {
+	for _, r := range result {
+		fmt.Printf("%s,%d,%d\n", r.op, r.bytes, r.elapsed.Nanoseconds()/1000000)
+	}
+}
+
+func MakeRandomData(desiredSize int) string {
+	chars := []rune("abcdefghijklmnopqrstuvwxyz" + "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+		"0123456789" + " - _ : /")
+	const (
+		kLineSize = 128
+	)
+	result := ""
+	for len(result)+kLineSize < desiredSize {
+		result = result + sample(chars, kLineSize-1) + "\n"
+	}
+	if len(result) < desiredSize {
+		result = result + sample(chars, desiredSize-len(result))
+	}
+	return result
+}
+
+func CreateOneObject(bucket *storage.BucketHandle, ctx context.Context,
+	objectName string, data string, objectChunkCount int) []IterationResult {
+	return WriteCommon(bucket, ctx, objectName, data, objectChunkCount, "CREATE")
+}
+
+func CreateAllObjects(bucket *storage.BucketHandle, ctx context.Context,
+	objectCount int, objectChunkCount int, threadCount int) []string {
+	names := make([]string, 0, objectCount)
+	for i := 0; i < objectCount; i++ {
+		names = append(names, MakeRandomObjectName())
+	}
+
+	data := MakeRandomData(kChunkSize)
+	fmt.Printf("# Creating test objects [N/A]\n")
+	start := time.Now()
+	for _, name := range names {
+		r := CreateOneObject(bucket, ctx, name, data, objectChunkCount)
+		PrintResult(r)
+	}
+	elapsed := time.Since(start)
+	fmt.Printf("# Created in %dms\n", elapsed.Nanoseconds()/1000000)
+	return names
+}
+
+func WriteOnce(bucket *storage.BucketHandle, ctx context.Context,
+	objectName string, data string, objectChunkCount int) []IterationResult {
+	return WriteCommon(bucket, ctx, objectName, data, objectChunkCount, "WRITE")
+}
+
+func WriteCommon(bucket *storage.BucketHandle, ctx context.Context,
+	objectName string, data string, objectChunkCount int, opName string) []IterationResult {
+	start := time.Now()
+	result := make([]IterationResult, 0, objectChunkCount)
+
+	w := bucket.Object(objectName).NewWriter(ctx)
+	for i := 0; i < objectChunkCount; i++ {
+		if _, err := w.Write([]byte(data)); err != nil {
+			result = append(result, IterationResult{op: "WRITE", bytes: -1, elapsed: time.Since(start)})
+		}
+		if i != 0 && i%kThroughputReportIntervalInChunks == 0 {
+			result = append(result, IterationResult{op: opName, bytes: i * len(data), elapsed: time.Since(start)})
+		}
+	}
+	if err := w.Close(); err != nil {
+		result = append(result, IterationResult{op: opName, bytes: objectChunkCount * len(data), elapsed: time.Since(start)})
+	}
+	return result
+}
+
+func ReadOnce(bucket *storage.BucketHandle, ctx context.Context, objectName string) []IterationResult {
+	start := time.Now()
+	result := make([]IterationResult, 0, kDefaultObjectChunkCount)
+
+	rd, err := bucket.Object(objectName).NewReader(ctx)
+	if err != nil {
+		result = append(result, IterationResult{op: "READ", bytes: 0, elapsed: time.Since(start)})
+		return result
+	}
+	buf := make([]byte, 4096)
+	totalSize := 0
+	const (
+		report = kThroughputReportIntervalInChunks * kChunkSize
+	)
+	for {
+		_, err = io.ReadFull(rd, buf)
+		if err != nil {
+			result = append(result, IterationResult{op: "READ", bytes: -1, elapsed: time.Since(start)})
+			continue
+		}
+		totalSize += len(buf)
+		if totalSize != 0 && totalSize%report == 0 {
+			result = append(result, IterationResult{op: "READ", bytes: totalSize, elapsed: time.Since(start)})
+		}
+	}
+	rd.Close()
+	result = append(result, IterationResult{op: "READ", bytes: totalSize, elapsed: time.Since(start)})
+	return result
+}
+
+func RunTestThread(bucket *storage.BucketHandle, ctx context.Context,
+	duration int, objectNames []string, objectChunkCount int, ch chan TestResult) {
+	data := MakeRandomData(kChunkSize)
+	result := make([]IterationResult, 0, 5*duration)
+	deadline := time.Now().Add(time.Duration(duration) * time.Second)
+	for time.Now().Before(deadline) {
+		name := objectNames[rand.Intn(len(objectNames))]
+		if rand.Intn(100) < 50 {
+			result = append(result, WriteOnce(bucket, ctx, name, data, objectChunkCount)...)
+		} else {
+			result = append(result, ReadOnce(bucket, ctx, name)...)
+		}
+	}
+	ch <- result
+}
+
+func RunTest(bucket *storage.BucketHandle, ctx context.Context,
+	duration int, objectNames []string, objectChunkCount int, threadCount int) {
+	ch := make(chan TestResult, threadCount)
+	for i := 0; i < threadCount; i++ {
+		go RunTestThread(bucket, ctx, duration, objectNames, objectChunkCount, ch)
+	}
+	for i := 0; i < threadCount; i++ {
+		result := <-ch
+		PrintResult(result)
+	}
+}
+
+func DeleteObject(bucket *storage.BucketHandle, ctx context.Context, objectName string) {
+	start := time.Now()
+	bucket.Object(objectName).Delete(ctx)
+	elapsed := time.Since(start)
+}
+
+func DeleteAllObjects(bucket *storage.BucketHandle, ctx context.Context, objectCount int) {
+	fmt.Printf("# Deleting test objects [N/A]\n")
+	start := time.Now()
+	names := make([]string, 0, objectCount)
+	it := bucket.Objects(ctx, nil)
+	for {
+		objAttrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			log.Fatal("%v while getting object list", err)
+		}
+		names = append(names, objAttrs.Name)
+	}
+	for _, name := range names {
+		DeleteObject(bucket, ctx, name)
+	}
+	elapsed := time.Since(start)
+	fmt.Printf("# Deleted in %dms\n", elapsed.Nanoseconds()/1000000)
+}

--- a/google/cloud/storage/benchmarks/storage_throughput_compare.R
+++ b/google/cloud/storage/benchmarks/storage_throughput_compare.R
@@ -1,0 +1,65 @@
+#!/usr/bin/env Rscript
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+args <- commandArgs(trailingOnly=TRUE)
+if (length(args) != 4) {
+    file.arg.name <- "--file="
+    all.args <- commandArgs(trailingOnly=FALSE)
+    cmd <- basename(sub(file.arg.name, "", all.args[grep(file.arg.name, all.args)]))
+    stop(paste("Usage:", cmd, "<a-file> <a-name> <b-file> <b-name>"))
+}
+
+require(ggplot2)
+
+a.filename <- args[1]
+a.run <- args[2]
+b.filename <- args[3]
+b.run <- args[4]
+
+load.throughput <- function(filename, run) {
+    df <- read.csv(filename, comment.char='#', header=FALSE,
+    col.names=c('op', 'bytes', 'ms'))
+    df$op <- factor(df$op)
+    df$run <- factor(run)
+    df$seconds <- df$ms / 1000.0
+    df$bits <- 8 * df$bytes
+    df$MiB <- df$bytes / (1024 * 1024.0)
+    df$Mbits <- df$bits / 10000000.0
+    df$Mbps <- df$Mbits / df$seconds
+    return(df);
+}
+
+a.df <- load.throughput(a.filename, a.run)
+b.df <- load.throughput(b.filename, b.run)
+df <- rbind(a.df, b.df)
+
+MiB.max <- max(df$MiB)
+aggregate(Mbps ~ run + MiB + op, data=subset(df, MiB == MiB.max), FUN=summary)
+
+aggregate(Mbps ~ run + MiB + op, data=subset(df, MiB == MiB.max), FUN=mean)
+
+# Skip the DELETE operations in this graph because they have "0" throughput.
+ggplot(data=df, mapping=aes(x=MiB, y=Mbps, color=run)) +
+    facet_grid(op ~ .) + geom_smooth()
+
+fig.height <- function(width) {
+    phi <- (1 + sqrt(5.0)) / 2
+    return(width / phi)
+}
+
+ggsave(paste('compare-throughput-', a.run, '-', b.run, '.png', sep=''),
+    width=8.5, height=fig.height(8.5))
+
+q(save="no")

--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -80,10 +80,6 @@ class ClientOptions {
 
   std::size_t connection_pool_size() const { return connection_pool_size_; }
   ClientOptions& set_connection_pool_size(std::size_t size) {
-    if (size == 0) {
-      google::cloud::internal::RaiseInvalidArgument(
-          "Cannot set connection pool size to 0");
-    }
     connection_pool_size_ = size;
     return *this;
   }


### PR DESCRIPTION
This fixes #572.

Measures the throughput to create, read, and write objects in the 250MiB
range. It reports the throughput every 10MiB, so we can see the effect
of the initial overhead.

Changed the ClientOptions and CurlClient classes to allow 0-sized
connection pools. They are interpreted as "no pooling".