### PR TITLE
Remove object leak from examples.

### DIFF
--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -246,6 +246,8 @@ run_all_object_examples() {
       "${bucket_name}" "${encrypted_copied_object_name}" "${key}"
   run_example ./storage_object_samples delete-object \
       "${bucket_name}" "${encrypted_copied_object_name}"
+  run_example ./storage_object_samples delete-object \
+      "${bucket_name}" "${encrypted_composed_object_name}"
 
   local newkey="$(./storage_object_samples generate-encryption-key |
       grep 'Base64 encoded key' | awk '{print $5}')"


### PR DESCRIPTION
Not that it matters, but the examples were leaking an object: we created
a encrypted object using `Objects: compose` that was never deleted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1202)
<!-- Reviewable:end -->
