### PR TITLE
InsertObject() computes MD5 hashes by default.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -481,8 +481,11 @@ class Client {
    * @param object_name the name of the object to be created.
    * @param contents the contents (media) for the new object.
    * @param options a list of optional query parameters and/or request headers.
-   *     Valid types for this operation include `IfMetagenerationMatch`,
-   *     `IfMetagenerationNotMatch`, `UserProject`, and `Projection`.
+   *     Valid types for this operation include `ContentEncoding`,
+   *     `ContentType`, `DisableMD5Hash`, `EncryptionKey`, `IfGenerationMatch`,
+   *     `IfGenerationNotMatch`, `IfMetagenerationMatch`,
+   *     `IfMetagenerationNotMatch`, `KmsKeyName`, `MD5HashValue`,
+   *     `PredefinedAcl`, `Projection`, and `UserProject`.
    *
    * @throw std::runtime_error if the operation cannot be completed using the
    *   current policies.

--- a/google/cloud/storage/hashing_options.h
+++ b/google/cloud/storage/hashing_options.h
@@ -41,6 +41,22 @@ struct MD5HashValue
  */
 std::string ComputeMD5Hash(std::string const& payload);
 
+/**
+ * Disable MD5 Hashing computations.
+ *
+ * By default the GCS client library computes MD5 hashes in all
+ * `Client::InsertObject` calls. The application can disable the hash
+ * computation by passing this parameter.
+ *
+ * @warning Disabling MD5 hashing exposes your application to data corruption.
+ *   We recommend that all uploads to GCS are protected by the supported
+ *   checksums and/or hashes.
+ */
+struct DisableMD5Hash : public internal::ComplexOption<DisableMD5Hash, bool> {
+  using ComplexOption<DisableMD5Hash, bool>::ComplexOption;
+  static char const* name() { return "disable-md5-hash"; }
+};
+
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -267,7 +267,7 @@ std::pair<Status, ObjectMetadata> CurlClient::InsertObjectMedia(
 
   // If the application has set an explicit hash value we need to use multipart
   // uploads.
-  if (request.HasOption<MD5HashValue>()) {
+  if (not request.HasOption<DisableMD5Hash>()) {
     return InsertObjectMediaMultipart(request);
   }
 
@@ -932,6 +932,8 @@ std::pair<Status, ObjectMetadata> CurlClient::InsertObjectMediaXml(
   if (request.HasOption<MD5HashValue>()) {
     builder.AddHeader("x-goog-hash: md5=" +
                       request.GetOption<MD5HashValue>().value());
+  } else if (not request.HasOption<DisableMD5Hash>()) {
+    builder.AddHeader("x-goog-hash: md5=" + ComputeMD5Hash(request.contents()));
   }
   if (request.HasOption<PredefinedAcl>()) {
     builder.AddHeader(
@@ -1094,6 +1096,8 @@ std::pair<Status, ObjectMetadata> CurlClient::InsertObjectMediaMultipart(
   nl::json metadata = nl::json::object();
   if (request.HasOption<MD5HashValue>()) {
     metadata["md5Hash"] = request.GetOption<MD5HashValue>().value();
+  } else {
+    metadata["md5Hash"] = ComputeMD5Hash(request.contents());
   }
 
   std::string crlf = "\r\n";

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -84,10 +84,10 @@ std::ostream& operator<<(std::ostream& os, GetObjectMetadataRequest const& r);
  */
 class InsertObjectMediaRequest
     : public GenericObjectRequest<
-          InsertObjectMediaRequest, ContentEncoding, ContentType, EncryptionKey,
-          IfGenerationMatch, IfGenerationNotMatch, IfMetagenerationMatch,
-          IfMetagenerationNotMatch, KmsKeyName, MD5HashValue, PredefinedAcl,
-          Projection, UserProject> {
+          InsertObjectMediaRequest, ContentEncoding, ContentType,
+          DisableMD5Hash, EncryptionKey, IfGenerationMatch,
+          IfGenerationNotMatch, IfMetagenerationMatch, IfMetagenerationNotMatch,
+          KmsKeyName, MD5HashValue, PredefinedAcl, Projection, UserProject> {
  public:
   InsertObjectMediaRequest() : GenericObjectRequest(), contents_() {}
 

--- a/google/cloud/storage/testbench/testbench.py
+++ b/google/cloud/storage/testbench/testbench.py
@@ -537,7 +537,7 @@ class GcsObject(object):
         next_line = multipart_upload_part.find('\r\n', index)
         while next_line != index:
             header_line = multipart_upload_part[index:next_line]
-            key, value = header_line.split(':', 2)
+            key, value = header_line.split(': ', 2)
             # This does not work for repeated headers, but we do not expect
             # those in the testbench.
             headers[key.encode('ascii', 'ignore')] = value
@@ -583,10 +583,10 @@ class GcsObject(object):
         # Apply any overrides from the resource object part.
         revision.update_from_metadata(json.loads(resource_body))
         # The content-type needs to be patched up, yuck.
-        if resource_headers.get('content-type') is not None:
+        if media_headers.get('content-type') is not None:
             revision.update_from_metadata({
                 'contentType':
-                resource_headers.get('content-type')
+                media_headers.get('content-type')
             })
         self._insert_revision(revision)
         return revision


### PR DESCRIPTION
The application can provide the MD5 hash value if they know it, or
disable the MD5 hash computation explicitly if they want to (but they
are warned against it).

This is part of the work for #563.
