### PR TITLE
Refactor target definitions to cmake/external.

### DIFF
--- a/cmake/IncludeGMock.cmake
+++ b/cmake/IncludeGMock.cmake
@@ -53,51 +53,6 @@ if (TARGET GTest::gmock)
 elseif("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "external")
     include(external/googletest)
 
-    # On Windows GTest uses library postfixes for debug versions, that is
-    # gtest.lib becomes gtestd.lib when compiled with for debugging.  This ugly
-    # expression computes that value. Note that it must be a generator
-    # expression because with MSBuild the config type can change after the
-    # configuration phase.
-    if (WIN32)
-        set(_lib_postfix $<$<CONFIG:DEBUG>:d>)
-    endif ()
-
-    include(ExternalProjectHelper)
-    add_library(GTest::gtest INTERFACE IMPORTED)
-    add_dependencies(GTest::gtest googletest_project)
-    set_library_properties_for_external_project(GTest::gtest
-                                                gtest${_lib_postfix})
-    set_property(TARGET GTest::gtest
-                 APPEND
-                 PROPERTY INTERFACE_LINK_LIBRARIES "Threads::Threads")
-
-    add_library(GTest::gtest_main INTERFACE IMPORTED)
-    add_dependencies(GTest::gtest_main googletest_project)
-    set_library_properties_for_external_project(GTest::gtest_main
-                                                gtest_main${_lib_postfix})
-    set_property(TARGET GTest::gtest_main
-                 APPEND
-                 PROPERTY INTERFACE_LINK_LIBRARIES
-                          "GTest::gtest;Threads::Threads")
-
-    add_library(GTest::gmock INTERFACE IMPORTED)
-    add_dependencies(GTest::gmock googletest_project)
-    set_library_properties_for_external_project(GTest::gmock
-                                                gmock${_lib_postfix})
-    set_property(TARGET GTest::gmock
-                 APPEND
-                 PROPERTY INTERFACE_LINK_LIBRARIES
-                          "GTest::gtest;Threads::Threads")
-
-    add_library(GTest::gmock_main INTERFACE IMPORTED)
-    add_dependencies(GTest::gmock_main googletest_project)
-    set_library_properties_for_external_project(GTest::gmock_main
-                                                gmock_main${_lib_postfix})
-    set_property(TARGET GTest::gmock_main
-                 APPEND
-                 PROPERTY INTERFACE_LINK_LIBRARIES
-                          "GTest::gmock;GTest::gtest;Threads::Threads")
-
 elseif("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "vcpkg")
     find_package(GTest REQUIRED)
 

--- a/cmake/IncludeGrpc.cmake
+++ b/cmake/IncludeGrpc.cmake
@@ -51,70 +51,7 @@ set(GOOGLE_CLOUD_CPP_MSVC_COMPILE_OPTIONS
     /wd4996)
 
 if ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "external")
-    include(external/protobuf)
     include(external/grpc)
-
-    include(ExternalProjectHelper)
-    add_library(protobuf::libprotobuf INTERFACE IMPORTED)
-    add_dependencies(protobuf::libprotobuf protobuf_project)
-    set_library_properties_for_external_project(protobuf::libprotobuf protobuf)
-    find_package(ZLIB REQUIRED)
-    set_property(TARGET protobuf::libprotobuf
-                 APPEND
-                 PROPERTY INTERFACE_LINK_LIBRARIES
-                          protobuf::libprotobuf
-                          ZLIB::ZLIB
-                          Threads::Threads)
-
-    add_library(c-ares::cares INTERFACE IMPORTED)
-    set_library_properties_for_external_project(c-ares::cares cares
-                                                ALWAYS_SHARED)
-    add_dependencies(c-ares::cares c_ares_project)
-
-    find_package(OpenSSL REQUIRED)
-
-    add_library(gRPC::address_sorting INTERFACE IMPORTED)
-    set_library_properties_for_external_project(gRPC::address_sorting
-                                                address_sorting)
-    add_dependencies(gRPC::address_sorting grpc_project)
-
-    add_library(gRPC::gpr INTERFACE IMPORTED)
-    set_library_properties_for_external_project(gRPC::gpr gpr)
-    add_dependencies(gRPC::gpr grpc_project)
-    set_property(TARGET gRPC::gpr
-                 APPEND
-                 PROPERTY INTERFACE_LINK_LIBRARIES c-ares::cares)
-
-    add_library(gRPC::grpc INTERFACE IMPORTED)
-    set_library_properties_for_external_project(gRPC::grpc grpc)
-    add_dependencies(gRPC::grpc grpc_project)
-    set_property(TARGET gRPC::grpc
-                 APPEND
-                 PROPERTY INTERFACE_LINK_LIBRARIES
-                          gRPC::address_sorting
-                          gRPC::gpr
-                          OpenSSL::SSL
-                          OpenSSL::Crypto
-                          protobuf::libprotobuf)
-
-    add_library(gRPC::grpc++ INTERFACE IMPORTED)
-    set_library_properties_for_external_project(gRPC::grpc++ grpc++)
-    add_dependencies(gRPC::grpc++ grpc_project)
-    set_property(TARGET gRPC::grpc++
-                 APPEND
-                 PROPERTY INTERFACE_LINK_LIBRARIES gRPC::grpc c-ares::cares)
-
-    # Discover the protobuf compiler and the gRPC plugin.
-    add_executable(protoc IMPORTED)
-    add_dependencies(protoc protobuf_project)
-    set_executable_name_for_external_project(protoc protoc)
-
-    add_executable(grpc_cpp_plugin IMPORTED)
-    add_dependencies(grpc_cpp_plugin grpc_project)
-    set_executable_name_for_external_project(grpc_cpp_plugin grpc_cpp_plugin)
-
-    list(APPEND PROTOBUF_IMPORT_DIRS "${PROJECT_BINARY_DIR}/external/include")
-
 elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" MATCHES "^(package|vcpkg)$")
     find_package(protobuf REQUIRED protobuf>=3.5.2)
     find_package(gRPC REQUIRED gRPC>=1.9)

--- a/cmake/external/c-ares.cmake
+++ b/cmake/external/c-ares.cmake
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ~~~
 
+include(ExternalProjectHelper)
+
 if (NOT TARGET c_ares_project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
@@ -54,4 +56,9 @@ if (NOT TARGET c_ares_project)
         LOG_CONFIGURE ON
         LOG_BUILD ON
         LOG_INSTALL ON)
+
+    add_library(c-ares::cares INTERFACE IMPORTED)
+    set_library_properties_for_external_project(c-ares::cares cares
+                                                ALWAYS_SHARED)
+    add_dependencies(c-ares::cares c_ares_project)
 endif ()

--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ~~~
 
+include(ExternalProjectHelper)
+
 if (NOT TARGET googletest_project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
@@ -56,4 +58,49 @@ if (NOT TARGET googletest_project)
         LOG_CONFIGURE ON
         LOG_BUILD ON
         LOG_INSTALL ON)
+
+    # On Windows GTest uses library postfixes for debug versions, that is
+    # gtest.lib becomes gtestd.lib when compiled with for debugging.  This ugly
+    # expression computes that value. Note that it must be a generator
+    # expression because with MSBuild the config type can change after the
+    # configuration phase.
+    if (WIN32)
+        set(_lib_postfix $<$<CONFIG:DEBUG>:d>)
+    endif ()
+
+    add_library(GTest::gtest INTERFACE IMPORTED)
+    add_dependencies(GTest::gtest googletest_project)
+    set_library_properties_for_external_project(GTest::gtest
+                                                gtest${_lib_postfix})
+    set_property(TARGET GTest::gtest
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES "Threads::Threads")
+
+    add_library(GTest::gtest_main INTERFACE IMPORTED)
+    add_dependencies(GTest::gtest_main googletest_project)
+    set_library_properties_for_external_project(GTest::gtest_main
+                                                gtest_main${_lib_postfix})
+    set_property(TARGET GTest::gtest_main
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES
+                          "GTest::gtest;Threads::Threads")
+
+    add_library(GTest::gmock INTERFACE IMPORTED)
+    add_dependencies(GTest::gmock googletest_project)
+    set_library_properties_for_external_project(GTest::gmock
+                                                gmock${_lib_postfix})
+    set_property(TARGET GTest::gmock
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES
+                          "GTest::gtest;Threads::Threads")
+
+    add_library(GTest::gmock_main INTERFACE IMPORTED)
+    add_dependencies(GTest::gmock_main googletest_project)
+    set_library_properties_for_external_project(GTest::gmock_main
+                                                gmock_main${_lib_postfix})
+    set_property(TARGET GTest::gmock_main
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES
+                          "GTest::gmock;GTest::gtest;Threads::Threads")
+
 endif ()

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ~~~
 
+include(ExternalProjectHelper)
 include(external/c-ares)
 include(external/protobuf)
 
@@ -71,4 +72,48 @@ if (NOT TARGET gprc_project)
         LOG_CONFIGURE ON
         LOG_BUILD ON
         LOG_INSTALL ON)
+
+    find_package(OpenSSL REQUIRED)
+
+    add_library(gRPC::address_sorting INTERFACE IMPORTED)
+    set_library_properties_for_external_project(gRPC::address_sorting
+                                                address_sorting)
+    add_dependencies(gRPC::address_sorting grpc_project)
+
+    add_library(gRPC::gpr INTERFACE IMPORTED)
+    set_library_properties_for_external_project(gRPC::gpr gpr)
+    add_dependencies(gRPC::gpr grpc_project)
+    set_property(TARGET gRPC::gpr
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES c-ares::cares)
+
+    add_library(gRPC::grpc INTERFACE IMPORTED)
+    set_library_properties_for_external_project(gRPC::grpc grpc)
+    add_dependencies(gRPC::grpc grpc_project)
+    set_property(TARGET gRPC::grpc
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES
+                          gRPC::address_sorting
+                          gRPC::gpr
+                          OpenSSL::SSL
+                          OpenSSL::Crypto
+                          protobuf::libprotobuf)
+
+    add_library(gRPC::grpc++ INTERFACE IMPORTED)
+    set_library_properties_for_external_project(gRPC::grpc++ grpc++)
+    add_dependencies(gRPC::grpc++ grpc_project)
+    set_property(TARGET gRPC::grpc++
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES gRPC::grpc c-ares::cares)
+
+    # Discover the protobuf compiler and the gRPC plugin.
+    add_executable(protoc IMPORTED)
+    add_dependencies(protoc protobuf_project)
+    set_executable_name_for_external_project(protoc protoc)
+
+    add_executable(grpc_cpp_plugin IMPORTED)
+    add_dependencies(grpc_cpp_plugin grpc_project)
+    set_executable_name_for_external_project(grpc_cpp_plugin grpc_cpp_plugin)
+
+    list(APPEND PROTOBUF_IMPORT_DIRS "${PROJECT_BINARY_DIR}/external/include")
 endif ()

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -14,6 +14,9 @@
 # limitations under the License.
 # ~~~
 
+include(ExternalProjectHelper)
+find_package(Threads REQUIRED)
+
 if (NOT TARGET protobuf_project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
@@ -62,4 +65,15 @@ if (NOT TARGET protobuf_project)
         LOG_CONFIGURE ON
         LOG_BUILD ON
         LOG_INSTALL ON)
+
+    add_library(protobuf::libprotobuf INTERFACE IMPORTED)
+    add_dependencies(protobuf::libprotobuf protobuf_project)
+    set_library_properties_for_external_project(protobuf::libprotobuf protobuf)
+    find_package(ZLIB REQUIRED)
+    set_property(TARGET protobuf::libprotobuf
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES
+                          protobuf::libprotobuf
+                          ZLIB::ZLIB
+                          Threads::Threads)
 endif ()


### PR DESCRIPTION
When using external projects it makes more sense to define the targets
in the same place where we define the external project. This is (I think)
more readable and easier to maintain. Part of the changes for #1248.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1310)
<!-- Reviewable:end -->
