### PR TITLE
Remove busy loop in uploads and downloads.

### DIFF
--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -106,6 +106,7 @@ class CurlDownloadRequest {
   /// Wait until a condition is met.
   template <typename Predicate>
   void Wait(Predicate&& predicate) {
+    int repeats = 0;
     // We can assert that the current thread is the leader, because the
     // predicate is satisfied, and the condition variable exited. Therefore,
     // this thread must run the I/O event loop.
@@ -121,7 +122,7 @@ class CurlDownloadRequest {
       if (running_handles == 0 or predicate()) {
         return;
       }
-      WaitForHandles();
+      WaitForHandles(repeats);
     }
   }
 
@@ -129,7 +130,7 @@ class CurlDownloadRequest {
   int PerformWork();
 
   /// Use libcurl to wait until the underlying data can perform work.
-  void WaitForHandles();
+  void WaitForHandles(int& repeats);
 
   /// Simplify handling of errors in the curl_multi_* API.
   void RaiseOnError(char const* where, CURLMcode result);

--- a/google/cloud/storage/internal/curl_upload_request.h
+++ b/google/cloud/storage/internal/curl_upload_request.h
@@ -108,6 +108,7 @@ class CurlUploadRequest {
   /// Waits until a condition is met.
   template <typename Predicate>
   void Wait(Predicate&& predicate) {
+    int repeats = 0;
     // We can assert that the current thread is the leader, because the
     // predicate is satisfied, and the condition variable exited. Therefore,
     // this thread must run the I/O event loop.
@@ -126,7 +127,7 @@ class CurlUploadRequest {
       if (running_handles == 0 or predicate()) {
         return;
       }
-      WaitForHandles();
+      WaitForHandles(repeats);
     }
   }
 
@@ -134,7 +135,7 @@ class CurlUploadRequest {
   int PerformWork();
 
   /// Uses libcurl to wait until the underlying data can perform work.
-  void WaitForHandles();
+  void WaitForHandles(int& repeats);
 
   /// Simplifies handling of errors in the curl_multi_* API.
   void RaiseOnError(char const* where, CURLMcode result);


### PR DESCRIPTION
I discovered this by just looking at the logs (when enabled), we were
busy looping because I thought curl_multi_wait() would actually wait,
but does not.  See the documentation at:
    https://curl.haxx.se/libcurl/c/curl_multi_wait.html
for details on how the loop should work.

libcurl uses similar loops (with a sleep!) in their code:
    https://github.com/curl/curl/blob/8f2bb0e3779a7a6fe20ce4b892569d7565e6ac08/lib/easy.c#L678

We now follow the documented practices to write the loop, though I do
not like them.

I did not run the statistics, but the graphs look pretty close, this change does not seem to affect latency in a meaningful way:

![compare-latency-cpp-baseline-cpp-spin](https://user-images.githubusercontent.com/6241635/46506832-a72cfa80-c803-11e8-8f66-511bac496d47.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1220)
<!-- Reviewable:end -->
