### PR TITLE
Run the gcs2cbt example in CI builds.

### DIFF
--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -190,9 +190,9 @@ ctest --output-on-failure
 
 # Run the integration tests. Not all projects have them, so just iterate over
 # the ones that do.
-for subdir in google/cloud/{bigtable,storage}; do
+for subdir in google/cloud google/cloud/bigtable google/cloud/storage; do
   echo
-  echo "Running integration tests for ${subdir}"
+  echo "${COLOR_GREEN}Running integration tests for ${subdir}${COLOR_RESET}"
   /v/${subdir}/ci/run_integration_tests.sh
 done
 

--- a/google/cloud/bigtable/tools/run_emulator_utils.sh
+++ b/google/cloud/bigtable/tools/run_emulator_utils.sh
@@ -41,11 +41,11 @@ function start_emulators {
 
   # The tests typically run in a Docker container, where the ports are largely
   # free; when using in manual tests, you can set EMULATOR_PORT.
-  local emulator_port=${EMULATOR_PORT:-9000}
+  local -r emulator_port=${EMULATOR_PORT:-9000}
   "${CBT_EMULATOR_CMD}" -port "${emulator_port}" >emulator.log 2>&1 </dev/null &
   EMULATOR_PID=$!
 
-  local instance_admin_port=${INSTANCE_ADMIN_EMULATOR_PORT:-9090}
+  local -r instance_admin_port=${INSTANCE_ADMIN_EMULATOR_PORT:-9090}
   "${CBT_INSTANCE_ADMIN_EMULATOR_CMD}" "${instance_admin_port}" >instance-admin-emulator.log 2>&1 </dev/null &
   INSTANCE_ADMIN_EMULATOR_PID=$!
 

--- a/google/cloud/ci/run_integration_tests.sh
+++ b/google/cloud/ci/run_integration_tests.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# This script should is called from the build directory, and it finds other
+# scripts in the source directory using its own path.
+if [ -z "${PROJECT_ROOT+x}" ]; then
+  readonly PROJECT_ROOT="$(cd "$(dirname $0)/../../.."; pwd)"
+fi
+source "${PROJECT_ROOT}/ci/colors.sh"
+
+# If the build has excluded the examples, then skip them.
+if [ -d google/cloud/examples ]; then
+  (cd google/cloud/examples ; \
+   ${PROJECT_ROOT}/google/cloud/examples/run_gcs2cbt_emulator.sh)
+else
+  echo "${COLOR_YELLOW}[ SKIPPED  ]${COLOR_RESET} google/cloud examples" \
+    " as the examples are not compiled for this build"
+fi

--- a/google/cloud/examples/run_gcs2cbt_emulator.sh
+++ b/google/cloud/examples/run_gcs2cbt_emulator.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [ -z "${PROJECT_ROOT+x}" ]; then
+  readonly PROJECT_ROOT="$(cd "$(dirname $0)/../../.."; pwd)"
+fi
+readonly CBT_INSTANCE_ADMIN_EMULATOR_CMD="../bigtable/tests/instance_admin_emulator"
+source "${PROJECT_ROOT}/ci/colors.sh"
+source "${PROJECT_ROOT}/ci/define-example-runner.sh"
+source "${PROJECT_ROOT}/google/cloud/storage/tools/run_testbench_utils.sh"
+source "${PROJECT_ROOT}/google/cloud/bigtable/tools/run_emulator_utils.sh"
+
+kill_emulator_and_testbench() {
+  kill_emulators || /bin/true
+  kill_testbench || /bin/true
+}
+
+echo "${COLOR_GREEN}[ -------- ]${COLOR_RESET} gcs2cbt test environment"
+start_testbench
+start_emulators
+
+# Reset the trap to kill both the GCS testbench and storage emulator.
+trap kill_emulator_and_testbench EXIT
+
+readonly PROJECT_ID="fake-project-$(date +%s)-${RANDOM}"
+readonly INSTANCE_ID="in-$(date +%s)-${RANDOM}"
+readonly ZONE_ID="fake-zone"
+readonly BUCKET_NAME="fake-bucket-$(date +%s)-${RANDOM}"
+readonly TABLE="csv-table-${RANDOM}"
+
+run_example ../bigtable/examples/table_admin_snippets \
+    create-table "${PROJECT_ID}" "${INSTANCE_ID}" "${TABLE}"
+
+run_example ../storage/examples/storage_bucket_samples \
+      create-bucket-for-project \
+      "${BUCKET_NAME}" "${PROJECT_ID}"
+
+readonly CSV_FILE="$(mktemp -t "contents.XXXXXX")"
+cat >"${CSV_FILE}" <<-_EOF_
+RowId,Header1,Header2,Header3
+1,v1,v2,v3
+3,v1,v2,v3
+_EOF_
+
+object_name="contents.csv"
+run_example ../storage/examples/storage_object_samples \
+      upload-file "${CSV_FILE}" "${BUCKET_NAME}" "${object_name}"
+
+run_example ./gcs2cbt --key=1 --separator=, \
+    "${PROJECT_ID}" "${INSTANCE_ID}" "${TABLE}"  "fam" \
+    "${BUCKET_NAME}" "${object_name}"
+
+run_example_usage ./gcs2cbt --help
+
+TESTBENCH_DUMP_LOG=no

--- a/google/cloud/storage/tools/run_testbench_utils.sh
+++ b/google/cloud/storage/tools/run_testbench_utils.sh
@@ -77,7 +77,7 @@ start_testbench() {
 
   # The tests typically run in a Docker container, where the ports are largely
   # free; when using in manual tests, you can set EMULATOR_PORT.
-  local testbench_port=${TESTBENCH_PORT:-8000}
+  local -r testbench_port=${TESTBENCH_PORT:-8000}
 
   gunicorn --bind 0.0.0.0:${testbench_port} \
       --worker-class gevent \


### PR DESCRIPTION
Some adjustments to the startup scripts are needed, but the example can
be executed in the CI builds (and should).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1239)
<!-- Reviewable:end -->
