### PR TITLE
removed grpc::StatusCode::OK from the definition of IsTransientFailure

### DIFF
--- a/google/cloud/bigtable/rpc_retry_policy.h
+++ b/google/cloud/bigtable/rpc_retry_policy.h
@@ -31,7 +31,7 @@ struct SafeGrpcRetry {
   // Sometimes we need to use google::protobuf::rpc::Status, in which case this
   // is a easier function
   static inline bool IsTransientFailure(grpc::StatusCode code) {
-    return code == grpc::StatusCode::OK or code == grpc::StatusCode::ABORTED or
+    return code == grpc::StatusCode::ABORTED or
            code == grpc::StatusCode::UNAVAILABLE or
            code == grpc::StatusCode::DEADLINE_EXCEEDED;
   }
@@ -41,7 +41,7 @@ struct SafeGrpcRetry {
     return IsTransientFailure(status.error_code());
   }
   static inline bool IsPermanentFailure(grpc::Status const& status) {
-    return not IsTransientFailure(status);
+    return not IsOk(status) && not IsTransientFailure(status);
   }
 };
 

--- a/google/cloud/bigtable/rpc_retry_policy.h
+++ b/google/cloud/bigtable/rpc_retry_policy.h
@@ -41,7 +41,7 @@ struct SafeGrpcRetry {
     return IsTransientFailure(status.error_code());
   }
   static inline bool IsPermanentFailure(grpc::Status const& status) {
-    return not IsOk(status) && not IsTransientFailure(status);
+    return not IsOk(status) and not IsTransientFailure(status);
   }
 };
 

--- a/google/cloud/bigtable/rpc_retry_policy_test.cc
+++ b/google/cloud/bigtable/rpc_retry_policy_test.cc
@@ -59,6 +59,15 @@ TEST(LimitedTimeRetryPolicy, Simple) {
   CheckLimitedTime(tested);
 }
 
+/// @test A simple test for grpc::StatusCode::OK is not Permanent Error.
+TEST(LimitedTimeRetryPolicy, PermanentFailureCheck) {
+  bigtable::LimitedTimeRetryPolicy tested(kLimitedTimeTestPeriod);
+  EXPECT_FALSE(tested.IsPermanentFailure(
+      grpc::Status(grpc::StatusCode::OK, "No Error")));
+  EXPECT_FALSE(tested.IsPermanentFailure(CreateTransientError()));
+  EXPECT_TRUE(tested.IsPermanentFailure(CreatePermanentError()));
+}
+
 /// @test Test cloning for LimitedTimeRetryPolicy.
 TEST(LimitedTimeRetryPolicy, Clone) {
   using namespace google::cloud::testing_util::chrono_literals;


### PR DESCRIPTION
This fixes #741

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1203)
<!-- Reviewable:end -->
