### PR TITLE
Fix CMake build issues

### DIFF
--- a/cmake/IncludeGrpc.cmake
+++ b/cmake/IncludeGrpc.cmake
@@ -233,9 +233,8 @@ elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "pkg-config")
             ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Release
             ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Debug)
     mark_as_advanced(PROTOC_GRPCPP_PLUGIN_EXECUTABLE)
-    add_executable(grpc_cpp_plugin ${PROTOC_GRPC_PLUGIN_EXECUTABLE})
+    add_executable(grpc_cpp_plugin IMPORTED)
     set_property(TARGET grpc_cpp_plugin
-                 PROPERTY IMPORTED_LOCATION
-                          ${PROTOC_GRPCPP_CPP_PLUGIN_EXECUTABLE})
+                 PROPERTY IMPORTED_LOCATION ${PROTOC_GRPCPP_PLUGIN_EXECUTABLE})
 
 endif ()

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -97,6 +97,13 @@ target_include_directories(google_cloud_cpp_common
                                   $<INSTALL_INTERFACE:include>)
 target_compile_options(google_cloud_cpp_common
                        PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+set_target_properties(
+    google_cloud_cpp_common
+    PROPERTIES
+        VERSION
+        ${GOOGLE_CLOUD_CPP_VERSION_MAJOR}.${GOOGLE_CLOUD_CPP_VERSION_MINOR}.${GOOGLE_CLOUD_CPP_VERSION_PATCH}
+        SOVERSION
+        ${GOOGLE_CLOUD_CPP_VERSION_MAJOR})
 
 include(CreateBazelConfig)
 create_bazel_config(google_cloud_cpp_common)

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -98,6 +98,13 @@ target_include_directories(bigtable_protos
                                   $<INSTALL_INTERFACE:include>)
 target_compile_options(bigtable_protos
                        PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+set_target_properties(
+    bigtable_protos
+    PROPERTIES
+        VERSION
+        ${BIGTABLE_CLIENT_VERSION_MAJOR}.${BIGTABLE_CLIENT_VERSION_MINOR}.${BIGTABLE_CLIENT_VERSION_PATCH}
+        SOVERSION
+        ${BIGTABLE_CLIENT_VERSION_MAJOR})
 add_library(bigtable::protos ALIAS bigtable_protos)
 
 # Enable unit tests
@@ -208,6 +215,13 @@ target_include_directories(bigtable_client
                                   $<INSTALL_INTERFACE:include>)
 target_compile_options(bigtable_client
                        PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+set_target_properties(
+    bigtable_client
+    PROPERTIES
+        VERSION
+        ${BIGTABLE_CLIENT_VERSION_MAJOR}.${BIGTABLE_CLIENT_VERSION_MINOR}.${BIGTABLE_CLIENT_VERSION_PATCH}
+        SOVERSION
+        ${BIGTABLE_CLIENT_VERSION_MAJOR})
 add_library(bigtable::client ALIAS bigtable_client)
 
 include(CreateBazelConfig)

--- a/google/cloud/firestore/CMakeLists.txt
+++ b/google/cloud/firestore/CMakeLists.txt
@@ -58,6 +58,13 @@ target_include_directories(firestore_client
                                   $<INSTALL_INTERFACE:include>)
 target_compile_options(firestore_client
                        PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+set_target_properties(
+    firestore_client
+    PROPERTIES
+        VERSION
+        ${FIRESTORE_CLIENT_VERSION_MAJOR}.${FIRESTORE_CLIENT_VERSION_MINOR}.${FIRESTORE_CLIENT_VERSION_PATCH}
+        SOVERSION
+        ${FIRESTORE_CLIENT_VERSION_MAJOR})
 add_library(firestore::client ALIAS firestore_client)
 
 include(CreateBazelConfig)
@@ -100,7 +107,8 @@ install(TARGETS
 
 # The exports can only be installed if all the dependencies are installed. CMake
 # needs to know where the submodules will be installed from,
-install(EXPORT firestore-targets DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake)
+install(EXPORT firestore-targets
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/firestore_client")
 
 install(TARGETS firestore_client
         EXPORT firestore-targets
@@ -138,4 +146,4 @@ install(
     FILES "${CMAKE_CURRENT_BINARY_DIR}/firestore_client-config.cmake"
           "${CMAKE_CURRENT_BINARY_DIR}/firestore_client-config-version.cmake"
           DESTINATION
-          ${CMAKE_INSTALL_DATAROOTDIR}/cmake)
+          "${CMAKE_INSTALL_LIBDIR}/cmake/firestore_client")

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -214,6 +214,13 @@ target_include_directories(storage_client
                                   $<INSTALL_INTERFACE:include>)
 target_compile_options(storage_client
                        PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+set_target_properties(
+    storage_client
+    PROPERTIES
+        VERSION
+        ${STORAGE_CLIENT_VERSION_MAJOR}.${STORAGE_CLIENT_VERSION_MINOR}.${STORAGE_CLIENT_VERSION_PATCH}
+        SOVERSION
+        ${STORAGE_CLIENT_VERSION_MAJOR})
 
 add_library(storage_client_testing
             testing/canonical_errors.h
@@ -333,7 +340,7 @@ install(TARGETS storage_client
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(DIRECTORY . DESTINATION include/storage/client
+install(DIRECTORY . DESTINATION include/google/cloud/storage/client
         FILES_MATCHING
         PATTERN "*.h"
         PATTERN "testing/*"


### PR DESCRIPTION
This fixes cmake so things are installed properly. Previously some of the libraries had their so versions set properly and some didn't, this fixes the remaining ones. and installs the CMake templates in the correct directory.

Also makes GOOGLE_CLOUD_CPP_GRPC_PROVIDER=pkg-config work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1178)
<!-- Reviewable:end -->
