### PR TITLE
Fix googletest when used as an installed package.

### DIFF
--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -102,6 +102,20 @@ function install_grpc {
   ldconfig
 }
 
+function install_googletest {
+  # Install googletest.
+  echo "${COLOR_YELLOW}Installing googletest $(date)${COLOR_RESET}"
+  wget -q https://github.com/google/googletest/archive/release-1.8.1.tar.gz
+  tar -xf release-1.8.1.tar.gz
+  cd googletest-release-1.8.1
+  env CXX="${cached_cxx}" CC="${cached_cc}"  cmake \
+      -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+      ${CMAKE_FLAGS} \
+      -H. -B.build/googletest
+  cmake --build .build/googletest --target install -- -j ${NCPU}
+  ldconfig
+}
+
 if [ "${TEST_INSTALL:-}" = "yes" -o "${SCAN_BUILD:-}" = "yes" ]; then
   echo
   echo "${COLOR_YELLOW}Started dependency install at: $(date)${COLOR_RESET}"
@@ -118,6 +132,7 @@ if [ "${TEST_INSTALL:-}" = "yes" -o "${SCAN_BUILD:-}" = "yes" ]; then
   (cd /var/tmp/build-dependencies; install_protobuf)
   (cd /var/tmp/build-dependencies; install_c_ares)
   (cd /var/tmp/build-dependencies; install_grpc)
+  (cd /var/tmp/build-dependencies; install_googletest)
   # DEBUG REMOVE BEFORE MERGE
   ${ccache_command} --show-stats
   # END DEBUG REMOVE BEFORE MERGE
@@ -134,6 +149,7 @@ echo "travis_fold:start:configure-cmake"
 cmake_install_flags=""
 if [ "${TEST_INSTALL:-}" = "yes" ]; then
   cmake_install_flags=-DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=package
+  cmake_install_flags="${cmake_install_flags} -DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=package"
 fi
 
 if [ "${SCAN_BUILD:-}" = "yes" ]; then

--- a/cmake/IncludeGMock.cmake
+++ b/cmake/IncludeGMock.cmake
@@ -35,6 +35,19 @@ set_property(CACHE GOOGLE_CLOUD_CPP_GMOCK_PROVIDER
                       "vcpkg"
                       "pkg-config")
 
+function (create_googletest_aliases)
+    # FindGTest() is a standard CMake module. It, unfortunately, *only* creates
+    # targets for the googletest libraries (not gmock), and with a name that is
+    # not the same names used by googletest: GTest::GTest vs. GTest::gtest and
+    # GTest::Main vs. GTest::gtest_main. We create aliases for them:
+    add_library(GTest_gtest INTERFACE)
+    target_link_libraries(GTest_gtest INTERFACE GTest::GTest)
+    add_library(GTest_gtest_main INTERFACE)
+    target_link_libraries(GTest_gtest_main INTERFACE GTest::Main)
+    add_library(GTest::gtest ALIAS GTest_gtest)
+    add_library(GTest::gtest_main ALIAS GTest_gtest_main)
+endfunction ()
+
 if (TARGET gmock)
     # gmock is already defined, do not define it again.
 elseif("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "external")
@@ -94,16 +107,7 @@ elseif("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "external")
 elseif("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "vcpkg")
     find_package(GTest REQUIRED)
 
-    # FindGTest() is a standard CMake module. It, unfortunately, *only* creates
-    # targets for the googletest libraries (not gmock), and with a name that is
-    # not the same names used by googletest: GTest::GTest vs. GTest::gtest and
-    # GTest::Main vs. GTest::gtest_main. We create aliases for them:
-    add_library(GTest_gtest INTERFACE)
-    target_link_libraries(GTest_gtest INTERFACE GTest::GTest)
-    add_library(GTest_gtest_main INTERFACE)
-    target_link_libraries(GTest_gtest_main INTERFACE GTest::Main)
-    add_library(GTest::gtest ALIAS GTest_gtest)
-    add_library(GTest::gtest_main ALIAS GTest_gtest_main)
+    create_googletest_aliases()
 
     # The FindGTest module finds GTest by default, but does not search for
     # GMock, though they are usually installed together. Define the
@@ -141,16 +145,7 @@ elseif("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "vcpkg")
 elseif("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "package")
     find_package(GTest REQUIRED)
 
-    # FindGTest() is a standard CMake module. It, unfortunately, *only* creates
-    # targets for the googletest libraries (not gmock), and with a name that is
-    # not the same names used by googletest: GTest::GTest vs. GTest::gtest and
-    # GTest::Main vs. GTest::gtest_main. We create aliases for them:
-    add_library(GTest_gtest INTERFACE)
-    target_link_libraries(GTest_gtest INTERFACE GTest::GTest)
-    add_library(GTest_gtest_main INTERFACE)
-    target_link_libraries(GTest_gtest_main INTERFACE GTest::Main)
-    add_library(GTest::gtest ALIAS GTest_gtest)
-    add_library(GTest::gtest_main ALIAS GTest_gtest_main)
+    create_googletest_aliases()
 
     # The FindGTest module finds GTest by default, but does not search for
     # GMock, though they are usually installed together. Define the

--- a/cmake/IncludeGMock.cmake
+++ b/cmake/IncludeGMock.cmake
@@ -94,6 +94,17 @@ elseif("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "external")
 elseif("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "vcpkg")
     find_package(GTest REQUIRED)
 
+    # FindGTest() is a standard CMake module. It, unfortunately, *only* creates
+    # targets for the googletest libraries (not gmock), and with a name that is
+    # not the same names used by googletest: GTest::GTest vs. GTest::gtest and
+    # GTest::Main vs. GTest::gtest_main. We create aliases for them:
+    add_library(GTest_gtest INTERFACE)
+    target_link_libraries(GTest_gtest INTERFACE GTest::GTest)
+    add_library(GTest_gtest_main INTERFACE)
+    target_link_libraries(GTest_gtest_main INTERFACE GTest::Main)
+    add_library(GTest::gtest ALIAS GTest_gtest)
+    add_library(GTest::gtest_main ALIAS GTest_gtest_main)
+
     # The FindGTest module finds GTest by default, but does not search for
     # GMock, though they are usually installed together. Define the
     # GTest::gmock* targets manually.
@@ -128,8 +139,18 @@ elseif("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "vcpkg")
     target_link_libraries(gmock INTERFACE GTest::gmock)
 
 elseif("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "package")
-    find_package(Threads REQUIRED)
     find_package(GTest REQUIRED)
+
+    # FindGTest() is a standard CMake module. It, unfortunately, *only* creates
+    # targets for the googletest libraries (not gmock), and with a name that is
+    # not the same names used by googletest: GTest::GTest vs. GTest::gtest and
+    # GTest::Main vs. GTest::gtest_main. We create aliases for them:
+    add_library(GTest_gtest INTERFACE)
+    target_link_libraries(GTest_gtest INTERFACE GTest::GTest)
+    add_library(GTest_gtest_main INTERFACE)
+    target_link_libraries(GTest_gtest_main INTERFACE GTest::Main)
+    add_library(GTest::gtest ALIAS GTest_gtest)
+    add_library(GTest::gtest_main ALIAS GTest_gtest_main)
 
     # The FindGTest module finds GTest by default, but does not search for
     # GMock, though they are usually installed together. Define the


### PR DESCRIPTION
Sigh, the CMake modules for GTest are a mess. This adds a test to verify
we can work with a installed googletest, and fixes some problems with
the googletest targets for that case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1278)
<!-- Reviewable:end -->
