### PR TITLE
Fix size_t -> int conversion warning.

### DIFF
--- a/google/cloud/storage/internal/openssl_util.h
+++ b/google/cloud/storage/internal/openssl_util.h
@@ -101,7 +101,7 @@ struct OpenSslUtils {
 
     auto pem_buffer = std::unique_ptr<BIO, decltype(&BIO_free)>(
         BIO_new_mem_buf(const_cast<char*>(pem_contents.c_str()),
-                        pem_contents.length()),
+                        static_cast<int>(pem_contents.length())),
         &BIO_free);
     if (not pem_buffer) handle_openssl_failure("Could not create PEM buffer.");
 


### PR DESCRIPTION
MSVC warns about implicit conversions from `std::size_t` to `int`, as
`int` may not be large enough to fit a `std::size_t`. In this case
we "know" it fits because all the platforms we support have `int` with
at least 32 bits, and the data is not likely to exceed a few MiB, much
less INT_MAX.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1298)
<!-- Reviewable:end -->
