### PR TITLE
Compute MD5 hash on uploads.

### DIFF
--- a/google/cloud/storage/client_write_object_test.cc
+++ b/google/cloud/storage/client_write_object_test.cc
@@ -60,6 +60,9 @@ class MockStreambuf : public internal::ObjectWriteStreambuf {
  public:
   MOCK_CONST_METHOD0(IsOpen, bool());
   MOCK_METHOD0(DoClose, internal::HttpResponse());
+  MOCK_METHOD1(ValidateHash, void(ObjectMetadata const&));
+  MOCK_CONST_METHOD0(received_hash, std::string const&());
+  MOCK_CONST_METHOD0(computed_hash, std::string const&());
 };
 
 TEST_F(WriteObjectTest, WriteObject) {

--- a/google/cloud/storage/internal/curl_streambuf.cc
+++ b/google/cloud/storage/internal/curl_streambuf.cc
@@ -88,7 +88,7 @@ CurlStreambuf::CurlStreambuf(CurlUploadRequest&& upload,
 bool CurlStreambuf::IsOpen() const { return upload_.IsOpen(); }
 
 void CurlStreambuf::ValidateHash(ObjectMetadata const& meta) {
-  hash_validator_->Received(meta);
+  hash_validator_->ProcessMetadata(meta);
   hash_validator_result_ = std::move(*hash_validator_).Finish(__func__);
 }
 
@@ -130,9 +130,6 @@ HttpResponse CurlStreambuf::DoClose() {
   auto response = upload_.Close();
   for (auto const& kv : response.headers) {
     hash_validator_->ProcessHeader(kv.first, kv.second);
-  }
-  if (response.status_code >= 300) {
-    return response;
   }
   return response;
 }

--- a/google/cloud/storage/internal/curl_streambuf.cc
+++ b/google/cloud/storage/internal/curl_streambuf.cc
@@ -77,12 +77,20 @@ CurlReadStreambuf::int_type CurlReadStreambuf::underflow() {
 }
 
 CurlStreambuf::CurlStreambuf(CurlUploadRequest&& upload,
-                             std::size_t max_buffer_size)
-    : upload_(std::move(upload)), max_buffer_size_(max_buffer_size) {
+                             std::size_t max_buffer_size,
+                             std::unique_ptr<HashValidator> hash_validator)
+    : upload_(std::move(upload)),
+      max_buffer_size_(max_buffer_size),
+      hash_validator_(std::move(hash_validator)) {
   current_ios_buffer_.reserve(max_buffer_size);
 }
 
 bool CurlStreambuf::IsOpen() const { return upload_.IsOpen(); }
+
+void CurlStreambuf::ValidateHash(ObjectMetadata const& meta) {
+  hash_validator_->Received(meta);
+  hash_validator_result_ = std::move(*hash_validator_).Finish(__func__);
+}
 
 CurlStreambuf::int_type CurlStreambuf::overflow(int_type ch) {
   Validate(__func__);
@@ -119,7 +127,14 @@ HttpResponse CurlStreambuf::DoClose() {
   GCP_LOG(INFO) << __func__ << "()";
   Validate(__func__);
   SwapBuffers();
-  return upload_.Close();
+  auto response = upload_.Close();
+  for (auto const& kv : response.headers) {
+    hash_validator_->ProcessHeader(kv.first, kv.second);
+  }
+  if (response.status_code >= 300) {
+    return response;
+  }
+  return response;
 }
 
 void CurlStreambuf::Validate(char const* where) const {
@@ -135,6 +150,7 @@ void CurlStreambuf::SwapBuffers() {
   // Shorten the buffer to the actual used size.
   current_ios_buffer_.resize(pptr() - pbase());
   // Push the buffer to the libcurl wrapper to be written as needed
+  hash_validator_->Update(current_ios_buffer_);
   upload_.NextBuffer(current_ios_buffer_);
   // Make the buffer big enough to receive more data before needing a flush.
   current_ios_buffer_.clear();

--- a/google/cloud/storage/internal/curl_streambuf.h
+++ b/google/cloud/storage/internal/curl_streambuf.h
@@ -63,11 +63,19 @@ class CurlReadStreambuf : public ObjectReadStreambuf {
 class CurlStreambuf : public ObjectWriteStreambuf {
  public:
   explicit CurlStreambuf(CurlUploadRequest&& upload,
-                         std::size_t max_buffer_size);
+                         std::size_t max_buffer_size,
+                         std::unique_ptr<HashValidator> hash_validator);
 
   ~CurlStreambuf() override = default;
 
   bool IsOpen() const override;
+  void ValidateHash(ObjectMetadata const& meta) override;
+  std::string const& received_hash() const override {
+    return hash_validator_result_.received;
+  }
+  std::string const& computed_hash() const override {
+    return hash_validator_result_.computed;
+  }
 
  protected:
   int sync() override;
@@ -85,6 +93,9 @@ class CurlStreambuf : public ObjectWriteStreambuf {
   CurlUploadRequest upload_;
   std::string current_ios_buffer_;
   std::size_t max_buffer_size_;
+
+  std::unique_ptr<HashValidator> hash_validator_;
+  HashValidator::Result hash_validator_result_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/hash_validator.cc
+++ b/google/cloud/storage/internal/hash_validator.cc
@@ -30,7 +30,7 @@ void MD5HashValidator::Update(std::string const& payload) {
   MD5_Update(&context_, payload.c_str(), payload.size());
 }
 
-void MD5HashValidator::Received(ObjectMetadata const& meta) {
+void MD5HashValidator::ProcessMetadata(ObjectMetadata const &meta) {
   if (meta.md5_hash().empty()) {
     // When using the XML API the metadata is empty, but the headers are not. In
     // that case we do not want to replace the received hash with an empty

--- a/google/cloud/storage/internal/hash_validator.cc
+++ b/google/cloud/storage/internal/hash_validator.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/internal/hash_validator.h"
 #include "google/cloud/storage/internal/openssl_util.h"
+#include "google/cloud/storage/object_metadata.h"
 #include "google/cloud/storage/status.h"
 #include <openssl/md5.h>
 
@@ -27,6 +28,16 @@ MD5HashValidator::MD5HashValidator() : context_{} { MD5_Init(&context_); }
 
 void MD5HashValidator::Update(std::string const& payload) {
   MD5_Update(&context_, payload.c_str(), payload.size());
+}
+
+void MD5HashValidator::Received(ObjectMetadata const& meta) {
+  if (meta.md5_hash().empty()) {
+    // When using the XML API the metadata is empty, but the headers are not. In
+    // that case we do not want to replace the received hash with an empty
+    // value.
+    return;
+  }
+  received_hash_ = meta.md5_hash();
 }
 
 void MD5HashValidator::ProcessHeader(std::string const& key,

--- a/google/cloud/storage/internal/hash_validator.h
+++ b/google/cloud/storage/internal/hash_validator.h
@@ -24,6 +24,7 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
+class ObjectMetadata;
 namespace internal {
 /**
  * Defines the interface to check hash values during uploads and downloads.
@@ -32,10 +33,13 @@ class HashValidator {
  public:
   virtual ~HashValidator() = default;
 
-  /// Update the actual hash value with some portion of the data.
+  /// Update the computed hash value with some portion of the data.
   virtual void Update(std::string const& payload) = 0;
 
-  /// Update the expected hash value based on a response header.
+  /// Update the received hash value based on object metadata.
+  virtual void Received(ObjectMetadata const& meta) = 0;
+
+  /// Update the received hash value based on a response header.
   virtual void ProcessHeader(std::string const& key,
                              std::string const& value) = 0;
 
@@ -66,6 +70,7 @@ class NullHashValidator : public HashValidator {
   NullHashValidator() = default;
 
   void Update(std::string const& payload) override {}
+  void Received(ObjectMetadata const& meta) override {}
   void ProcessHeader(std::string const& key,
                      std::string const& value) override {}
   Result Finish(std::string const& msg) && override { return Result{}; }
@@ -82,6 +87,7 @@ class MD5HashValidator : public HashValidator {
   MD5HashValidator& operator=(MD5HashValidator const&) = delete;
 
   void Update(std::string const& payload) override;
+  void Received(ObjectMetadata const& meta) override;
   void ProcessHeader(std::string const& key, std::string const& value) override;
   Result Finish(std::string const& msg) && override;
 

--- a/google/cloud/storage/internal/hash_validator.h
+++ b/google/cloud/storage/internal/hash_validator.h
@@ -36,8 +36,8 @@ class HashValidator {
   /// Update the computed hash value with some portion of the data.
   virtual void Update(std::string const& payload) = 0;
 
-  /// Update the received hash value based on object metadata.
-  virtual void Received(ObjectMetadata const& meta) = 0;
+  /// Update the received hash value based on a ObjectMetadata response.
+  virtual void ProcessMetadata(ObjectMetadata const& meta) = 0;
 
   /// Update the received hash value based on a response header.
   virtual void ProcessHeader(std::string const& key,
@@ -70,7 +70,7 @@ class NullHashValidator : public HashValidator {
   NullHashValidator() = default;
 
   void Update(std::string const& payload) override {}
-  void Received(ObjectMetadata const& meta) override {}
+  void ProcessMetadata(ObjectMetadata const& meta) override {}
   void ProcessHeader(std::string const& key,
                      std::string const& value) override {}
   Result Finish(std::string const& msg) && override { return Result{}; }
@@ -87,7 +87,7 @@ class MD5HashValidator : public HashValidator {
   MD5HashValidator& operator=(MD5HashValidator const&) = delete;
 
   void Update(std::string const& payload) override;
-  void Received(ObjectMetadata const& meta) override;
+  void ProcessMetadata(ObjectMetadata const& meta) override;
   void ProcessHeader(std::string const& key, std::string const& value) override;
   Result Finish(std::string const& msg) && override;
 

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -114,11 +114,11 @@ std::ostream& operator<<(std::ostream& os, InsertObjectMediaRequest const& r);
  * application.
  */
 class InsertObjectStreamingRequest
-    : public GenericObjectRequest<InsertObjectStreamingRequest, ContentEncoding,
-                                  ContentType, EncryptionKey, IfGenerationMatch,
-                                  IfGenerationNotMatch, IfMetagenerationMatch,
-                                  IfMetagenerationNotMatch, KmsKeyName,
-                                  PredefinedAcl, Projection, UserProject> {
+    : public GenericObjectRequest<
+          InsertObjectStreamingRequest, ContentEncoding, ContentType,
+          DisableMD5Hash, EncryptionKey, IfGenerationMatch,
+          IfGenerationNotMatch, IfMetagenerationMatch, IfMetagenerationNotMatch,
+          KmsKeyName, PredefinedAcl, Projection, UserProject> {
  public:
   using GenericObjectRequest::GenericObjectRequest;
 };

--- a/google/cloud/storage/internal/object_streambuf.h
+++ b/google/cloud/storage/internal/object_streambuf.h
@@ -22,6 +22,7 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
+class ObjectMetadata;
 namespace internal {
 /**
  * Defines a compilation barrier for libcurl.
@@ -65,6 +66,9 @@ class ObjectWriteStreambuf : public std::basic_streambuf<char> {
 
   HttpResponse Close();
   virtual bool IsOpen() const = 0;
+  virtual void ValidateHash(ObjectMetadata const& meta) = 0;
+  virtual std::string const& received_hash() const = 0;
+  virtual std::string const& computed_hash() const = 0;
 
  protected:
   virtual HttpResponse DoClose() = 0;

--- a/google/cloud/storage/object_stream.cc
+++ b/google/cloud/storage/object_stream.cc
@@ -87,9 +87,12 @@ ObjectMetadata ObjectWriteStream::Close() {
     google::cloud::internal::RaiseRuntimeError(os.str());
   }
   if (response.payload.empty()) {
+    buf_->ValidateHash(ObjectMetadata());
     return ObjectMetadata();
   }
-  return ObjectMetadata::ParseFromString(response.payload);
+  auto metadata = ObjectMetadata::ParseFromString(response.payload);
+  buf_->ValidateHash(metadata);
+  return metadata;
 }
 
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -120,6 +120,9 @@ class ObjectWriteStream : public std::basic_ostream<char> {
   /// Close the stream and return the (unparsed) result, useful for testing.
   internal::HttpResponse CloseRaw();
 
+  std::string const& received_hash() const { return buf_->received_hash(); }
+  std::string const& computed_hash() const { return buf_->computed_hash(); }
+
  private:
   std::unique_ptr<internal::ObjectWriteStreambuf> buf_;
 };

--- a/google/cloud/storage/testbench/testbench.py
+++ b/google/cloud/storage/testbench/testbench.py
@@ -1923,9 +1923,11 @@ def xmlapi_put_object(bucket_name, object_name):
     metageneration_match = flask.request.headers.get('x-goog-if-metageneration-match')
     gcs_object.check_preconditions_by_value(generation_match, None,
                                             metageneration_match, None)
-    gcs_object.insert_xml(gcs_url, flask.request)
+    revision = gcs_object.insert_xml(gcs_url, flask.request)
     testbench_utils.insert_object(object_path, gcs_object)
-    return ''
+    response = flask.make_response('')
+    response.headers['x-goog-hash'] = 'md5=%s' % revision.metadata.get('md5Hash', '')
+    return response
 
 
 application = wsgi.DispatcherMiddleware(

--- a/google/cloud/storage/tests/curl_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/curl_streambuf_integration_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/storage/internal/curl_request_builder.h"
 #include "google/cloud/storage/internal/curl_streambuf.h"
@@ -38,8 +39,9 @@ TEST(CurlStreambufIntegrationTest, WriteManyBytes) {
                                        internal::GetDefaultCurlHandleFactory());
   builder.AddHeader("Content-Type: application/octet-stream");
   builder.SetMethod("POST");
-  std::unique_ptr<internal::CurlStreambuf> buf(
-      new internal::CurlStreambuf(builder.BuildUpload(), 128 * 1024));
+  std::unique_ptr<internal::CurlStreambuf> buf(new internal::CurlStreambuf(
+      builder.BuildUpload(), 128 * 1024,
+      google::cloud::internal::make_unique<internal::NullHashValidator>()));
   ObjectWriteStream writer(std::move(buf));
 
   auto generator = google::cloud::internal::MakeDefaultPRNG();

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -1487,7 +1487,7 @@ TEST_F(ObjectIntegrationTest, DisableMD5StreamingReadJSON) {
   client.DeleteObject(bucket_name, object_name);
 }
 
-/// @test Verify that MD5 hashes are computed by default on downloads.
+/// @test Verify that MD5 hashes are computed by default on uploads.
 TEST_F(ObjectIntegrationTest, DefaultMD5StreamingWriteXML) {
   Client client;
   auto bucket_name = ObjectTestEnvironment::bucket_name();
@@ -1522,7 +1522,7 @@ TEST_F(ObjectIntegrationTest, DefaultMD5StreamingWriteXML) {
   client.DeleteObject(bucket_name, object_name);
 }
 
-/// @test Verify that MD5 hashes are computed by default on downloads.
+/// @test Verify that MD5 hashes are computed by default on uploads.
 TEST_F(ObjectIntegrationTest, DefaultMD5StreamingWriteJSON) {
   Client client;
   auto bucket_name = ObjectTestEnvironment::bucket_name();
@@ -1556,7 +1556,7 @@ TEST_F(ObjectIntegrationTest, DefaultMD5StreamingWriteJSON) {
   client.DeleteObject(bucket_name, object_name);
 }
 
-/// @test Verify that MD5 hashes can be disabled on downloads.
+/// @test Verify that MD5 hashes can be disabled on uploads.
 TEST_F(ObjectIntegrationTest, DisableMD5StreamingWriteXML) {
   Client client;
   auto bucket_name = ObjectTestEnvironment::bucket_name();
@@ -1591,7 +1591,7 @@ TEST_F(ObjectIntegrationTest, DisableMD5StreamingWriteXML) {
   client.DeleteObject(bucket_name, object_name);
 }
 
-/// @test Verify that MD5 hashes can be disabled on downloads.
+/// @test Verify that MD5 hashes can be disabled on uploads.
 TEST_F(ObjectIntegrationTest, DisableMD5StreamingWriteJSON) {
   Client client;
   auto bucket_name = ObjectTestEnvironment::bucket_name();


### PR DESCRIPTION
With this PR all uploads compute MD5 hashes by default, and compare them
against the hash value reported by the service. If there is a mismatch,
and exceptions are enabled, an exception is reported. Without exceptions
the application needs to check the values themselves.

Note that this validation is on the client side, so the corrupted data
is already stored by GCS by the time the error is detected. This is not
as good as sending the hash value before the data, but we cannot do that
when the data is generated dynamically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1284)
<!-- Reviewable:end -->
