### PR TITLE
Support setting the user-agent prefix.

### DIFF
--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -90,6 +90,17 @@ class ClientOptions {
   std::size_t upload_buffer_size() const { return upload_buffer_size_; }
   ClientOptions& SetUploadBufferSize(std::size_t size);
 
+  std::string const& user_agent_prefix() const { return user_agent_prefix_; }
+  ClientOptions& add_user_agent_prefx(std::string const& v) {
+    std::string prefix = v;
+    if (not user_agent_prefix_.empty()) {
+      prefix += '/';
+      prefix += user_agent_prefix_;
+    }
+    user_agent_prefix_ = std::move(prefix);
+    return *this;
+  }
+
  private:
   void SetupFromEnvironment();
 
@@ -103,6 +114,7 @@ class ClientOptions {
   std::size_t connection_pool_size_;
   std::size_t download_buffer_size_;
   std::size_t upload_buffer_size_;
+  std::string user_agent_prefix_;
 };
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -146,6 +146,9 @@ class CurlClient : public RawClient {
   void UnlockShared();
 
  private:
+  /// Setup the configuration parameters that do not depend on the request.
+  void SetupBuilderCommon(CurlRequestBuilder& builder, char const* method);
+
   /// Applies the common configuration parameters to @p builder.
   template <typename Request>
   void SetupBuilder(CurlRequestBuilder& builder, Request const& request,

--- a/google/cloud/storage/storage_client_options_test.cc
+++ b/google/cloud/storage/storage_client_options_test.cc
@@ -131,6 +131,15 @@ TEST_F(ClientOptionsTest, SetUploadBufferSize) {
   EXPECT_EQ(default_size, client_options.upload_buffer_size());
 }
 
+TEST_F(ClientOptionsTest, UserAgentPrefix) {
+  ClientOptions options(CreateInsecureCredentials());
+  EXPECT_EQ("", options.user_agent_prefix());
+  options.add_user_agent_prefx("foo-1.0");
+  EXPECT_EQ("foo-1.0", options.user_agent_prefix());
+  options.add_user_agent_prefx("bar-2.2");
+  EXPECT_EQ("bar-2.2/foo-1.0", options.user_agent_prefix());
+}
+
 }  // namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage


### PR DESCRIPTION
This fixes #511. It adds a configuration parameter to storage::ClientOptions that
adds prefixes to the user-agent string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1171)
<!-- Reviewable:end -->
