### PR TITLE
Improve error messages when loading credentials.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -174,6 +174,7 @@ add_library(storage_client
             oauth2/anonymous_credentials.h
             oauth2/anonymous_credentials.cc
             oauth2/authorized_user_credentials.h
+            oauth2/authorized_user_credentials.cc
             oauth2/credential_constants.h
             oauth2/credentials.h
             oauth2/google_application_default_credentials_file.h

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -181,6 +181,7 @@ add_library(storage_client
             oauth2/google_credentials.h
             oauth2/google_credentials.cc
             oauth2/service_account_credentials.h
+            oauth2/service_account_credentials.cc
             object_access_control.h
             object_access_control.cc
             object_metadata.h

--- a/google/cloud/storage/oauth2/authorized_user_credentials.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.cc
@@ -1,0 +1,57 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/oauth2/authorized_user_credentials.h"
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace oauth2 {
+AuthorizedUserCredentialsInfo ParseAuthorizedUserCredentials(
+    std::string const& content, std::string const& source) {
+  auto credentials =
+      storage::internal::nl::json::parse(content, nullptr, false);
+  if (credentials.is_discarded()) {
+    google::cloud::internal::RaiseInvalidArgument(
+        "Invalid AuthorizedUserCredentials, parsing failed on data from " +
+        source);
+  }
+
+  char const CLIENT_ID_KEY[] = "client_id";
+  char const CLIENT_SECRET_KEY[] = "client_secret";
+  char const REFRESH_TOKEN_KEY[] = "refresh_token";
+  for (auto const& key :
+       {CLIENT_ID_KEY, CLIENT_SECRET_KEY, REFRESH_TOKEN_KEY}) {
+    if (credentials.count(key) == 0U) {
+      google::cloud::internal::RaiseInvalidArgument(
+          "Invalid AuthorizedUserCredentials, the " + std::string(key) +
+          " field is missing on data loaded from " + source);
+    }
+    if (credentials.value(key, "").empty()) {
+      google::cloud::internal::RaiseInvalidArgument(
+          "Invalid AuthorizedUserCredentials, the " + std::string(key) +
+          " field is empty on data loaded from " + source);
+    }
+  }
+  return AuthorizedUserCredentialsInfo{
+      credentials.value(CLIENT_ID_KEY, ""),
+      credentials.value(CLIENT_SECRET_KEY, ""),
+      credentials.value(REFRESH_TOKEN_KEY, "")};
+}
+}  // namespace oauth2
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/oauth2/authorized_user_credentials.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.cc
@@ -29,11 +29,11 @@ AuthorizedUserCredentialsInfo ParseAuthorizedUserCredentials(
         source);
   }
 
-  char const CLIENT_ID_KEY[] = "client_id";
-  char const CLIENT_SECRET_KEY[] = "client_secret";
-  char const REFRESH_TOKEN_KEY[] = "refresh_token";
+  char const client_id_key[] = "client_id";
+  char const client_secret_key[] = "client_secret";
+  char const refresh_token_key[] = "refresh_token";
   for (auto const& key :
-       {CLIENT_ID_KEY, CLIENT_SECRET_KEY, REFRESH_TOKEN_KEY}) {
+       {client_id_key, client_secret_key, refresh_token_key}) {
     if (credentials.count(key) == 0U) {
       google::cloud::internal::RaiseInvalidArgument(
           "Invalid AuthorizedUserCredentials, the " + std::string(key) +
@@ -46,9 +46,9 @@ AuthorizedUserCredentialsInfo ParseAuthorizedUserCredentials(
     }
   }
   return AuthorizedUserCredentialsInfo{
-      credentials.value(CLIENT_ID_KEY, ""),
-      credentials.value(CLIENT_SECRET_KEY, ""),
-      credentials.value(REFRESH_TOKEN_KEY, "")};
+      credentials.value(client_id_key, ""),
+      credentials.value(client_secret_key, ""),
+      credentials.value(refresh_token_key, "")};
 }
 }  // namespace oauth2
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/oauth2/authorized_user_credentials.h
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.h
@@ -79,17 +79,11 @@ class AuthorizedUserCredentials : public Credentials {
     auto info = ParseAuthorizedUserCredentials(content, source);
     std::string payload("grant_type=refresh_token");
     payload += "&client_id=";
-    payload +=
-        request_builder.MakeEscapedString(info.client_id)
-            .get();
+    payload += request_builder.MakeEscapedString(info.client_id).get();
     payload += "&client_secret=";
-    payload += request_builder
-                   .MakeEscapedString(info.client_secret)
-                   .get();
+    payload += request_builder.MakeEscapedString(info.client_secret).get();
     payload += "&refresh_token=";
-    payload += request_builder
-                   .MakeEscapedString(info.refresh_token)
-                   .get();
+    payload += request_builder.MakeEscapedString(info.refresh_token).get();
     payload_ = std::move(payload);
     request_ = request_builder.BuildRequest();
   }

--- a/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
@@ -87,7 +87,7 @@ TEST_F(AuthorizedUserCredentialsTest, Simple) {
       "type": "magic_type"
 })""";
 
-  AuthorizedUserCredentials<MockHttpRequestBuilder> credentials(config);
+  AuthorizedUserCredentials<MockHttpRequestBuilder> credentials(config, "test");
   EXPECT_EQ("Authorization: Type access-token-value",
             credentials.AuthorizationHeader());
 }
@@ -137,13 +137,68 @@ TEST_F(AuthorizedUserCredentialsTest, Refresh) {
       "refresh_token": "1/THETOKEN",
       "type": "magic_type"
 })""";
-  AuthorizedUserCredentials<MockHttpRequestBuilder> credentials(config);
+  AuthorizedUserCredentials<MockHttpRequestBuilder> credentials(config, "test");
   EXPECT_EQ("Authorization: Type access-token-r1",
             credentials.AuthorizationHeader());
   EXPECT_EQ("Authorization: Type access-token-r2",
             credentials.AuthorizationHeader());
   EXPECT_EQ("Authorization: Type access-token-r2",
             credentials.AuthorizationHeader());
+}
+
+/// @test Verify that invalid contents result in a readable error.
+TEST_F(AuthorizedUserCredentialsTest, InvalidContents) {
+  std::string config = R"""( not-a-valid-json-string })""";
+
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  auto mock_builder = MockHttpRequestBuilder::mock;
+  EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint()))
+      .Times(1);
+  EXPECT_THROW(
+      try {
+        AuthorizedUserCredentials<MockHttpRequestBuilder> credentials(
+            config, "test-as-a-source");
+      } catch (std::invalid_argument const& ex) {
+        EXPECT_THAT(ex.what(), HasSubstr("Invalid AuthorizedUserCredentials"));
+        EXPECT_THAT(ex.what(), HasSubstr("test-as-a-source"));
+        throw;
+      },
+      std::invalid_argument);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(
+      AuthorizedUserCredentials<MockHttpRequestBuilder>(config, "test-as-a-source"),
+      "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+/// @test Verify that missing fields result in a readable error.
+TEST_F(AuthorizedUserCredentialsTest, MissingContents) {
+  std::string config = R"""({
+      // "client_id": "a-client-id.example.com",
+      "client_secret": "a-123456ABCDEF",
+      "refresh_token": "1/THETOKEN",
+      "type": "magic_type"
+})""";
+
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  auto mock_builder = MockHttpRequestBuilder::mock;
+  EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint()))
+      .Times(1);
+  EXPECT_THROW(
+      try {
+        AuthorizedUserCredentials<MockHttpRequestBuilder> credentials(
+            config, "test-as-a-source");
+      } catch (std::invalid_argument const& ex) {
+        EXPECT_THAT(ex.what(), HasSubstr("the client_id field is missing"));
+        EXPECT_THAT(ex.what(), HasSubstr("test-as-a-source"));
+        throw;
+      },
+      std::invalid_argument);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(
+      AuthorizedUserCredentials<MockHttpRequestBuilder>(config, "test-as-a-source"),
+      "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 }  // namespace

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -1,0 +1,66 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/oauth2/service_account_credentials.h"
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace oauth2 {
+
+ServiceAccountCredentialsInfo ParseServiceAccountCredentials(
+    std::string const& content, std::string const& source,
+    std::string const& default_token_uri) {
+  namespace nl = storage::internal::nl;
+  nl::json credentials = nl::json::parse(content, nullptr, false);
+  if (credentials.is_discarded()) {
+    google::cloud::internal::RaiseInvalidArgument(
+        "Invalid ServiceAccountCredentials, "
+        "parsing failed on data loaded from " +
+            source);
+  }
+  char const PRIVATE_KEY_ID_KEY[] = "private_key_id";
+  char const PRIVATE_KEY_KEY[] = "private_key";
+  char const TOKEN_URI_KEY[] = "token_uri";
+  char const CLIENT_EMAIL_KEY[] = "client_email";
+  for (auto const &key : {PRIVATE_KEY_ID_KEY, PRIVATE_KEY_KEY, TOKEN_URI_KEY,
+                          CLIENT_EMAIL_KEY}) {
+    if (credentials.count(key) == 0U) {
+      google::cloud::internal::RaiseInvalidArgument(
+          "Invalid ServiceAccountCredentials, the " + std::string(key) +
+              " field is missing on data loaded from " + source);
+    }
+    if (credentials.value(key, "").empty()) {
+      google::cloud::internal::RaiseInvalidArgument(
+          "Invalid ServiceAccountCredentials, the " + std::string(key) +
+              " field is empty on data loaded from " + source);
+    }
+  }
+  return ServiceAccountCredentialsInfo{
+      credentials.value(PRIVATE_KEY_ID_KEY, ""),
+      credentials.value(PRIVATE_KEY_KEY, ""),
+      // Some credential formats (e.g. gcloud's ADC file) don't contain a
+      // "token_uri" attribute in the JSON object.  In this case, we try using the
+      // default value.
+      credentials.value(TOKEN_URI_KEY, default_token_uri),
+      credentials.value(CLIENT_EMAIL_KEY, ""),
+  };
+}
+
+}  // namespace oauth2
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -31,12 +31,12 @@ ServiceAccountCredentialsInfo ParseServiceAccountCredentials(
         " parsing failed on data loaded from " +
         source);
   }
-  char const PRIVATE_KEY_ID_KEY[] = "private_key_id";
-  char const PRIVATE_KEY_KEY[] = "private_key";
-  char const TOKEN_URI_KEY[] = "token_uri";
-  char const CLIENT_EMAIL_KEY[] = "client_email";
+  char const private_key_id_key[] = "private_key_id";
+  char const private_key_key[] = "private_key";
+  char const token_uri_key[] = "token_uri";
+  char const client_email_key[] = "client_email";
   for (auto const& key :
-       {PRIVATE_KEY_ID_KEY, PRIVATE_KEY_KEY, CLIENT_EMAIL_KEY}) {
+       {private_key_id_key, private_key_key, client_email_key}) {
     if (credentials.count(key) == 0U) {
       google::cloud::internal::RaiseInvalidArgument(
           "Invalid ServiceAccountCredentials, the " + std::string(key) +
@@ -49,20 +49,20 @@ ServiceAccountCredentialsInfo ParseServiceAccountCredentials(
     }
   }
   // The token_uri field may be missing, but may not be empty:
-  if (credentials.count(TOKEN_URI_KEY) != 0U and
-      credentials.value(TOKEN_URI_KEY, "").empty()) {
+  if (credentials.count(token_uri_key) != 0U and
+      credentials.value(token_uri_key, "").empty()) {
     google::cloud::internal::RaiseInvalidArgument(
-        "Invalid ServiceAccountCredentials, the " + std::string(TOKEN_URI_KEY) +
+        "Invalid ServiceAccountCredentials, the " + std::string(token_uri_key) +
         " field is empty on data loaded from " + source);
   }
   return ServiceAccountCredentialsInfo{
-      credentials.value(PRIVATE_KEY_ID_KEY, ""),
-      credentials.value(PRIVATE_KEY_KEY, ""),
+      credentials.value(private_key_id_key, ""),
+      credentials.value(private_key_key, ""),
       // Some credential formats (e.g. gcloud's ADC file) don't contain a
       // "token_uri" attribute in the JSON object.  In this case, we try using
       // the default value.
-      credentials.value(TOKEN_URI_KEY, default_token_uri),
-      credentials.value(CLIENT_EMAIL_KEY, ""),
+      credentials.value(token_uri_key, default_token_uri),
+      credentials.value(client_email_key, ""),
   };
 }
 

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -164,7 +164,7 @@ class ServiceAccountCredentials : public Credentials {
     }
 
     nl::json access_token = nl::json::parse(response.payload, nullptr, false);
-    if (access_token.is_null() or access_token.count("token_type") == 0U or
+    if (access_token.is_discarded() or access_token.count("token_type") == 0U or
         access_token.count("access_token") == 0U or
         access_token.count("expires_in") == 0U) {
       return false;

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -57,14 +57,35 @@ template <typename HttpRequestBuilderType =
           typename ClockType = std::chrono::system_clock>
 class ServiceAccountCredentials : public Credentials {
  public:
-  explicit ServiceAccountCredentials(std::string const& content)
-      : ServiceAccountCredentials(content, GoogleOAuthRefreshEndpoint()) {}
+  explicit ServiceAccountCredentials(std::string const& content,
+                                     std::string const& source)
+      : ServiceAccountCredentials(content, source,
+                                  GoogleOAuthRefreshEndpoint()) {}
 
   explicit ServiceAccountCredentials(std::string const& content,
+                                     std::string const& source,
                                      std::string default_token_uri)
       : expiration_time_(), clock_() {
     namespace nl = storage::internal::nl;
-    nl::json credentials = nl::json::parse(content);
+    nl::json credentials = nl::json::parse(content, nullptr, false);
+    if (credentials.is_discarded()) {
+      google::cloud::internal::RaiseInvalidArgument(
+          "Invalid ServiceAccountCredentials, "
+          "parsing failed on data loaded from " +
+          source);
+    }
+    char const PRIVATE_KEY_ID_KEY[] = "private_key_id";
+    char const PRIVATE_KEY_KEY[] = "private_key";
+    char const TOKEN_URI_KEY[] = "token_uri";
+    char const CLIENT_EMAIL_KEY[] = "client_email";
+    for (auto const& key : {PRIVATE_KEY_ID_KEY, PRIVATE_KEY_KEY, TOKEN_URI_KEY,
+                            CLIENT_EMAIL_KEY}) {
+      if (credentials.count(key) == 0U) {
+        google::cloud::internal::RaiseInvalidArgument(
+            "Invalid ServiceAccountCredentials, the " + std::string(key) +
+            " field is missing on data loaded from " + source);
+      }
+    }
     // Below, we construct a JWT refresh request used to obtain an access token.
     // The structure of a JWT is defined in RFC 7519 (see
     // https://tools.ietf.org/html/rfc7519), and Google-specific JWT validation
@@ -72,31 +93,36 @@ class ServiceAccountCredentials : public Credentials {
     // https://cloud.google.com/endpoints/docs/frameworks/java/troubleshoot-jwt
     nl::json assertion_header = {
         {"alg", "RS256"},
-        {"kid", credentials["private_key_id"].get_ref<std::string const&>()},
+        {"kid", credentials.value(PRIVATE_KEY_ID_KEY, "")},
         {"typ", "JWT"}};
 
     std::string scope = GoogleOAuthScopeCloudPlatform();
     // Some credential formats (e.g. gcloud's ADC file) don't contain a
     // "token_uri" attribute in the JSON object.  In this case, we try using the
     // default value.
-    char const TOKEN_URI_KEY[] = "token_uri";
     std::string token_uri = credentials.value(TOKEN_URI_KEY, default_token_uri);
-    long int cur_time = static_cast<long int>(
-        std::chrono::system_clock::to_time_t(clock_.now()));
-    long int expiration_time =
-        cur_time + GoogleOAuthAccessTokenLifetime().count();
+
+    // As much as possible do the time arithmetic using the std::chrono types,
+    // convert to longs only when we are dealing with timestamps since the
+    // epoch.
+    auto now = clock_.now();
+    auto expiration = now + GoogleOAuthAccessTokenLifetime();
+    auto now_from_epoch =
+        static_cast<long>(std::chrono::system_clock::to_time_t(now));
+    auto expiration_from_epoch =
+        static_cast<long>(std::chrono::system_clock::to_time_t(expiration));
     nl::json assertion_payload = {
-        {"iss", credentials["client_email"].get_ref<std::string const&>()},
+        {"iss", credentials.value(CLIENT_EMAIL_KEY, "")},
         {"scope", scope},
         {"aud", token_uri},
-        {"iat", cur_time},
+        {"iat", now_from_epoch},
         // Resulting access token should be expire after one hour.
-        {"exp", expiration_time}};
+        {"exp", expiration_from_epoch}};
 
     HttpRequestBuilderType request_builder(
         std::move(token_uri), storage::internal::GetDefaultCurlHandleFactory());
     std::string svc_acct_private_key_pem =
-        credentials["private_key"].get_ref<std::string const&>();
+        credentials.value(PRIVATE_KEY_KEY, "");
     // This is the value of grant_type for JSON-formatted service account
     // keyfiles downloaded from Cloud Console.
     std::string payload("grant_type=");
@@ -144,18 +170,23 @@ class ServiceAccountCredentials : public Credentials {
 
     // TODO(#516) - use retry policies to refresh the credentials.
     auto response = request_.MakeRequest(payload_);
-    if (200 != response.status_code) {
+    if (response.status_code >= 300) {
       return false;
     }
 
-    nl::json access_token = nl::json::parse(response.payload);
+    nl::json access_token = nl::json::parse(response.payload, nullptr, false);
+    if (access_token.is_null() or access_token.count("token_type") == 0U or
+        access_token.count("access_token") == 0U or
+        access_token.count("expires_in") == 0U) {
+      return false;
+    }
     // Response should have the attributes "access_token", "expires_in", and
     // "token_type".
     std::string header =
-        "Authorization: " +
-        access_token["token_type"].get_ref<std::string const&>() + " " +
-        access_token["access_token"].get_ref<std::string const&>();
-    auto expires_in = std::chrono::seconds(access_token["expires_in"]);
+        "Authorization: " + access_token.value("token_type", "") + " " +
+        access_token.value("access_token", "");
+    auto expires_in =
+        std::chrono::seconds(access_token.value("expires_in", int(0)));
     auto new_expiration = std::chrono::system_clock::now() + expires_in -
                           GoogleOAuthAccessTokenExpirationSlack();
     // Do not update any state until all potential exceptions are raised.

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -188,6 +188,16 @@ TEST_F(ServiceAccountCredentialsTest,
             credentials.AuthorizationHeader());
 }
 
+/// @test Verify that nl::json::parse() failures are reported as is_discarded.
+TEST_F(ServiceAccountCredentialsTest, JsonParsingFailure) {
+  std::string config = R"""( not-a-valid-json-string )""";
+  // The documentation for nl::json::parse() is a bit ambiguous, so wrote a
+  // little test to verify it works as I expected.
+  internal::nl::json parsed = internal::nl::json::parse(config, nullptr, false);
+  EXPECT_TRUE(parsed.is_discarded());
+  EXPECT_FALSE(parsed.is_null());
+}
+
 /// @test Verify that invalid contents result in a readable error.
 TEST_F(ServiceAccountCredentialsTest, InvalidContents) {
   std::string config = R"""( not-a-valid-json-string )""";

--- a/google/cloud/storage/storage_client.bzl
+++ b/google/cloud/storage/storage_client.bzl
@@ -103,6 +103,7 @@ storage_client_SRCS = [
     "oauth2/anonymous_credentials.cc",
     "oauth2/google_application_default_credentials_file.cc",
     "oauth2/google_credentials.cc",
+    "oauth2/service_account_credentials.cc",
     "object_access_control.cc",
     "object_metadata.cc",
     "object_rewriter.cc",

--- a/google/cloud/storage/storage_client.bzl
+++ b/google/cloud/storage/storage_client.bzl
@@ -101,6 +101,7 @@ storage_client_SRCS = [
     "list_objects_reader.cc",
     "notification_metadata.cc",
     "oauth2/anonymous_credentials.cc",
+    "oauth2/authorized_user_credentials.cc",
     "oauth2/google_application_default_credentials_file.cc",
     "oauth2/google_credentials.cc",
     "oauth2/service_account_credentials.cc",


### PR DESCRIPTION
This fixes #974. The error messages when loading an invalid or missing
credentials file were sometimes very obscure (typically some parsing
problem in the JSON library). The new error messages should make it
easier to diagnose the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1212)
<!-- Reviewable:end -->
