### PR TITLE
More splitting of testbench.py

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,4 +45,4 @@ build_script:
 
 test_script:
   - ps: cd build-output
-  - ctest --output-on-failure -C "%CONFIG%" -j 2
+  - ctest --output-on-failure -C "%CONFIG%"

--- a/google/cloud/storage/testbench/testbench.py
+++ b/google/cloud/storage/testbench/testbench.py
@@ -1288,7 +1288,7 @@ gcs.debug = True
 
 
 def insert_magic_bucket(base_url):
-    if testbench_utils.has_buckets() == 0:
+    if len(testbench_utils.all_buckets()) == 0:
         bucket_name = os.environ.get('BUCKET_NAME', 'test-bucket')
         bucket = GcsBucket(base_url, bucket_name)
         # Enable versioning in the Bucket, the integration tests expect this to

--- a/google/cloud/storage/testbench/testbench_utils.py
+++ b/google/cloud/storage/testbench/testbench_utils.py
@@ -240,11 +240,6 @@ def lookup_bucket(bucket_name):
     return bucket
 
 
-def has_buckets():
-    """Return True if there are any buckets in the global collection."""
-    return len(GCS_BUCKETS) != 0
-
-
 def has_bucket(bucket_name):
     """Return True if the bucket already exists in the global collection."""
     return GCS_BUCKETS.get(bucket_name) is not None
@@ -300,9 +295,10 @@ def get_object(bucket_name, object_name, default_value):
 
     :param bucket_name:str the name of the Bucket that contains the object.
     :param object_name:str the name of the Object.
+    :param default_value:GcsObject the default value returned if the object is
+        not found.
     :return: tuple the object path and the object.
     :rtype: (str,GcsObject)
-    :raises:ErrorResponse if the object is not found.
     """
     object_path = bucket_name + '/o/' + object_name
     return object_path, GCS_OBJECTS.get(object_path, default_value)

--- a/google/cloud/storage/testbench/testbench_utils.py
+++ b/google/cloud/storage/testbench/testbench_utils.py
@@ -280,8 +280,7 @@ def lookup_object(bucket_name, object_name):
     :rtype: (str,GcsObject)
     :raises:ErrorResponse if the object is not found.
     """
-    object_path = bucket_name + '/o/' + object_name
-    gcs_object = GCS_OBJECTS.get(object_path)
+    object_path, gcs_object = get_object(bucket_name, object_name, None)
     if gcs_object is None:
         raise error_response.ErrorResponse(
             'Object %s in %s not found' % (object_name, bucket_name),


### PR DESCRIPTION
This moves the functions to manipulate the global collections of buckets
and objects to testbench_utils.py that will make it easier to split the
GcsBucket and GcsObject classes to their own files later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1222)
<!-- Reviewable:end -->
