### PR TITLE
Simulate hash failures

### DIFF
--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -978,6 +978,7 @@ std::pair<Status, ObjectMetadata> CurlClient::InsertObjectMediaXml(
   // to the XML format for them.
   //
   // Fields cannot be set, checked by the caller.
+  builder.AddOption(request.GetOption<CustomHeader>());
   builder.AddOption(request.GetOption<IfMatchEtag>());
   builder.AddOption(request.GetOption<IfNoneMatchEtag>());
   // QuotaUser cannot be set, checked by the caller.
@@ -1007,7 +1008,7 @@ CurlClient::ReadObjectXml(ReadObjectRangeRequest const& request) {
   builder.AddHeader("Host: storage.googleapis.com");
 
   //
-  // Apply the options from InsertObjectMediaRequest that are set, translating
+  // Apply the options from ReadObjectMediaRequest that are set, translating
   // to the XML format for them.
   //
   builder.AddOption(request.GetOption<EncryptionKey>());
@@ -1030,6 +1031,7 @@ CurlClient::ReadObjectXml(ReadObjectRangeRequest const& request) {
   // Apply the options from GenericRequestBase<> that are set, translating
   // to the XML format for them.
   //
+  builder.AddOption(request.GetOption<CustomHeader>());
   builder.AddOption(request.GetOption<IfMatchEtag>());
   builder.AddOption(request.GetOption<IfNoneMatchEtag>());
   // QuotaUser cannot be set, checked by the caller.
@@ -1091,6 +1093,7 @@ CurlClient::WriteObjectXml(InsertObjectStreamingRequest const& request) {
   // to the XML format for them.
   //
   // Fields cannot be set, checked by the caller.
+  builder.AddOption(request.GetOption<CustomHeader>());
   builder.AddOption(request.GetOption<IfMatchEtag>());
   builder.AddOption(request.GetOption<IfNoneMatchEtag>());
   // QuotaUser cannot be set, checked by the caller.

--- a/google/cloud/storage/internal/curl_request_builder.h
+++ b/google/cloud/storage/internal/curl_request_builder.h
@@ -102,6 +102,14 @@ class CurlRequestBuilder {
     return *this;
   }
 
+  /// Adds a custom header to the request.
+  CurlRequestBuilder& AddOption(CustomHeader const& p) {
+    if (p.has_value()) {
+      AddHeader(p.custom_header_name() + ": " + p.value());
+    }
+    return *this;
+  }
+
   /// Adds one of the well-known encryption header groups to the request.
   CurlRequestBuilder& AddOption(EncryptionKey const& p) {
     if (p.has_value()) {

--- a/google/cloud/storage/internal/generic_request.h
+++ b/google/cloud/storage/internal/generic_request.h
@@ -176,10 +176,10 @@ class GenericRequestBase : public GenericRequestBase<Derived, Options...> {
  */
 template <typename Derived, typename... Options>
 class GenericRequest
-    : public GenericRequestBase<Derived, Fields, IfMatchEtag, IfNoneMatchEtag,
-                                QuotaUser, Options...> {
+    : public GenericRequestBase<Derived, CustomHeader, Fields, IfMatchEtag,
+                                IfNoneMatchEtag, QuotaUser, Options...> {
  public:
-  using Super = GenericRequestBase<Derived, Fields, IfMatchEtag,
+  using Super = GenericRequestBase<Derived, CustomHeader, Fields, IfMatchEtag,
                                    IfNoneMatchEtag, QuotaUser, Options...>;
 
   template <typename H, typename... T>

--- a/google/cloud/storage/testbench/gcs_object.py
+++ b/google/cloud/storage/testbench/gcs_object.py
@@ -44,6 +44,9 @@ class GcsObjectVersion(object):
         now = time.gmtime(time.time())
         timestamp = time.strftime('%Y-%m-%dT%H:%M:%SZ', now)
         self.media = media
+        instructions = request.headers.get('x-goog-testbench-instructions')
+        if instructions == 'inject-upload-data-error':
+            self.media = testbench_utils.corrupt_media(media)
 
         self.metadata = {
             'timeCreated': timestamp,

--- a/google/cloud/storage/testbench/testbench.py
+++ b/google/cloud/storage/testbench/testbench.py
@@ -971,8 +971,13 @@ def objects_get(bucket_name, object_name):
     if media != 'media':
         raise error_response.ErrorResponse('Invalid alt=%s parameter' % media)
     revision.validate_encryption_for_read(flask.request)
-    response = flask.make_response(revision.media)
-    length = len(revision.media)
+    instructions = flask.request.headers.get('x-goog-testbench-instructions')
+    if instructions == 'return-corrupted-data':
+        response_payload = testbench_utils.corrupt_media(revision.media)
+    else:
+        response_payload = revision.media
+    response = flask.make_response(response_payload)
+    length = len(response_payload)
     response.headers['Content-Range'] = 'bytes 0-%d/%d' % (length - 1, length)
     response.headers['x-goog-hash'] = 'md5=%s' % revision.metadata.get('md5Hash', '')
     return response
@@ -1196,8 +1201,13 @@ def xmlapi_get_object(bucket_name, object_name):
     blob.check_preconditions_by_value(generation_match, None,
                                       metageneration_match, None)
     revision = blob.get_revision(flask.request)
-    response = flask.make_response(revision.media)
-    length = len(revision.media)
+    instructions = flask.request.headers.get('x-goog-testbench-instructions')
+    if instructions == 'return-corrupted-data':
+        response_payload = testbench_utils.corrupt_media(revision.media)
+    else:
+        response_payload = revision.media
+    response = flask.make_response(response_payload)
+    length = len(response_payload)
     response.headers['Content-Range'] = 'bytes 0-%d/%d' % (length - 1, length)
     response.headers['x-goog-hash'] = 'md5=%s' % revision.metadata.get('md5Hash', '')
     return response

--- a/google/cloud/storage/testbench/testbench_utils.py
+++ b/google/cloud/storage/testbench/testbench_utils.py
@@ -229,37 +229,12 @@ def corrupt_media(media):
     :return: a string that is slightly different than media.
     :rtype: str
     """
-    # Deal with the boundary conditions.
-    if media is None or len(media) == 0:
+    # Deal with the boundary condition.
+    if not media:
         return str(random.sample("abcdefghijklmnopqrstuvwxyz", 1))
-
-    if all([media[0] == media[k] for k in range(0, len(media))]):
-        # When all the characters in the source string are identical we need to
-        # generate the random characters from somewhere, but cannot use the
-        # string itself as a source, this is probably Okay.
-        def generator():
-            return random.sample("abcdefghijklmnopqrstuvwxyz", 1)
-    else:
-        # Pick one character from the original string, this is arbitrary, but it
-        # changes the string without introducing new characters.
-        def generator():
-            return random.sample(media, 1)
-
-    result = media
-    while True:
-        tmp = ''
-        for i in range(0, len(result)):
-            # Modify about 0.1% of the characters, this value is arbitrary, but
-            # it is high enough that it will change things, but not so high that
-            # it will change most characters.
-            c = result[i]
-            if random.random() < 0.001:
-                c = generator()
-            tmp = tmp + str(c)
-        result = tmp
-        if result != media:
-            break
-    return result
+    if media[0] == 'A':
+        return 'B' + media[1:]
+    return 'A' + media[1:]
 
 
 # Define the collection of Buckets indexed by <bucket_name>

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(storage_client_integration_tests
     curl_download_request_integration_test.cc
     curl_request_integration_test.cc
     curl_streambuf_integration_test.cc
+    object_media_integration_test.cc
     object_integration_test.cc
     service_account_integration_test.cc
     storage_include_test.cc

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -1,0 +1,257 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/random.h"
+#include "google/cloud/log.h"
+#include "google/cloud/storage/client.h"
+#include "google/cloud/testing_util/init_google_mock.h"
+#include <gmock/gmock.h>
+#include <regex>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+using ::testing::HasSubstr;
+namespace {
+/// Store the project and instance captured from the command-line arguments.
+class ObjectMediaTestEnvironment : public ::testing::Environment {
+ public:
+  ObjectMediaTestEnvironment(std::string project, std::string instance) {
+    project_id_ = std::move(project);
+    bucket_name_ = std::move(instance);
+  }
+
+  static std::string const& project_id() { return project_id_; }
+  static std::string const& bucket_name() { return bucket_name_; }
+
+ private:
+  static std::string project_id_;
+  static std::string bucket_name_;
+};
+
+std::string ObjectMediaTestEnvironment::project_id_;
+std::string ObjectMediaTestEnvironment::bucket_name_;
+
+class ObjectMediaIntegrationTest : public ::testing::Test {
+ protected:
+  std::string MakeRandomObjectName() {
+    return "ob-read-" +
+           google::cloud::internal::Sample(generator_, 32,
+                                           "abcdefghijklmnopqrstuvwxyz"
+                                           "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                           "012456789") +
+           ".txt";
+  }
+
+  std::string LoremIpsum() const {
+    return R"""(Lorem ipsum dolor sit amet, consectetur adipiscing
+elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit
+esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+)""";
+  }
+
+ protected:
+  google::cloud::internal::DefaultPRNG generator_ =
+      google::cloud::internal::MakeDefaultPRNG();
+};
+
+bool UsingTestbench() {
+  return std::getenv("CLOUD_STORAGE_TESTBENCH_ENDPOINT") != nullptr;
+}
+
+/// @test Verify that MD5 hash mismatches are reported by default on downloads.
+TEST_F(ObjectMediaIntegrationTest, MismatchedMD5StreamingReadXML) {
+  if (not UsingTestbench()) {
+    // This test is disabled when not using the testbench as it relies on the
+    // testbench to inject faults.
+    return;
+  }
+  Client client;
+  auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+
+  // Create an object and a stream to read it back.
+  ObjectMetadata meta =
+      client.InsertObject(bucket_name, object_name, LoremIpsum(),
+                          IfGenerationMatch(0), Projection::Full());
+  auto stream = client.ReadObject(
+      bucket_name, object_name,
+      CustomHeader("x-goog-testbench-instructions", "return-corrupted-data"));
+
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(
+      try {
+        std::string actual(std::istreambuf_iterator<char>{stream},
+                           std::istreambuf_iterator<char>{});
+      } catch (HashMismatchError const& ex) {
+        EXPECT_NE(ex.received_hash(), ex.computed_hash());
+        EXPECT_THAT(ex.what(), HasSubstr("mismatched hashes"));
+        throw;
+      },
+      HashMismatchError);
+#else
+  std::string actual(std::istreambuf_iterator<char>{stream}, {});
+  EXPECT_NE(stream.received_hash(), stream.computed_hash());
+  EXPECT_EQ(stream.received_hash(), meta.md5_hash());
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+
+  client.DeleteObject(bucket_name, object_name);
+}
+
+/// @test Verify that MD5 hash mismatches are reported by default on downloads.
+TEST_F(ObjectMediaIntegrationTest, MismatchedMD5StreamingReadJSON) {
+  if (not UsingTestbench()) {
+    // This test is disabled when not using the testbench as it relies on the
+    // testbench to inject faults.
+    return;
+  }
+  Client client;
+  auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+
+  // Create an object and a stream to read it back.
+  ObjectMetadata meta =
+      client.InsertObject(bucket_name, object_name, LoremIpsum(),
+                          IfGenerationMatch(0), Projection::Full());
+  auto stream = client.ReadObject(
+      bucket_name, object_name, IfMetagenerationNotMatch(0),
+      CustomHeader("x-goog-testbench-instructions", "return-corrupted-data"));
+
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(
+      try {
+        std::string actual(std::istreambuf_iterator<char>{stream},
+                           std::istreambuf_iterator<char>{});
+      } catch (HashMismatchError const& ex) {
+        EXPECT_NE(ex.received_hash(), ex.computed_hash());
+        EXPECT_THAT(ex.what(), HasSubstr("mismatched hashes"));
+        throw;
+      },
+      HashMismatchError);
+#else
+  std::string actual(std::istreambuf_iterator<char>{stream}, {});
+  EXPECT_FALSE(stream.received_hash().empty());
+  EXPECT_FALSE(stream.computed_hash().empty());
+  EXPECT_NE(stream.received_hash(), stream.computed_hash());
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+
+  client.DeleteObject(bucket_name, object_name);
+}
+
+/// @test Verify that MD5 hash mismatches are reported by default on downloads.
+TEST_F(ObjectMediaIntegrationTest, MismatchedMD5StreamingWriteXML) {
+  if (not UsingTestbench()) {
+    // This test is disabled when not using the testbench as it relies on the
+    // testbench to inject faults.
+    return;
+  }
+  Client client;
+  auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+
+  // Create a stream to upload an object.
+  ObjectWriteStream stream = client.WriteObject(
+      bucket_name, object_name, IfGenerationMatch(0), Fields(""),
+      CustomHeader("x-goog-testbench-instructions",
+                   "inject-upload-data-error"));
+  stream << LoremIpsum() << "\n";
+  stream << LoremIpsum();
+  std::string md5_hash = ComputeMD5Hash(LoremIpsum() + "\n" + LoremIpsum());
+
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(try { stream.Close(); } catch (HashMismatchError const& ex) {
+    EXPECT_NE(ex.received_hash(), ex.computed_hash());
+    EXPECT_THAT(ex.what(), HasSubstr("ValidateHash"));
+    throw;
+  },
+               HashMismatchError);
+#else
+  stream.Close();
+  EXPECT_FALSE(stream.received_hash().empty());
+  EXPECT_FALSE(stream.computed_hash().empty());
+  EXPECT_NE(stream.received_hash(), stream.computed_hash());
+  EXPECT_EQ(stream.computed_hash(), md5_hash);
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+
+  client.DeleteObject(bucket_name, object_name);
+}
+
+/// @test Verify that MD5 hash mismatches are reported by default on downloads.
+TEST_F(ObjectMediaIntegrationTest, MismatchedMD5StreamingWriteJSON) {
+  if (not UsingTestbench()) {
+    // This test is disabled when not using the testbench as it relies on the
+    // testbench to inject faults.
+    return;
+  }
+  Client client;
+  auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+
+  // Create a stream to upload an object.
+  ObjectWriteStream stream =
+      client.WriteObject(bucket_name, object_name, IfGenerationMatch(0),
+                         CustomHeader("x-goog-testbench-instructions",
+                                      "inject-upload-data-error"));
+  stream << LoremIpsum() << "\n";
+  stream << LoremIpsum();
+  std::string md5_hash = ComputeMD5Hash(LoremIpsum() + "\n" + LoremIpsum());
+
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(try { stream.Close(); } catch (HashMismatchError const& ex) {
+    EXPECT_NE(ex.received_hash(), ex.computed_hash());
+    EXPECT_THAT(ex.what(), HasSubstr("ValidateHash"));
+    throw;
+  },
+               HashMismatchError);
+#else
+  stream.Close();
+  EXPECT_FALSE(stream.received_hash().empty());
+  EXPECT_FALSE(stream.computed_hash().empty());
+  EXPECT_NE(stream.received_hash(), stream.computed_hash());
+  EXPECT_EQ(stream.computed_hash(), md5_hash);
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+
+  client.DeleteObject(bucket_name, object_name);
+}
+
+}  // anonymous namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+int main(int argc, char* argv[]) {
+  google::cloud::testing_util::InitGoogleMock(argc, argv);
+
+  // Make sure the arguments are valid.
+  if (argc != 3) {
+    std::string const cmd = argv[0];
+    auto last_slash = std::string(argv[0]).find_last_of('/');
+    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
+              << " <project-id> <bucket-name>" << std::endl;
+    return 1;
+  }
+
+  std::string const project_id = argv[1];
+  std::string const bucket_name = argv[2];
+  (void)::testing::AddGlobalTestEnvironment(
+      new google::cloud::storage::ObjectMediaTestEnvironment(project_id,
+                                                             bucket_name));
+
+  return RUN_ALL_TESTS();
+}

--- a/google/cloud/storage/tests/run_integration_tests_production.sh
+++ b/google/cloud/storage/tests/run_integration_tests_production.sh
@@ -33,6 +33,10 @@ echo "Running GCS Object APIs integration tests."
 ./object_integration_test "${PROJECT_ID}" "${BUCKET_NAME}"
 
 echo
+echo "Running GCS Object media integration tests."
+./object_media_integration_test "${PROJECT_ID}" "${BUCKET_NAME}"
+
+echo
 echo "Running GCS Projects.serviceAccount integration tests."
 ./thread_integration_test "${PROJECT_ID}" "${STORAGE_REGION_ID}"
 

--- a/google/cloud/storage/tests/run_integration_tests_testbench.sh
+++ b/google/cloud/storage/tests/run_integration_tests_testbench.sh
@@ -58,6 +58,10 @@ echo "Running GCS Object APIs integration tests."
 ./object_integration_test "${PROJECT_ID}" "${BUCKET_NAME}"
 
 echo
+echo "Running GCS Object media integration tests."
+./object_media_integration_test "${PROJECT_ID}" "${BUCKET_NAME}"
+
+echo
 echo "Running GCS multi-threaded integration test."
 ./thread_integration_test "${PROJECT_ID}" "${LOCATION}"
 

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -5,6 +5,7 @@ storage_client_integration_tests = [
     "curl_download_request_integration_test.cc",
     "curl_request_integration_test.cc",
     "curl_streambuf_integration_test.cc",
+    "object_media_integration_test.cc",
     "object_integration_test.cc",
     "service_account_integration_test.cc",
     "storage_include_test.cc",

--- a/google/cloud/storage/well_known_headers.cc
+++ b/google/cloud/storage/well_known_headers.cc
@@ -36,6 +36,13 @@ std::string Sha256AsBase64(std::string const& key) {
 }
 }  // namespace
 
+std::ostream& operator<<(std::ostream& os, CustomHeader const& rhs) {
+  if (not rhs.has_value()) {
+    return os;
+  }
+  return os << rhs.custom_header_name() << ": " << rhs.value();
+}
+
 EncryptionKeyData EncryptionDataFromBinaryKey(std::string const& key) {
   return EncryptionKeyData{"AES256", internal::OpenSslUtils::Base64Encode(key),
                            Sha256AsBase64(key)};

--- a/google/cloud/storage/well_known_headers.h
+++ b/google/cloud/storage/well_known_headers.h
@@ -71,6 +71,28 @@ struct ContentType
 };
 
 /**
+ * An option to inject custom headers into the request.
+ *
+ * In some cases it is necessary to inject a custom header into the request. For
+ * example, because the protocol has added new headers and the library has not
+ * been updated to support them, or because
+ */
+class CustomHeader
+ : public internal::WellKnownHeader<CustomHeader, std::string> {
+ public:
+  CustomHeader() = default;
+  explicit CustomHeader(std::string name, std::string value)
+  : WellKnownHeader(std::move(value)), name_(std::move(name)) {}
+
+  std::string const& custom_header_name() const { return name_; }
+
+ private:
+  std::string name_;
+};
+
+std::ostream& operator<<(std::ostream& os, CustomHeader const& rhs);
+
+/**
  * A pre-condition: apply this operation only if the HTTP Entity Tag matches.
  *
  * [HTTP Entity Tags](https://en.wikipedia.org/wiki/HTTP_ETag) allow

--- a/google/cloud/storage/well_known_headers.h
+++ b/google/cloud/storage/well_known_headers.h
@@ -78,11 +78,11 @@ struct ContentType
  * been updated to support them, or because
  */
 class CustomHeader
- : public internal::WellKnownHeader<CustomHeader, std::string> {
+    : public internal::WellKnownHeader<CustomHeader, std::string> {
  public:
   CustomHeader() = default;
   explicit CustomHeader(std::string name, std::string value)
-  : WellKnownHeader(std::move(value)), name_(std::move(name)) {}
+      : WellKnownHeader(std::move(value)), name_(std::move(name)) {}
 
   std::string const& custom_header_name() const { return name_; }
 

--- a/google/cloud/storage/well_known_headers_test.cc
+++ b/google/cloud/storage/well_known_headers_test.cc
@@ -22,6 +22,15 @@ inline namespace STORAGE_CLIENT_NS {
 namespace {
 using ::testing::HasSubstr;
 
+/// @test Verify that CustomHeader works as expected.
+TEST(WellKnownHeader, CustomHeader) {
+  CustomHeader header("x-goog-testbench-instructions", "do-stuff");
+  std::ostringstream os;
+  os << header;
+  EXPECT_THAT(os.str(), HasSubstr("do-stuff"));
+  EXPECT_THAT(os.str(), HasSubstr("x-goog-testbench-instructions"));
+}
+
 /// @test Verify that EncryptionKey streaming works as expected.
 TEST(WellKnownHeader, EncryptionKey) {
   EncryptionKey header(


### PR DESCRIPTION
This PR introduces new integration tests to verify that data corruption
on both uploads and downloads is detected. Or more precisely, that
mismatches in the MD5 hash are detected (or detectable for builds
without exception).

Use a separate file for this integration tests because the
object_integration_test.cc file is too large already. In a future PR we
will refactor more tests to this new file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1303)
<!-- Reviewable:end -->
