### PR TITLE
Fix warnings about MT vs. MD options with MSVC.

### DIFF
--- a/cmake/IncludeGrpc.cmake
+++ b/cmake/IncludeGrpc.cmake
@@ -125,11 +125,25 @@ elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" MATCHES "^(package|vcpkg)$")
                 "Expected protobuf::libprotobuf target created by FindProtobuf")
     endif ()
 
-    if (VCPKG_TARGET_TRIPLET MATCHES "-static$")
+    if (VCPKG_TARGET_TRIPLET MATCHES "-static$" AND MSVC)
+        # Replace the runtime flags because all the dependencies are linked
+        # statically in this case.
         message(STATUS " RELEASE=${CMAKE_CXX_FLAGS_RELEASE}")
         message(STATUS " DEBUG=${CMAKE_CXX_FLAGS_DEBUG}")
-        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
-        set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+        foreach (flag_var
+                 CMAKE_CXX_FLAGS
+                 CMAKE_CXX_FLAGS_DEBUG
+                 CMAKE_CXX_FLAGS_RELEASE
+                 CMAKE_CXX_FLAGS_MINSIZEREL
+                 CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+            if (${flag_var} MATCHES "/MD")
+                string(REGEX
+                       REPLACE "/MD"
+                               "/MT"
+                               ${flag_var}
+                               "${${flag_var}}")
+            endif ()
+        endforeach (flag_var)
         message(STATUS " RELEASE=${CMAKE_CXX_FLAGS_RELEASE}")
         message(STATUS " DEBUG=${CMAKE_CXX_FLAGS_DEBUG}")
         message(STATUS " DEFAULT=${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
MSVC has different runtime support libraries for static vs. dynamically
linked programs. Because gRPC does not support shared libraries on
Windows, we must link statically when we use gRPC. But adding the "use
static runtime" option (/MT or /MTd) creates a warning because the "use
dynamic runtime" option is already in the command-line. The solution is
to *replace* the option instead.

I am not convinced that this is the best place to manipulate the options,
the change is needed for more than just gRPC. But that should be done in
a separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1285)
<!-- Reviewable:end -->
