### PR TITLE
Only enable std::clog once.

### DIFF
--- a/google/cloud/log.h
+++ b/google/cloud/log.h
@@ -290,17 +290,27 @@ class LogSink {
   long AddBackend(std::shared_ptr<LogBackend> backend);
   void RemoveBackend(long id);
   void ClearBackends();
+  std::size_t BackendCount() const;
 
   void Log(LogRecord log_record);
 
   /// Enable `std::clog` on `LogSink::Instance()`.
-  static long EnableStdClog();
+  static void EnableStdClog() { Instance().EnableStdClogImpl(); }
+
+  /// Disable `std::clog` on `LogSink::Instance()`.
+  static void DisableStdClog() { Instance().DisableStdClogImpl(); }
 
  private:
+  void EnableStdClogImpl();
+  void DisableStdClogImpl();
+  long AddBackendImpl(std::shared_ptr<LogBackend> backend);
+  void RemoveBackendImpl(long id);
+
   std::atomic<bool> empty_;
   std::atomic<int> minimum_severity_;
-  std::mutex mu_;
+  std::mutex mutable mu_;
   long next_id_;
+  long clog_backend_id_;
   std::map<long, std::shared_ptr<LogBackend>> backends_;
 };
 

--- a/google/cloud/log_test.cc
+++ b/google/cloud/log_test.cc
@@ -113,8 +113,29 @@ TEST(LogSinkTest, LogToClog) {
   EXPECT_FALSE(LogSink::Instance().empty());
   LogSink::Instance().set_minimum_severity(Severity::GCP_LS_NOTICE);
   GCP_LOG(NOTICE) << "test message";
+  LogSink::DisableStdClog();
+  EXPECT_TRUE(LogSink::Instance().empty());
+  EXPECT_EQ(0U, LogSink::Instance().BackendCount());
   LogSink::Instance().ClearBackends();
 }
+
+TEST(LogSinkTest, ClogMultiple) {
+  LogSink::EnableStdClog();
+  EXPECT_FALSE(LogSink::Instance().empty());
+  EXPECT_EQ(1U, LogSink::Instance().BackendCount());
+  LogSink::EnableStdClog();
+  EXPECT_FALSE(LogSink::Instance().empty());
+  EXPECT_EQ(1U, LogSink::Instance().BackendCount());
+  LogSink::EnableStdClog();
+  EXPECT_FALSE(LogSink::Instance().empty());
+  EXPECT_EQ(1U, LogSink::Instance().BackendCount());
+  LogSink::Instance().set_minimum_severity(Severity::GCP_LS_NOTICE);
+  GCP_LOG(NOTICE) << "test message";
+  LogSink::DisableStdClog();
+  EXPECT_TRUE(LogSink::Instance().empty());
+  EXPECT_EQ(0U, LogSink::Instance().BackendCount());
+}
+
 
 namespace {
 /// A class to count calls to IOStream operator.


### PR DESCRIPTION
This fixes #921. It was possible to enable std::clog as a backend
multiple times, which produces too much output. Changed the Log classes
API to make this impossible, add a test to verify it works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1164)
<!-- Reviewable:end -->
