### PR TITLE
Fix function to generate message boundaries.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -136,6 +136,7 @@ add_library(storage_client
             internal/empty_response.cc
             internal/format_rfc3339.h
             internal/format_rfc3339.cc
+            internal/generate_message_boundary.h
             internal/generic_object_request.h
             internal/generic_request.h
             internal/hash_validator.h
@@ -272,6 +273,7 @@ set(storage_client_unit_tests
     internal/bucket_requests_test.cc
     internal/default_object_acl_requests_test.cc
     internal/format_rfc3339_test.cc
+    internal/generate_message_boundary_test.cc
     internal/hash_validator_test.cc
     internal/http_response_test.cc
     internal/logging_client_test.cc

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/internal/make_unique.h"
 #include "google/cloud/storage/internal/curl_request_builder.h"
 #include "google/cloud/storage/internal/curl_streambuf.h"
+#include "google/cloud/storage/internal/generate_message_boundary.h"
 #include "google/cloud/storage/object_stream.h"
 
 namespace google {
@@ -1154,12 +1155,8 @@ std::string CurlClient::PickBoundary(std::string const& text_to_avoid) {
   };
   constexpr int INITIAL_CANDIDATE_SIZE = 16;
   constexpr int CANDIDATE_GROWTH_SIZE = 4;
-  std::string candidate = generate_candidate(INITIAL_CANDIDATE_SIZE);
-  for (std::string::size_type i = text_to_avoid.find(candidate, 0);
-       i != std::string::npos; text_to_avoid.find(candidate, i)) {
-    candidate += generate_candidate(CANDIDATE_GROWTH_SIZE);
-  }
-  return candidate;
+  return GenerateMessageBoundary(text_to_avoid, std::move(generate_candidate),
+                                 INITIAL_CANDIDATE_SIZE, CANDIDATE_GROWTH_SIZE);
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/generate_message_boundary.h
+++ b/google/cloud/storage/internal/generate_message_boundary.h
@@ -1,0 +1,74 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GENERATE_MESSAGE_BOUNDARY_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GENERATE_MESSAGE_BOUNDARY_H_
+
+#include "google/cloud/internal/invoke_result.h"
+#include "google/cloud/storage/version.h"
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+
+/**
+ * Generate a string that is not found in @p message.
+ *
+ * When sending messages over multipart MIME payloads we need a separator that
+ * is not found in the body of the message *and* that is not too large (it is
+ * trivial to generate a string not found in @p message, just append some
+ * characters to the message itself).
+ *
+ * The algorithm is to generate a short random string, and search for it in the
+ * message, if the message has that string, append some more random characters
+ * and keep searching.
+ *
+ * This function is a template because the string generator is typically a
+ * lambda that captures state variables (such as the random number generator),
+ * of the class that uses it.
+ *
+ * @param message a message body, typically the payload of a HTTP request that
+ *     will need to be encoded as a MIME multipart message.
+ * @param random_string_generator a callable to generate random strings.
+ *     Typically a lambda that captures the generator and any locks necessary
+ *     to generate the string. This is also used in testing to verify things
+ *     work when the initial string is found.
+ * @param initial_size the length for the initial string.
+ * @param growth_size how fast to grow the random string.
+ * @return a string not found in @p message.
+ */
+template <typename RandomStringGenerator,
+          typename std::enable_if<google::cloud::internal::is_invocable<
+                                      RandomStringGenerator, int>::value,
+                                  int>::type = 0>
+std::string GenerateMessageBoundary(
+    std::string const& message, RandomStringGenerator&& random_string_generator,
+    int initial_size, int growth_size) {
+  std::string candidate = random_string_generator(initial_size);
+  for (std::string::size_type i = message.find(candidate, 0);
+       i != std::string::npos; i = message.find(candidate, i)) {
+    candidate += random_string_generator(growth_size);
+  }
+  return candidate;
+}
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GENERATE_MESSAGE_BOUNDARY_H_

--- a/google/cloud/storage/internal/generate_message_boundary_test.cc
+++ b/google/cloud/storage/internal/generate_message_boundary_test.cc
@@ -34,8 +34,8 @@ TEST(GenerateMessageBoundaryTest, Simple) {
     return google::cloud::internal::Sample(generator, n, chars);
   };
 
-  // The magic constants here are uninteresting, we just want a large message
-  // and a relatives short string to start searching for a boundary.
+  // The magic constants here are uninteresting. We just want a large message
+  // and a relatively short string to start searching for a boundary.
   auto message = string_generator(1024);
   auto boundary =
       GenerateMessageBoundary(message, std::move(string_generator), 16, 4);
@@ -76,7 +76,8 @@ TEST(GenerateMessageBoundaryTest, RequiresGrowth) {
       GenerateMessageBoundary(message, std::move(string_generator),
           kMatchedStringLength / 2, kMatchedStringLength / 4);
   EXPECT_THAT(message, Not(HasSubstr(boundary)));
-  // We expect that
+
+  // We expect that the string is longer than the common characters.
   EXPECT_LT(kMatchedStringLength, boundary.size());
 }
 

--- a/google/cloud/storage/internal/generate_message_boundary_test.cc
+++ b/google/cloud/storage/internal/generate_message_boundary_test.cc
@@ -1,0 +1,88 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/generate_message_boundary.h"
+#include "google/cloud/internal/random.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+using ::testing::Not;
+using ::testing::HasSubstr;
+
+TEST(GenerateMessageBoundaryTest, Simple) {
+  auto generator = google::cloud::internal::MakeDefaultPRNG();
+
+  auto string_generator = [&generator](int n) {
+    static std::string const chars =
+        "abcdefghijklmnopqrstuvwxyz012456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    return google::cloud::internal::Sample(generator, n, chars);
+  };
+
+  // The magic constants here are uninteresting, we just want a large message
+  // and a relatives short string to start searching for a boundary.
+  auto message = string_generator(1024);
+  auto boundary =
+      GenerateMessageBoundary(message, std::move(string_generator), 16, 4);
+  EXPECT_THAT(message, Not(HasSubstr(boundary)));
+}
+
+TEST(GenerateMessageBoundaryTest, RequiresGrowth) {
+  static std::string const chars =
+      "abcdefghijklmnopqrstuvwxyz012456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+  auto generator = google::cloud::internal::MakeDefaultPRNG();
+
+  // This test will ensure that both the message and the initial string contain
+  // at least this many common characters.
+  int constexpr kMatchedStringLength = 32;
+  int constexpr kMismatchedStringLength = 512;
+
+  auto g1 = google::cloud::internal::MakeDefaultPRNG();
+  std::string message = google::cloud::internal::Sample(
+      g1, kMismatchedStringLength, chars);
+  // Copy the PRNG to obtain the same sequence of random numbers that
+  // `generator` will create later.
+  g1 = generator;
+  message += google::cloud::internal::Sample(g1, kMatchedStringLength, chars);
+  g1 = google::cloud::internal::MakeDefaultPRNG();
+  message += google::cloud::internal::Sample(g1, kMismatchedStringLength, chars);
+
+  auto string_generator = [&generator](int n) {
+    return google::cloud::internal::Sample(generator, n, chars);
+  };
+
+  // The initial_size and growth_size parameters are set to
+  // (kMatchedStringLength / 2) and (kMatchedStringLength / 4) respectively,
+  // that forces the algorithm to find the initial string, and to grow it
+  // several times before the kMatchedStringLength common characters are
+  // exhausted.
+  auto boundary =
+      GenerateMessageBoundary(message, std::move(string_generator),
+          kMatchedStringLength / 2, kMatchedStringLength / 4);
+  EXPECT_THAT(message, Not(HasSubstr(boundary)));
+  // We expect that
+  EXPECT_LT(kMatchedStringLength, boundary.size());
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/storage_client.bzl
+++ b/google/cloud/storage/storage_client.bzl
@@ -23,6 +23,7 @@ storage_client_HDRS = [
     "internal/default_object_acl_requests.h",
     "internal/empty_response.h",
     "internal/format_rfc3339.h",
+    "internal/generate_message_boundary.h",
     "internal/generic_object_request.h",
     "internal/generic_request.h",
     "internal/hash_validator.h",

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -17,6 +17,7 @@ storage_client_unit_tests = [
     "internal/bucket_requests_test.cc",
     "internal/default_object_acl_requests_test.cc",
     "internal/format_rfc3339_test.cc",
+    "internal/generate_message_boundary_test.cc",
     "internal/hash_validator_test.cc",
     "internal/http_response_test.cc",
     "internal/logging_client_test.cc",


### PR DESCRIPTION
The function to generate a message boundary was not working if the
initial string was found in the message. I found this because MSVC
issues a warning when the value of string::find() is discarded, which it
was in this case (creating an infinite loop too I think).

This is why we cleanup warnings, because sometimes they show you bugs
that you could not find otherwise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1286)
<!-- Reviewable:end -->
