### PR TITLE
Use Ninja as the CMake backend for faster AppVeyor builds.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,10 +40,8 @@ install:
   - powershell -exec bypass ci\appveyor\install-windows.ps1
 
 build_script:
-  - path
-    call @"c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
-    path
-    powershell -exec bypass ci\appveyor\build-windows.ps1
+  - call "c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
+  - powershell -exec bypass ci\appveyor\build-windows.ps1
 
 test_script:
   - ps: cd build-output

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,6 +35,7 @@ cache:
   - c:\projects\vcpkg\installed -> ci\appveyor\install-windows.ps1
 
 install:
+  - choco install -y ninja
   - git submodule update --init
   - powershell -exec bypass ci\appveyor\install-windows.ps1
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,6 @@ environment:
   matrix:
     - PROVIDER: vcpkg
       CONFIG: Debug
-      GENERATOR: "Visual Studio 15 2017 Win64"
       APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
 cache:
@@ -40,8 +39,11 @@ install:
   - powershell -exec bypass ci\appveyor\install-windows.ps1
 
 build_script:
+  - path
+  - call @"c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - path
   - powershell -exec bypass ci\appveyor\build-windows.ps1
 
 test_script:
   - ps: cd build-output
-  - ctest --output-on-failure -C "%CONFIG%"
+  - ctest --output-on-failure -C "%CONFIG%" -j 2

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,9 +41,9 @@ install:
 
 build_script:
   - path
-  - call @"c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
-  - path
-  - powershell -exec bypass ci\appveyor\build-windows.ps1
+    call @"c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+    path
+    powershell -exec bypass ci\appveyor\build-windows.ps1
 
 test_script:
   - ps: cd build-output

--- a/ci/appveyor/build-windows.ps1
+++ b/ci/appveyor/build-windows.ps1
@@ -21,15 +21,12 @@ $ErrorActionPreference = "Stop"
 if (-not (Test-Path env:PROVIDER)) {
     throw "Aborting build because the PROVIDER environment variable is not set."
 }
-if (-not (Test-Path env:GENERATOR)) {
-    throw "Aborting build because the GENERATOR environment variable is not set."
-}
 if (-not (Test-Path env:CONFIG)) {
     throw "Aborting build because the CONFIG environment variable is not set."
 }
 
 # By default assume "module", use the configuration parameters and build in the `build-output` directory.
-$cmake_flags=@("-G$env:GENERATOR", "-DCMAKE_BUILD_TYPE=$env:CONFIG", "-H.", "-Bbuild-output")
+$cmake_flags=@("-GNinja", "-DCMAKE_BUILD_TYPE=$env:CONFIG", "-H.", "-Bbuild-output")
 
 if ($env:PROVIDER -eq "vcpkg") {
     # Setup the environment for vcpkg:
@@ -57,7 +54,7 @@ if ($LastExitCode) {
 }
 
 # Compile inside the build directory. Pass /m flag to msbuild to use all cores.
-cmake --build build-output --config $env:CONFIG -- /m
+cmake --build build-output --config $env:CONFIG
 if ($LastExitCode) {
     throw "cmake build failed with exit code $LastExitCode"
 }

--- a/ci/appveyor/build-windows.ps1
+++ b/ci/appveyor/build-windows.ps1
@@ -45,6 +45,8 @@ if ($env:PROVIDER -eq "vcpkg") {
     $cmake_flags += "-DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=$env:PROVIDER"
     $cmake_flags += "-DCMAKE_TOOLCHAIN_FILE=`"$dir\vcpkg\scripts\buildsystems\vcpkg.cmake`""
     $cmake_flags += "-DVCPKG_TARGET_TRIPLET=x64-windows-static"
+    $cmake_flags += "-DCMAKE_C_COMPILER=cl.exe"
+    $cmake_flags += "-DCMAKE_CXX_COMPILER=cl.exe"
 }
 
 # Create a build directory, and run cmake in it.


### PR DESCRIPTION
With this change our AppVeyor builds use Ninja instead of MSBuild as the CMake backend.

The builds are faster: 18m vs. 25m with a hot cache.  They also produce more readable output: 1200 vs over 5000 lines of logs.

I can already tell we are setting at least one option to MSVC incorrectly from this build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1247)
<!-- Reviewable:end -->
