### PR TITLE
Use a single option to control dependency sources.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,47 @@ if ("${GOOGLE_CLOUD_CPP_ENABLE_CCACHE}")
     endif ()
 endif ()
 
+# The default source for dependencies.
+set(GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER "external" CACHE STRING "[===[
+How to find the dependencies for google-cloud-cpp.
+
+The Google Cloud C++ client libraries have several external dependencies,
+notably gRPC, libcurl, OpenSSL, and a few others.
+
+This configuration option controls how are these dependencies are found. It can
+be set to:
+
+* external: use CMake's `ExternalProject` to download and compile the
+  dependencies. This is the recommended configuration for development, as it
+  isolates your build from the system configuration.
+
+* package: use CMake's `find_package()` to find the dependencies. This is the
+  recommended configuration for compiling and installing google-cloud-cpp.
+
+* vcpkg: use github.com/Microsoft/vcpkg to find the dependencies. vcpkg
+  largely behaves as `package`, but we have a few bugs in our CMake
+  configuration that need to be cleaned up. This option will be changed to
+  behave exactly as `package` once we fix these problems.
+
+* pkg-config: use this if the dependencies have been installed, but without
+  CMake support. Sometimes using pkg-config(1) can work as an alternative way
+  to find the dependency. WARNING: this is poorly tested, use at your own risk.
+
+To experiment with different configurations developers can override the setting
+for one or more dependencies. For example, you could set
+`GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER` to `package` and
+`GOOGLE_CLOUD_CPP_GMOCK_PROVIDER` to `external`. These overrides are intended
+for development and testing of new dependencies, they are not recommended for
+production use.
+]===]")
+
+set_property(CACHE GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER
+             PROPERTY STRINGS
+                      "external"
+                      "package"
+                      "vcpkg"
+                      "pkg-config")
+
 set(PROJECT_THIRD_PARTY_DIR "${PROJECT_SOURCE_DIR}/third_party")
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,15 +114,17 @@ be set to:
   configuration that need to be cleaned up. This option will be changed to
   behave exactly as `package` once we fix these problems.
 
-* pkg-config: use this if the dependencies have been installed, but without
-  CMake support. Sometimes using pkg-config(1) can work as an alternative way
-  to find the dependency. WARNING: this is poorly tested, use at your own risk.
+* pkg-config: use pkg-config(1) to find the dependencies. Sometimes the
+  dependencies are installed in the system, but the CMake configuration files
+  to support them are not. WARNING: this option may be removed in the future,
+  we think that modern CMake features like `ExternalProject` and `find_package`
+  are better options for dependency management.
 
 To experiment with different configurations developers can override the setting
 for one or more dependencies. For example, you could set
 `GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER` to `package` and
 `GOOGLE_CLOUD_CPP_GMOCK_PROVIDER` to `external`. These overrides are intended
-for development and testing of new dependencies, they are not recommended for
+for development and testing of new dependencies and are not recommended for
 production use.
 ]===]")
 

--- a/ci/appveyor/build-windows.ps1
+++ b/ci/appveyor/build-windows.ps1
@@ -41,8 +41,7 @@ if ($env:PROVIDER -eq "vcpkg") {
         throw "vcpkg integrate failed with exit code $LastExitCode"
     }
 
-    $cmake_flags += "-DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=$env:PROVIDER"
-    $cmake_flags += "-DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=$env:PROVIDER"
+    $cmake_flags += "-DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=$env:PROVIDER"
     $cmake_flags += "-DCMAKE_TOOLCHAIN_FILE=`"$dir\vcpkg\scripts\buildsystems\vcpkg.cmake`""
     $cmake_flags += "-DVCPKG_TARGET_TRIPLET=x64-windows-static"
     $cmake_flags += "-DCMAKE_C_COMPILER=cl.exe"

--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -148,12 +148,11 @@ echo "travis_fold:start:configure-cmake"
 # Tweak configuration for TEST_INSTALL=yes and SCAN_BUILD=yes builds.
 cmake_install_flags=""
 if [ "${TEST_INSTALL:-}" = "yes" ]; then
-  cmake_install_flags=-DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=package
-  cmake_install_flags="${cmake_install_flags} -DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=package"
+  cmake_install_flags=-DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package
 fi
 
 if [ "${SCAN_BUILD:-}" = "yes" ]; then
-  cmake_install_flags=-DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=package
+  cmake_install_flags=-DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package
   cmake_install_flags="${cmake_install_flags} -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=OFF"
 fi
 

--- a/cmake/IncludeGMock.cmake
+++ b/cmake/IncludeGMock.cmake
@@ -26,7 +26,7 @@ find_package(Threads REQUIRED)
 # In this file we try to normalize the situation to the packages defined in the
 # source.  Not perfect, but better than the mess we have otherwise.
 
-set(GOOGLE_CLOUD_CPP_GMOCK_PROVIDER "external"
+set(GOOGLE_CLOUD_CPP_GMOCK_PROVIDER ${GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER}
     CACHE STRING "How to find the googlemock library")
 set_property(CACHE GOOGLE_CLOUD_CPP_GMOCK_PROVIDER
              PROPERTY STRINGS

--- a/cmake/IncludeGrpc.cmake
+++ b/cmake/IncludeGrpc.cmake
@@ -19,7 +19,7 @@ find_package(Threads REQUIRED)
 
 # Configure the gRPC dependency, this can be found as a submodule, package, or
 # installed with pkg-config support.
-set(GOOGLE_CLOUD_CPP_GRPC_PROVIDER "external"
+set(GOOGLE_CLOUD_CPP_GRPC_PROVIDER ${GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER}
     CACHE STRING "How to find the gRPC library")
 set_property(CACHE GOOGLE_CLOUD_CPP_GRPC_PROVIDER
              PROPERTY STRINGS

--- a/doc/setup-development-environment.md
+++ b/doc/setup-development-environment.md
@@ -75,7 +75,7 @@ And compile the code using:
 ```commandline
 C:\...> mkdir .build
 C:\...> cd .build
-C:\...> cmake -DCMAKE_TOOLCHAIN_FILE=C:/Users/%USERNAME%/vcpkg/scripts/buildsystems/vcpkg.cmake -DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=package ..
+C:\...> cmake -DCMAKE_TOOLCHAIN_FILE=C:/Users/%USERNAME%/vcpkg/scripts/buildsystems/vcpkg.cmake -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package ..
 C:\...> cmake --build . -- /m
 ```
 

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -374,14 +374,9 @@ install(TARGETS bigtable_protos bigtable_common_options
 # Install proto generated files into include/google.
 google_cloud_cpp_install_headers(bigtable_protos include)
 
-# The exports can only be installed if all the dependencies are installed. CMake
-# needs to know where the submodules will be installed from,
-if (NOT ${GOOGLE_CLOUD_CPP_GRPC_PROVIDER} STREQUAL "module")
-
-    # Export the CMake targets to make it easy to create configuration files.
-    install(EXPORT bigtable-targets
-            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/bigtable_client")
-endif ()
+# Export the CMake targets to make it easy to create configuration files.
+install(EXPORT bigtable-targets
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/bigtable_client")
 
 install(TARGETS bigtable_client
         EXPORT bigtable-targets


### PR DESCRIPTION
This is part of the work for #1248. It introduces a configuration option
to set the source for all dependencies. As we add dependencies (e.g.
zlib, libcurl, google/crc32c, etc.) they will all share this dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1281)
<!-- Reviewable:end -->
