### PR TITLE
Fix MSVC warnings.

### DIFF
--- a/google/cloud/storage/well_known_headers.h
+++ b/google/cloud/storage/well_known_headers.h
@@ -247,8 +247,8 @@ static EncryptionKeyData CreateKeyFromGenerator(Generator& gen) {
       "describing your platform details to request support for it.");
   constexpr int kKeySize = 256 / std::numeric_limits<unsigned char>::digits;
 
-  constexpr auto minchar = std::numeric_limits<char>::min();
-  constexpr auto maxchar = std::numeric_limits<char>::max();
+  constexpr auto minchar = (std::numeric_limits<char>::min)();
+  constexpr auto maxchar = (std::numeric_limits<char>::max)();
   std::uniform_int_distribution<int> uni(minchar, maxchar);
   std::string key(static_cast<std::size_t>(kKeySize), ' ');
   std::generate_n(key.begin(), key.size(),


### PR DESCRIPTION
MSVC defines `min()` and `max()` as macros, which creates trouble when
using `min()` and/or `max()` in some namespace. Workaround the problem
by wrapping the names in parenthesis (yuck).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1207)
<!-- Reviewable:end -->
