### PR TITLE
Better control of #includes in the main headers.

### DIFF
--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -184,9 +184,8 @@ void ReadObject(google::cloud::storage::Client client, int& argc,
   (std::move(client), bucket_name, object_name);
 }
 
-// We can't name this DeleteObject due #1208.
-void DeleteObjectFn(google::cloud::storage::Client client, int& argc,
-                    char* argv[]) {
+void DeleteObject(google::cloud::storage::Client client, int& argc,
+                  char* argv[]) {
   if (argc < 2) {
     throw Usage{"delete-object <bucket-name> <object-name>"};
   }
@@ -768,7 +767,7 @@ int main(int argc, char* argv[]) try {
       {"copy-encrypted-object", &CopyEncryptedObject},
       {"get-object-metadata", &GetObjectMetadata},
       {"read-object", &ReadObject},
-      {"delete-object", &DeleteObjectFn},
+      {"delete-object", &DeleteObject},
       {"write-object", &WriteObject},
       {"write-large-object", &WriteLargeObject},
       {"update-object-metadata", &UpdateObjectMetadata},

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -15,7 +15,10 @@
 #include "google/cloud/storage/oauth2/google_credentials.h"
 #include "google/cloud/internal/throw_delegate.h"
 #include "google/cloud/storage/internal/nljson.h"
+#include "google/cloud/storage/oauth2/anonymous_credentials.h"
+#include "google/cloud/storage/oauth2/authorized_user_credentials.h"
 #include "google/cloud/storage/oauth2/google_application_default_credentials_file.h"
+#include "google/cloud/storage/oauth2/service_account_credentials.h"
 #include <fstream>
 #include <iterator>
 
@@ -50,30 +53,30 @@ std::shared_ptr<Credentials> GoogleDefaultCredentials() {
       "No eligible credential types were found to use as default credentials.");
 }
 
-std::shared_ptr<AnonymousCredentials> CreateAnonymousCredentials() {
+std::shared_ptr<Credentials> CreateAnonymousCredentials() {
   return std::make_shared<AnonymousCredentials>();
 }
 
-std::shared_ptr<AuthorizedUserCredentials<>>
+std::shared_ptr<Credentials>
 CreateAuthorizedUserCredentialsFromJsonFilePath(std::string const& path) {
   std::ifstream is(path);
   std::string contents(std::istreambuf_iterator<char>{is}, {});
   return CreateAuthorizedUserCredentialsFromJsonContents(contents);
 }
 
-std::shared_ptr<AuthorizedUserCredentials<>>
+std::shared_ptr<Credentials>
 CreateAuthorizedUserCredentialsFromJsonContents(std::string const& contents) {
   return std::make_shared<AuthorizedUserCredentials<>>(contents);
 }
 
-std::shared_ptr<ServiceAccountCredentials<>>
+std::shared_ptr<Credentials>
 CreateServiceAccountCredentialsFromJsonFilePath(std::string const& path) {
   std::ifstream is(path);
   std::string contents(std::istreambuf_iterator<char>{is}, {});
   return CreateServiceAccountCredentialsFromJsonContents(contents);
 }
 
-std::shared_ptr<ServiceAccountCredentials<>>
+std::shared_ptr<Credentials>
 CreateServiceAccountCredentialsFromJsonContents(std::string const& contents) {
   return std::make_shared<ServiceAccountCredentials<>>(contents);
 }

--- a/google/cloud/storage/oauth2/google_credentials.h
+++ b/google/cloud/storage/oauth2/google_credentials.h
@@ -15,13 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_GOOGLE_CREDENTIALS_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_GOOGLE_CREDENTIALS_H_
 
-#include "google/cloud/internal/throw_delegate.h"
-#include "google/cloud/storage/oauth2/anonymous_credentials.h"
-#include "google/cloud/storage/oauth2/authorized_user_credentials.h"
-#include "google/cloud/storage/oauth2/service_account_credentials.h"
-#include "google/cloud/storage/version.h"
+#include "google/cloud/storage/oauth2/credentials.h"
 #include <memory>
-#include <utility>
 
 namespace google {
 namespace cloud {
@@ -46,7 +41,7 @@ std::shared_ptr<Credentials> GoogleDefaultCredentials();
  */
 
 /// Creates an "anonymous" credential.
-std::shared_ptr<AnonymousCredentials> CreateAnonymousCredentials();
+std::shared_ptr<Credentials> CreateAnonymousCredentials();
 
 /**
  * Creates an "authorized user" credential from a JSON file at the given path.
@@ -54,8 +49,8 @@ std::shared_ptr<AnonymousCredentials> CreateAnonymousCredentials();
  * @note It is strongly preferred to instead use service account credentials
  * with Cloud Storage client libraries.
  */
-std::shared_ptr<AuthorizedUserCredentials<>>
-CreateAuthorizedUserCredentialsFromJsonFilePath(std::string const&);
+std::shared_ptr<Credentials> CreateAuthorizedUserCredentialsFromJsonFilePath(
+    std::string const&);
 
 /**
  * Creates an "authorized user" credential from a JSON string.
@@ -63,16 +58,16 @@ CreateAuthorizedUserCredentialsFromJsonFilePath(std::string const&);
  * @note It is strongly preferred to instead use service account credentials
  * with Cloud Storage client libraries.
  */
-std::shared_ptr<AuthorizedUserCredentials<>>
-CreateAuthorizedUserCredentialsFromJsonContents(std::string const&);
+std::shared_ptr<Credentials> CreateAuthorizedUserCredentialsFromJsonContents(
+    std::string const&);
 
 /// Creates a "service account" credential from a JSON file at the given path.
-std::shared_ptr<ServiceAccountCredentials<>>
-CreateServiceAccountCredentialsFromJsonFilePath(std::string const&);
+std::shared_ptr<Credentials> CreateServiceAccountCredentialsFromJsonFilePath(
+    std::string const&);
 
 /// Creates a "service account" credential from a JSON string.
-std::shared_ptr<ServiceAccountCredentials<>>
-CreateServiceAccountCredentialsFromJsonContents(std::string const&);
+std::shared_ptr<Credentials> CreateServiceAccountCredentialsFromJsonContents(
+    std::string const&);
 
 // TODO(#1193): Should we support loading service account credentials from a P12
 // file too? Other libraries do, but the JSON format is strongly preferred.

--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -14,7 +14,10 @@
 
 #include "google/cloud/storage/oauth2/google_credentials.h"
 #include "google/cloud/internal/setenv.h"
+#include "google/cloud/storage/oauth2/anonymous_credentials.h"
+#include "google/cloud/storage/oauth2/authorized_user_credentials.h"
 #include "google/cloud/storage/oauth2/google_application_default_credentials_file.h"
+#include "google/cloud/storage/oauth2/service_account_credentials.h"
 #include "google/cloud/testing_util/environment_variable_restore.h"
 #include <gmock/gmock.h>
 #include <fstream>
@@ -184,4 +187,3 @@ TEST_F(GoogleCredentialsTest, LoadValidAnonymousCredentials) {
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
-

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(storage_client_integration_tests
     curl_streambuf_integration_test.cc
     object_integration_test.cc
     service_account_integration_test.cc
+    storage_include_test.cc
     thread_integration_test.cc)
 
 foreach (fname ${storage_client_integration_tests})

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -7,5 +7,6 @@ storage_client_integration_tests = [
     "curl_streambuf_integration_test.cc",
     "object_integration_test.cc",
     "service_account_integration_test.cc",
+    "storage_include_test.cc",
     "thread_integration_test.cc",
 ]

--- a/google/cloud/storage/tests/storage_include_test.cc
+++ b/google/cloud/storage/tests/storage_include_test.cc
@@ -1,0 +1,38 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/oauth2/google_credentials.h"
+#include <iostream>
+
+int main() {
+  // Adding openssl to the global namespace when the user does not explicitly
+  // asks for it is too much namespace pollution. The application may not want
+  // that many dependencies. Also, on Windows that may drag really unwanted
+  // dependencies.
+#ifdef OPENSSL_VERSION_NUMBER
+#error "OPENSSL should not be included by storage public headers"
+#endif  // OPENSSL_VERSION_NUMBER
+
+  // Adding libcurl to the global namespace when the user does not explicitly
+  // asks for it is too much namespace pollution. The application may not want
+  // that many dependencies. Also, on Windows that may drag really unwanted
+  // dependencies.
+#ifdef LIBCURL_VERSION
+#error "LIBCURL should not be included by storage public headers"
+#endif  // OPENSSL_VERSION_NUMBER
+
+  std::cout << "PASSED: this is a compile-time test" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
The main headers for the library (storage/client.h,
oauth2/google_credentials.h) should avoid including libcurl and/or
openssl headers. Those headers drag too much system-level stuff to the
global namespace.

This fixes #1208.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1213)
<!-- Reviewable:end -->
