### PR TITLE
Disable parallel runs for ctest on Windows.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,4 +45,4 @@ build_script:
 
 test_script:
   - ps: cd build-output
-  - ctest --output-on-failure -C "%CONFIG%" -j 2
+  - ctest --output-on-failure -C "%CONFIG%"


### PR DESCRIPTION
gRPC has a bug:

https://github.com/grpc/grpc/issues/16872

that prevent us from running two test programs at the same time on
Windows. Apparently I got lucky when I tested this the first few times.
Sigh.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1279)
<!-- Reviewable:end -->
