### PR TITLE
Implement example of making data public.

### DIFF
--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -521,6 +521,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
     return *this;
   }
 
+  using CommonMetadata::has_owner;
   using CommonMetadata::owner;
 
   std::int64_t const& project_number() const { return project_number_; }

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -306,6 +306,26 @@ void PatchObjectContentType(google::cloud::storage::Client client, int& argc,
   (std::move(client), bucket_name, object_name, content_type);
 }
 
+void MakeObjectPublic(google::cloud::storage::Client client, int& argc,
+                      char* argv[]) {
+  if (argc != 3) {
+    throw Usage{"make-object-public <bucket-name> <object-name>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  auto object_name = ConsumeArg(argc, argv);
+  //! [make object public] [START storage_make_public]
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string bucket_name, std::string object_name) {
+    gcs::ObjectMetadata updated = client.PatchObject(
+        bucket_name, object_name, gcs::ObjectMetadataPatchBuilder(),
+        gcs::PredefinedAcl::PublicRead());
+    std::cout << "Object updated. The full metadata after the update is: "
+              << updated << std::endl;
+  }
+  //! [make object public] [END storage_make_public]
+  (std::move(client), bucket_name, object_name);
+}
+
 void GenerateEncryptionKey(google::cloud::storage::Client client, int& argc,
                            char* argv[]) {
   if (argc != 1) {

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -208,6 +208,7 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
   std::map<std::string, std::string>& mutable_metadata() { return metadata_; }
   //@}
 
+  using CommonMetadata::has_owner;
   using CommonMetadata::metageneration;
   using CommonMetadata::name;
   using CommonMetadata::owner;

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -603,6 +603,268 @@ TEST_F(ObjectIntegrationTest, WriteWithContentType) {
   client.DeleteObject(bucket_name, object_name);
 }
 
+std::vector<ObjectAccessControl>::difference_type CountMatchingEntities(
+    std::vector<ObjectAccessControl> const& acl,
+    ObjectAccessControl const& expected) {
+  return std::count_if(
+      acl.begin(), acl.end(), [&expected](ObjectAccessControl const& x) {
+        return x.entity() == expected.entity() and x.role() == expected.role();
+      });
+}
+
+TEST_F(ObjectIntegrationTest, InsertPredefinedAclAuthenticatedRead) {
+  Client client;
+  auto bucket_name = ObjectTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+
+  ObjectMetadata meta = client.InsertObject(
+      bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
+      PredefinedAcl::AuthenticatedRead(), Projection::Full());
+  EXPECT_LT(0, CountMatchingEntities(meta.acl(),
+                                      ObjectAccessControl()
+                                          .set_entity("allAuthenticatedUsers")
+                                          .set_role("READER")))
+      << meta;
+
+  client.DeleteObject(bucket_name, object_name);
+}
+
+TEST_F(ObjectIntegrationTest, InsertPredefinedAclBucketOwnerFullControl) {
+  Client client;
+  auto bucket_name = ObjectTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+
+  BucketMetadata bucket =
+      client.GetBucketMetadata(bucket_name, Projection::Full());
+  ASSERT_TRUE(bucket.has_owner());
+  std::string owner = bucket.owner().entity;
+
+  ObjectMetadata meta = client.InsertObject(
+      bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
+      PredefinedAcl::BucketOwnerFullControl(), Projection::Full());
+  EXPECT_LT(0, CountMatchingEntities(
+                    meta.acl(),
+                    ObjectAccessControl().set_entity(owner).set_role("OWNER")))
+      << meta;
+
+  client.DeleteObject(bucket_name, object_name);
+}
+
+TEST_F(ObjectIntegrationTest, InsertPredefinedAclBucketOwnerRead) {
+  Client client;
+  auto bucket_name = ObjectTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+
+  BucketMetadata bucket =
+      client.GetBucketMetadata(bucket_name, Projection::Full());
+  ASSERT_TRUE(bucket.has_owner());
+  std::string owner = bucket.owner().entity;
+
+  ObjectMetadata meta = client.InsertObject(
+      bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
+      PredefinedAcl::BucketOwnerRead(), Projection::Full());
+  EXPECT_LT(0, CountMatchingEntities(
+                    meta.acl(),
+                    ObjectAccessControl().set_entity(owner).set_role("READER")))
+      << meta;
+
+  client.DeleteObject(bucket_name, object_name);
+}
+
+TEST_F(ObjectIntegrationTest, InsertPredefinedAclPrivate) {
+  Client client;
+  auto bucket_name = ObjectTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+
+  ObjectMetadata meta = client.InsertObject(
+      bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
+      PredefinedAcl::Private(), Projection::Full());
+  ASSERT_TRUE(meta.has_owner());
+  EXPECT_LT(
+      0, CountMatchingEntities(meta.acl(), ObjectAccessControl()
+                                                .set_entity(meta.owner().entity)
+                                                .set_role("OWNER")))
+      << meta;
+
+  client.DeleteObject(bucket_name, object_name);
+}
+
+TEST_F(ObjectIntegrationTest, InsertPredefinedAclProjectPrivate) {
+  Client client;
+  auto bucket_name = ObjectTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+
+  ObjectMetadata meta = client.InsertObject(
+      bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
+      PredefinedAcl::ProjectPrivate(), Projection::Full());
+  ASSERT_TRUE(meta.has_owner());
+  EXPECT_LT(
+      0, CountMatchingEntities(meta.acl(), ObjectAccessControl()
+                                                .set_entity(meta.owner().entity)
+                                                .set_role("OWNER")))
+      << meta;
+
+  client.DeleteObject(bucket_name, object_name);
+}
+
+TEST_F(ObjectIntegrationTest, InsertPredefinedAclPublicRead) {
+  Client client;
+  auto bucket_name = ObjectTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+
+  ObjectMetadata meta = client.InsertObject(
+      bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
+      PredefinedAcl::PublicRead(), Projection::Full());
+  EXPECT_LT(
+      0, CountMatchingEntities(
+              meta.acl(),
+              ObjectAccessControl().set_entity("allUsers").set_role("READER")))
+      << meta;
+
+  client.DeleteObject(bucket_name, object_name);
+}
+
+TEST_F(ObjectIntegrationTest, CopyPredefinedAclAuthenticatedRead) {
+  Client client;
+  auto bucket_name = ObjectTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+  auto copy_name = MakeRandomObjectName();
+
+  ObjectMetadata original = client.InsertObject(
+      bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
+  ObjectMetadata meta = client.CopyObject(
+      bucket_name, object_name, bucket_name, copy_name, ObjectMetadata(),
+      IfGenerationMatch(0),
+      DestinationPredefinedAcl::AuthenticatedRead(), Projection::Full());
+  EXPECT_LT(0, CountMatchingEntities(meta.acl(),
+                                     ObjectAccessControl()
+                                         .set_entity("allAuthenticatedUsers")
+                                         .set_role("READER")))
+            << meta;
+
+  client.DeleteObject(bucket_name, copy_name);
+  client.DeleteObject(bucket_name, object_name);
+}
+
+TEST_F(ObjectIntegrationTest, CopyPredefinedAclBucketOwnerFullControl) {
+  Client client;
+  auto bucket_name = ObjectTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+  auto copy_name = MakeRandomObjectName();
+
+  BucketMetadata bucket =
+      client.GetBucketMetadata(bucket_name, Projection::Full());
+  ASSERT_TRUE(bucket.has_owner());
+  std::string owner = bucket.owner().entity;
+
+  ObjectMetadata original = client.InsertObject(
+      bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
+  ObjectMetadata meta = client.CopyObject(
+      bucket_name, object_name, bucket_name, copy_name, ObjectMetadata(),
+      IfGenerationMatch(0),
+      DestinationPredefinedAcl::BucketOwnerFullControl(), Projection::Full());
+  EXPECT_LT(0, CountMatchingEntities(
+      meta.acl(),
+      ObjectAccessControl().set_entity(owner).set_role("OWNER")))
+            << meta;
+
+  client.DeleteObject(bucket_name, copy_name);
+  client.DeleteObject(bucket_name, object_name);
+}
+
+TEST_F(ObjectIntegrationTest, CopyPredefinedAclBucketOwnerRead) {
+  Client client;
+  auto bucket_name = ObjectTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+  auto copy_name = MakeRandomObjectName();
+
+  BucketMetadata bucket =
+      client.GetBucketMetadata(bucket_name, Projection::Full());
+  ASSERT_TRUE(bucket.has_owner());
+  std::string owner = bucket.owner().entity;
+
+  ObjectMetadata original = client.InsertObject(
+      bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
+  ObjectMetadata meta = client.CopyObject(
+      bucket_name, object_name, bucket_name, copy_name, ObjectMetadata(),
+      IfGenerationMatch(0),
+      DestinationPredefinedAcl::BucketOwnerRead(), Projection::Full());
+  EXPECT_LT(0, CountMatchingEntities(
+      meta.acl(),
+      ObjectAccessControl().set_entity(owner).set_role("READER")))
+            << meta;
+
+  client.DeleteObject(bucket_name, copy_name);
+  client.DeleteObject(bucket_name, object_name);
+}
+
+TEST_F(ObjectIntegrationTest, CopyPredefinedAclPrivate) {
+  Client client;
+  auto bucket_name = ObjectTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+  auto copy_name = MakeRandomObjectName();
+
+  ObjectMetadata original = client.InsertObject(
+      bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
+  ObjectMetadata meta = client.CopyObject(
+      bucket_name, object_name, bucket_name, copy_name, ObjectMetadata(),
+      IfGenerationMatch(0),
+      DestinationPredefinedAcl::Private(), Projection::Full());
+  ASSERT_TRUE(meta.has_owner());
+  EXPECT_LT(
+      0, CountMatchingEntities(meta.acl(), ObjectAccessControl()
+      .set_entity(meta.owner().entity)
+      .set_role("OWNER")))
+            << meta;
+
+  client.DeleteObject(bucket_name, copy_name);
+  client.DeleteObject(bucket_name, object_name);
+}
+
+TEST_F(ObjectIntegrationTest, CopyPredefinedAclProjectPrivate) {
+  Client client;
+  auto bucket_name = ObjectTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+  auto copy_name = MakeRandomObjectName();
+
+  ObjectMetadata original = client.InsertObject(
+      bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
+  ObjectMetadata meta = client.CopyObject(
+      bucket_name, object_name, bucket_name, copy_name, ObjectMetadata(),
+      IfGenerationMatch(0),
+      DestinationPredefinedAcl::ProjectPrivate(), Projection::Full());
+  ASSERT_TRUE(meta.has_owner());
+  EXPECT_LT(
+      0, CountMatchingEntities(meta.acl(), ObjectAccessControl()
+      .set_entity(meta.owner().entity)
+      .set_role("OWNER")))
+            << meta;
+
+  client.DeleteObject(bucket_name, copy_name);
+  client.DeleteObject(bucket_name, object_name);
+}
+
+TEST_F(ObjectIntegrationTest, CopyPredefinedAclPublicRead) {
+  Client client;
+  auto bucket_name = ObjectTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+  auto copy_name = MakeRandomObjectName();
+
+  ObjectMetadata original = client.InsertObject(
+      bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
+  ObjectMetadata meta = client.CopyObject(
+      bucket_name, object_name, bucket_name, copy_name, ObjectMetadata(),
+      IfGenerationMatch(0),
+      DestinationPredefinedAcl::PublicRead(), Projection::Full());
+  EXPECT_LT(
+      0, CountMatchingEntities(
+      meta.acl(),
+      ObjectAccessControl().set_entity("allUsers").set_role("READER")))
+            << meta;
+
+  client.DeleteObject(bucket_name, object_name);
+}
+
 TEST_F(ObjectIntegrationTest, ComposeSimple) {
   Client client;
   auto bucket_name = ObjectTestEnvironment::bucket_name();
@@ -649,10 +911,9 @@ TEST_F(ObjectIntegrationTest, ComposedUsingEncryptedObject) {
   auto composed_object_name = MakeRandomObjectName();
   std::vector<ComposeSourceObject> source_objects = {{object_name},
                                                      {object_name}};
-  ObjectMetadata composed_meta =
-      client.ComposeObject(bucket_name, source_objects, composed_object_name,
-                           ObjectMetadata().set_content_type("plain/text"),
-                          EncryptionKey(key));
+  ObjectMetadata composed_meta = client.ComposeObject(
+      bucket_name, source_objects, composed_object_name,
+      ObjectMetadata().set_content_type("plain/text"), EncryptionKey(key));
 
   EXPECT_EQ(meta.size() * 2, composed_meta.size());
   client.DeleteObject(bucket_name, composed_object_name);

--- a/google/cloud/storage/tests/testbench.py
+++ b/google/cloud/storage/tests/testbench.py
@@ -70,6 +70,8 @@ def canonical_entity_name(entity):
     :param entity:str convert this entity to its canonical name.
     :return:str the name in canonical form.
     """
+    if entity == 'allUsers' or entity == 'allAuthenticatedUsers':
+        return entity
     if entity.startswith('project-owners-'):
         entity = 'project-owners-123456789'
     if entity.startswith('project-editors-'):
@@ -257,7 +259,11 @@ class GcsObjectVersion(object):
             'location': 'US',
             'storageClass': 'STANDARD',
             'size': len(self.media),
-            'etag': 'XYZ='
+            'etag': 'XYZ=',
+            'owner': {
+                'entity': 'project-owners-123456789',
+                'entityId': '',
+            },
         }
         if request.headers.get('content-type') is not None:
             self.metadata['contentType'] = request.headers.get('content-type')
@@ -265,13 +271,7 @@ class GcsObjectVersion(object):
         self.update_from_metadata({})
         # Capture any encryption key headers.
         self._capture_customer_encryption(request)
-        # Insert the well-known values for the ACL.
-        self.insert_acl(
-            canonical_entity_name('project-owners-123456789'), 'OWNER')
-        self.insert_acl(
-            canonical_entity_name('project-editors-123456789'), 'OWNER')
-        self.insert_acl(
-            canonical_entity_name('project-viewers-123456789'), 'READER')
+        self._update_predefined_acl(request.args.get('predefinedAcl'))
 
     def update_from_metadata(self, metadata):
         """Update from a metadata dictionary.
@@ -350,6 +350,41 @@ class GcsObjectVersion(object):
             "keySha256": hash_header_value,
         }
 
+    def _update_predefined_acl(self, predefined_acl):
+        """Update the ACL based on the given request parameter value."""
+        if predefined_acl is None:
+            predefined_acl = 'projectPrivate'
+        self.insert_acl(
+            canonical_entity_name('project-owners-123456789'), 'OWNER')
+        bucket = lookup_bucket(self.bucket_name)
+        owner = bucket.metadata.get('owner')
+        if owner is None:
+            owner_entity = 'project-owners-123456789'
+        else:
+            owner_entity = owner.get('entity')
+        if predefined_acl == 'authenticatedRead':
+            self.insert_acl('allAuthenticatedUsers', 'READER')
+        elif predefined_acl == 'bucketOwnerFullControl':
+            self.insert_acl(owner_entity, 'OWNER')
+        elif predefined_acl == 'bucketOwnerRead':
+            self.insert_acl(owner_entity, 'READER')
+        elif predefined_acl == 'private':
+            self.insert_acl('project-owners', 'OWNER')
+        elif predefined_acl == 'projectPrivate':
+            self.insert_acl(
+                canonical_entity_name('project-editors-123456789'), 'OWNER')
+            self.insert_acl(
+                canonical_entity_name('project-viewers-123456789'), 'READER')
+        elif predefined_acl == 'publicRead':
+            self.insert_acl(canonical_entity_name('allUsers'), 'READER')
+        else:
+            raise ErrorResponse('Invalid predefinedAcl value', status_code=400)
+
+    def reset_predefined_acl(self, predefined_acl):
+        """Reset the ACL based on the given request parameter value."""
+        self.metadata['acl'] = []
+        self._update_predefined_acl(predefined_acl)
+
     def insert_acl(self, entity, role):
         """
         Insert (or update) a new AccessControl entry for this object.
@@ -401,7 +436,7 @@ class GcsObjectVersion(object):
         """
         entity = canonical_entity_name(entity)
         for acl in self.metadata.get('acl', []):
-            if acl.get('entity', '').lower() == entity:
+            if acl.get('entity', '') == entity:
                 return acl
         raise ErrorResponse('Entity %s not found in object %s' % (entity,
                                                                   self.name))
@@ -654,8 +689,7 @@ class GcsObject(object):
         return revision
 
     def copy_from(self, gcs_url, request, source_revision):
-        """
-        Insert a new revision based on the give flask request.
+        """Insert a new revision based on the give flask request.
 
         :param gcs_url:str the root URL for the fake GCS service.
         :param request:flask.Request the contents of the HTTP request.
@@ -669,14 +703,16 @@ class GcsObject(object):
         revision = GcsObjectVersion(gcs_url, self.bucket_name, self.name,
                                     self.generation, request,
                                     source_revision.media)
+        revision.reset_predefined_acl(
+            request.args.get('destinationPredefinedAcl'))
         metadata = json.loads(request.data)
         revision.update_from_metadata(metadata)
         self._insert_revision(revision)
         return revision
 
     def compose_from(self, gcs_url, request, composed_media):
-        """
-        Compose a new revision based on the give flask request.
+        """Compose a new revision based on the give flask request.
+
         :param gcs_url:str the root URL for the fake GCS service.
         :param request:flask.Request the contents of the HTTP request.
         :param composed_media:str contents of the composed object
@@ -685,6 +721,8 @@ class GcsObject(object):
         self.generation += 1
         revision = GcsObjectVersion(gcs_url, self.bucket_name, self.name,
                                     self.generation, request, composed_media)
+        revision.reset_predefined_acl(
+            request.args.get('destinationPredefinedAcl'))
         payload = json.loads(request.data)
         if payload.get('destination') is not None:
             revision.update_from_metadata(payload.get('destination'))
@@ -873,6 +911,10 @@ class GcsBucket(object):
             'labels': {
                 'foo': 'bar',
                 'baz': 'qux'
+            },
+            'owner': {
+                'entity': 'project-owners-123456789',
+                'entityId': '',
             }
         }
         self.notification_id = 1
@@ -1030,7 +1072,7 @@ class GcsBucket(object):
         """
         entity = canonical_entity_name(entity)
         for acl in self.metadata.get('acl', []):
-            if acl.get('entity', '').lower() == entity:
+            if acl.get('entity', '') == entity:
                 return acl
         raise ErrorResponse('Entity %s not found in object %s' % (entity,
                                                                   self.name))
@@ -1093,7 +1135,7 @@ class GcsBucket(object):
         """
         entity = canonical_entity_name(entity)
         for acl in self.metadata.get('defaultObjectAcl', []):
-            if acl.get('entity', '').lower() == entity:
+            if acl.get('entity', '') == entity:
                 return acl
         raise ErrorResponse('Entity %s not found in object %s' % (entity,
                                                                   self.name))

--- a/google/cloud/storage/well_known_parameters.h
+++ b/google/cloud/storage/well_known_parameters.h
@@ -278,6 +278,21 @@ struct PredefinedAcl
     : public internal::WellKnownParameter<PredefinedAcl, std::string> {
   using WellKnownParameter<PredefinedAcl, std::string>::WellKnownParameter;
   static char const* well_known_parameter_name() { return "predefinedAcl"; }
+
+  static PredefinedAcl AuthenticatedRead() {
+    return PredefinedAcl("authenticatedRead");
+  }
+  static PredefinedAcl BucketOwnerFullControl() {
+    return PredefinedAcl("bucketOwnerFullControl");
+  }
+  static PredefinedAcl BucketOwnerRead() {
+    return PredefinedAcl("bucketOwnerRead");
+  }
+  static PredefinedAcl Private() { return PredefinedAcl("private"); }
+  static PredefinedAcl ProjectPrivate() {
+    return PredefinedAcl("projectPrivate");
+  }
+  static PredefinedAcl PublicRead() { return PredefinedAcl("publicRead"); }
 };
 
 /**
@@ -297,6 +312,25 @@ struct DestinationPredefinedAcl
                            std::string>::WellKnownParameter;
   static char const* well_known_parameter_name() {
     return "destinationPredefinedAcl";
+  }
+
+  static DestinationPredefinedAcl AuthenticatedRead() {
+    return DestinationPredefinedAcl("authenticatedRead");
+  }
+  static DestinationPredefinedAcl BucketOwnerFullControl() {
+    return DestinationPredefinedAcl("bucketOwnerFullControl");
+  }
+  static DestinationPredefinedAcl BucketOwnerRead() {
+    return DestinationPredefinedAcl("bucketOwnerRead");
+  }
+  static DestinationPredefinedAcl Private() {
+    return DestinationPredefinedAcl("private");
+  }
+  static DestinationPredefinedAcl ProjectPrivate() {
+    return DestinationPredefinedAcl("projectPrivate");
+  }
+  static DestinationPredefinedAcl PublicRead() {
+    return DestinationPredefinedAcl("publicRead");
   }
 };
 
@@ -352,6 +386,9 @@ struct Projection
     : public internal::WellKnownParameter<Projection, std::string> {
   using WellKnownParameter<Projection, std::string>::WellKnownParameter;
   static char const* well_known_parameter_name() { return "projection"; }
+
+  static Projection NoAcl() { return Projection("noAcl"); }
+  static Projection Full() { return Projection("full"); }
 };
 
 /**


### PR DESCRIPTION
This fixes #1121. To test the example I had to change the testbench
quite a bit (supporting `PredefinedAcl` and `DestinationPredefinedAcl`
correctly). I also added some constants for `PredefinedAcl` values, and
introduced integration tests for all these constants.

While trying to write the tests I found `has_owner` missing in both
`ObjectMetadata` and `BucketMetadata`, so I fixed that too.