### PR TITLE
Move optional out of the internal namespace.

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -75,7 +75,6 @@ add_library(google_cloud_cpp_common
             internal/build_info.h
             ${CMAKE_CURRENT_BINARY_DIR}/internal/build_info.cc
             internal/make_unique.h
-            internal/optional.h
             internal/port_platform.h
             internal/random.h
             internal/random.cc
@@ -87,6 +86,7 @@ add_library(google_cloud_cpp_common
             internal/throw_delegate.cc
             log.h
             log.cc
+            optional.h
             version.h)
 target_link_libraries(google_cloud_cpp_common
                       PUBLIC Threads::Threads
@@ -125,12 +125,12 @@ create_bazel_config(google_cloud_cpp_testing)
 set(google_cloud_cpp_common_unit_tests
     iam_bindings_test.cc
     internal/backoff_policy_test.cc
-    internal/optional_test.cc
     internal/random_test.cc
     internal/invoke_result_test.cc
     internal/retry_policy_test.cc
     internal/throw_delegate_test.cc
-    log_test.cc)
+    log_test.cc
+    optional_test.cc)
 
 # Export the list of unit tests so the Bazel BUILD file can pick it up.
 export_list_to_bazel("google_cloud_cpp_common_unit_tests.bzl"

--- a/google/cloud/bigtable/internal/rowreaderiterator.h
+++ b/google/cloud/bigtable/internal/rowreaderiterator.h
@@ -16,8 +16,8 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ROWREADERITERATOR_H_
 
 #include "google/cloud/bigtable/row.h"
-#include "google/cloud/internal/optional.h"
 #include "google/cloud/internal/throw_delegate.h"
+#include "google/cloud/optional.h"
 #include <iterator>
 
 namespace google {
@@ -33,7 +33,7 @@ namespace internal {
  *
  * TODO(#277) - replace with absl::optional<> or std::optional<> when possible.
  */
-using OptionalRow = google::cloud::internal::optional<Row>;
+using OptionalRow = google::cloud::optional<Row>;
 
 /**
  * The input iterator used to scan the rows in a RowReader.

--- a/google/cloud/bigtable/testing/mock_read_rows_reader.h
+++ b/google/cloud/bigtable/testing/mock_read_rows_reader.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_MOCK_READ_ROWS_READER_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_MOCK_READ_ROWS_READER_H_
 
-#include "mock_response_reader.h"
+#include "google/cloud/bigtable/testing/mock_response_reader.h"
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
 #include <gmock/gmock.h>
 

--- a/google/cloud/bigtable/testing/mock_sample_row_keys_reader.h
+++ b/google/cloud/bigtable/testing/mock_sample_row_keys_reader.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_MOCK_SAMPLE_ROW_KEYS_READER_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_MOCK_SAMPLE_ROW_KEYS_READER_H_
 
-#include "mock_response_reader.h"
+#include "google/cloud/bigtable/testing/mock_response_reader.h"
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
 #include <gmock/gmock.h>
 

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -6,7 +6,6 @@ google_cloud_cpp_common_HDRS = [
     "internal/backoff_policy.h",
     "internal/build_info.h",
     "internal/make_unique.h",
-    "internal/optional.h",
     "internal/port_platform.h",
     "internal/random.h",
     "internal/invoke_result.h",
@@ -14,6 +13,7 @@ google_cloud_cpp_common_HDRS = [
     "internal/setenv.h",
     "internal/throw_delegate.h",
     "log.h",
+    "optional.h",
     "version.h",
 ]
 

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -2,10 +2,10 @@
 google_cloud_cpp_common_unit_tests = [
     "iam_bindings_test.cc",
     "internal/backoff_policy_test.cc",
-    "internal/optional_test.cc",
     "internal/random_test.cc",
     "internal/invoke_result_test.cc",
     "internal/retry_policy_test.cc",
     "internal/throw_delegate_test.cc",
     "log_test.cc",
+    "optional_test.cc",
 ]

--- a/google/cloud/internal/random_test.cc
+++ b/google/cloud/internal/random_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "random.h"
+#include "google/cloud/internal/random.h"
 #include <gmock/gmock.h>
 
 using namespace google::cloud::internal;

--- a/google/cloud/optional.h
+++ b/google/cloud/optional.h
@@ -12,17 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_OPTIONAL_H_
-#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_OPTIONAL_H_
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPTIONAL_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPTIONAL_H_
 
-#include "google/cloud/internal/throw_delegate.h"
+#include "internal/throw_delegate.h"
 #include <type_traits>
 #include <utility>
 
 namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
-namespace internal {
 /**
  * A poor's man version of std::optional<T>.
  *
@@ -258,9 +257,8 @@ optional<T> make_optional(T&& t) {
   return optional<T>(std::forward<T>(t));
 }
 
-}  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_OPTIONAL_H_
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPTIONAL_H_

--- a/google/cloud/optional.h
+++ b/google/cloud/optional.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPTIONAL_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPTIONAL_H_
 
-#include "internal/throw_delegate.h"
+#include "google/cloud/internal/throw_delegate.h"
 #include <type_traits>
 #include <utility>
 

--- a/google/cloud/optional_test.cc
+++ b/google/cloud/optional_test.cc
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/optional.h"
+#include "google/cloud/optional.h"
 #include <gmock/gmock.h>
 
-using namespace ::testing;
-
-/// Helper types to test google::cloud::internal::optional<T>
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+/// Helper types to test google::cloud::optional<T>
 namespace {
 class Observable {
  public:
@@ -94,10 +95,11 @@ class NoDefaultConstructor {
  private:
   std::string str_;
 };
-}  // namespace
+
+using OptionalObservable = optional<Observable>;
 
 TEST(OptionalTest, Simple) {
-  google::cloud::internal::optional<int> actual;
+  optional<int> actual;
   EXPECT_FALSE(actual.has_value());
   EXPECT_FALSE(static_cast<bool>(actual));
 
@@ -114,8 +116,6 @@ TEST(OptionalTest, Simple) {
   EXPECT_EQ(24, actual.value_or(42));
   EXPECT_EQ(24, actual.value());
 }
-
-using OptionalObservable = google::cloud::internal::optional<Observable>;
 
 TEST(OptionalTest, NoDefaultConstruction) {
   Observable::reset_counters();
@@ -393,8 +393,7 @@ TEST(OptionalTest, MoveValueOr) {
 }
 
 TEST(OptionalTest, WithNoDefaultConstructor) {
-  using TestedOptional =
-      google::cloud::internal::optional<NoDefaultConstructor>;
+  using TestedOptional = optional<NoDefaultConstructor>;
   TestedOptional empty;
   EXPECT_FALSE(empty.has_value());
 
@@ -402,3 +401,7 @@ TEST(OptionalTest, WithNoDefaultConstructor) {
   EXPECT_TRUE(actual.has_value());
   EXPECT_EQ(actual->str(), "foo");
 }
+}  // namespace
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BUCKET_METADATA_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BUCKET_METADATA_H_
 
-#include "google/cloud/internal/optional.h"
+#include "google/cloud/optional.h"
 #include "google/cloud/storage/bucket_access_control.h"
 #include "google/cloud/storage/internal/common_metadata.h"
 #include "google/cloud/storage/internal/nljson.h"
@@ -85,7 +85,7 @@ inline bool operator>=(BucketBilling const& lhs, BucketBilling const& rhs) {
  *     on how to set and troubleshoot CORS settings.
  */
 struct CorsEntry {
-  google::cloud::internal::optional<std::int64_t> max_age_seconds;
+  google::cloud::optional<std::int64_t> max_age_seconds;
   std::vector<std::string> method;
   std::vector<std::string> origin;
   std::vector<std::string> response_header;
@@ -370,7 +370,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
    */
   bool has_billing() const { return billing_.has_value(); }
   BucketBilling const& billing() const { return *billing_; }
-  cloud::internal::optional<BucketBilling> const& billing_as_optional() const {
+  google::cloud::optional<BucketBilling> const& billing_as_optional() const {
     return billing_;
   }
   BucketMetadata& set_billing(BucketBilling const& v) {
@@ -440,7 +440,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
    */
   bool has_encryption() const { return encryption_.has_value(); }
   BucketEncryption const& encryption() const { return *encryption_; }
-  cloud::internal::optional<BucketEncryption> const& encryption_as_optional()
+  google::cloud::optional<BucketEncryption> const& encryption_as_optional()
       const {
     return encryption_;
   }
@@ -500,8 +500,8 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
    */
   bool has_lifecycle() const { return lifecycle_.has_value(); }
   BucketLifecycle const& lifecycle() const { return *lifecycle_; }
-  google::cloud::internal::optional<BucketLifecycle> const&
-  lifecycle_as_optional() const {
+  google::cloud::optional<BucketLifecycle> const& lifecycle_as_optional()
+      const {
     return lifecycle_;
   }
   BucketMetadata& set_lifecycle(BucketLifecycle v) {
@@ -524,7 +524,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   /// @name Accessors and modifiers for logging configuration.
   bool has_logging() const { return logging_.has_value(); }
   BucketLogging const& logging() const { return *logging_; }
-  cloud::internal::optional<BucketLogging> const& logging_as_optional() const {
+  google::cloud::optional<BucketLogging> const& logging_as_optional() const {
     return logging_;
   }
   BucketMetadata& set_logging(BucketLogging v) {
@@ -562,8 +562,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
 
   //@{
   /// @name Accessors and modifiers for versioning configuration.
-  google::cloud::internal::optional<BucketVersioning> const& versioning()
-      const {
+  google::cloud::optional<BucketVersioning> const& versioning() const {
     return versioning_;
   }
   bool has_versioning() const { return versioning_.has_value(); }
@@ -579,8 +578,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
     versioning_.reset();
     return *this;
   }
-  BucketMetadata& set_versioning(
-      google::cloud::internal::optional<BucketVersioning> v) {
+  BucketMetadata& set_versioning(google::cloud::optional<BucketVersioning> v) {
     versioning_ = std::move(v);
     return *this;
   }
@@ -590,7 +588,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   /// @name Accessors and modifiers for website configuration.
   bool has_website() const { return website_.has_value(); }
   BucketWebsite const& website() const { return *website_; }
-  cloud::internal::optional<BucketWebsite> const& website_as_optional() const {
+  google::cloud::optional<BucketWebsite> const& website_as_optional() const {
     return website_;
   }
   BucketMetadata& set_website(BucketWebsite v) {
@@ -610,17 +608,17 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   friend std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs);
   // Keep the fields in alphabetical order.
   std::vector<BucketAccessControl> acl_;
-  google::cloud::internal::optional<BucketBilling> billing_;
+  google::cloud::optional<BucketBilling> billing_;
   std::vector<CorsEntry> cors_;
   std::vector<ObjectAccessControl> default_acl_;
-  google::cloud::internal::optional<BucketEncryption> encryption_;
+  google::cloud::optional<BucketEncryption> encryption_;
   std::map<std::string, std::string> labels_;
-  google::cloud::internal::optional<BucketLifecycle> lifecycle_;
+  google::cloud::optional<BucketLifecycle> lifecycle_;
   std::string location_;
-  google::cloud::internal::optional<BucketLogging> logging_;
+  google::cloud::optional<BucketLogging> logging_;
   std::int64_t project_number_;
-  google::cloud::internal::optional<BucketVersioning> versioning_;
-  google::cloud::internal::optional<BucketWebsite> website_;
+  google::cloud::optional<BucketVersioning> versioning_;
+  google::cloud::optional<BucketWebsite> website_;
 };
 
 std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs);

--- a/google/cloud/storage/bucket_metadata_test.cc
+++ b/google/cloud/storage/bucket_metadata_test.cc
@@ -21,8 +21,8 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using google::cloud::internal::make_optional;
-using google::cloud::internal::optional;
+using google::cloud::make_optional;
+using google::cloud::optional;
 using ::testing::HasSubstr;
 using ::testing::Not;
 
@@ -702,7 +702,7 @@ TEST(BucketMetadataPatchBuilder, SetCors) {
   std::vector<CorsEntry> v;
   v.emplace_back(CorsEntry{{}, {"method1", "method2"}, {}, {"header1"}});
   v.emplace_back(
-      CorsEntry{google::cloud::internal::optional<std::int64_t>(86400),
+      CorsEntry{google::cloud::optional<std::int64_t>(86400),
                 {},
                 {"origin1"},
                 {}});

--- a/google/cloud/storage/internal/access_control_common.h
+++ b/google/cloud/storage/internal/access_control_common.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ACCESS_CONTROL_COMMON_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ACCESS_CONTROL_COMMON_H_
 
-#include "google/cloud/internal/optional.h"
+#include "google/cloud/optional.h"
 #include "google/cloud/storage/internal/common_metadata.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include <utility>
@@ -113,8 +113,7 @@ class AccessControlCommon {
 
   bool has_project_team() const { return project_team_.has_value(); }
   ProjectTeam const& project_team() const { return *project_team_; }
-  google::cloud::internal::optional<ProjectTeam> const&
-  project_team_as_optional() const {
+  google::cloud::optional<ProjectTeam> const& project_team_as_optional() const {
     return project_team_;
   }
 
@@ -146,7 +145,7 @@ class AccessControlCommon {
   std::string etag_;
   std::string id_;
   std::string kind_;
-  google::cloud::internal::optional<ProjectTeam> project_team_;
+  google::cloud::optional<ProjectTeam> project_team_;
   std::string role_;
   std::string self_link_;
 };

--- a/google/cloud/storage/internal/common_metadata.h
+++ b/google/cloud/storage/internal/common_metadata.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_COMMON_METADATA_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_COMMON_METADATA_H_
 
-#include "google/cloud/internal/optional.h"
+#include "google/cloud/optional.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include <chrono>
@@ -139,7 +139,7 @@ class CommonMetadata {
   std::string kind_;
   std::int64_t metageneration_;
   std::string name_;
-  google::cloud::internal::optional<Owner> owner_;
+  google::cloud::optional<Owner> owner_;
   std::string self_link_;
   std::string storage_class_;
   std::chrono::system_clock::time_point time_created_;

--- a/google/cloud/storage/internal/patch_builder.h
+++ b/google/cloud/storage/internal/patch_builder.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_PATCH_BUILDER_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_PATCH_BUILDER_H_
 
-#include "google/cloud/internal/optional.h"
+#include "google/cloud/optional.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include <string>
 #include <vector>
@@ -111,9 +111,9 @@ class PatchBuilder {
    *     patch that removes the previous value.
    */
   template <typename T>
-  PatchBuilder& AddOptionalField(
-      char const* field_name, google::cloud::internal::optional<T> const& lhs,
-      google::cloud::internal::optional<T> const& rhs) {
+  PatchBuilder& AddOptionalField(char const* field_name,
+                                 google::cloud::optional<T> const& lhs,
+                                 google::cloud::optional<T> const& rhs) {
     if (lhs == rhs) return *this;
     if (not rhs.has_value()) {
       patch_[field_name] = nullptr;

--- a/google/cloud/storage/internal/patch_builder_test.cc
+++ b/google/cloud/storage/internal/patch_builder_test.cc
@@ -66,7 +66,7 @@ TEST(PatchBuilderTest, Int) {
 
 TEST(PatchBuilderTest, OptionalBool) {
   PatchBuilder builder;
-  using bopt = google::cloud::internal::optional<bool>;
+  using bopt = google::cloud::optional<bool>;
   builder.AddOptionalField("set-value", bopt(false), bopt(true));
   builder.AddOptionalField("unset-value", bopt(false), bopt());
   builder.AddOptionalField("untouched-value", bopt(true), bopt(true));
@@ -80,7 +80,7 @@ TEST(PatchBuilderTest, OptionalBool) {
 
 TEST(PatchBuilderTest, OptionalInt) {
   PatchBuilder builder;
-  using opt = google::cloud::internal::optional<std::int64_t>;
+  using opt = google::cloud::optional<std::int64_t>;
   builder.AddOptionalField("set-value", opt(0), opt(42));
   builder.AddOptionalField("unset-value", opt(42), opt());
   builder.AddOptionalField("untouched-value", opt(7), opt(7));

--- a/google/cloud/storage/lifecycle_rule.h
+++ b/google/cloud/storage/lifecycle_rule.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_LIFECYCLE_RULE_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_LIFECYCLE_RULE_H_
 
-#include "google/cloud/internal/optional.h"
+#include "google/cloud/optional.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/internal/parse_rfc3339.h"
 #include "google/cloud/storage/storage_class.h"
@@ -69,13 +69,11 @@ std::ostream& operator<<(std::ostream& os, LifecycleRuleAction const& rhs);
 
 /// Implement a wrapper for Lifecycle Conditions.
 struct LifecycleRuleCondition {
-  google::cloud::internal::optional<std::int32_t> age;
-  google::cloud::internal::optional<std::chrono::system_clock::time_point>
-      created_before;
-  google::cloud::internal::optional<bool> is_live;
-  google::cloud::internal::optional<std::vector<std::string>>
-      matches_storage_class;
-  google::cloud::internal::optional<std::int32_t> num_newer_versions;
+  google::cloud::optional<std::int32_t> age;
+  google::cloud::optional<std::chrono::system_clock::time_point> created_before;
+  google::cloud::optional<bool> is_live;
+  google::cloud::optional<std::vector<std::string>> matches_storage_class;
+  google::cloud::optional<std::int32_t> num_newer_versions;
 };
 
 inline bool operator==(LifecycleRuleCondition const& lhs,

--- a/google/cloud/storage/list_buckets_reader.cc
+++ b/google/cloud/storage/list_buckets_reader.cc
@@ -59,8 +59,7 @@ static_assert(
     "ListBucketsReader::iterator &>");
 
 ListBucketsIterator::ListBucketsIterator(
-    ListBucketsReader* owner,
-    google::cloud::internal::optional<BucketMetadata> value)
+    ListBucketsReader* owner, google::cloud::optional<BucketMetadata> value)
     : owner_(owner), value_(std::move(value)) {
   if (not value_) {
     // This iterator was initialized by begin() on an empty list, turn it into
@@ -82,10 +81,10 @@ ListBucketsReader::iterator ListBucketsReader::begin() {
   return iterator(this, GetNext());
 }
 
-google::cloud::internal::optional<BucketMetadata> ListBucketsReader::GetNext() {
+google::cloud::optional<BucketMetadata> ListBucketsReader::GetNext() {
   if (current_buckets_.end() == current_) {
     if (on_last_page_) {
-      return google::cloud::internal::optional<BucketMetadata>();
+      return google::cloud::optional<BucketMetadata>();
     }
     request_.set_page_token(std::move(next_page_token_));
     auto response = client_->ListBuckets(request_);
@@ -96,11 +95,10 @@ google::cloud::internal::optional<BucketMetadata> ListBucketsReader::GetNext() {
       on_last_page_ = true;
     }
     if (current_buckets_.end() == current_) {
-      return google::cloud::internal::optional<BucketMetadata>();
+      return google::cloud::optional<BucketMetadata>();
     }
   }
-  return google::cloud::internal::optional<BucketMetadata>(
-      std::move(*current_++));
+  return google::cloud::optional<BucketMetadata>(std::move(*current_++));
 }
 
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/list_buckets_reader.h
+++ b/google/cloud/storage/list_buckets_reader.h
@@ -71,13 +71,12 @@ class ListBucketsIterator {
 
  private:
   friend class ListBucketsReader;
-  explicit ListBucketsIterator(
-      ListBucketsReader* owner,
-      google::cloud::internal::optional<BucketMetadata> value);
+  explicit ListBucketsIterator(ListBucketsReader* owner,
+                               google::cloud::optional<BucketMetadata> value);
 
  private:
   ListBucketsReader* owner_;
-  google::cloud::internal::optional<BucketMetadata> value_;
+  google::cloud::optional<BucketMetadata> value_;
 };
 
 /**
@@ -125,7 +124,7 @@ class ListBucketsReader {
    *
    * @return an unset optional if there are no more buckets in the stream.
    */
-  google::cloud::internal::optional<BucketMetadata> GetNext();
+  google::cloud::optional<BucketMetadata> GetNext();
 
  private:
   std::shared_ptr<internal::RawClient> client_;

--- a/google/cloud/storage/list_objects_reader.cc
+++ b/google/cloud/storage/list_objects_reader.cc
@@ -59,8 +59,7 @@ static_assert(
     "ListObjectsReader::iterator &>");
 
 ListObjectsIterator::ListObjectsIterator(
-    ListObjectsReader* owner,
-    google::cloud::internal::optional<ObjectMetadata> value)
+    ListObjectsReader* owner, google::cloud::optional<ObjectMetadata> value)
     : owner_(owner), value_(std::move(value)) {
   if (not value_) {
     // This iterator was initialized by begin() on an empty list, turn it into
@@ -82,10 +81,10 @@ ListObjectsReader::iterator ListObjectsReader::begin() {
   return iterator(this, GetNext());
 }
 
-google::cloud::internal::optional<ObjectMetadata> ListObjectsReader::GetNext() {
+google::cloud::optional<ObjectMetadata> ListObjectsReader::GetNext() {
   if (current_objects_.end() == current_) {
     if (on_last_page_) {
-      return google::cloud::internal::optional<ObjectMetadata>();
+      return google::cloud::optional<ObjectMetadata>();
     }
     request_.set_page_token(std::move(next_page_token_));
     auto response = client_->ListObjects(request_);
@@ -99,11 +98,10 @@ google::cloud::internal::optional<ObjectMetadata> ListObjectsReader::GetNext() {
       on_last_page_ = true;
     }
     if (current_objects_.end() == current_) {
-      return google::cloud::internal::optional<ObjectMetadata>();
+      return google::cloud::optional<ObjectMetadata>();
     }
   }
-  return google::cloud::internal::optional<ObjectMetadata>(
-      std::move(*current_++));
+  return google::cloud::optional<ObjectMetadata>(std::move(*current_++));
 }
 
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/list_objects_reader.h
+++ b/google/cloud/storage/list_objects_reader.h
@@ -71,13 +71,12 @@ class ListObjectsIterator {
 
  private:
   friend class ListObjectsReader;
-  explicit ListObjectsIterator(
-      ListObjectsReader* owner,
-      google::cloud::internal::optional<ObjectMetadata> value);
+  explicit ListObjectsIterator(ListObjectsReader* owner,
+                               google::cloud::optional<ObjectMetadata> value);
 
  private:
   ListObjectsReader* owner_;
-  google::cloud::internal::optional<ObjectMetadata> value_;
+  google::cloud::optional<ObjectMetadata> value_;
 };
 
 /**
@@ -125,7 +124,7 @@ class ListObjectsReader {
    *
    * @return an unset optional if there are no more objects in the stream.
    */
-  google::cloud::internal::optional<ObjectMetadata> GetNext();
+  google::cloud::optional<ObjectMetadata> GetNext();
 
  private:
   std::shared_ptr<internal::RawClient> client_;

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OBJECT_METADATA_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OBJECT_METADATA_H_
 
-#include "google/cloud/internal/optional.h"
+#include "google/cloud/optional.h"
 #include "google/cloud/storage/internal/common_metadata.h"
 #include "google/cloud/storage/object_access_control.h"
 #include <map>
@@ -35,8 +35,8 @@ struct CustomerEncryption {
 /// Defines one of the source objects for a compose operation.
 struct ComposeSourceObject {
   std::string object_name;
-  google::cloud::internal::optional<long> generation;
-  google::cloud::internal::optional<long> if_generation_match;
+  google::cloud::optional<long> generation;
+  google::cloud::optional<long> if_generation_match;
 };
 
 std::ostream& operator<<(std::ostream& os, ComposeSourceObject const& r);
@@ -243,7 +243,7 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
   std::string content_language_;
   std::string content_type_;
   std::string crc32c_;
-  google::cloud::internal::optional<CustomerEncryption> customer_encryption_;
+  google::cloud::optional<CustomerEncryption> customer_encryption_;
   std::int64_t generation_;
   std::string kms_key_name_;
   std::string md5_hash_;

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -186,7 +186,7 @@ TEST_F(BucketIntegrationTest, FullPatch) {
 
   // cors()
   desired_state.mutable_cors().push_back(CorsEntry{
-      google::cloud::internal::optional<std::int64_t>(86400), {"GET"}, {}, {}});
+      google::cloud::optional<std::int64_t>(86400), {"GET"}, {}, {}});
 
   // default_acl()
   desired_state.mutable_default_acl().push_back(

--- a/google/cloud/storage/well_known_headers.h
+++ b/google/cloud/storage/well_known_headers.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_WELL_KNOWN_HEADERS_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_WELL_KNOWN_HEADERS_H_
 
-#include "google/cloud/internal/optional.h"
 #include "google/cloud/internal/random.h"
+#include "google/cloud/optional.h"
 #include "google/cloud/storage/version.h"
 #include <cstdint>
 #include <iostream>
@@ -46,7 +46,7 @@ class WellKnownHeader {
   T const& value() const { return value_.value(); }
 
  private:
-  google::cloud::internal::optional<T> value_;
+  google::cloud::optional<T> value_;
 };
 
 template <typename H, typename T>

--- a/google/cloud/storage/well_known_parameters.h
+++ b/google/cloud/storage/well_known_parameters.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_WELL_KNOWN_PARAMETERS_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_WELL_KNOWN_PARAMETERS_H_
 
-#include "google/cloud/internal/optional.h"
+#include "google/cloud/optional.h"
 #include "google/cloud/storage/version.h"
 #include <cstdint>
 #include <string>
@@ -43,7 +43,7 @@ class WellKnownParameter {
   T const& value() const { return value_.value(); }
 
  private:
-  google::cloud::internal::optional<T> value_;
+  google::cloud::optional<T> value_;
 };
 
 template <typename P, typename T>


### PR DESCRIPTION
This fixes #1099.

The `google::cloud::internal::optional<T>` class became part of the
public API, we need to move it out of `internal` or we are sending a
confusing message to our users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1195)
<!-- Reviewable:end -->
