### PR TITLE
Use GTest::* targets for gtest & gmock.

### DIFF
--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -44,7 +44,7 @@ include(EnableCxxExceptions)
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
 
-# Add the gmock library if it does not exist.
+# Discover and add targets for the GTest::gtest and GTest::gmock libraries.
 include(IncludeGMock)
 
 if (${CMAKE_VERSION} VERSION_LESS "3.9")

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -119,7 +119,7 @@ add_library(google_cloud_cpp_testing
             testing_util/init_google_mock.h
             testing_util/init_google_mock.cc)
 target_link_libraries(google_cloud_cpp_testing
-                      PUBLIC google_cloud_cpp_common gmock)
+                      PUBLIC google_cloud_cpp_common GTest::gmock)
 
 create_bazel_config(google_cloud_cpp_testing)
 
@@ -150,7 +150,9 @@ foreach (fname ${google_cloud_cpp_common_unit_tests})
     target_link_libraries(${target}
                           PRIVATE google_cloud_cpp_testing
                                   google_cloud_cpp_common
-                                  gmock
+                                  GTest::gmock_main
+                                  GTest::gmock
+                                  GTest::gtest
                                   google_cloud_cpp_common_options)
     add_test(NAME ${target} COMMAND ${target})
 endforeach ()

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -110,7 +110,7 @@ add_library(bigtable::protos ALIAS bigtable_protos)
 # Enable unit tests
 enable_testing()
 
-add_dependencies(skip-scanbuild-targets gmock bigtable_protos)
+add_dependencies(skip-scanbuild-targets bigtable_protos)
 
 # Generate the version information from the CMake values.
 configure_file(version_info.h.in version_info.h)
@@ -254,7 +254,9 @@ add_library(bigtable_client_testing
 target_link_libraries(bigtable_client_testing
                       PUBLIC bigtable_client
                              bigtable_protos
-                             gmock
+                             GTest::gmock_main
+                             GTest::gmock
+                             GTest::gtest
                              gRPC::grpc++
                              gRPC::grpc
                              protobuf::libprotobuf
@@ -332,7 +334,9 @@ foreach (fname ${bigtable_client_unit_tests})
                                   bigtable_protos
                                   google_cloud_cpp_testing
                                   google_cloud_cpp_common
-                                  gmock
+                                  GTest::gmock_main
+                                  GTest::gmock
+                                  GTest::gtest
                                   gRPC::grpc++
                                   gRPC::grpc
                                   protobuf::libprotobuf

--- a/google/cloud/bigtable/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigtable/benchmarks/CMakeLists.txt
@@ -55,7 +55,9 @@ foreach (fname ${bigtable_benchmarks_unit_tests})
                                   bigtable_common_options
                                   google_cloud_cpp_testing
                                   google_cloud_cpp_common
-                                  gmock
+                                  GTest::gmock_main
+                                  GTest::gmock
+                                  GTest::gtest
                                   gRPC::grpc++
                                   gRPC::grpc
                                   protobuf::libprotobuf)

--- a/google/cloud/bigtable/tests/CMakeLists.txt
+++ b/google/cloud/bigtable/tests/CMakeLists.txt
@@ -46,7 +46,9 @@ foreach (fname ${bigtable_client_integration_tests})
                                   bigtable_protos
                                   google_cloud_cpp_testing
                                   google_cloud_cpp_common
-                                  gmock
+                                  GTest::gmock_main
+                                  GTest::gmock
+                                  GTest::gtest
                                   gRPC::grpc++
                                   gRPC::grpc
                                   protobuf::libprotobuf

--- a/google/cloud/firestore/CMakeLists.txt
+++ b/google/cloud/firestore/CMakeLists.txt
@@ -92,7 +92,9 @@ foreach (fname ${firestore_client_unit_tests})
                           PRIVATE firestore_client
                                   google_cloud_cpp_testing
                                   google_cloud_cpp_common
-                                  gmock
+                                  GTest::gmock_main
+                                  GTest::gmock
+                                  GTest::gtest
                                   firestore_common_options)
     add_test(NAME ${target} COMMAND ${target})
 endforeach ()

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -239,7 +239,11 @@ add_library(storage_client_testing
             testing/mock_http_request.cc
             testing/retry_tests.h)
 target_link_libraries(storage_client_testing
-                      PUBLIC storage_client nlohmann_json gmock
+                      PUBLIC storage_client
+                             nlohmann_json
+                             GTest::gmock_main
+                             GTest::gmock
+                             GTest::gtest
                       PRIVATE storage_common_options)
 target_include_directories(storage_client_testing
                            PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
@@ -318,7 +322,9 @@ foreach (fname ${storage_client_unit_tests})
                                   google_cloud_cpp_testing
                                   storage_client
                                   google_cloud_cpp_testing
-                                  gmock
+                                  GTest::gmock_main
+                                  GTest::gmock
+                                  GTest::gtest
                                   CURL::CURL
                                   storage_common_options
                                   nlohmann_json)

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -39,7 +39,9 @@ foreach (fname ${storage_client_integration_tests})
                           PRIVATE storage_client
                                   google_cloud_cpp_testing
                                   google_cloud_cpp_common
-                                  gmock
+                                  GTest::gmock_main
+                                  GTest::gmock
+                                  GTest::gtest
                                   CURL::CURL
                                   Threads::Threads
                                   nlohmann_json


### PR DESCRIPTION
Now that googletest and googlemock are external projects (as opposed to
submodules) we can use them consistently as GTest::gmock, GTest::gtest,
GTest::gmock_main, and GTest::gtest_main. Those targets are present (or
can be created) regardless of how we find these libraries: as external
projects, via find_package(), or via pkg-config.

This fixes #310.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1280)
<!-- Reviewable:end -->
