### PR TITLE
Examples using Bucket default CMEKs.

### DIFF
--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -242,6 +242,16 @@ run_all_cmek_examples() {
 
   run_example ./storage_object_samples delete-object \
       "${bucket_name}" "${object_name}"
+
+  run_example ./storage_bucket_samples get-bucket-default-kms-key \
+      "${bucket_name}"
+  run_example ./storage_bucket_samples add-bucket-default-kms-key \
+      "${bucket_name}" "${cmek}"
+  run_example ./storage_bucket_samples get-bucket-default-kms-key \
+      "${bucket_name}"
+  run_example ./storage_bucket_samples remove-bucket-default-kms-key \
+      "${bucket_name}"
+
   run_example ./storage_bucket_samples delete-bucket \
       "${bucket_name}"
 }


### PR DESCRIPTION
This PR implements some examples that configure the Bucket's default
customer-managed encryption key.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1151)
<!-- Reviewable:end -->
