### PR TITLE
Make dependency versions configurable.

### DIFF
--- a/cmake/external/c-ares.cmake
+++ b/cmake/external/c-ares.cmake
@@ -15,6 +15,13 @@
 # ~~~
 
 if (NOT TARGET c_ares_project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(GOOGLE_CLOUD_CPP_C_ARES_URL
+        "https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz")
+    set(GOOGLE_CLOUD_CPP_C_ARES_SHA256
+        "62dd12f0557918f89ad6f5b759f0bf4727174ae9979499f5452c02be38d9d3e8")
+
     if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
         OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
         include(ProcessorCount)
@@ -30,9 +37,8 @@ if (NOT TARGET c_ares_project)
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/c-ares"
         INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
-        URL https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
-        URL_HASH
-            SHA256=62dd12f0557918f89ad6f5b759f0bf4727174ae9979499f5452c02be38d9d3e8
+        URL ${GOOGLE_CLOUD_CPP_C_ARES_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_C_ARES_SHA256}
         CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
                    -DCMAKE_BUILD_TYPE=Release
                    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -18,6 +18,13 @@ include(external/c-ares)
 include(external/protobuf)
 
 if (NOT TARGET gprc_project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(GOOGLE_CLOUD_CPP_GRPC_URL
+        "https://github.com/grpc/grpc/archive/v1.14.1.tar.gz")
+    set(GOOGLE_CLOUD_CPP_GRPC_SHA256
+        "16f22430210abf92e06626a5a116e114591075e5854ac78f1be8564171658b70")
+
     if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
         OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
         include(ProcessorCount)
@@ -34,9 +41,8 @@ if (NOT TARGET gprc_project)
         EXCLUDE_FROM_ALL ON
         PREFIX "external/grpc"
         INSTALL_DIR "external"
-        URL https://github.com/grpc/grpc/archive/v1.14.1.tar.gz
-        URL_HASH
-            SHA256=16f22430210abf92e06626a5a116e114591075e5854ac78f1be8564171658b70
+        URL ${GOOGLE_CLOUD_CPP_GRPC_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GRPC_SHA256}
         CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
                    -DCMAKE_BUILD_TYPE=Release
                    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -15,6 +15,13 @@
 # ~~~
 
 if (NOT TARGET protobuf_project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(GOOGLE_CLOUD_CPP_PROTOBUF_URL
+        "https://github.com/google/protobuf/archive/v3.5.2.tar.gz")
+    set(GOOGLE_CLOUD_CPP_PROTOBUF_SHA256
+        "4ffd420f39f226e96aebc3554f9c66a912f6cad6261f39f194f16af8a1f6dab2")
+
     if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
         OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
         include(ProcessorCount)
@@ -30,9 +37,8 @@ if (NOT TARGET protobuf_project)
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/protobuf"
         INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
-        URL https://github.com/google/protobuf/archive/v3.5.2.tar.gz
-        URL_HASH
-            SHA256=4ffd420f39f226e96aebc3554f9c66a912f6cad6261f39f194f16af8a1f6dab2
+        URL ${GOOGLE_CLOUD_CPP_PROTOBUF_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_PROTOBUF_SHA256}
         CONFIGURE_COMMAND ${CMAKE_COMMAND}
                           -G${CMAKE_GENERATOR}
                           ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}


### PR DESCRIPTION
This fixes #1009. It makes it possible for users to configure the
version of each dependency when compiling with external projects:

```
cmake -H. -Bbuild-outpout \
   -DGOOGLE_CLOUD_CPP_GRPC_VERSION=... \
   -DGOOGLE_CLOUD_CPP_GRPC_SHA256=...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1296)
<!-- Reviewable:end -->
