### PR TITLE
Speedup code coverage builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,6 @@ matrix:
       os: linux
       compiler: gcc
       env:
-        CMAKE_FLAGS=-DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=no
         BUILD_TYPE=Coverage
         DISTRO=ubuntu
         DISTRO_VERSION=18.04

--- a/ci/travis/upload-codecov.sh
+++ b/ci/travis/upload-codecov.sh
@@ -32,6 +32,7 @@ readonly CI_ENV=$(bash <(curl -s https://codecov.io/env))
 readonly IMAGE="cached-${DISTRO}-${DISTRO_VERSION}"
 sudo docker run $CI_ENV \
     --volume $PWD:/v --workdir /v \
-    "${IMAGE}:tip" /bin/bash -c "/bin/bash <(curl -s https://codecov.io/bash)"
+    "${IMAGE}:tip" /bin/bash -c \
+    "/bin/bash <(curl -s https://codecov.io/bash) -g './build-output/ccache/*'"
 
 dump_log codecov.log


### PR DESCRIPTION
This will speed up the code coverage builds. We needed to exclude the
ccache directory when searching for coverage files, there are copies of
the .gcno files there that confuse gcov(1).

With this change the build goes from about 31 minutes:

https://travis-ci.org/coryan/google-cloud-cpp/builds/441745612

To 11 minutes (when the cache is warm):

https://travis-ci.org/coryan/google-cloud-cpp/builds/441766089

This is the longest build on Travis, so it reduces the latency for all PRs.
