### PR TITLE
Add crc32c dependency

### DIFF
--- a/bazel/crc32c.BUILD
+++ b/bazel/crc32c.BUILD
@@ -1,0 +1,135 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # BSD
+
+crc32c_arm64_HDRS = [
+    "src/crc32c_arm64.h",
+]
+
+crc32c_arm64_SRCS = [
+    "src/crc32c_arm64.cc",
+]
+
+crc32c_sse42_HDRS = [
+    "src/crc32c_sse42.h",
+]
+
+crc32c_sse42_SRCS = [
+    "src/crc32c_sse42.cc",
+]
+
+crc32c_HDRS = [
+    "src/crc32c_arm64.h",
+    "src/crc32c_arm64_linux_check.h",
+    "src/crc32c_internal.h",
+    "src/crc32c_prefetch.h",
+    "src/crc32c_read_le.h",
+    "src/crc32c_round_up.h",
+    "src/crc32c_sse42.h",
+    "src/crc32c_sse42_check.h",
+    "include/crc32c/crc32c.h",
+]
+
+crc32c_SRCS = [
+    "src/crc32c_portable.cc",
+    "src/crc32c.cc",
+]
+
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_x86_64",
+    values = {"cpu": "k8"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "darwin",
+    values = {"cpu": "darwin"},
+    visibility = ["//visibility:public"],
+)
+
+sse42_copts = select({
+    ":windows": ["/arch:AVX"],
+    ":linux_x86_64": ["-msse4.2"],
+    ":darwin": ["-msse4.2"],
+    "//conditions:default": [],
+})
+
+sse42_enabled = select({
+    ":windows": "1",
+    ":linux_x86_64": "1",
+    ":darwin": "1",
+    "//conditions:default": "0",
+})
+
+genrule(
+    name = "generate_config",
+    srcs = ["src/crc32c_config.h.in"],
+    outs = ["crc32c/crc32c_config.h"],
+    cmd = """
+sed -e 's/#cmakedefine01/#define/' \
+    -e 's/ BYTE_ORDER_BIG_ENDIAN/ BYTE_ORDER_BIG_ENDIAN 0/' \
+    -e 's/ HAVE_BUILTIN_PREFETCH/ HAVE_BUILTIN_PREFETCH 0/' \
+    -e 's/ HAVE_MM_PREFETCH/ HAVE_MM_PREFETCH 0/' \
+    -e 's/ HAVE_SSE42/ HAVE_SSE42 1/' \
+    -e 's/ HAVE_ARM64_CRC32C/ HAVE_ARM64_CRC32C 0/' \
+    -e 's/ HAVE_STRONG_GETAUXVAL/ HAVE_STRONG_GETAUXVAL 0/' \
+    -e 's/ HAVE_WEAK_GETAUXVAL/ HAVE_WEAK_GETAUXVAL 0/' \
+    -e 's/ CRC32C_TESTS_BUILT_WITH_GLOG/ CRC32C_TESTS_BUILT_WITH_GLOG 0/' \
+    < $< > $@
+""",
+)
+
+cc_library(
+    name = "crc32c",
+    srcs = crc32c_SRCS + crc32c_sse42_SRCS + crc32c_arm64_SRCS,
+    hdrs = crc32c_HDRS + ["crc32c/crc32c_config.h"],
+    deps = [],
+    includes = ["include"],
+    copts = sse42_copts,
+)
+
+crc32c_test_sources = [
+    "src/crc32c_arm64_unittest.cc",
+    "src/crc32c_extend_unittests.h",
+    "src/crc32c_portable_unittest.cc",
+    "src/crc32c_prefetch_unittest.cc",
+    "src/crc32c_read_le_unittest.cc",
+    "src/crc32c_round_up_unittest.cc",
+    "src/crc32c_sse42_unittest.cc",
+    "src/crc32c_unittest.cc",
+    "src/crc32c_test_main.cc",
+]
+
+cc_test(
+    name = "crc32c_test",
+    srcs = crc32c_test_sources,
+    deps = [
+        ":crc32c",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+exports_files([
+    "LICENSE",
+])

--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -78,6 +78,18 @@ def google_cloud_cpp_deps():
             sha256 = "fbdfec4b4cf63b3b565d09f87e6c3c183bdd45c5be1864d3fcb338f6f02c1733",
         )
 
+    # Load google/crc32c, a library to efficiently compute CRC32C checksums.
+    if "com_github_google_crc32c" not in native.existing_rules():
+        native.new_http_archive(
+            name = "com_github_google_crc32c",
+            strip_prefix = "crc32c-1.0.5",
+            urls = [
+                "https://github.com/google/crc32c/archive/1.0.5.tar.gz",
+            ],
+            sha256 = "c2c0dcc8d155a6a56cc8d56bc1413e076aa32c35784f4d457831e8ccebd9260b",
+            build_file = "@com_github_googlecloudplatform_google_cloud_cpp//bazel:crc32c.BUILD",
+        )
+
     # We use the cc_proto_library() rule from @com_google_protobuf, which
     # assumes that grpc_cpp_plugin and grpc_lib are in the //external: module
     native.bind(

--- a/ci/appveyor/build-windows.ps1
+++ b/ci/appveyor/build-windows.ps1
@@ -42,6 +42,8 @@ if ($env:PROVIDER -eq "vcpkg") {
     }
 
     $cmake_flags += "-DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=$env:PROVIDER"
+    # As of 2018-10-19 the vcpkg port of google/crc32c does not work, workaround that for now.
+    $cmake_flags += "-DGOOGLE_CLOUD_CPP_CRC32C_PROVIDER=external"
     $cmake_flags += "-DCMAKE_TOOLCHAIN_FILE=`"$dir\vcpkg\scripts\buildsystems\vcpkg.cmake`""
     $cmake_flags += "-DVCPKG_TARGET_TRIPLET=x64-windows-static"
     $cmake_flags += "-DCMAKE_C_COMPILER=cl.exe"

--- a/ci/appveyor/install-windows.ps1
+++ b/ci/appveyor/install-windows.ps1
@@ -79,7 +79,7 @@ if ($LastExitCode) {
 $packages = @("zlib:x64-windows-static", "openssl:x64-windows-static",
               "protobuf:x64-windows-static", "c-ares:x64-windows-static",
               "grpc:x64-windows-static", "curl:x64-windows-static",
-              "gtest:x64-windows-static")
+              "gtest:x64-windows-static", "crc32c:x64-windows-static")
 foreach ($pkg in $packages) {
     .\vcpkg.exe install $pkg
     if ($LastExitCode) {

--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -37,6 +37,23 @@ fi
 
 ccache_command="$(which ccache)"
 
+function install_crc32c {
+  # Install googletest.
+  echo "${COLOR_YELLOW}Installing Crc32c $(date)${COLOR_RESET}"
+  wget -q https://github.com/google/crc32c/archive/1.0.5.tar.gz
+  tar -xf 1.0.5.tar.gz
+  cd crc32c-1.0.5
+  env CXX="${cached_cxx}" CC="${cached_cc}"  cmake \
+      -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+      -DCRC32C_BUILD_TESTS=OFF \
+      -DCRC32C_BUILD_BENCHMARKS=OFF \
+      -DCRC32C_USE_GLOG=OFF \
+      ${CMAKE_FLAGS} \
+      -H. -B.build/crc32c
+  cmake --build .build/crc32c --target install -- -j ${NCPU}
+  ldconfig
+}
+
 function install_protobuf {
   # Install protobuf using CMake.  Some distributions include protobuf, gRPC
   # requires 3.4.x or newer, and many of those distribution use older versions.
@@ -129,6 +146,7 @@ if [ "${TEST_INSTALL:-}" = "yes" -o "${SCAN_BUILD:-}" = "yes" ]; then
     cached_cxx="${ccache_command} ${CXX}"
     cached_cc="${ccache_command} ${CC}"
   fi
+  (cd /var/tmp/build-dependencies; install_crc32c)
   (cd /var/tmp/build-dependencies; install_protobuf)
   (cd /var/tmp/build-dependencies; install_c_ares)
   (cd /var/tmp/build-dependencies; install_grpc)

--- a/cmake/IncludeCrc32c.cmake
+++ b/cmake/IncludeCrc32c.cmake
@@ -19,9 +19,9 @@ find_package(Threads REQUIRED)
 
 # Configure the gRPC dependency, this can be found as a submodule, package, or
 # installed with pkg-config support.
-set(GOOGLE_CLOUD_CPP_GRPC_PROVIDER ${GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER}
-    CACHE STRING "How to find the gRPC library")
-set_property(CACHE GOOGLE_CLOUD_CPP_GRPC_PROVIDER
+set(GOOGLE_CLOUD_CPP_CRC32C_PROVIDER ${GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER}
+    CACHE STRING "How to find the Crc32c library")
+set_property(CACHE GOOGLE_CLOUD_CPP_CRC32C_PROVIDER
              PROPERTY STRINGS
                       "external"
                       "package"
@@ -30,8 +30,8 @@ set_property(CACHE GOOGLE_CLOUD_CPP_GRPC_PROVIDER
 
 if (TARGET Crc32c::crc32c)
     # Crc32c::crc32c is already defined, do not define it again.
-elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "external")
+elseif("${GOOGLE_CLOUD_CPP_CRC32C_PROVIDER}" STREQUAL "external")
     include(external/crc32c)
-elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" MATCHES "^(package|vcpkg)$")
+elseif("${GOOGLE_CLOUD_CPP_CRC32C_PROVIDER}" MATCHES "^(package|vcpkg)$")
     find_package(Crc32c CONFIG REQUIRED)
 endif ()

--- a/cmake/IncludeCrc32c.cmake
+++ b/cmake/IncludeCrc32c.cmake
@@ -1,0 +1,37 @@
+# ~~~
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+# gRPC always requires thread support.
+find_package(Threads REQUIRED)
+
+# Configure the gRPC dependency, this can be found as a submodule, package, or
+# installed with pkg-config support.
+set(GOOGLE_CLOUD_CPP_GRPC_PROVIDER ${GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER}
+    CACHE STRING "How to find the gRPC library")
+set_property(CACHE GOOGLE_CLOUD_CPP_GRPC_PROVIDER
+             PROPERTY STRINGS
+                      "external"
+                      "package"
+                      "vcpkg"
+                      "pkg-config")
+
+if (TARGET Crc32c::crc32c)
+    # Crc32c::crc32c is already defined, do not define it again.
+elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "external")
+    include(external/crc32c)
+elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" MATCHES "^(package|vcpkg)$")
+    find_package(Crc32c CONFIG REQUIRED)
+endif ()

--- a/cmake/external/crc32c.cmake
+++ b/cmake/external/crc32c.cmake
@@ -1,0 +1,66 @@
+# ~~~
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+if (NOT TARGET crc32c_project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(GOOGLE_CLOUD_CPP_CRC32C_URL
+        "https://github.com/google/crc32c/archive/1.0.5.tar.gz")
+    set(GOOGLE_CLOUD_CPP_CRC32C_SHA256
+        "c2c0dcc8d155a6a56cc8d56bc1413e076aa32c35784f4d457831e8ccebd9260b")
+
+    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
+        OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
+        include(ProcessorCount)
+        processorcount(NCPU)
+        set(PARALLEL "--" "-j" "${NCPU}")
+    else()
+        set(PARALLEL "")
+    endif ()
+
+    include(ExternalProject)
+    externalproject_add(
+        crc32c_project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/crc32c"
+        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
+        URL ${GOOGLE_CLOUD_CPP_CRC32C_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_CRC32C_SHA256}
+        CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+                   -DCMAKE_BUILD_TYPE=Release
+                   -DCRC32C_BUILD_TESTS=OFF
+                   -DCRC32C_BUILD_BENCHMARKS=OFF
+                   -DCRC32C_USE_GLOG=OFF
+                   -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                   -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
+        BUILD_COMMAND ${CMAKE_COMMAND}
+                      --build
+                      <BINARY_DIR>
+                      ${PARALLEL}
+        BUILD_BYPRODUCTS
+            <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}crc32c${CMAKE_STATIC_LIBRARY_SUFFIX}
+            <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}crc32c${CMAKE_SHARED_LIBRARY_SUFFIX}
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+
+    include(ExternalProjectHelper)
+    add_library(Crc32c::crc32c INTERFACE IMPORTED)
+    add_dependencies(Crc32c::crc32c crc32c_project)
+    set_library_properties_for_external_project(Crc32c::crc32c crc32c)
+endif ()

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -38,6 +38,7 @@ set(DOXYGEN_EXCLUDE_PATTERNS
 
 include(GoogleCloudCppCommon)
 include(IncludeNlohmannJson)
+include(IncludeCrc32c)
 
 # Generate the version information from the CMake values.
 configure_file(version_info.h.in version_info.h)


### PR DESCRIPTION
This will be used (obviously) to implement the CRC32C checksums,
just like we compute MD5 hashes.  Also, note how easy it is to
incorporate a properly packaged library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1312)
<!-- Reviewable:end -->
