### PR TITLE
Fix include rules for headers.

### DIFF
--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -216,6 +216,27 @@ if [ "${TEST_INSTALL:-}" = "yes" ]; then
   # Checking the ABI requires installation, so this is the first opportunity to
   # run the check.
   (cd /v ; ./ci/check-abi.sh)
+
+  # Also verify that the install directory does not get unexpected files or
+  # directories installed.
+  echo
+  echo "${COLOR_YELLOW}Verify installed headers created only" \
+      " expected directories.${COLOR_RESET}"
+  cmake --build . --target install -- DESTDIR=/var/tmp/staging
+  if comm -23 \
+      <(find /var/tmp/staging/include/google/cloud -type d | sort) \
+      <(echo /var/tmp/staging/include/google/cloud ; \
+        echo /var/tmp/staging/include/google/cloud/bigtable ; \
+        echo /var/tmp/staging/include/google/cloud/bigtable/internal ; \
+        echo /var/tmp/staging/include/google/cloud/firestore ; \
+        echo /var/tmp/staging/include/google/cloud/internal ; \
+        echo /var/tmp/staging/include/google/cloud/storage ; \
+        echo /var/tmp/staging/include/google/cloud/storage/internal ; \
+        echo /var/tmp/staging/include/google/cloud/storage/oauth2 ; \
+        /bin/true) | grep -c /var/tmp; then
+      echo "${COLOR_YELLOW}Installed directories does not match expectation.${COLOR_RESET}"
+      /bin/false
+   fi
 fi
 
 # If document generation is enabled, run it now.

--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -224,17 +224,20 @@ if [ "${TEST_INSTALL:-}" = "yes" ]; then
       " expected directories.${COLOR_RESET}"
   cmake --build . --target install -- DESTDIR=/var/tmp/staging
   if comm -23 \
-      <(find /var/tmp/staging/include/google/cloud -type d | sort) \
-      <(echo /var/tmp/staging/include/google/cloud ; \
-        echo /var/tmp/staging/include/google/cloud/bigtable ; \
-        echo /var/tmp/staging/include/google/cloud/bigtable/internal ; \
-        echo /var/tmp/staging/include/google/cloud/firestore ; \
-        echo /var/tmp/staging/include/google/cloud/internal ; \
-        echo /var/tmp/staging/include/google/cloud/storage ; \
-        echo /var/tmp/staging/include/google/cloud/storage/internal ; \
-        echo /var/tmp/staging/include/google/cloud/storage/oauth2 ; \
-        /bin/true) | grep -c /var/tmp; then
-      echo "${COLOR_YELLOW}Installed directories does not match expectation.${COLOR_RESET}"
+      <(find /var/tmp/staging/usr/local/include/google/cloud -type d | sort) \
+      <(echo /var/tmp/staging/usr/local/include/google/cloud ; \
+        echo /var/tmp/staging/usr/local/include/google/cloud/bigtable ; \
+        echo /var/tmp/staging/usr/local/include/google/cloud/bigtable/internal ; \
+        echo /var/tmp/staging/usr/local/include/google/cloud/firestore ; \
+        echo /var/tmp/staging/usr/local/include/google/cloud/internal ; \
+        echo /var/tmp/staging/usr/local/include/google/cloud/storage ; \
+        echo /var/tmp/staging/usr/local/include/google/cloud/storage/internal ; \
+        echo /var/tmp/staging/usr/local/include/google/cloud/storage/oauth2 ; \
+        /bin/true) | grep -q /var/tmp; then
+      echo "${COLOR_YELLOW}Installed directories do not match expectation.${COLOR_RESET}"
+      echo "${COLOR_RED}Found:"
+      find /var/tmp/staging/usr/local/include/google/cloud -type d | sort
+      echo "${COLOR_RESET}"
       /bin/false
    fi
 fi

--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -134,7 +134,7 @@ endfunction ()
 function (google_cloud_cpp_install_headers target destination)
     get_target_property(target_sources ${target} SOURCES)
     foreach (header ${target_sources})
-        if (NOT ${header} MATCHES "\\.h$")
+        if (NOT "${header}" MATCHES "\\.h$" AND NOT "${header}" MATCHES "\\.inc$")
             continue()
         endif ()
         string(REPLACE "${CMAKE_CURRENT_BINARY_DIR}/"

--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -134,7 +134,9 @@ endfunction ()
 function (google_cloud_cpp_install_headers target destination)
     get_target_property(target_sources ${target} SOURCES)
     foreach (header ${target_sources})
-        if (NOT "${header}" MATCHES "\\.h$" AND NOT "${header}" MATCHES "\\.inc$")
+        if (NOT "${header}" MATCHES "\\.h$"
+            AND
+            NOT "${header}" MATCHES "\\.inc$")
             continue()
         endif ()
         string(REPLACE "${CMAKE_CURRENT_BINARY_DIR}/"

--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -119,3 +119,29 @@ function (google_cloud_cpp_add_clang_tidy target)
                               PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
     endif ()
 endfunction ()
+
+#
+# google_cloud_cpp_install_headers : install all the headers in a target
+#
+# Find all the headers in @p target and install them at @p destination,
+# preserving the directory structure.
+#
+# * target the name of the target.
+# * destination the destination directory, relative to <PREFIX>. Typically this
+#   starts with `include/google/cloud`, the function requires the full
+#   destination in case some headers get installed elsewhere in the future.
+#
+function (google_cloud_cpp_install_headers target destination)
+    get_target_property(target_sources ${target} SOURCES)
+    foreach (header ${target_sources})
+        if (NOT ${header} MATCHES "\\.h$")
+            continue()
+        endif ()
+        string(REPLACE "${CMAKE_CURRENT_BINARY_DIR}/"
+                       ""
+                       relative
+                       "${header}")
+        get_filename_component(dir "${relative}" DIRECTORY)
+        install(FILES "${header}" DESTINATION "${destination}/${dir}")
+    endforeach ()
+endfunction ()

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -85,6 +85,7 @@ add_library(google_cloud_cpp_common
             internal/setenv.cc
             internal/throw_delegate.h
             internal/throw_delegate.cc
+            ${CMAKE_CURRENT_BINARY_DIR}/internal/version_info.h
             log.h
             log.cc
             version.h)

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -165,11 +165,7 @@ install(TARGETS google_cloud_cpp_common google_cloud_cpp_common_options
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(DIRECTORY . DESTINATION include/google/cloud
-        FILES_MATCHING
-        PATTERN "*.h")
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/internal/version_info.h DESTINATION
-              include/google/cloud/internal)
+google_cloud_cpp_install_headers(google_cloud_cpp_common include/google/cloud)
 
 # Setup global variables used in the following *.in files.
 set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_MAJOR ${GOOGLE_CLOUD_CPP_VERSION_MAJOR})

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -368,10 +368,7 @@ install(TARGETS bigtable_protos bigtable_common_options
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 # Install proto generated files into include/google.
-install(DIRECTORY ${CMAKE_BINARY_DIR}/google/cloud/bigtable/google/ DESTINATION
-                  include/google
-        FILES_MATCHING
-        PATTERN "*.h")
+google_cloud_cpp_install_headers(bigtable_protos include)
 
 # The exports can only be installed if all the dependencies are installed. CMake
 # needs to know where the submodules will be installed from,
@@ -387,14 +384,7 @@ install(TARGETS bigtable_client
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(DIRECTORY . DESTINATION include/google/cloud/bigtable
-        FILES_MATCHING
-        PATTERN "*.inc"
-        PATTERN "*.h"
-        PATTERN "testing/*"
-        EXCLUDE)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/version_info.h DESTINATION
-              include/google/cloud/bigtable)
+google_cloud_cpp_install_headers(bigtable_client include/google/cloud/bigtable)
 
 # Setup global variables used in the following *.in files.
 set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_MAJOR ${BIGTABLE_CLIENT_VERSION_MAJOR})

--- a/google/cloud/firestore/CMakeLists.txt
+++ b/google/cloud/firestore/CMakeLists.txt
@@ -115,13 +115,8 @@ install(TARGETS firestore_client
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(DIRECTORY . DESTINATION include/google/cloud/firestore
-        FILES_MATCHING
-        PATTERN "*.h"
-        PATTERN "testing/*"
-        EXCLUDE)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/version_info.h DESTINATION
-              include/google/cloud/firestore)
+google_cloud_cpp_install_headers(
+    firestore_client include/google/cloud/firestore)
 
 # Setup global variables used in the following *.in files.
 set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_MAJOR ${FIRESTORE_CLIENT_VERSION_MAJOR})

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -340,13 +340,7 @@ install(TARGETS storage_client
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(DIRECTORY . DESTINATION include/google/cloud/storage/client
-        FILES_MATCHING
-        PATTERN "*.h"
-        PATTERN "testing/*"
-        EXCLUDE)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/version_info.h DESTINATION
-              include/google/cloud/storage)
+google_cloud_cpp_install_headers(storage_client include/google/cloud/storage)
 install(
     FILES
         ${CMAKE_BINARY_DIR}/external/nlohmann_json/include/google/cloud/storage/internal/nlohmann_json.hpp


### PR DESCRIPTION
This fixes #1179. Each library should only install its public headers.
Headers used for testing, benchmarks, and examples should not be
installed. The internal headers are more difficult, we should probably
install the minimum set that is used in the implementation of public
types, but that is too fine grained to easily support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1196)
<!-- Reviewable:end -->
