### PR TITLE
Reduce data copying in the write path.

### DIFF
--- a/google/cloud/storage/internal/authorized_user_credentials.h
+++ b/google/cloud/storage/internal/authorized_user_credentials.h
@@ -72,7 +72,8 @@ class AuthorizedUserCredentials : public storage::Credentials {
     payload += "&refresh_token=";
     payload +=
         request_builder.MakeEscapedString(credentials["refresh_token"]).get();
-    request_ = request_builder.BuildRequest(std::move(payload));
+    payload_ = std::move(payload);
+    request_ = request_builder.BuildRequest();
   }
 
   std::string AuthorizationHeader() override {
@@ -88,7 +89,7 @@ class AuthorizedUserCredentials : public storage::Credentials {
     }
 
     // TODO(#516) - use retry policies to refresh the credentials.
-    auto response = request_.MakeRequest();
+    auto response = request_.MakeRequest(payload_);
     if (200 != response.status_code) {
       return false;
     }
@@ -108,6 +109,7 @@ class AuthorizedUserCredentials : public storage::Credentials {
   }
 
   typename HttpRequestBuilderType::RequestType request_;
+  std::string payload_;
   std::mutex mu_;
   std::condition_variable cv_;
   std::string authorization_header_;

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -176,7 +176,7 @@ std::pair<Status, IamPolicy> CurlClient::GetBucketIamPolicy(
                              "/iam",
                              storage_factory_);
   SetupBuilder(builder, request, "GET");
-  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)}, IamPolicy{});
@@ -191,7 +191,7 @@ std::pair<Status, IamPolicy> CurlClient::SetBucketIamPolicy(
                              storage_factory_);
   SetupBuilder(builder, request, "PUT");
   builder.AddHeader("Content-Type: application/json");
-  auto payload = builder.BuildRequest(request.json_payload()).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(request.json_payload());
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)}, IamPolicy{});

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -78,7 +78,7 @@ std::pair<Status, ListBucketsResponse> CurlClient::ListBuckets(
   CurlRequestBuilder builder(storage_endpoint_ + "/b", storage_factory_);
   SetupBuilder(builder, request, "GET");
   builder.AddQueryParameter("project", request.project_id());
-  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -95,7 +95,7 @@ std::pair<Status, BucketMetadata> CurlClient::CreateBucket(
   SetupBuilder(builder, request, "POST");
   builder.AddQueryParameter("project", request.project_id());
   builder.AddHeader("Content-Type: application/json");
-  auto payload = builder.BuildRequest(request.json_payload()).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(request.json_payload());
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -111,7 +111,7 @@ std::pair<Status, BucketMetadata> CurlClient::GetBucketMetadata(
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name(),
                              storage_factory_);
   SetupBuilder(builder, request, "GET");
-  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
   if (200 != payload.status_code) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -127,7 +127,7 @@ std::pair<Status, EmptyResponse> CurlClient::DeleteBucket(
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name(),
                              storage_factory_);
   SetupBuilder(builder, request, "DELETE");
-  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -143,7 +143,7 @@ std::pair<Status, BucketMetadata> CurlClient::UpdateBucket(
       storage_endpoint_ + "/b/" + request.metadata().name(), storage_factory_);
   SetupBuilder(builder, request, "PUT");
   builder.AddHeader("Content-Type: application/json");
-  auto payload = builder.BuildRequest(request.json_payload()).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(request.json_payload());
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -160,7 +160,7 @@ std::pair<Status, BucketMetadata> CurlClient::PatchBucket(
                              storage_factory_);
   SetupBuilder(builder, request, "PATCH");
   builder.AddHeader("Content-Type: application/json");
-  auto payload = builder.BuildRequest(request.payload()).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(request.payload());
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -201,7 +201,6 @@ std::pair<Status, IamPolicy> CurlClient::SetBucketIamPolicy(
 
 std::pair<Status, ObjectMetadata> CurlClient::InsertObjectMedia(
     InsertObjectMediaRequest const& request) {
-  // Assume the bucket name is validated by the caller.
   CurlRequestBuilder builder(
       upload_endpoint_ + "/b/" + request.bucket_name() + "/o", upload_factory_);
   SetupBuilder(builder, request, "POST");
@@ -214,7 +213,7 @@ std::pair<Status, ObjectMetadata> CurlClient::InsertObjectMedia(
   builder.AddQueryParameter("name", request.object_name());
   builder.AddHeader("Content-Length: " +
                     std::to_string(request.contents().size()));
-  auto payload = builder.BuildRequest(request.contents()).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(request.contents());
   if (200 != payload.status_code) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -233,7 +232,7 @@ std::pair<Status, ObjectMetadata> CurlClient::CopyObject(
       storage_factory_);
   SetupBuilder(builder, request, "POST");
   builder.AddHeader("Content-Type: application/json");
-  auto payload = builder.BuildRequest(request.json_payload()).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(request.json_payload());
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -249,7 +248,7 @@ std::pair<Status, ObjectMetadata> CurlClient::GetObjectMetadata(
                                  "/o/" + request.object_name(),
                              storage_factory_);
   SetupBuilder(builder, request, "GET");
-  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -302,7 +301,7 @@ std::pair<Status, ListObjectsResponse> CurlClient::ListObjects(
       storage_factory_);
   SetupBuilder(builder, request, "GET");
   builder.AddQueryParameter("pageToken", request.page_token());
-  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
   if (200 != payload.status_code) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -320,7 +319,7 @@ std::pair<Status, EmptyResponse> CurlClient::DeleteObject(
                                  "/o/" + request.object_name(),
                              storage_factory_);
   SetupBuilder(builder, request, "DELETE");
-  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -336,7 +335,7 @@ std::pair<Status, ObjectMetadata> CurlClient::UpdateObject(
                              storage_factory_);
   SetupBuilder(builder, request, "PUT");
   builder.AddHeader("Content-Type: application/json");
-  auto payload = builder.BuildRequest(request.json_payload()).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(request.json_payload());
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -353,7 +352,7 @@ std::pair<Status, ObjectMetadata> CurlClient::PatchObject(
                              storage_factory_);
   SetupBuilder(builder, request, "PATCH");
   builder.AddHeader("Content-Type: application/json");
-  auto payload = builder.BuildRequest(request.payload()).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(request.payload());
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -370,7 +369,7 @@ std::pair<Status, ObjectMetadata> CurlClient::ComposeObject(
                              storage_factory_);
   SetupBuilder(builder, request, "POST");
   builder.AddHeader("Content-Type: application/json");
-  auto payload = builder.BuildRequest(request.json_payload()).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(request.json_payload());
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -386,7 +385,7 @@ std::pair<Status, ListBucketAclResponse> CurlClient::ListBucketAcl(
       storage_endpoint_ + "/b/" + request.bucket_name() + "/acl",
       storage_factory_);
   SetupBuilder(builder, request, "GET");
-  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -403,7 +402,7 @@ std::pair<Status, BucketAccessControl> CurlClient::GetBucketAcl(
                                  "/acl/" + request.entity(),
                              storage_factory_);
   SetupBuilder(builder, request, "GET");
-  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -423,7 +422,7 @@ std::pair<Status, BucketAccessControl> CurlClient::CreateBucketAcl(
   nl::json object;
   object["entity"] = request.entity();
   object["role"] = request.role();
-  auto payload = builder.BuildRequest(object.dump()).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(object.dump());
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -439,7 +438,7 @@ std::pair<Status, EmptyResponse> CurlClient::DeleteBucketAcl(
                                  "/acl/" + request.entity(),
                              storage_factory_);
   SetupBuilder(builder, request, "DELETE");
-  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -458,7 +457,7 @@ std::pair<Status, BucketAccessControl> CurlClient::UpdateBucketAcl(
   nl::json patch;
   patch["entity"] = request.entity();
   patch["role"] = request.role();
-  auto payload = builder.BuildRequest(patch.dump()).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(patch.dump());
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -475,7 +474,7 @@ std::pair<Status, BucketAccessControl> CurlClient::PatchBucketAcl(
                              storage_factory_);
   SetupBuilder(builder, request, "PATCH");
   builder.AddHeader("Content-Type: application/json");
-  auto payload = builder.BuildRequest(request.payload()).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(request.payload());
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -492,7 +491,7 @@ std::pair<Status, ListObjectAclResponse> CurlClient::ListObjectAcl(
                                  "/o/" + request.object_name() + "/acl",
                              storage_factory_);
   SetupBuilder(builder, request, "GET");
-  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -513,7 +512,7 @@ std::pair<Status, ObjectAccessControl> CurlClient::CreateObjectAcl(
   nl::json object;
   object["entity"] = request.entity();
   object["role"] = request.role();
-  auto payload = builder.BuildRequest(object.dump()).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(object.dump());
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -530,7 +529,7 @@ std::pair<Status, EmptyResponse> CurlClient::DeleteObjectAcl(
                                  request.entity(),
                              storage_factory_);
   SetupBuilder(builder, request, "DELETE");
-  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -546,7 +545,7 @@ std::pair<Status, ObjectAccessControl> CurlClient::GetObjectAcl(
                                  request.entity(),
                              storage_factory_);
   SetupBuilder(builder, request, "GET");
-  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -567,7 +566,7 @@ std::pair<Status, ObjectAccessControl> CurlClient::UpdateObjectAcl(
   nl::json object;
   object["entity"] = request.entity();
   object["role"] = request.role();
-  auto payload = builder.BuildRequest(object.dump()).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(object.dump());
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -585,7 +584,7 @@ std::pair<Status, ObjectAccessControl> CurlClient::PatchObjectAcl(
                              storage_factory_);
   SetupBuilder(builder, request, "PATCH");
   builder.AddHeader("Content-Type: application/json");
-  auto payload = builder.BuildRequest(request.payload()).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(request.payload());
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -602,7 +601,7 @@ CurlClient::ListDefaultObjectAcl(ListDefaultObjectAclRequest const& request) {
       storage_endpoint_ + "/b/" + request.bucket_name() + "/defaultObjectAcl",
       storage_factory_);
   SetupBuilder(builder, request, "GET");
-  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -623,7 +622,7 @@ std::pair<Status, ObjectAccessControl> CurlClient::CreateDefaultObjectAcl(
   object["entity"] = request.entity();
   object["role"] = request.role();
   builder.AddHeader("Content-Type: application/json");
-  auto payload = builder.BuildRequest(object.dump()).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(object.dump());
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -639,7 +638,7 @@ std::pair<Status, EmptyResponse> CurlClient::DeleteDefaultObjectAcl(
                                  "/defaultObjectAcl/" + request.entity(),
                              storage_factory_);
   SetupBuilder(builder, request, "DELETE");
-  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -654,7 +653,7 @@ std::pair<Status, ObjectAccessControl> CurlClient::GetDefaultObjectAcl(
                                  "/defaultObjectAcl/" + request.entity(),
                              storage_factory_);
   SetupBuilder(builder, request, "GET");
-  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -674,7 +673,7 @@ std::pair<Status, ObjectAccessControl> CurlClient::UpdateDefaultObjectAcl(
   nl::json object;
   object["entity"] = request.entity();
   object["role"] = request.role();
-  auto payload = builder.BuildRequest(object.dump()).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(object.dump());
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -691,7 +690,7 @@ std::pair<Status, ObjectAccessControl> CurlClient::PatchDefaultObjectAcl(
                              storage_factory_);
   SetupBuilder(builder, request, "PATCH");
   builder.AddHeader("Content-Type: application/json");
-  auto payload = builder.BuildRequest(request.payload()).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(request.payload());
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -707,7 +706,7 @@ std::pair<Status, ServiceAccount> CurlClient::GetServiceAccount(
                                  request.project_id() + "/serviceAccount",
                              storage_factory_);
   SetupBuilder(builder, request, "GET");
-  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -724,7 +723,7 @@ std::pair<Status, ListNotificationsResponse> CurlClient::ListNotifications(
                                  "/notificationConfigs",
                              storage_factory_);
   SetupBuilder(builder, request, "GET");
-  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -742,7 +741,7 @@ std::pair<Status, NotificationMetadata> CurlClient::CreateNotification(
                              storage_factory_);
   SetupBuilder(builder, request, "POST");
   builder.AddHeader("Content-Type: application/json");
-  auto payload = builder.BuildRequest(request.json_payload()).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(request.json_payload());
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -759,7 +758,7 @@ std::pair<Status, NotificationMetadata> CurlClient::GetNotification(
                                  request.notification_id(),
                              storage_factory_);
   SetupBuilder(builder, request, "GET");
-  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},
@@ -776,7 +775,7 @@ std::pair<Status, EmptyResponse> CurlClient::DeleteNotification(
                                  request.notification_id(),
                              storage_factory_);
   SetupBuilder(builder, request, "DELETE");
-  auto payload = builder.BuildRequest(std::string{}).MakeRequest();
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -152,7 +152,7 @@ class CurlClient : public RawClient {
   std::string upload_endpoint_;
 
   std::mutex mu_;
-  CurlShare share_ /* GUARDER_BY(mu_) */;
+  CurlShare share_ /* GUARDED_BY(mu_) */;
 
   // The factories must be listed *after* the CurlShare. libcurl keeps a
   // usage count on each CURLSH* handle, which is only released once the CURL*

--- a/google/cloud/storage/internal/curl_request.cc
+++ b/google/cloud/storage/internal/curl_request.cc
@@ -22,7 +22,11 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 CurlRequest::CurlRequest() : headers_(nullptr, &curl_slist_free_all) {}
 
-HttpResponse CurlRequest::MakeRequest() {
+HttpResponse CurlRequest::MakeRequest(std::string const& payload) {
+  if (not payload.empty()) {
+    handle_.SetOption(CURLOPT_POSTFIELDSIZE, payload.length());
+    handle_.SetOption(CURLOPT_POSTFIELDS, payload.c_str());
+  }
   handle_.EasyPerform();
   handle_.FlushDebug(__func__);
   long code = handle_.GetResponseCode();
@@ -34,10 +38,6 @@ void CurlRequest::ResetOptions() {
   handle_.SetOption(CURLOPT_URL, url_.c_str());
   handle_.SetOption(CURLOPT_HTTPHEADER, headers_.get());
   handle_.SetOption(CURLOPT_USERAGENT, user_agent_.c_str());
-  if (not payload_.empty()) {
-    handle_.SetOption(CURLOPT_POSTFIELDSIZE, payload_.length());
-    handle_.SetOption(CURLOPT_POSTFIELDS, payload_.c_str());
-  }
   handle_.SetWriterCallback(
       [this](void* ptr, std::size_t size, std::size_t nmemb) {
         response_payload_.append(static_cast<char*>(ptr), size * nmemb);

--- a/google/cloud/storage/internal/curl_request.h
+++ b/google/cloud/storage/internal/curl_request.h
@@ -46,7 +46,6 @@ class CurlRequest {
       : url_(std::move(rhs.url_)),
         headers_(std::move(rhs.headers_)),
         user_agent_(std::move(rhs.user_agent_)),
-        payload_(std::move(rhs.payload_)),
         response_payload_(std::move(rhs.response_payload_)),
         received_headers_(std::move(rhs.received_headers_)),
         logging_enabled_(rhs.logging_enabled_),
@@ -59,7 +58,6 @@ class CurlRequest {
     url_ = std::move(rhs.url_);
     headers_ = std::move(rhs.headers_);
     user_agent_ = std::move(rhs.user_agent_);
-    payload_ = std::move(rhs.payload_);
     response_payload_ = std::move(rhs.response_payload_);
     received_headers_ = std::move(rhs.received_headers_);
     logging_enabled_ = rhs.logging_enabled_;
@@ -79,7 +77,7 @@ class CurlRequest {
    *
    * @throw std::runtime_error if the request cannot be made at all.
    */
-  HttpResponse MakeRequest();
+  HttpResponse MakeRequest(std::string const& payload);
 
  private:
   friend class CurlRequestBuilder;
@@ -88,7 +86,6 @@ class CurlRequest {
   std::string url_;
   CurlHeaders headers_;
   std::string user_agent_;
-  std::string payload_;
   std::string response_payload_;
   CurlReceivedHeaders received_headers_;
   bool logging_enabled_;

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -34,13 +34,12 @@ CurlRequestBuilder::CurlRequestBuilder(
       logging_enabled_(false),
       initial_buffer_size_(GOOGLE_CLOUD_CPP_STORAGE_INITIAL_BUFFER_SIZE) {}
 
-CurlRequest CurlRequestBuilder::BuildRequest(std::string payload) {
+CurlRequest CurlRequestBuilder::BuildRequest() {
   ValidateBuilderState(__func__);
   CurlRequest request;
   request.url_ = std::move(url_);
   request.headers_ = std::move(headers_);
   request.user_agent_ = user_agent_prefix_ + UserAgentSuffix();
-  request.payload_ = std::move(payload);
   request.handle_ = std::move(handle_);
   request.factory_ = std::move(factory_);
   request.logging_enabled_ = logging_enabled_;

--- a/google/cloud/storage/internal/curl_request_builder.h
+++ b/google/cloud/storage/internal/curl_request_builder.h
@@ -43,7 +43,7 @@ class CurlRequestBuilder {
    * This function invalidates the builder. The application should not use this
    * builder once this function is called.
    */
-  CurlRequest BuildRequest(std::string payload);
+  CurlRequest BuildRequest();
 
   /**
    * Create a http request where the payload is provided dynamically.

--- a/google/cloud/storage/internal/curl_upload_request.cc
+++ b/google/cloud/storage/internal/curl_upload_request.cc
@@ -99,7 +99,6 @@ void CurlUploadRequest::ResetOptions() {
   handle_.EnableLogging(logging_enabled_);
 
   handle_.SetOption(CURLOPT_UPLOAD, 1L);
-  handle_.SetOption(CURLOPT_CUSTOMREQUEST, "POST");
 }
 
 std::size_t CurlUploadRequest::ReadCallback(char* ptr, std::size_t size,

--- a/google/cloud/storage/testing/mock_http_request.h
+++ b/google/cloud/storage/testing/mock_http_request.h
@@ -36,10 +36,13 @@ class MockHttpRequest {
  public:
   MockHttpRequest() : mock(std::make_shared<Impl>()) {}
 
-  internal::HttpResponse MakeRequest() { return mock->MakeRequest(); }
+  internal::HttpResponse MakeRequest(std::string const& s) {
+    return mock->MakeRequest(s);
+  }
 
   struct Impl {
-    MOCK_METHOD0(MakeRequest, storage::internal::HttpResponse());
+    MOCK_METHOD1(MakeRequest,
+                 storage::internal::HttpResponse(std::string const&));
   };
 
   std::shared_ptr<Impl> mock;
@@ -89,9 +92,7 @@ class MockHttpRequestBuilder {
     mock->AddQueryParameter(p.parameter_name(), p.value() ? "true" : "false");
   }
 
-  MockHttpRequest BuildRequest(std::string payload) {
-    return mock->BuildRequest(std::move(payload));
-  }
+  MockHttpRequest BuildRequest() { return mock->BuildRequest(); }
 
   void AddUserAgentPrefix(std::string const& prefix) {
     mock->AddUserAgentPrefix(prefix);
@@ -115,7 +116,7 @@ class MockHttpRequestBuilder {
 
   struct Impl {
     MOCK_METHOD1(Constructor, void(std::string));
-    MOCK_METHOD1(BuildRequest, MockHttpRequest(std::string));
+    MOCK_METHOD0(BuildRequest, MockHttpRequest());
     MOCK_METHOD1(AddUserAgentPrefix, void(std::string const&));
     MOCK_METHOD1(AddHeader, void(std::string const&));
     MOCK_METHOD2(AddQueryParameter,

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -42,7 +42,7 @@ TEST(CurlRequestTest, SimpleGET) {
   request.AddHeader("Accept: application/json");
   request.AddHeader("charsets: utf-8");
 
-  auto response = request.BuildRequest(std::string{}).MakeRequest();
+  auto response = request.BuildRequest().MakeRequest(std::string{});
   EXPECT_EQ(200, response.status_code);
   nl::json parsed = nl::json::parse(response.payload);
   nl::json args = parsed["args"];
@@ -56,11 +56,12 @@ TEST(CurlRequestTest, FailedGET) {
   storage::internal::CurlRequestBuilder request(
       "https://localhost:0/", storage::internal::GetDefaultCurlHandleFactory());
 
-  auto req = request.BuildRequest(std::string{});
+  auto req = request.BuildRequest();
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(req.MakeRequest(), std::exception);
+  EXPECT_THROW(req.MakeRequest(std::string{}), std::exception);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(req.MakeRequest(), "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(req.MakeRequest(std::string{}),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -73,8 +74,8 @@ TEST(CurlRequestTest, RepeatedGET) {
   request.AddHeader("Accept: application/json");
   request.AddHeader("charsets: utf-8");
 
-  auto req = request.BuildRequest(std::string{});
-  auto response = req.MakeRequest();
+  auto req = request.BuildRequest();
+  auto response = req.MakeRequest(std::string{});
 
   EXPECT_EQ(200, response.status_code);
   nl::json parsed = nl::json::parse(response.payload);
@@ -82,7 +83,7 @@ TEST(CurlRequestTest, RepeatedGET) {
   EXPECT_EQ("foo1&&&foo2", args["foo"].get<std::string>());
   EXPECT_EQ("bar1==bar2=", args["bar"].get<std::string>());
 
-  response = req.MakeRequest();
+  response = req.MakeRequest(std::string{});
   EXPECT_EQ(200, response.status_code);
   parsed = nl::json::parse(response.payload);
   args = parsed["args"];
@@ -112,7 +113,7 @@ TEST(CurlRequestTest, SimplePOST) {
   request.AddHeader("Content-Type: application/x-www-form-urlencoded");
   request.AddHeader("charsets: utf-8");
 
-  auto response = request.BuildRequest(data).MakeRequest();
+  auto response = request.BuildRequest().MakeRequest(data);
   EXPECT_EQ(200, response.status_code);
   nl::json parsed = nl::json::parse(response.payload);
   nl::json form = parsed["form"];
@@ -128,7 +129,7 @@ TEST(CurlRequestTest, Handle404) {
   request.AddHeader("Accept: application/json");
   request.AddHeader("charsets: utf-8");
 
-  auto response = request.BuildRequest(std::string{}).MakeRequest();
+  auto response = request.BuildRequest().MakeRequest(std::string{});
   EXPECT_EQ(404, response.status_code);
 }
 
@@ -140,7 +141,7 @@ TEST(CurlRequestTest, HandleTeapot) {
   request.AddHeader("Accept: application/json");
   request.AddHeader("charsets: utf-8");
 
-  auto response = request.BuildRequest(std::string{}).MakeRequest();
+  auto response = request.BuildRequest().MakeRequest(std::string{});
   EXPECT_EQ(418, response.status_code);
   EXPECT_THAT(response.payload, HasSubstr("[ teapot ]"));
 }
@@ -160,7 +161,7 @@ TEST(CurlRequestTest, CheckResponseHeaders) {
   request.AddHeader("Accept: application/json");
   request.AddHeader("charsets: utf-8");
 
-  auto response = request.BuildRequest(std::string{}).MakeRequest();
+  auto response = request.BuildRequest().MakeRequest(std::string{});
   EXPECT_EQ(200, response.status_code);
   EXPECT_EQ(1U, response.headers.count("x-test-empty"));
   EXPECT_EQ("", response.headers.find("x-test-empty")->second);
@@ -177,7 +178,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_Projection) {
   request.AddHeader("charsets: utf-8");
   request.AddOption(storage::Projection("full"));
 
-  auto response = request.BuildRequest(std::string{}).MakeRequest();
+  auto response = request.BuildRequest().MakeRequest(std::string{});
   EXPECT_EQ(200, response.status_code);
   nl::json parsed = nl::json::parse(response.payload);
   nl::json args = parsed["args"];
@@ -199,7 +200,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_UserProject) {
   request.AddHeader("charsets: utf-8");
   request.AddOption(storage::UserProject("a-project"));
 
-  auto response = request.BuildRequest(std::string{}).MakeRequest();
+  auto response = request.BuildRequest().MakeRequest(std::string{});
   EXPECT_EQ(200, response.status_code);
   nl::json parsed = nl::json::parse(response.payload);
   nl::json args = parsed["args"];
@@ -221,7 +222,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_IfGenerationMatch) {
   request.AddHeader("charsets: utf-8");
   request.AddOption(storage::IfGenerationMatch(42));
 
-  auto response = request.BuildRequest(std::string{}).MakeRequest();
+  auto response = request.BuildRequest().MakeRequest(std::string{});
   EXPECT_EQ(200, response.status_code);
   nl::json parsed = nl::json::parse(response.payload);
   nl::json args = parsed["args"];
@@ -243,7 +244,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_IfGenerationNotMatch) {
   request.AddHeader("charsets: utf-8");
   request.AddOption(storage::IfGenerationNotMatch(42));
 
-  auto response = request.BuildRequest(std::string{}).MakeRequest();
+  auto response = request.BuildRequest().MakeRequest(std::string{});
   EXPECT_EQ(200, response.status_code);
   nl::json parsed = nl::json::parse(response.payload);
   nl::json args = parsed["args"];
@@ -265,7 +266,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_IfMetagenerationMatch) {
   request.AddHeader("charsets: utf-8");
   request.AddOption(storage::IfMetagenerationMatch(42));
 
-  auto response = request.BuildRequest(std::string{}).MakeRequest();
+  auto response = request.BuildRequest().MakeRequest(std::string{});
   EXPECT_EQ(200, response.status_code);
   nl::json parsed = nl::json::parse(response.payload);
   nl::json args = parsed["args"];
@@ -287,7 +288,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_IfMetagenerationNotMatch) {
   request.AddHeader("charsets: utf-8");
   request.AddOption(storage::IfMetagenerationNotMatch(42));
 
-  auto response = request.BuildRequest(std::string{}).MakeRequest();
+  auto response = request.BuildRequest().MakeRequest(std::string{});
   EXPECT_EQ(200, response.status_code);
   nl::json parsed = nl::json::parse(response.payload);
   nl::json args = parsed["args"];
@@ -311,7 +312,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_Multiple) {
   request.AddOption(storage::IfMetagenerationMatch(7));
   request.AddOption(storage::IfGenerationNotMatch(42));
 
-  auto response = request.BuildRequest(std::string{}).MakeRequest();
+  auto response = request.BuildRequest().MakeRequest(std::string{});
   EXPECT_EQ(200, response.status_code);
   nl::json parsed = nl::json::parse(response.payload);
   nl::json args = parsed["args"];
@@ -355,7 +356,7 @@ TEST(CurlRequestTest, Logging) {
     request.AddHeader("charsets: utf-8");
     request.AddHeader("x-test-header: foo");
 
-    auto response = request.BuildRequest("this is some text").MakeRequest();
+    auto response = request.BuildRequest().MakeRequest("this is some text");
     EXPECT_EQ(200, response.status_code);
   }
 

--- a/google/cloud/storage/tests/curl_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/curl_streambuf_integration_test.cc
@@ -37,6 +37,7 @@ TEST(CurlStreambufIntegrationTest, WriteManyBytes) {
   internal::CurlRequestBuilder builder(HttpBinEndpoint() + "/post",
                                        internal::GetDefaultCurlHandleFactory());
   builder.AddHeader("Content-Type: application/octet-stream");
+  builder.SetMethod("POST");
   std::unique_ptr<internal::CurlStreambuf> buf(
       new internal::CurlStreambuf(builder.BuildUpload(), 128 * 1024));
   ObjectWriteStream writer(std::move(buf));

--- a/google/cloud/storage/tests/curl_upload_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_upload_request_integration_test.cc
@@ -41,6 +41,7 @@ TEST(CurlUploadRequestTest, UploadPartial) {
   CurlRequestBuilder builder(HttpBinEndpoint() + "/post",
                              storage::internal::GetDefaultCurlHandleFactory());
   builder.AddHeader("Content-Type: application/octet-stream");
+  builder.SetMethod("POST");
   CurlUploadRequest upload = builder.BuildUpload();
 
   // A small function to generate random data.


### PR DESCRIPTION
Using [callgrind][callgrind-link] I discovered that 6% of the time in
`Client::InsertObjectMedia()` was spent on data copying. The problem is
we copied the buffer into the `CurlRequest`, even though we could just
use the data provided by the caller in MakeRequest.

[callgrind-link]: http://valgrind.org/docs/manual/cl-manual.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1149)
<!-- Reviewable:end -->
