### PR TITLE
Fix golang version of the latency benchmark.

### DIFF
--- a/google/cloud/storage/benchmarks/storage_latency_benchmark_go.go
+++ b/google/cloud/storage/benchmarks/storage_latency_benchmark_go.go
@@ -169,7 +169,7 @@ func MakeRandomData(desiredSize int) string {
 		result = result + sample(chars, kLineSize-1) + "\n"
 	}
 	if len(result) < desiredSize {
-		result = sample(chars, desiredSize-len(result))
+		result = result + sample(chars, desiredSize-len(result))
 	}
 	return result
 }

--- a/google/cloud/storage/benchmarks/storage_throughput_benchmark_go.go
+++ b/google/cloud/storage/benchmarks/storage_throughput_benchmark_go.go
@@ -286,9 +286,7 @@ func RunTest(bucket *storage.BucketHandle, ctx context.Context,
 }
 
 func DeleteObject(bucket *storage.BucketHandle, ctx context.Context, objectName string) {
-	start := time.Now()
 	bucket.Object(objectName).Delete(ctx)
-	elapsed := time.Since(start)
 }
 
 func DeleteAllObjects(bucket *storage.BucketHandle, ctx context.Context, objectCount int) {


### PR DESCRIPTION
The benchmark was just sending 128 bytes of data, it was supposed
to be 1 MiB, oops.

With that the benchmark results are:

![compare-latency-go-cpp-xml](https://user-images.githubusercontent.com/6241635/46101832-c2ec2d00-c181-11e8-93ba-bb03fba09bae.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1180)
<!-- Reviewable:end -->
