### PR TITLE
Build only once with Bazel.

### DIFF
--- a/ci/travis/build-bazel.sh
+++ b/ci/travis/build-bazel.sh
@@ -21,16 +21,16 @@ source "${BINDIR}/../colors.sh"
 
 export PATH=$PATH:$HOME/bin
 
-# We cannot simply use //...:all because when submodules are checked out that
-# includes the BUILD files for gRPC, protobuf, etc.
-bazel --batch build "//google/cloud/...:all"
-bazel --batch test \
-    --test_output=errors \
-    --action_env="GTEST_COLOR=1" \
-    "//google/cloud/...:all"
-
 if [ "${TEST_BAZEL_AS_DEPENDENCY:-}" = "yes" ]; then
   echo
   echo "${COLOR_YELLOW}Testing Bazel files as dependency${COLOR_RESET}"
   (cd ci/test-install && bazel --batch build //...:all)
+else
+  # We cannot simply use //...:all because when submodules are checked out that
+  # includes the BUILD files for gRPC, protobuf, etc.
+  bazel --batch build "//google/cloud/...:all"
+  bazel --batch test \
+      --test_output=errors \
+      --action_env="GTEST_COLOR=1" \
+      "//google/cloud/...:all"
 fi


### PR DESCRIPTION
With Bazel we are building the code 2 times when
TEST_BAZEL_AS_DEPENDENCY=yes.  That is super slow and contributes to
long (and sometimes failed) build times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1163)
<!-- Reviewable:end -->
