### PR TITLE
Implements helper classes to retry asynchronous operations

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -138,6 +138,7 @@ add_library(bigtable_client
             instance_config.cc
             instance_update_config.h
             instance_update_config.cc
+            internal/async_retry_unary_rpc.h
             internal/bulk_mutator.h
             internal/bulk_mutator.cc
             internal/completion_queue_impl.h
@@ -226,6 +227,7 @@ add_library(bigtable_client_testing
             testing/inprocess_data_client.cc
             testing/inprocess_admin_client.h
             testing/inprocess_admin_client.cc
+            testing/mock_completion_queue.h
             testing/mock_mutate_rows_reader.h
             testing/mock_read_rows_reader.h
             testing/mock_response_reader.h
@@ -268,6 +270,7 @@ set(bigtable_client_unit_tests
     internal/grpc_error_delegate_test.cc
     internal/prefix_range_end_test.cc
     internal/table_admin_test.cc
+    internal/table_async_apply_test.cc
     internal/table_test.cc
     mutations_test.cc
     table_admin_test.cc

--- a/google/cloud/bigtable/async_operation.h
+++ b/google/cloud/bigtable/async_operation.h
@@ -96,8 +96,6 @@ class AsyncOperation {
    *   the operation were canceled. Note that errors are a "normal" completion.
    */
   virtual void Notify(CompletionQueue& cq, Disposition disposition) = 0;
-
-  virtual void SimulateNotify() = 0;
 };
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/google/cloud/bigtable/async_operation.h
+++ b/google/cloud/bigtable/async_operation.h
@@ -23,6 +23,8 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+class CompletionQueue;
+
 namespace internal {
 class CompletionQueueImpl;
 }  // namespace internal
@@ -94,6 +96,8 @@ class AsyncOperation {
    *   the operation were canceled. Note that errors are a "normal" completion.
    */
   virtual void Notify(CompletionQueue& cq, Disposition disposition) = 0;
+
+  virtual void SimulateNotify() = 0;
 };
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/google/cloud/bigtable/bigtable_client.bzl
+++ b/google/cloud/bigtable/bigtable_client.bzl
@@ -16,6 +16,7 @@ bigtable_client_HDRS = [
     "instance_admin.h",
     "instance_config.h",
     "instance_update_config.h",
+    "internal/async_retry_unary_rpc.h",
     "internal/bulk_mutator.h",
     "internal/completion_queue_impl.h",
     "internal/common_client.h",

--- a/google/cloud/bigtable/bigtable_client_testing.bzl
+++ b/google/cloud/bigtable/bigtable_client_testing.bzl
@@ -7,6 +7,7 @@ bigtable_client_testing_HDRS = [
     "testing/mock_instance_admin_client.h",
     "testing/inprocess_data_client.h",
     "testing/inprocess_admin_client.h",
+    "testing/mock_completion_queue.h",
     "testing/mock_mutate_rows_reader.h",
     "testing/mock_read_rows_reader.h",
     "testing/mock_response_reader.h",

--- a/google/cloud/bigtable/bigtable_client_unit_tests.bzl
+++ b/google/cloud/bigtable/bigtable_client_unit_tests.bzl
@@ -21,6 +21,7 @@ bigtable_client_unit_tests = [
     "internal/grpc_error_delegate_test.cc",
     "internal/prefix_range_end_test.cc",
     "internal/table_admin_test.cc",
+    "internal/table_async_apply_test.cc",
     "internal/table_test.cc",
     "mutations_test.cc",
     "table_admin_test.cc",

--- a/google/cloud/bigtable/completion_queue.h
+++ b/google/cloud/bigtable/completion_queue.h
@@ -57,7 +57,7 @@ class CompletionQueue {
   std::shared_ptr<AsyncOperation> MakeDeadlineTimer(
       std::chrono::system_clock::time_point deadline, Functor&& functor) {
     auto op = std::make_shared<internal::AsyncTimerFunctor<Functor>>(
-        std::forward<Functor>(functor));
+        std::forward<Functor>(functor), impl_->CreateAlarm());
     void* tag = impl_->RegisterOperation(op);
     op->Set(impl_->cq(), deadline, tag);
     return op;

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc.h
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc.h
@@ -1,0 +1,231 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_RETRY_UNARY_RPC_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_RETRY_UNARY_RPC_H_
+
+#include "google/cloud/bigtable/completion_queue.h"
+#include "google/cloud/bigtable/metadata_update_policy.h"
+#include "google/cloud/bigtable/rpc_backoff_policy.h"
+#include "google/cloud/bigtable/rpc_retry_policy.h"
+#include "google/cloud/internal/make_unique.h"
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
+/**
+ * Perform an asynchronous unary RPC request, with retries.
+ *
+ * @tparam Client the class implementing the asynchronous operation, examples
+ *     include `DataClient`, `AdminClient`, and `InstanceAdminClient`.
+ *
+ * @tparam MemberFunctionType the type of the member function to call on the
+ *     `Client` object. This type must meet the requirements of
+ *     `internal::CheckAsyncUnaryRpcSignature`, the `AsyncRetryUnaryRpc`
+ *     template is disabled otherwise.
+ *
+ * @tparam IdempotentPolicy the policy used to determine if an operation is
+ *     idempotent. In most cases this is just `ConstantIdempotentPolicy`
+ *     because the decision around idempotency can be made before the retry loop
+ *     starts. Some calls may dynamically determine if a retry (or a partial
+ *     retry for BulkApply) are idempotent.
+ *
+ * @tparam Functor the type of the function-like object that will receive the
+ *     results.
+ *
+ * @tparam Sig A formal parameter to discover if `MemberFunctionType` matches
+ *     the required signature for an asynchronous gRPC call, and if so, what are
+ *     the request and response parameter types for the RPC.
+ *
+ * @tparam valid_member_function_type a formal parameter, uses
+ *     `std::enable_if<>` to disable this template if the member function type
+ *     does not match the desired signature.
+ *
+ * @tparam valid_callback_type a format parameter, uses `std::enable_if<>` to
+ *     disable this template if the functor does not match the expected
+ *     signature.
+ */
+template <
+    typename Client, typename MemberFunctionType, typename IdempotentPolicy,
+    typename Functor,
+    typename Sig = internal::CheckAsyncUnaryRpcSignature<MemberFunctionType>,
+    typename std::enable_if<Sig::value, int>::type valid_member_function_type =
+        0,
+    typename std::enable_if<
+        google::cloud::internal::is_invocable<Functor, CompletionQueue&,
+                                              typename Sig::ResponseType&,
+                                              grpc::Status&>::value,
+        int>::type valid_callback_type = 0>
+class AsyncRetryUnaryRpc
+    : public std::enable_shared_from_this<AsyncRetryUnaryRpc<
+          Client, MemberFunctionType, IdempotentPolicy, Functor>> {
+ public:
+  //@{
+  /// @name Convenience aliases for the RPC request and response types.
+  using Request = typename Sig::RequestType;
+  using Response = typename Sig::ResponseType;
+  //@}
+
+  /// The type used by `CompletionQueue` to return the RPC results.
+  using AsyncResult = AsyncUnaryRpcResult<Response>;
+
+  explicit AsyncRetryUnaryRpc(
+      char const* error_message,
+      std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
+      std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
+      IdempotentPolicy idempotent_policy,
+      MetadataUpdatePolicy metadata_update_policy,
+      std::shared_ptr<Client> client, MemberFunctionType Client::*call,
+      Request&& request, Functor&& callback)
+      : error_message_(error_message),
+        rpc_retry_policy_(std::move(rpc_retry_policy)),
+        rpc_backoff_policy_(std::move(rpc_backoff_policy)),
+        idempotent_policy_(std::move(idempotent_policy)),
+        metadata_update_policy_(std::move(metadata_update_policy)),
+        client_(std::move(client)),
+        call_(std::move(call)),
+        request_(std::move(request)),
+        callback_(std::forward<Functor>(callback)) {}
+
+  /**
+   * Kick off the asynchronous request.
+   *
+   * @param cq the completion queue to run the asynchronous operations.
+   */
+  void Start(CompletionQueue& cq) {
+    auto self = this->shared_from_this();
+    auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
+    rpc_retry_policy_->Setup(*context);
+    rpc_backoff_policy_->Setup(*context);
+    metadata_update_policy_.Setup(*context);
+
+    cq.MakeUnaryRpc(*client_, call_, request_, std::move(context),
+                    [self](CompletionQueue& cq, AsyncResult& op,
+                           AsyncOperation::Disposition d) {
+                      self->OnCompletion(cq, op, d);
+                    });
+  }
+
+ private:
+  std::string FullErrorMessage(char const* where) {
+    std::string full_message = error_message_;
+    full_message += "(" + metadata_update_policy_.value() + ") ";
+    full_message += where;
+    return full_message;
+  }
+
+  std::string FullErrorMessage(char const* where, grpc::Status const& status) {
+    std::string full_message = FullErrorMessage(where);
+    full_message += ", last error=";
+    full_message += status.error_message();
+    return full_message;
+  }
+
+  /// The callback to handle one asynchronous request completing.
+  void OnCompletion(CompletionQueue& cq, AsyncResult& op,
+                    AsyncOperation::Disposition d) {
+    if (d == AsyncOperation::CANCELLED) {
+      // Cancelled, no retry necessary.
+      callback_(cq, op.response,
+                grpc::Status(
+                    grpc::StatusCode::CANCELLED,
+                    FullErrorMessage("pending operation cancelled", op.status),
+                    op.status.error_details()));
+      return;
+    }
+    if (op.status.ok()) {
+      // Success, just report the result.
+      callback_(cq, op.response, op.status);
+      return;
+    }
+    if (not idempotent_policy_.is_idempotent()) {
+      callback_(cq, op.response,
+                grpc::Status(op.status.error_code(),
+                             FullErrorMessage("non-idempotent operation failed",
+                                              op.status),
+                             op.status.error_details()));
+      return;
+    }
+    if (not rpc_retry_policy_->OnFailure(op.status)) {
+      std::string full_message =
+          FullErrorMessage(RPCRetryPolicy::IsPermanentFailure(op.status)
+                               ? "permanent error"
+                               : "too many transient errors",
+                           op.status);
+      callback_(cq, op.response,
+                grpc::Status(op.status.error_code(), full_message,
+                             op.status.error_details()));
+      return;
+    }
+
+    auto delay = rpc_backoff_policy_->OnCompletion(op.status);
+    auto self = this->shared_from_this();
+    cq.MakeRelativeTimer(
+        delay,
+        [self](CompletionQueue& cq, AsyncTimerResult timer,
+               AsyncOperation::Disposition d) { self->OnTimer(cq, timer, d); });
+  }
+
+  void OnTimer(CompletionQueue& cq, AsyncTimerResult& timer,
+               AsyncOperation::Disposition d) {
+    if (d == AsyncOperation::CANCELLED) {
+      // Cancelled, no more action to take.
+      Response placeholder{};
+      callback_(cq, placeholder,
+                grpc::Status(grpc::StatusCode::CANCELLED,
+                             FullErrorMessage("pending timer cancelled")));
+      return;
+    }
+    Start(cq);
+  }
+
+  char const* error_message_;
+  std::unique_ptr<RPCRetryPolicy> rpc_retry_policy_;
+  std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy_;
+  IdempotentPolicy idempotent_policy_;
+  MetadataUpdatePolicy metadata_update_policy_;
+  std::shared_ptr<Client> client_;
+  MemberFunctionType Client::*call_;
+  Request request_;
+
+  Functor callback_;
+};
+
+/**
+ * An idempotent policy for `AsyncRetryUnaryRpc` based on a pre-computed value.
+ *
+ * In most APIs the idempotency of the API is either known at compile-time or
+ * the value is unchanged during the retry loop. This class can be used in those
+ * cases as the `IdempotentPolicy` template parameter for `AsyncRetryUnaryRpc`.
+ */
+class ConstantIdempotentPolicy {
+ public:
+  explicit ConstantIdempotentPolicy(bool is_idempotent)
+      : is_idempotent_(is_idempotent) {}
+
+  bool is_idempotent() const { return is_idempotent_; }
+
+ private:
+  bool is_idempotent_;
+};
+
+}  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_RETRY_UNARY_RPC_H_

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc.h
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc.h
@@ -37,7 +37,7 @@ namespace internal {
  *     `internal::CheckAsyncUnaryRpcSignature`, the `AsyncRetryUnaryRpc`
  *     template is disabled otherwise.
  *
- * @tparam IdempotentPolicy the policy used to determine if an operation is
+ * @tparam IdempotencyPolicy the policy used to determine if an operation is
  *     idempotent. In most cases this is just `ConstantIdempotentPolicy`
  *     because the decision around idempotency can be made before the retry loop
  *     starts. Some calls may dynamically determine if a retry (or a partial
@@ -59,7 +59,7 @@ namespace internal {
  *     signature.
  */
 template <
-    typename Client, typename MemberFunctionType, typename IdempotentPolicy,
+    typename Client, typename MemberFunctionType, typename IdempotencyPolicy,
     typename Functor,
     typename Sig = internal::CheckAsyncUnaryRpcSignature<MemberFunctionType>,
     typename std::enable_if<Sig::value, int>::type valid_member_function_type =
@@ -71,7 +71,7 @@ template <
         int>::type valid_callback_type = 0>
 class AsyncRetryUnaryRpc
     : public std::enable_shared_from_this<AsyncRetryUnaryRpc<
-          Client, MemberFunctionType, IdempotentPolicy, Functor>> {
+          Client, MemberFunctionType, IdempotencyPolicy, Functor>> {
  public:
   //@{
   /// @name Convenience aliases for the RPC request and response types.
@@ -86,7 +86,7 @@ class AsyncRetryUnaryRpc
       char const* error_message,
       std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
       std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
-      IdempotentPolicy idempotent_policy,
+      IdempotencyPolicy idempotent_policy,
       MetadataUpdatePolicy metadata_update_policy,
       std::shared_ptr<Client> client, MemberFunctionType Client::*call,
       Request&& request, Functor&& callback)
@@ -195,7 +195,7 @@ class AsyncRetryUnaryRpc
   char const* error_message_;
   std::unique_ptr<RPCRetryPolicy> rpc_retry_policy_;
   std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy_;
-  IdempotentPolicy idempotent_policy_;
+  IdempotencyPolicy idempotent_policy_;
   MetadataUpdatePolicy metadata_update_policy_;
   std::shared_ptr<Client> client_;
   MemberFunctionType Client::*call_;
@@ -211,9 +211,9 @@ class AsyncRetryUnaryRpc
  * the value is unchanged during the retry loop. This class can be used in those
  * cases as the `IdempotentPolicy` template parameter for `AsyncRetryUnaryRpc`.
  */
-class ConstantIdempotentPolicy {
+class ConstantIdempotencyPolicy {
  public:
-  explicit ConstantIdempotentPolicy(bool is_idempotent)
+  explicit ConstantIdempotencyPolicy(bool is_idempotent)
       : is_idempotent_(is_idempotent) {}
 
   bool is_idempotent() const { return is_idempotent_; }

--- a/google/cloud/bigtable/internal/table.h
+++ b/google/cloud/bigtable/internal/table.h
@@ -192,12 +192,12 @@ class Table {
 
     using Retry =
         internal::AsyncRetryUnaryRpc<DataClient, MemberFunction,
-                                     internal::ConstantIdempotentPolicy,
+                                     internal::ConstantIdempotencyPolicy,
                                      Functor>;
 
     auto retry = std::make_shared<Retry>(
         __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
-        internal::ConstantIdempotentPolicy(is_idempotent),
+        internal::ConstantIdempotencyPolicy(is_idempotent),
         metadata_update_policy_, client_, &DataClient::AsyncMutateRow,
         std::move(request), std::forward<Functor>(callback));
     retry->Start(cq);

--- a/google/cloud/bigtable/internal/table.h
+++ b/google/cloud/bigtable/internal/table.h
@@ -20,6 +20,7 @@
 #include "google/cloud/bigtable/data_client.h"
 #include "google/cloud/bigtable/filters.h"
 #include "google/cloud/bigtable/idempotent_mutation_policy.h"
+#include "google/cloud/bigtable/internal/async_retry_unary_rpc.h"
 #include "google/cloud/bigtable/metadata_update_policy.h"
 #include "google/cloud/bigtable/mutations.h"
 #include "google/cloud/bigtable/read_modify_write_rule.h"
@@ -73,6 +74,17 @@ struct RowKeySample {
  * Provide APIs to access and modify data in a Cloud Bigtable table.
  */
 namespace noex {
+
+/**
+ * Manipulate data in a Cloud Bigtable table.
+ *
+ * This class implements APIs to manipulate data in a Cloud Bigtable table. It
+ * uses a `grpc::Status` parameter to signal errors, as opposed to
+ * `google::cloud::bigtable::Table` which uses exceptions.
+ *
+ * In general, the documentation for `google::cloud::bigtable::Table` applies to
+ * both.
+ */
 class Table {
  public:
   Table(std::shared_ptr<DataClient> client,
@@ -114,8 +126,16 @@ class Table {
    * @name No exception versions of Table::*
    *
    * These functions provide the same functionality as their counterparts in the
-   * `bigtable::Table` class, but do not raise exceptions on errors, instead
-   * they return the error on the status parameter.
+   * `bigtable::Table` class. Unless otherwise noted, these functions do not
+   * raise exceptions of failure, instead they return the error on the
+   * `grpc::Status` parameter.
+   */
+
+  /**
+   * Apply multiple mutations to a single row.
+   *
+   * @return The list of mutations that failed, empty when the operation is
+   *     successful.
    */
   std::vector<FailedMutation> Apply(SingleRowMutation&& mut);
 
@@ -137,39 +157,50 @@ class Table {
    * @return A handle to the asynchronous operation, applications can request
    *   the operation to be canceled.
    */
-  template <typename Functor,
-            typename std::enable_if<
-                google::cloud::internal::is_invocable<
-                    Functor, google::bigtable::v2::MutateRowResponse&,
-                    grpc::Status&>::value,
-                int>::type valid_callback_type = 0>
-  std::shared_ptr<AsyncOperation> AsyncApply(SingleRowMutation&& mut,
-                                             CompletionQueue& cq,
-                                             Functor&& callback) {
-    using AsyncOpResult =
-        AsyncUnaryRpcResult<google::bigtable::v2::MutateRowResponse>;
-
-    auto rpc_policy = rpc_retry_policy_->clone();
-    auto backoff_policy = rpc_backoff_policy_->clone();
-    auto idempotent_policy = idempotent_mutation_policy_->clone();
-
+  template <
+      typename Functor,
+      typename std::enable_if<
+          google::cloud::internal::is_invocable<
+              Functor, CompletionQueue&,
+              google::bigtable::v2::MutateRowResponse&, grpc::Status&>::value,
+          int>::type valid_callback_type = 0>
+  void AsyncApply(SingleRowMutation&& mut, CompletionQueue& cq,
+                  Functor&& callback) {
     google::bigtable::v2::MutateRowRequest request;
     internal::SetCommonTableOperationRequest<
         google::bigtable::v2::MutateRowRequest>(request, app_profile_id_.get(),
                                                 table_name_.get());
     mut.MoveTo(request);
     auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
-    return cq.MakeUnaryRpc(
-        *client_, &DataClient::AsyncMutateRow, request, std::move(context),
-        [callback](CompletionQueue& cq, AsyncOpResult& result, bool ok) {
-          if (not ok) {
-            callback(result.response,
-                     grpc::Status(grpc::StatusCode::CANCELLED,
-                                  result.status.error_message()));
-          } else {
-            callback(result.response, result.status);
-          }
+
+    // Determine if all the mutations are idempotent. The idempotency of the
+    // mutations won't change as the retry loop executes, so we can just compute
+    // it once and use a constant value for the loop.
+    auto idempotent_mutation_policy = idempotent_mutation_policy_->clone();
+    bool const is_idempotent = std::all_of(
+        request.mutations().begin(), request.mutations().end(),
+        [&idempotent_mutation_policy](google::bigtable::v2::Mutation const& m) {
+          return idempotent_mutation_policy->is_idempotent(m);
         });
+
+    static_assert(internal::ExtractMemberFunctionType<decltype(
+                      &DataClient::AsyncMutateRow)>::value,
+                  "Cannot extract member function type");
+    using MemberFunction =
+        typename internal::ExtractMemberFunctionType<decltype(
+            &DataClient::AsyncMutateRow)>::MemberFunction;
+
+    using Retry =
+        internal::AsyncRetryUnaryRpc<DataClient, MemberFunction,
+                                     internal::ConstantIdempotentPolicy,
+                                     Functor>;
+
+    auto retry = std::make_shared<Retry>(
+        __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
+        internal::ConstantIdempotentPolicy(is_idempotent),
+        metadata_update_policy_, client_, &DataClient::AsyncMutateRow,
+        std::move(request), std::forward<Functor>(callback));
+    retry->Start(cq);
   }
 
   std::vector<FailedMutation> BulkApply(BulkMutation&& mut,

--- a/google/cloud/bigtable/internal/table_async_apply_test.cc
+++ b/google/cloud/bigtable/internal/table_async_apply_test.cc
@@ -1,0 +1,431 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/internal/table.h"
+#include "google/cloud/bigtable/testing/internal_table_test_fixture.h"
+#include "google/cloud/bigtable/testing/mock_completion_queue.h"
+#include "google/cloud/bigtable/testing/mock_mutate_rows_reader.h"
+#include "google/cloud/testing_util/chrono_literals.h"
+#include <gmock/gmock.h>
+#include <thread>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace noex {
+namespace {
+class NoexTableAsyncApplyTest
+    : public bigtable::testing::internal::TableTestFixture {};
+
+using ::testing::_;
+using ::testing::HasSubstr;
+using ::testing::Invoke;
+using ::testing::Return;
+using namespace google::cloud::testing_util::chrono_literals;
+namespace btproto = google::bigtable::v2;
+
+using testing::MockAsyncApplyReader;
+
+/// @test Verify that noex::Table::AsyncApply() works in a simple case.
+TEST_F(NoexTableAsyncApplyTest, SuccessAfterOneRetry) {
+  auto impl = std::make_shared<testing::MockCompletionQueue>();
+  bigtable::CompletionQueue cq(impl);
+
+  // Simulate a transient failure first.
+  auto r1 = google::cloud::internal::make_unique<MockAsyncApplyReader>();
+  bool r1_called = false;
+  EXPECT_CALL(*r1, Finish(_, _, _))
+      .WillOnce(Invoke([&r1_called](btproto::MutateRowResponse*,
+                                    grpc::Status* status, void*) {
+        r1_called = true;
+        *status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
+      }));
+
+  // Then simulate a successful response.
+  auto r2 = google::cloud::internal::make_unique<MockAsyncApplyReader>();
+  bool r2_called = false;
+  EXPECT_CALL(*r2, Finish(_, _, _))
+      .WillOnce(Invoke([&r2_called](btproto::MutateRowResponse* r,
+                                    grpc::Status* status, void* tag) {
+        r2_called = true;
+        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+      }));
+
+  // Because there is a transient failure, we expect two calls.
+  EXPECT_CALL(*client_, AsyncMutateRow(_, _, _))
+      .WillOnce(
+          Invoke([&r1](grpc::ClientContext*, btproto::MutateRowRequest const&,
+                       grpc::CompletionQueue*) {
+            // This is safe, see comments in MockAsyncResponseReader.
+            return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
+                btproto::MutateRowResponse>>(r1.get());
+          }))
+      .WillOnce(
+          Invoke([&r2](grpc::ClientContext*, btproto::MutateRowRequest const&,
+                       grpc::CompletionQueue*) {
+            // This is safe, see comments in MockAsyncResponseReader.
+            return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
+                btproto::MutateRowResponse>>(r2.get());
+          }));
+
+  // Make the asynchronous request.
+  bool op_called = false;
+  grpc::Status capture_status;
+  table_.AsyncApply(
+      bigtable::SingleRowMutation(
+          "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}),
+      cq,
+      [&op_called, &capture_status](CompletionQueue& cq,
+                                    google::bigtable::v2::MutateRowResponse& r,
+                                    grpc::Status const& status) {
+        op_called = true;
+        capture_status = status;
+      });
+
+  // At this point r1 is fired, but neither r2, nor the final callback are
+  // called, verify that and simulate the first request completing.
+  EXPECT_TRUE(r1_called);
+  EXPECT_FALSE(r2_called);
+  EXPECT_FALSE(op_called);
+  EXPECT_EQ(1U, impl->size());
+  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+
+  // That should have created a timer, but not fired r2, verify that and
+  // simulate the timer completion.
+  EXPECT_TRUE(r1_called);
+  EXPECT_FALSE(r2_called);
+  EXPECT_FALSE(op_called);
+  EXPECT_EQ(1U, impl->size());
+  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+
+  // Once the timer completes, r2 should be fired, but op, verify this and
+  // simulate r2 completing.
+  EXPECT_TRUE(r1_called);
+  EXPECT_TRUE(r2_called);
+  EXPECT_FALSE(op_called);
+  EXPECT_EQ(1U, impl->size());
+  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+
+  // At this point all requests and the final callback should be completed.
+  EXPECT_TRUE(r1_called);
+  EXPECT_TRUE(r2_called);
+  EXPECT_TRUE(op_called);
+  EXPECT_TRUE(impl->empty());
+
+  EXPECT_TRUE(capture_status.ok());
+  EXPECT_EQ("mocked-status", capture_status.error_message());
+}
+
+/// @test Verify that noes::Table::AsyncApply() fails on a permanent error.
+TEST_F(NoexTableAsyncApplyTest, PermanentFailure) {
+  auto impl = std::make_shared<testing::MockCompletionQueue>();
+  bigtable::CompletionQueue cq(impl);
+
+  // Simulate an immediate permanent failure.
+  auto r1 = google::cloud::internal::make_unique<MockAsyncApplyReader>();
+  bool r1_called = false;
+  EXPECT_CALL(*r1, Finish(_, _, _))
+      .WillOnce(Invoke([&r1_called](btproto::MutateRowResponse*,
+                                    grpc::Status* status, void*) {
+        r1_called = true;
+        *status = grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "uh-oh");
+      }));
+
+  // Because there is a permanent failure, we expect a single call.
+  EXPECT_CALL(*client_, AsyncMutateRow(_, _, _))
+      .WillOnce(
+          Invoke([&r1](grpc::ClientContext*, btproto::MutateRowRequest const&,
+                       grpc::CompletionQueue*) {
+            // This is safe, see comments in MockAsyncResponseReader.
+            return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
+                btproto::MutateRowResponse>>(r1.get());
+          }));
+
+  // Make the asynchronous request.
+  bool op_called = false;
+  grpc::Status capture_status;
+  table_.AsyncApply(
+      bigtable::SingleRowMutation(
+          "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}),
+      cq,
+      [&op_called, &capture_status](CompletionQueue& cq,
+                                    google::bigtable::v2::MutateRowResponse& r,
+                                    grpc::Status const& status) {
+        op_called = true;
+        capture_status = status;
+      });
+
+  // At this point r1 is fired, but the final callback is not, verify that and
+  // simulate the first request completing.
+  EXPECT_TRUE(r1_called);
+  EXPECT_FALSE(op_called);
+  EXPECT_EQ(1U, impl->size());
+  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+
+  // At this point the final callback should be completed.
+  EXPECT_TRUE(r1_called);
+  EXPECT_TRUE(op_called);
+  EXPECT_TRUE(impl->empty());
+
+  EXPECT_FALSE(capture_status.ok());
+  EXPECT_EQ(grpc::StatusCode::FAILED_PRECONDITION, capture_status.error_code());
+  EXPECT_THAT(capture_status.error_message(), HasSubstr("AsyncApply"));
+  EXPECT_THAT(capture_status.error_message(), HasSubstr(table_.table_name()));
+  EXPECT_THAT(capture_status.error_message(), HasSubstr("permanent error"));
+  EXPECT_THAT(capture_status.error_message(), HasSubstr("uh-oh"));
+}
+
+std::vector<std::shared_ptr<MockAsyncApplyReader>>
+SetupMockForMultipleTransients(
+    std::shared_ptr<testing::MockDataClient> client) {
+  // We prepare the client to return multiple readers, all of them returning
+  // transient failures.
+  std::vector<std::shared_ptr<MockAsyncApplyReader>> readers;
+  EXPECT_CALL(*client, AsyncMutateRow(_, _, _))
+      .WillRepeatedly(Invoke([&readers](grpc::ClientContext*,
+                                        btproto::MutateRowRequest const&,
+                                        grpc::CompletionQueue*) {
+        auto r = std::make_shared<MockAsyncApplyReader>();
+        readers.push_back(r);
+        EXPECT_CALL(*r, Finish(_, _, _))
+            .WillOnce(Invoke(
+                [](btproto::MutateRowResponse*, grpc::Status* status, void*) {
+                  *status =
+                      grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
+                }));
+        // This is safe, see comments in MockAsyncResponseReader.
+        return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
+            btproto::MutateRowResponse>>(r.get());
+      }));
+  return readers;
+}
+
+/// @test Verify that noex::Table::AsyncApply() stops retrying on too many
+/// transient failures.
+TEST_F(NoexTableAsyncApplyTest, TooManyTransientFailures) {
+  auto impl = std::make_shared<testing::MockCompletionQueue>();
+  bigtable::CompletionQueue cq(impl);
+
+  auto readers = SetupMockForMultipleTransients(client_);
+
+  // Create a table that accepts at most 3 failures.
+  constexpr int kMaxTransients = 3;
+  bigtable::noex::Table tested(
+      client_, "test-table",
+      bigtable::LimitedErrorCountRetryPolicy(kMaxTransients),
+      bigtable::ExponentialBackoffPolicy(10_ms, 100_ms));
+
+  // Make the asynchronous request.
+  bool op_called = false;
+  grpc::Status capture_status;
+  tested.AsyncApply(
+      bigtable::SingleRowMutation(
+          "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}),
+      cq,
+      [&op_called, &capture_status](CompletionQueue& cq,
+                                    google::bigtable::v2::MutateRowResponse& r,
+                                    grpc::Status const& status) {
+        op_called = true;
+        capture_status = status;
+      });
+
+  // We expect call -> timer -> call -> timer -> call -> timer -> call[failed],
+  // so simulate the cycle 6 times:
+  for (int i = 0; i != 2 * kMaxTransients; ++i) {
+    EXPECT_FALSE(op_called);
+    EXPECT_EQ(1U, impl->size());
+    impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  }
+
+  // Okay, simulate one more iteration, that should exhaust the policy:
+  EXPECT_FALSE(op_called);
+  EXPECT_EQ(1U, impl->size());
+  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  EXPECT_TRUE(impl->empty());
+
+  EXPECT_FALSE(capture_status.ok());
+  EXPECT_EQ(grpc::StatusCode::UNAVAILABLE, capture_status.error_code());
+  EXPECT_THAT(capture_status.error_message(), HasSubstr("AsyncApply"));
+  EXPECT_THAT(capture_status.error_message(), HasSubstr(tested.table_name()));
+  EXPECT_THAT(capture_status.error_message(), HasSubstr("transient error"));
+  EXPECT_THAT(capture_status.error_message(), HasSubstr("try-again"));
+
+  impl->Shutdown();
+}
+
+/// @test Verify that noex::Table::AsyncApply() fails on transient errors
+/// for non-idempotent calls.
+TEST_F(NoexTableAsyncApplyTest, TransientFailureNonIdempotent) {
+  auto impl = std::make_shared<testing::MockCompletionQueue>();
+  bigtable::CompletionQueue cq(impl);
+
+  // Simulate an immediate permanent failure.
+  auto r1 = google::cloud::internal::make_unique<MockAsyncApplyReader>();
+  bool r1_called = false;
+  EXPECT_CALL(*r1, Finish(_, _, _))
+      .WillOnce(Invoke([&r1_called](btproto::MutateRowResponse*,
+                                    grpc::Status* status, void*) {
+        r1_called = true;
+        *status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
+      }));
+
+  // Because there is a permanent failure, we expect a single call.
+  EXPECT_CALL(*client_, AsyncMutateRow(_, _, _))
+      .WillOnce(
+          Invoke([&r1](grpc::ClientContext*, btproto::MutateRowRequest const&,
+                       grpc::CompletionQueue*) {
+            // This is safe, see comments in MockAsyncResponseReader.
+            return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
+                btproto::MutateRowResponse>>(r1.get());
+          }));
+
+  // Make the asynchronous request, use the server-side timestamp to test with
+  // non-idempotent mutations.
+  bool op_called = false;
+  grpc::Status capture_status;
+  table_.AsyncApply(
+      bigtable::SingleRowMutation("bar",
+                                  {bigtable::SetCell("fam", "col", "val")}),
+      cq,
+      [&op_called, &capture_status](CompletionQueue& cq,
+                                    google::bigtable::v2::MutateRowResponse& r,
+                                    grpc::Status const& status) {
+        op_called = true;
+        capture_status = status;
+      });
+
+  // At this point r1 is fired, but the final callback is not, verify that and
+  // simulate the first request completing.
+  EXPECT_TRUE(r1_called);
+  EXPECT_FALSE(op_called);
+  EXPECT_EQ(1U, impl->size());
+  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+
+  // At this point the final callback should be completed.
+  EXPECT_TRUE(r1_called);
+  EXPECT_TRUE(op_called);
+  EXPECT_EQ(0U, impl->size());
+
+  EXPECT_FALSE(capture_status.ok());
+  EXPECT_EQ(grpc::StatusCode::UNAVAILABLE, capture_status.error_code());
+  EXPECT_THAT(capture_status.error_message(), HasSubstr("AsyncApply"));
+  EXPECT_THAT(capture_status.error_message(), HasSubstr(table_.table_name()));
+  EXPECT_THAT(capture_status.error_message(), HasSubstr("non-idempotent"));
+  EXPECT_THAT(capture_status.error_message(), HasSubstr("try-again"));
+}
+
+/// @test Verify that noex::Table::AsyncApply() stops retrying if one attempt
+/// is canceled.
+TEST_F(NoexTableAsyncApplyTest, StopRetryOnOperationCancel) {
+  auto impl = std::make_shared<testing::MockCompletionQueue>();
+  bigtable::CompletionQueue cq(impl);
+
+  auto readers = SetupMockForMultipleTransients(client_);
+
+  // Create a table that accepts at most 3 failures.
+  constexpr int kMaxTransients = 3;
+  bigtable::noex::Table tested(
+      client_, "test-table",
+      bigtable::LimitedErrorCountRetryPolicy(kMaxTransients),
+      bigtable::ExponentialBackoffPolicy(10_ms, 100_ms));
+
+  // Make the asynchronous request.
+  bool op_called = false;
+  grpc::Status capture_status;
+  tested.AsyncApply(
+      bigtable::SingleRowMutation(
+          "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}),
+      cq,
+      [&op_called, &capture_status](CompletionQueue& cq,
+                                    google::bigtable::v2::MutateRowResponse& r,
+                                    grpc::Status const& status) {
+        op_called = true;
+        capture_status = status;
+      });
+
+  // Cancel the pending operation, this should immediately fail.
+  EXPECT_FALSE(op_called);
+  EXPECT_EQ(1U, impl->size());
+  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+
+  // At this point the operation should immediately fail.
+  EXPECT_TRUE(op_called);
+  EXPECT_TRUE(impl->empty());
+
+  EXPECT_FALSE(capture_status.ok());
+  EXPECT_EQ(grpc::StatusCode::CANCELLED, capture_status.error_code());
+  EXPECT_THAT(capture_status.error_message(), HasSubstr("AsyncApply"));
+  EXPECT_THAT(capture_status.error_message(), HasSubstr(tested.table_name()));
+  EXPECT_THAT(capture_status.error_message(),
+              HasSubstr("pending operation cancelled"));
+}
+
+/// @test Verify that noex::Table::AsyncApply() stops retrying if a timer
+/// between attempts is cancelled.
+TEST_F(NoexTableAsyncApplyTest, StopRetryOnTimerCancel) {
+  auto impl = std::make_shared<testing::MockCompletionQueue>();
+  bigtable::CompletionQueue cq(impl);
+
+  auto readers = SetupMockForMultipleTransients(client_);
+
+  // Create a table that accepts at most 3 failures.
+  constexpr int kMaxTransients = 3;
+  bigtable::noex::Table tested(
+      client_, "test-table",
+      bigtable::LimitedErrorCountRetryPolicy(kMaxTransients),
+      bigtable::ExponentialBackoffPolicy(10_ms, 100_ms));
+
+  // Make the asynchronous request.
+  bool op_called = false;
+  grpc::Status capture_status;
+  tested.AsyncApply(
+      bigtable::SingleRowMutation(
+          "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}),
+      cq,
+      [&op_called, &capture_status](CompletionQueue& cq,
+                                    google::bigtable::v2::MutateRowResponse& r,
+                                    grpc::Status const& status) {
+        op_called = true;
+        capture_status = status;
+      });
+
+  // Simulate a failure in the pending operation, that should create a timer.
+  EXPECT_FALSE(op_called);
+  EXPECT_EQ(1U, impl->size());
+  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+
+  // Cancel the pending timer.
+  EXPECT_FALSE(op_called);
+  EXPECT_EQ(1U, impl->size());
+  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+
+  // At this point the operation should immediately fail.
+  EXPECT_TRUE(op_called);
+  EXPECT_TRUE(impl->empty());
+
+  EXPECT_FALSE(capture_status.ok());
+  EXPECT_EQ(grpc::StatusCode::CANCELLED, capture_status.error_code());
+  EXPECT_THAT(capture_status.error_message(), HasSubstr("AsyncApply"));
+  EXPECT_THAT(capture_status.error_message(), HasSubstr(tested.table_name()));
+  EXPECT_THAT(capture_status.error_message(),
+              HasSubstr("pending timer cancelled"));
+}
+
+}  // namespace
+}  // namespace noex
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/testing/mock_completion_queue.h
+++ b/google/cloud/bigtable/testing/mock_completion_queue.h
@@ -27,6 +27,13 @@ namespace testing {
 class MockCompletionQueue
     : public google::cloud::bigtable::internal::CompletionQueueImpl {
  public:
+  std::unique_ptr<grpc::Alarm> CreateAlarm() const override {
+    // grpc::Alarm objects are really hard to cleanup when mocking their
+    // behavior, so we do not create an alarm, instead we return nullptr, which
+    // the classes that care (AsyncTimerFunctor) know what to do with.
+    return std::unique_ptr<grpc::Alarm>();
+  }
+
   using CompletionQueueImpl::empty;
   using CompletionQueueImpl::SimulateCompletion;
   using CompletionQueueImpl::size;

--- a/google/cloud/bigtable/testing/mock_completion_queue.h
+++ b/google/cloud/bigtable/testing/mock_completion_queue.h
@@ -1,0 +1,39 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_MOCK_COMPLETION_QUEUE_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_MOCK_COMPLETION_QUEUE_H_
+
+#include "google/cloud/bigtable/completion_queue.h"
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+namespace testing {
+// Tests typically create an instance of this class, then create a
+// `google::cloud::bigtable::CompletionQueue` to wrap it, keeping a reference to
+// the instance to manipulate its state directly.
+class MockCompletionQueue
+    : public google::cloud::bigtable::internal::CompletionQueueImpl {
+ public:
+  using CompletionQueueImpl::empty;
+  using CompletionQueueImpl::SimulateCompletion;
+  using CompletionQueueImpl::size;
+};
+}  // namespace testing
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_MOCK_COMPLETION_QUEUE_H_

--- a/google/cloud/bigtable/testing/mock_mutate_rows_reader.h
+++ b/google/cloud/bigtable/testing/mock_mutate_rows_reader.h
@@ -27,6 +27,12 @@ using MockMutateRowsReader =
     MockResponseReader<google::bigtable::v2::MutateRowsResponse,
                        google::bigtable::v2::MutateRowsRequest>;
 
+// An alternative name could be `MockAsyncMutateRowReader`, but that is too
+// small a difference with `MockAsyncMutateRowsReader` (note the `s` is `Rows`)
+// so we prefer to call them by the higher-level API (Apply vs. BulkApply).
+using MockAsyncApplyReader =
+    MockAsyncResponseReader<google::bigtable::v2::MutateRowResponse>;
+
 }  // namespace testing
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/testing/mock_response_reader.h
+++ b/google/cloud/bigtable/testing/mock_response_reader.h
@@ -18,6 +18,7 @@
 #include <gmock/gmock.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/impl/codegen/sync_stream.h>
+#include <grpcpp/support/async_unary_call.h>
 
 namespace google {
 namespace cloud {
@@ -61,7 +62,46 @@ class MockResponseReader : public grpc::ClientReaderInterface<Response> {
     return [this](grpc::ClientContext*, Request const&) {
       return UniquePtr(this);
     };
-  };
+  }
+};
+
+/**
+ * Define the interface to mock the result of starting a unary async RPC.
+ *
+ * Note that using this mock often requires special memory management. The
+ * google mock library requires all mocks to be destroyed. In contrast, grpc
+ * specializes `std::unique_ptr<>` to *not* delete objects of type
+ * `grpc::ClientAsyncResponseReaderInterface<T>`:
+ *
+ *
+ *     https://github.com/grpc/grpc/blob/608188c680961b8506847c135b5170b41a9081e8/include/grpcpp/impl/codegen/async_unary_call.h#L305
+ *
+ * No delete, no destructor, nothing. The gRPC library expects all
+ * `grpc::ClientAsyncResponseReader<R>` objects to be allocated from a
+ * per-call arena, and deleted in bulk with other objects when the call
+ * completes and the full arena is released. Unfortunately, our mocks are
+ * allocated from the global heap, as they do not have an associated call or
+ * arena. The override in the gRPC library results in a leak, unless we manage
+ * the memory explicitly.
+ *
+ * As a result, the unit tests need to manually delete the objects. The idiom we
+ * use is a terrible, horrible, no good, very bad hack:
+ *
+ * We create a unique pointer to `MockAsyncResponseReader<T>`, then we pass that
+ * pointer to gRPC using `reader.get()`, and gRPC promptly puts it into a
+ * `std::unique_ptr<ClientAsyncResponseReaderInterface<T>>`. That looks like a
+ * double delete waiting to happen, but it is not, because gRPC has done the
+ * weird specialization of `std::unique_ptr`.
+ *
+ * @tparam Response the type of the RPC response
+ */
+template <typename Response>
+class MockAsyncResponseReader
+    : public grpc::ClientAsyncResponseReaderInterface<Response> {
+ public:
+  MOCK_METHOD0(StartCall, void());
+  MOCK_METHOD1(ReadInitialMetadata, void(void*));
+  MOCK_METHOD3_T(Finish, void(Response*, grpc::Status*, void*));
 };
 
 }  // namespace testing

--- a/google/cloud/bigtable/tests/data_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_integration_test.cc
@@ -53,12 +53,13 @@ TEST_F(DataAsyncIntegrationTest, TableApply) {
 
   noex::Table table(data_client_, table_id);
   std::promise<void> done;
-  table.AsyncApply(std::move(mut), cq,
-                   [&done](google::bigtable::v2::MutateRowResponse& r,
-                           grpc::Status const& status) {
-                     done.set_value();
-                     EXPECT_TRUE(status.ok());
-                   });
+  table.AsyncApply(
+      std::move(mut), cq,
+      [&done](CompletionQueue& cq, google::bigtable::v2::MutateRowResponse& r,
+              grpc::Status const& status) {
+        done.set_value();
+        EXPECT_TRUE(status.ok());
+      });
 
   // Block until the asynchronous operation completes. This is not what one
   // would do in a real application (the synchronous API is better in that


### PR DESCRIPTION
This PR introduces a helper class (`AsyncRetryUnaryRpc<>`) to implement asynchronous operations with retries.  `noex::Table::AsyncApply()` uses this new class. The unit test is extended to cover the multiple retry scenarios.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1141)
<!-- Reviewable:end -->
