### PR TITLE
Use ClientOptions to control buffer sizes.

### DIFF
--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -41,6 +41,14 @@ std::size_t DefaultConnectionPoolSize() {
   return 4 * nthreads;
 }
 
+// There is nothing special about the buffer sizes here. They are relatively
+// small, because we do not want to consume too much memory from the
+// application. They are larger than the typical socket buffer size (64KiB), to
+// be able to read the full buffer into userspace if it happens to be full.
+#ifndef GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE
+#define GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE 128 * 1024
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE
+
 }  // namespace
 
 ClientOptions::ClientOptions() : ClientOptions(StorageDefaultCredentials()) {}
@@ -51,7 +59,9 @@ ClientOptions::ClientOptions(std::shared_ptr<Credentials> credentials)
       version_("v1"),
       enable_http_tracing_(false),
       enable_raw_client_tracing_(false),
-      connection_pool_size_(DefaultConnectionPoolSize()) {
+      connection_pool_size_(DefaultConnectionPoolSize()),
+      download_buffer_size_(GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE),
+      upload_buffer_size_(GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE) {
   char const* emulator = std::getenv("CLOUD_STORAGE_TESTBENCH_ENDPOINT");
   if (emulator != nullptr) {
     endpoint_ = emulator;
@@ -90,6 +100,24 @@ void ClientOptions::SetupFromEnvironment() {
   if (project_id != nullptr) {
     project_id_ = project_id;
   }
+}
+
+ClientOptions& ClientOptions::SetDownloadBufferSize(std::size_t size) {
+  if (size == 0) {
+    download_buffer_size_ = GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE;
+  } else {
+    download_buffer_size_ = size;
+  }
+  return *this;
+}
+
+ClientOptions& ClientOptions::SetUploadBufferSize(std::size_t size) {
+  if (size == 0) {
+    upload_buffer_size_ = GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE;
+  } else {
+    upload_buffer_size_ = size;
+  }
+  return *this;
 }
 
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -84,6 +84,12 @@ class ClientOptions {
     return *this;
   }
 
+  std::size_t download_buffer_size() const { return download_buffer_size_; }
+  ClientOptions& SetDownloadBufferSize(std::size_t size);
+
+  std::size_t upload_buffer_size() const { return upload_buffer_size_; }
+  ClientOptions& SetUploadBufferSize(std::size_t size);
+
  private:
   void SetupFromEnvironment();
 
@@ -95,6 +101,8 @@ class ClientOptions {
   bool enable_raw_client_tracing_;
   std::string project_id_;
   std::size_t connection_pool_size_;
+  std::size_t download_buffer_size_;
+  std::size_t upload_buffer_size_;
 };
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -33,11 +33,6 @@ class CurlRequestBuilder;
  */
 class CurlClient : public RawClient {
  public:
-  // TODO(#937) - use the client options to set the buffer size.
-  // This value is mostly arbitrary. It is big enough to fit the typical socket
-  // buffer, but not so large that we worry about memory utilization.
-  static constexpr std::size_t kDefaultBufferSize = 128 * 1024;
-
   explicit CurlClient(std::shared_ptr<Credentials> credentials)
       : CurlClient(ClientOptions(std::move(credentials))) {}
 

--- a/google/cloud/storage/storage_client_options_test.cc
+++ b/google/cloud/storage/storage_client_options_test.cc
@@ -111,6 +111,26 @@ TEST_F(ClientOptionsTest, SetProjectId) {
   EXPECT_EQ("test-project-id", options.project_id());
 }
 
+TEST_F(ClientOptionsTest, SetdownloadBufferSize) {
+  ClientOptions client_options;
+  auto default_size = client_options.download_buffer_size();
+  EXPECT_NE(0U, default_size);
+  client_options.SetDownloadBufferSize(1024);
+  EXPECT_EQ(1024U, client_options.download_buffer_size());
+  client_options.SetDownloadBufferSize(0);
+  EXPECT_EQ(default_size, client_options.download_buffer_size());
+}
+
+TEST_F(ClientOptionsTest, SetUploadBufferSize) {
+  ClientOptions client_options;
+  auto default_size = client_options.upload_buffer_size();
+  EXPECT_NE(0U, default_size);
+  client_options.SetUploadBufferSize(1024);
+  EXPECT_EQ(1024U, client_options.upload_buffer_size());
+  client_options.SetUploadBufferSize(0);
+  EXPECT_EQ(default_size, client_options.upload_buffer_size());
+}
+
 }  // namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage


### PR DESCRIPTION
This fixes #937. The upload and download buffer sizes were hardcoded,
this change makes them adjustable by the application.