### PR TITLE
[Storage] Add region tag around read object sample

### DIFF
--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -166,7 +166,7 @@ void ReadObject(google::cloud::storage::Client client, int& argc,
   }
   auto bucket_name = ConsumeArg(argc, argv);
   auto object_name = ConsumeArg(argc, argv);
-  //! [read object]
+  //! [read object] [START storage_download_file]
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
     gcs::ObjectReadStream stream = client.ReadObject(bucket_name, object_name);
@@ -178,7 +178,7 @@ void ReadObject(google::cloud::storage::Client client, int& argc,
     }
     std::cout << "The object has " << count << " lines" << std::endl;
   }
-  //! [read object]
+  //! [read object] [END storage_download_file]
   (std::move(client), bucket_name, object_name);
 }
 


### PR DESCRIPTION
Let's have a sample for a download. It might not be exactly the same, but I don't think it's far enough a developer couldn't use it to download an object to a file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1184)
<!-- Reviewable:end -->
