### PR TITLE
Fix warnings about sscanf().

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -225,6 +225,19 @@ target_include_directories(storage_client
                                   $<INSTALL_INTERFACE:include>)
 target_compile_options(storage_client
                        PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+if (MSVC)
+    # MSVC warns about using sscanf(), this is a valuable warning, so we do not
+    # want to disable for everything. But for these files the usage is "safe".
+    # This is a relatively obscure feature to add compile flags to just one
+    # source:
+    set_property(SOURCE internal/parse_rfc3339.cc
+                 APPEND_STRING
+                 PROPERTY COMPILE_DEFINITIONS "_CRT_SECURE_NO_WARNINGS")
+    set_property(SOURCE internal/object_requests.cc
+                 APPEND_STRING
+                 PROPERTY COMPILE_DEFINITIONS "_CRT_SECURE_NO_WARNINGS")
+endif ()
+
 set_target_properties(
     storage_client
     PROPERTIES


### PR DESCRIPTION
MSVC warns about using `sscanf()` because it can be unsafe. We are (I
believe) using it in a safe way, but I do not want to disable the
warning for all files. First because we might use it unsafely in a
future file, and second because the macro used to disable this warning
disables a lot more than just `sscanf()` warnings. So make a very targeted
removal of the warning only in the files where it is relevant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1301)
<!-- Reviewable:end -->
