### PR TITLE
Implement Client::RewriteObject.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -762,12 +762,13 @@ class Client {
    * Creates a `ObjectRewriter` to copy the source object.
    *
    * Applications use this function to reliably copy objects across location
-   * boundaries, and to rewrite objects with different Customer-Supplied
-   * Encryption Keys. The operation returns a `ObjectRewriter`, the application
-   * can use this object to initiate the copy, and to iterate if the copy
-   * requires more than one call to complete.
+   * boundaries, and to rewrite objects with different encryption keys. The
+   * operation returns a `ObjectRewriter`, which the application can use to
+   * initiate the copy and to iterate if the copy requires more than one call
+   * to complete.
    *
-   * @param source_bucket_name where is the source object located.
+   * @param source_bucket_name the name of the bucket containing the source
+   *     object.
    * @param source_object_name the name of the source object.
    * @param destination_bucket_name where the destination object will be
    *     located.
@@ -806,14 +807,15 @@ class Client {
    * Creates a `ObjectRewriter` to resume a previously created rewrite.
    *
    * Applications use this function to resume a rewrite operation, possibly
-   * created with `RewriteObject`. Rewrite can reliably copy objects across
-   * location boundaries, and to can rewrite objects with different
-   * Customer-Supplied Encryption Keys. For large objects this operation can
-   * take a long time, applications should consider checkpointing the rewrite
-   * token (accessible in the `ObjectRewriter`) and restarting the operations
-   * in the event their program is terminated.
+   * created with `RewriteObject()`. Rewrite can reliably copy objects across
+   * location boundaries, and can rewrite objects with different encryption
+   * keys. For large objects this operation can take a long time, thus
+   * applications should consider checkpointing the rewrite token (accessible in
+   * the `ObjectRewriter`) and restarting the operation in the event the program
+   * is terminated.
    *
-   * @param source_bucket_name where is the source object located.
+   * @param source_bucket_name the name of the bucket containing the source
+   *     object.
    * @param source_object_name the name of the source object.
    * @param destination_bucket_name where the destination object will be
    *     located.
@@ -821,8 +823,8 @@ class Client {
    * @param destination_object_metadata the new metadata for the Object. Only
    *     the writeable fields accepted by the `Objects: rewrite` API are used,
    *     all other fields are ignored.
-   * @param rewrite_token the last sucessful token from a previous rewrite
-   *     operation. Can be the empty string, in which case this starts a new
+   * @param rewrite_token the token from a previous successful rewrite
+   *     iteration. Can be the empty string, in which case this starts a new
    *     rewrite operation.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `DestinationKmsKeyName`,
@@ -857,15 +859,16 @@ class Client {
    * Rewrites the object, blocking until the rewrite completes.
    *
    * Applications use this function to reliably copy objects across location
-   * boundaries, and to rewrite objects with different Customer-Supplied
-   * Encryption Keys. The operation blocks until the rewrite completes, and
-   * returns the resulting `ObjectMetadata`.
+   * boundaries and to rewrite objects with different encryption keys. The
+   * operation blocks until the rewrite completes, and returns the resulting
+   * `ObjectMetadata`.
    *
    * @note Application developers should be aware that rewriting large objects
    *     may take multiple hours. In such cases the application should consider
-   *     using `RewriteObject` or `ResumeRewriteObject`.
+   *     using `RewriteObject()` or `ResumeRewriteObject()`.
    *
-   * @param source_bucket_name where is the source object located.
+   * @param source_bucket_name the name of the bucket containing the source
+   *     object.
    * @param source_object_name the name of the source object.
    * @param destination_bucket_name where the destination object will be
    *     located.

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -759,7 +759,7 @@ class Client {
   }
 
   /**
-   * Creates a `ObjectRewriter` to copy the source object.
+   * Creates an `ObjectRewriter` to copy the source object.
    *
    * Applications use this function to reliably copy objects across location
    * boundaries, and to rewrite objects with different encryption keys. The
@@ -804,7 +804,7 @@ class Client {
   }
 
   /**
-   * Creates a `ObjectRewriter` to resume a previously created rewrite.
+   * Creates an `ObjectRewriter` to resume a previously created rewrite.
    *
    * Applications use this function to resume a rewrite operation, possibly
    * created with `RewriteObject()`. Rewrite can reliably copy objects across
@@ -856,7 +856,8 @@ class Client {
   }
 
   /**
-   * Rewrites the object, blocking until the rewrite completes.
+   * Rewrites the object, blocking until the rewrite completes, and returns the
+   * resulting `ObjectMetadata`.
    *
    * Applications use this function to reliably copy objects across location
    * boundaries and to rewrite objects with different encryption keys. The

--- a/google/cloud/storage/examples/run_examples_testbench.sh
+++ b/google/cloud/storage/examples/run_examples_testbench.sh
@@ -28,13 +28,16 @@ start_testbench
 
 # Create most likely unique names for the project and bucket so multiple tests
 # can use the same testbench.
-readonly PROJECT_ID="fake-project-$(date +%s)"
-readonly BUCKET_NAME="fake-bucket-$(date +%s)"
-readonly TOPIC_NAME="fake-topic-$(date +%s)"
+readonly PROJECT_ID="fake-project-$(date +%s)-${RANDOM}"
+readonly BUCKET_NAME="fake-bucket-$(date +%s)-${RANDOM}"
+readonly DESTINATION_BUCKET_NAME="destination-bucket-$(date +%s)-${RANDOM}"
+readonly TOPIC_NAME="fake-topic-$(date +%s)-${RANDOM}"
 readonly STORAGE_CMEK_KEY="projects/${PROJECT_ID}/locations/global/keyRings/fake-key-ring/cryptoKeys/fake-key"
 
 # Most of the examples assume a bucket already exists, create one for them.
 run_example ./storage_bucket_samples create-bucket-for-project \
       "${BUCKET_NAME}" "${PROJECT_ID}"
+run_example ./storage_bucket_samples create-bucket-for-project \
+      "${DESTINATION_BUCKET_NAME}" "${PROJECT_ID}"
 
 run_all_storage_examples

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -280,6 +280,8 @@ run_all_object_rewrite_examples() {
 
   local object_name="rewrite-source-object-$(date +%s)-${RANDOM}.txt"
   local rewrite_object_name="rewrite-object-$(date +%s)-${RANDOM}.txt"
+  run_example ./storage_object_samples write-large-object \
+      "${source_bucket_name}" "${object_name}" "16"
   local msg=$(./storage_object_samples rewrite-object-token \
       "${source_bucket_name}" "${object_name}" \
       "${destination_bucket_name}" "${rewrite_object_name}")

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -314,7 +314,8 @@ class RewriteObjectRequest
           IfMetagenerationMatch, IfMetagenerationNotMatch,
           IfSourceGenerationMatch, IfSourceGenerationNotMatch,
           IfSourceMetagenerationMatch, IfSourceMetagenerationNotMatch,
-          Projection, SourceEncryptionKey, SourceGeneration, UserProject> {
+          MaxBytesRewrittenPerCall, Projection, SourceEncryptionKey,
+          SourceGeneration, UserProject> {
  public:
   RewriteObjectRequest() = default;
   RewriteObjectRequest(std::string source_bucket, std::string source_object,

--- a/google/cloud/storage/object_rewriter.h
+++ b/google/cloud/storage/object_rewriter.h
@@ -95,8 +95,9 @@ class ObjectRewriter {
                                         Functor, RewriteProgress>::value,
                                     int>::type = 0>
   ObjectMetadata ResultWithProgressCallback(Functor cb) {
-    for (auto progress = progress_; not progress.done; progress = Iterate()) {
-      cb(progress);
+    while (not progress_.done) {
+      Iterate();
+      cb(progress_);
     }
     return result_;
   }

--- a/google/cloud/storage/object_test.cc
+++ b/google/cloud/storage/object_test.cc
@@ -532,12 +532,10 @@ TEST_F(ObjectTest, RewriteObject) {
   Client client{std::shared_ptr<internal::RawClient>(mock),
                 LimitedErrorCountRetryPolicy(2)};
 
-  ObjectRewriter copier(
-      client.raw_client(),
-      internal::RewriteObjectRequest(
-          "test-source-bucket-name", "test-source-object-name",
-          "test-destination-bucket-name", "test-destination-object-name", "",
-          ObjectMetadata().upsert_metadata("test-key", "test-value")));
+  auto copier = client.RewriteObject(
+      "test-source-bucket-name", "test-source-object-name",
+      "test-destination-bucket-name", "test-destination-object-name",
+      ObjectMetadata().upsert_metadata("test-key", "test-value"));
   auto actual = copier.Iterate();
   EXPECT_FALSE(actual.done);
   EXPECT_EQ(1048576UL, actual.total_bytes_rewritten);
@@ -562,12 +560,9 @@ TEST_F(ObjectTest, RewriteObjectTooManyFailures) {
   testing::TooManyFailuresTest<internal::RewriteObjectResponse>(
       mock, EXPECT_CALL(*mock, RewriteObject(_)),
       [](Client& client) {
-        ObjectRewriter rewrite(
-            client.raw_client(),
-            internal::RewriteObjectRequest(
-                "test-source-bucket-name", "test-source-object-name",
-                "test-destination-bucket-name", "test-destination-object-name",
-                "", ObjectMetadata()));
+        auto rewrite = client.RewriteObject(
+            "test-source-bucket-name", "test-source-object",
+            "test-dest-bucket-name", "test-dest-object", ObjectMetadata());
         rewrite.Result();
       },
       "RewriteObject");
@@ -577,12 +572,9 @@ TEST_F(ObjectTest, RewriteObjectPermanentFailure) {
   testing::PermanentFailureTest<internal::RewriteObjectResponse>(
       *client, EXPECT_CALL(*mock, RewriteObject(_)),
       [](Client& client) {
-        ObjectRewriter rewrite(
-            client.raw_client(),
-            internal::RewriteObjectRequest(
-                "test-source-bucket-name", "test-source-object-name",
-                "test-destination-bucket-name", "test-destination-object-name",
-                "", ObjectMetadata()));
+        auto rewrite = client.RewriteObject(
+            "test-source-bucket-name", "test-source-object",
+            "test-dest-bucket-name", "test-dest-object", ObjectMetadata());
         rewrite.Result();
       },
       "RewriteObject");

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -470,7 +470,8 @@ TEST_F(ObjectIntegrationTest, XmlStreamingWrite) {
   };
 
   // Create the object, but only if it does not exist already.
-  auto os = client.WriteObject(bucket_name, object_name, IfGenerationMatch(0), Fields(""));
+  auto os = client.WriteObject(bucket_name, object_name, IfGenerationMatch(0),
+                               Fields(""));
   for (int line = 0; line != 1000; ++line) {
     std::string random = generate_random_line() + "\n";
     os << line << ": " << random;
@@ -682,9 +683,9 @@ TEST_F(ObjectIntegrationTest, InsertPredefinedAclAuthenticatedRead) {
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::AuthenticatedRead(), Projection::Full());
   EXPECT_LT(0, CountMatchingEntities(meta.acl(),
-                                      ObjectAccessControl()
-                                          .set_entity("allAuthenticatedUsers")
-                                          .set_role("READER")))
+                                     ObjectAccessControl()
+                                         .set_entity("allAuthenticatedUsers")
+                                         .set_role("READER")))
       << meta;
 
   client.DeleteObject(bucket_name, object_name);
@@ -704,8 +705,8 @@ TEST_F(ObjectIntegrationTest, InsertPredefinedAclBucketOwnerFullControl) {
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::BucketOwnerFullControl(), Projection::Full());
   EXPECT_LT(0, CountMatchingEntities(
-                    meta.acl(),
-                    ObjectAccessControl().set_entity(owner).set_role("OWNER")))
+                   meta.acl(),
+                   ObjectAccessControl().set_entity(owner).set_role("OWNER")))
       << meta;
 
   client.DeleteObject(bucket_name, object_name);
@@ -725,8 +726,8 @@ TEST_F(ObjectIntegrationTest, InsertPredefinedAclBucketOwnerRead) {
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::BucketOwnerRead(), Projection::Full());
   EXPECT_LT(0, CountMatchingEntities(
-                    meta.acl(),
-                    ObjectAccessControl().set_entity(owner).set_role("READER")))
+                   meta.acl(),
+                   ObjectAccessControl().set_entity(owner).set_role("READER")))
       << meta;
 
   client.DeleteObject(bucket_name, object_name);
@@ -743,8 +744,8 @@ TEST_F(ObjectIntegrationTest, InsertPredefinedAclPrivate) {
   ASSERT_TRUE(meta.has_owner());
   EXPECT_LT(
       0, CountMatchingEntities(meta.acl(), ObjectAccessControl()
-                                                .set_entity(meta.owner().entity)
-                                                .set_role("OWNER")))
+                                               .set_entity(meta.owner().entity)
+                                               .set_role("OWNER")))
       << meta;
 
   client.DeleteObject(bucket_name, object_name);
@@ -761,8 +762,8 @@ TEST_F(ObjectIntegrationTest, InsertPredefinedAclProjectPrivate) {
   ASSERT_TRUE(meta.has_owner());
   EXPECT_LT(
       0, CountMatchingEntities(meta.acl(), ObjectAccessControl()
-                                                .set_entity(meta.owner().entity)
-                                                .set_role("OWNER")))
+                                               .set_entity(meta.owner().entity)
+                                               .set_role("OWNER")))
       << meta;
 
   client.DeleteObject(bucket_name, object_name);
@@ -778,8 +779,8 @@ TEST_F(ObjectIntegrationTest, InsertPredefinedAclPublicRead) {
       PredefinedAcl::PublicRead(), Projection::Full());
   EXPECT_LT(
       0, CountMatchingEntities(
-              meta.acl(),
-              ObjectAccessControl().set_entity("allUsers").set_role("READER")))
+             meta.acl(),
+             ObjectAccessControl().set_entity("allUsers").set_role("READER")))
       << meta;
 
   client.DeleteObject(bucket_name, object_name);
@@ -795,13 +796,13 @@ TEST_F(ObjectIntegrationTest, CopyPredefinedAclAuthenticatedRead) {
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
   ObjectMetadata meta = client.CopyObject(
       bucket_name, object_name, bucket_name, copy_name, ObjectMetadata(),
-      IfGenerationMatch(0),
-      DestinationPredefinedAcl::AuthenticatedRead(), Projection::Full());
+      IfGenerationMatch(0), DestinationPredefinedAcl::AuthenticatedRead(),
+      Projection::Full());
   EXPECT_LT(0, CountMatchingEntities(meta.acl(),
                                      ObjectAccessControl()
                                          .set_entity("allAuthenticatedUsers")
                                          .set_role("READER")))
-            << meta;
+      << meta;
 
   client.DeleteObject(bucket_name, copy_name);
   client.DeleteObject(bucket_name, object_name);
@@ -822,12 +823,12 @@ TEST_F(ObjectIntegrationTest, CopyPredefinedAclBucketOwnerFullControl) {
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
   ObjectMetadata meta = client.CopyObject(
       bucket_name, object_name, bucket_name, copy_name, ObjectMetadata(),
-      IfGenerationMatch(0),
-      DestinationPredefinedAcl::BucketOwnerFullControl(), Projection::Full());
+      IfGenerationMatch(0), DestinationPredefinedAcl::BucketOwnerFullControl(),
+      Projection::Full());
   EXPECT_LT(0, CountMatchingEntities(
-      meta.acl(),
-      ObjectAccessControl().set_entity(owner).set_role("OWNER")))
-            << meta;
+                   meta.acl(),
+                   ObjectAccessControl().set_entity(owner).set_role("OWNER")))
+      << meta;
 
   client.DeleteObject(bucket_name, copy_name);
   client.DeleteObject(bucket_name, object_name);
@@ -848,12 +849,12 @@ TEST_F(ObjectIntegrationTest, CopyPredefinedAclBucketOwnerRead) {
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
   ObjectMetadata meta = client.CopyObject(
       bucket_name, object_name, bucket_name, copy_name, ObjectMetadata(),
-      IfGenerationMatch(0),
-      DestinationPredefinedAcl::BucketOwnerRead(), Projection::Full());
+      IfGenerationMatch(0), DestinationPredefinedAcl::BucketOwnerRead(),
+      Projection::Full());
   EXPECT_LT(0, CountMatchingEntities(
-      meta.acl(),
-      ObjectAccessControl().set_entity(owner).set_role("READER")))
-            << meta;
+                   meta.acl(),
+                   ObjectAccessControl().set_entity(owner).set_role("READER")))
+      << meta;
 
   client.DeleteObject(bucket_name, copy_name);
   client.DeleteObject(bucket_name, object_name);
@@ -869,14 +870,14 @@ TEST_F(ObjectIntegrationTest, CopyPredefinedAclPrivate) {
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
   ObjectMetadata meta = client.CopyObject(
       bucket_name, object_name, bucket_name, copy_name, ObjectMetadata(),
-      IfGenerationMatch(0),
-      DestinationPredefinedAcl::Private(), Projection::Full());
+      IfGenerationMatch(0), DestinationPredefinedAcl::Private(),
+      Projection::Full());
   ASSERT_TRUE(meta.has_owner());
   EXPECT_LT(
       0, CountMatchingEntities(meta.acl(), ObjectAccessControl()
-      .set_entity(meta.owner().entity)
-      .set_role("OWNER")))
-            << meta;
+                                               .set_entity(meta.owner().entity)
+                                               .set_role("OWNER")))
+      << meta;
 
   client.DeleteObject(bucket_name, copy_name);
   client.DeleteObject(bucket_name, object_name);
@@ -892,14 +893,14 @@ TEST_F(ObjectIntegrationTest, CopyPredefinedAclProjectPrivate) {
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
   ObjectMetadata meta = client.CopyObject(
       bucket_name, object_name, bucket_name, copy_name, ObjectMetadata(),
-      IfGenerationMatch(0),
-      DestinationPredefinedAcl::ProjectPrivate(), Projection::Full());
+      IfGenerationMatch(0), DestinationPredefinedAcl::ProjectPrivate(),
+      Projection::Full());
   ASSERT_TRUE(meta.has_owner());
   EXPECT_LT(
       0, CountMatchingEntities(meta.acl(), ObjectAccessControl()
-      .set_entity(meta.owner().entity)
-      .set_role("OWNER")))
-            << meta;
+                                               .set_entity(meta.owner().entity)
+                                               .set_role("OWNER")))
+      << meta;
 
   client.DeleteObject(bucket_name, copy_name);
   client.DeleteObject(bucket_name, object_name);
@@ -915,13 +916,13 @@ TEST_F(ObjectIntegrationTest, CopyPredefinedAclPublicRead) {
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
   ObjectMetadata meta = client.CopyObject(
       bucket_name, object_name, bucket_name, copy_name, ObjectMetadata(),
-      IfGenerationMatch(0),
-      DestinationPredefinedAcl::PublicRead(), Projection::Full());
+      IfGenerationMatch(0), DestinationPredefinedAcl::PublicRead(),
+      Projection::Full());
   EXPECT_LT(
       0, CountMatchingEntities(
-      meta.acl(),
-      ObjectAccessControl().set_entity("allUsers").set_role("READER")))
-            << meta;
+             meta.acl(),
+             ObjectAccessControl().set_entity("allUsers").set_role("READER")))
+      << meta;
 
   client.DeleteObject(bucket_name, object_name);
 }
@@ -994,13 +995,80 @@ TEST_F(ObjectIntegrationTest, RewriteSimple) {
 
   // Rewrite object into a new object.
   auto object_name = MakeRandomObjectName();
-  ObjectRewriter rewriter(
-      client.raw_client(),
-      internal::RewriteObjectRequest(
-          bucket_name, source_name, bucket_name, object_name, "",
-          ObjectMetadata().set_content_type("plain/text")));
+  ObjectMetadata rewritten_meta = client.RewriteObjectBlocking(
+      bucket_name, source_name, bucket_name, object_name,
+      ObjectMetadata().set_content_type("plain/text"));
+
+  EXPECT_EQ(bucket_name, rewritten_meta.bucket());
+  EXPECT_EQ(object_name, rewritten_meta.name());
+
+  client.DeleteObject(bucket_name, object_name);
+  client.DeleteObject(bucket_name, source_name);
+}
+
+TEST_F(ObjectIntegrationTest, RewriteEncrypted) {
+  Client client;
+  auto bucket_name = ObjectTestEnvironment::bucket_name();
+  auto source_name = MakeRandomObjectName();
+
+  // Create the object, but only if it does not exist already.
+  EncryptionKeyData source_key = MakeEncryptionKeyData();
+  ObjectMetadata source_meta =
+      client.InsertObject(bucket_name, source_name, LoremIpsum(),
+                          IfGenerationMatch(0), EncryptionKey(source_key));
+  EXPECT_EQ(source_name, source_meta.name());
+  EXPECT_EQ(bucket_name, source_meta.bucket());
+
+  // Compose new of object using previously created object
+  auto object_name = MakeRandomObjectName();
+  EncryptionKeyData dest_key = MakeEncryptionKeyData();
+  ObjectRewriter rewriter = client.RewriteObject(
+      bucket_name, source_name, bucket_name, object_name,
+      ObjectMetadata().set_content_type("plain/text"),
+      SourceEncryptionKey(source_key), EncryptionKey(dest_key));
 
   ObjectMetadata rewritten_meta = rewriter.Result();
+  EXPECT_EQ(bucket_name, rewritten_meta.bucket());
+  EXPECT_EQ(object_name, rewritten_meta.name());
+
+  client.DeleteObject(bucket_name, object_name);
+  client.DeleteObject(bucket_name, source_name);
+}
+
+TEST_F(ObjectIntegrationTest, RewriteLarge) {
+  // The testbench always requires multiple iterations to copy this object.
+  Client client;
+  auto bucket_name = ObjectTestEnvironment::bucket_name();
+  auto source_name = MakeRandomObjectName();
+
+  std::string large_text;
+  long const lines = 8 * 1024 * 1024 / 128;
+  for (long i = 0; i != lines; ++i) {
+    auto line = google::cloud::internal::Sample(generator_, 127,
+                                                "abcdefghijklmnopqrstuvwxyz"
+                                                "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                                "012456789");
+    large_text += line + "\n";
+  }
+
+  ObjectMetadata source_meta = client.InsertObject(
+      bucket_name, source_name, large_text, IfGenerationMatch(0));
+  EXPECT_EQ(source_name, source_meta.name());
+  EXPECT_EQ(bucket_name, source_meta.bucket());
+
+  // Rewrite object into a new object.
+  auto object_name = MakeRandomObjectName();
+  ObjectRewriter writer =
+      client.RewriteObject(bucket_name, source_name, bucket_name, object_name,
+                           ObjectMetadata().set_content_type("plain/text"));
+
+  ObjectMetadata rewritten_meta =
+      writer.ResultWithProgressCallback([](RewriteProgress const& p) {
+        EXPECT_TRUE((p.total_bytes_rewritten < p.object_size) xor p.done)
+            << "p.done=" << p.done << ", p.object_size=" << p.object_size
+            << ", p.total_bytes_rewritten=" << p.total_bytes_rewritten;
+      });
+
   EXPECT_EQ(bucket_name, rewritten_meta.bucket());
   EXPECT_EQ(object_name, rewritten_meta.name());
 

--- a/google/cloud/storage/well_known_parameters.h
+++ b/google/cloud/storage/well_known_parameters.h
@@ -265,6 +265,23 @@ struct MaxResults
 };
 
 /**
+ * Limit the number of bytes rewritten in a `Objects: rewrite` step.
+ *
+ * Applications should not need for the most part. It is used during testing, to
+ * ensure the code handles partial rewrites properly. Note that the value must
+ * be a multiple of 1 MiB (1048576).
+ */
+struct MaxBytesRewrittenPerCall
+    : public internal::WellKnownParameter<MaxBytesRewrittenPerCall,
+                                          std::int64_t> {
+  using WellKnownParameter<MaxBytesRewrittenPerCall,
+                           std::int64_t>::WellKnownParameter;
+  static char const* well_known_parameter_name() {
+    return "maxBytesRewrittenPerCall";
+  }
+};
+
+/**
  * Set the ACL to predefined values when creating Buckets or Objects.
  *
  * A predefined ACL is an alias for a set of specific ACL entries that you can


### PR DESCRIPTION
This fixes #816. There are two overloads for this API.  One returns
an object that the application can use to iterate until the rewrite
completes. The second does the iteration, but can block for a really
long time.  That made the unit tests are bit more complex, because
I wanted to test the iteration. The integration tests also test with CSEK,
and test the iteration too for large objects, so they are also bigger than
usual.

This PR also introduces an example and runs the example in the CI build.

Finally a bunch of code got reformatted by clang-format(1) :man_shrugging: 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1162)
<!-- Reviewable:end -->
