### PR TITLE
Cleanup attribute convenience functions.

### DIFF
--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -458,15 +458,38 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   using CommonMetadata::id;
   using CommonMetadata::kind;
 
-  std::size_t label_count() const { return labels_.size(); }
+  //@{
+  /// @name Accessors and modifiers to the `labels`.
   bool has_label(std::string const& key) const {
     return labels_.end() != labels_.find(key);
   }
   std::string const& label(std::string const& key) const {
     return labels_.at(key);
   }
+  /// Delete a label. This is a no-op if the key does not exist.
+  BucketMetadata& delete_label(std::string const& key) {
+    auto i = labels_.find(key);
+    if (i == labels_.end()) {
+      return *this;
+    }
+    labels_.erase(i);
+    return *this;
+  }
+
+  /// Insert or update the label entry.
+  BucketMetadata& upsert_label(std::string key, std::string value) {
+    auto i = labels_.lower_bound(key);
+    if (i == labels_.end() or i->first != key) {
+      labels_.emplace_hint(i, std::move(key), std::move(value));
+    } else {
+      i->second = std::move(value);
+    }
+    return *this;
+  }
+
   std::map<std::string, std::string> const& labels() const { return labels_; }
   std::map<std::string, std::string>& mutable_labels() { return labels_; }
+  //@}
 
   //@{
   /**

--- a/google/cloud/storage/bucket_metadata_test.cc
+++ b/google/cloud/storage/bucket_metadata_test.cc
@@ -173,7 +173,7 @@ TEST(BucketMetadataTest, Parse) {
   EXPECT_EQ("XYZ=", actual.etag());
   EXPECT_EQ("test-bucket", actual.id());
   EXPECT_EQ("storage#bucket", actual.kind());
-  EXPECT_EQ(2U, actual.label_count());
+  EXPECT_EQ(2U, actual.labels().size());
   EXPECT_TRUE(actual.has_label("label-key-1"));
   EXPECT_EQ("label-value-1", actual.label("label-key-1"));
   EXPECT_FALSE(actual.has_label("not-a-label-key"));
@@ -375,6 +375,39 @@ TEST(BucketMetadataTest, ToJsonString) {
   ASSERT_TRUE(actual["website"].is_object()) << actual;
   EXPECT_EQ("index.html", actual["website"].value("mainPageSuffix", ""));
   EXPECT_EQ("404.html", actual["website"].value("notFoundPage", ""));
+}
+
+/// @test Verify we can delete label fields.
+TEST(BucketMetadataTest, DeleteLabels) {
+  auto expected = CreateBucketMetadataForTest();
+  auto copy = expected;
+  EXPECT_TRUE(copy.has_label("label-key-1"));
+  copy.delete_label("label-key-1");
+  EXPECT_FALSE(copy.has_label("label-key-1"));
+  EXPECT_FALSE(copy.has_label("not-there"));
+  copy.delete_label("not-there");
+  EXPECT_FALSE(copy.has_label("not-there"));
+  EXPECT_NE(expected, copy);
+}
+
+/// @test Verify we can change metadata existing label fields.
+TEST(BuucketMetadataTest, ChangeLabels) {
+  auto expected = CreateBucketMetadataForTest();
+  auto copy = expected;
+  EXPECT_TRUE(copy.has_label("label-key-1"));
+  copy.upsert_label("label-key-1", "some-new-value");
+  EXPECT_EQ("some-new-value", copy.label("label-key-1"));
+  EXPECT_NE(expected, copy);
+}
+
+/// @test Verify we can change insert new label fields.
+TEST(BUcketMetadataTest, InsertLabels) {
+  auto expected = CreateBucketMetadataForTest();
+  auto copy = expected;
+  EXPECT_FALSE(copy.has_label("not-there"));
+  copy.upsert_label("not-there", "now-it-is");
+  EXPECT_EQ("now-it-is", copy.label("not-there"));
+  EXPECT_NE(expected, copy);
 }
 
 /// @test Verify we can make changes to one Acl in BucketMetadata.

--- a/google/cloud/storage/notification_metadata.h
+++ b/google/cloud/storage/notification_metadata.h
@@ -49,9 +49,6 @@ class NotificationMetadata {
 
   //@{
   /// @name Accessors and modifiers to the custom attributes.
-  std::size_t custom_attributes_size() const {
-    return custom_attributes_.size();
-  }
   bool has_custom_attribute(std::string const& key) const {
     return custom_attributes_.end() != custom_attributes_.find(key);
   }

--- a/google/cloud/storage/notification_metadata_test.cc
+++ b/google/cloud/storage/notification_metadata_test.cc
@@ -51,7 +51,6 @@ NotificationMetadata CreateNotificationMetadataForTest() {
 TEST(NotificationMetadataTest, Parse) {
   auto actual = CreateNotificationMetadataForTest();
   EXPECT_EQ(2U, actual.custom_attributes().size());
-  EXPECT_EQ(2U, actual.custom_attributes_size());
   EXPECT_TRUE(actual.has_custom_attribute("test-ca-1"));
   EXPECT_EQ("value1", actual.custom_attribute("test-ca-1"));
   EXPECT_TRUE(actual.has_custom_attribute("test-ca-2"));

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -172,11 +172,9 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
 
   //@{
   /// @name Accessors and modifiers to the `metadata` labels.
-  std::size_t metadata_count() const { return metadata_.size(); }
   bool has_metadata(std::string const& key) const {
     return metadata_.end() != metadata_.find(key);
   }
-
   std::string const& metadata(std::string const& key) const {
     return metadata_.at(key);
   }

--- a/google/cloud/storage/object_metadata_test.cc
+++ b/google/cloud/storage/object_metadata_test.cc
@@ -124,7 +124,7 @@ TEST(ObjectMetadataTest, Parse) {
       "https://www.googleapis.com/storage/v1/b/foo-bar/o/"
       "baz?generation=12345&alt=media",
       actual.media_link());
-  EXPECT_EQ(2U, actual.metadata_count());
+  EXPECT_EQ(2U, actual.metadata().size());
   EXPECT_TRUE(actual.has_metadata("foo"));
   EXPECT_EQ("bar", actual.metadata("foo"));
   EXPECT_EQ(4, actual.metageneration());


### PR DESCRIPTION
We had inconsistent convenience functions in `ObjectMetadata` (for the
metadata attributes), `BucketMetadata` (for the label attributes), and
`NotificationMetadata` (for the custom_attributes). With this change we
remove the `*_count()` helper functions, that fixes #1148. We also make
sure they all have the `upsert_*()` helper functions, that fixes #1046.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1157)
<!-- Reviewable:end -->
