### PR TITLE
Refactor endian byteswap

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(google_cloud_cpp_common
             iam_policy.cc
             internal/backoff_policy.h
             internal/backoff_policy.cc
+            internal/big_endian.h
             internal/build_info.h
             ${CMAKE_CURRENT_BINARY_DIR}/internal/build_info.cc
             internal/getenv.h
@@ -130,6 +131,7 @@ create_bazel_config(google_cloud_cpp_testing)
 set(google_cloud_cpp_common_unit_tests
     iam_bindings_test.cc
     internal/backoff_policy_test.cc
+    internal/big_endian_test.cc
     internal/random_test.cc
     internal/invoke_result_test.cc
     internal/retry_policy_test.cc

--- a/google/cloud/bigtable/internal/endian.cc
+++ b/google/cloud/bigtable/internal/endian.cc
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/internal/endian.h"
+#include "google/cloud/internal/big_endian.h"
 #include "google/cloud/internal/throw_delegate.h"
-#include <cstring>
-#include <limits>
 
 #ifdef _MSC_VER
 #include <stdlib.h>
@@ -31,11 +30,6 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
 
-constexpr char ENDIAN_DETECTOR[sizeof(int)] = {1};
-constexpr bool IsBigEndian() {
-  return ENDIAN_DETECTOR[0] != 1;  // ignore different type comparison
-}
-
 /**
  * Convert BigEndian numeric value into a string of bytes and return it.
  */
@@ -46,7 +40,7 @@ std::string Encoder<bigtable::bigendian64_t>::Encode(
                 "This code assumes char is an 8-bit number");
 
   char big_endian_buffer[sizeof(bigtable::bigendian64_t) + 1] = "";
-  if (IsBigEndian()) {
+  if (google::cloud::internal::IsBigEndian()) {
     std::memcpy(&big_endian_buffer, &value, sizeof(value));
   } else {
     bigtable::bigendian64_t swapped_value = ByteSwap64(value);
@@ -69,33 +63,15 @@ bigtable::bigendian64_t Encoder<bigtable::bigendian64_t>::Decode(
   bigtable::bigendian64_t big_endian_value(0);
   std::memcpy(&big_endian_value, value.c_str(),
               sizeof(bigtable::bigendian64_t));
-  if (!IsBigEndian()) {
+  if (!google::cloud::internal::IsBigEndian()) {
     big_endian_value = ByteSwap64(big_endian_value);
   }
   return big_endian_value;
 }
 
 inline bigtable::bigendian64_t ByteSwap64(bigtable::bigendian64_t value) {
-#ifdef _MSC_VER
-  return bigtable::bigendian64_t(_byteswap_uint64(value.get()));
-#elif defined(__APPLE__)
-  return bigtable::bigendian64_t(OSSwapInt64(value.get()));
-#elif defined(__GNUC__) || defined(__clang__)
-  return bigtable::bigendian64_t(__builtin_bswap64(value.get()));
-#else
-  std::int64_t num_value = value.get();
-
-  std::int64_t return_value = ((((num_value)&0xff00000000000000ull) >> 56) |
-                               (((num_value)&0x00ff000000000000ull) >> 40) |
-                               (((num_value)&0x0000ff0000000000ull) >> 24) |
-                               (((num_value)&0x000000ff00000000ull) >> 8) |
-                               (((num_value)&0x00000000ff000000ull) << 8) |
-                               (((num_value)&0x0000000000ff0000ull) << 24) |
-                               (((num_value)&0x000000000000ff00ull) << 40) |
-                               (((num_value)&0x00000000000000ffull) << 56));
-
-  return bigtable::bigendian64_t(return_value);
-#endif
+  return bigtable::bigendian64_t(
+      google::cloud::internal::ToBigEndian(value.get()));
 }
 
 std::string AsBigEndian64(bigtable::bigendian64_t value) {

--- a/google/cloud/bigtable/internal/endian.cc
+++ b/google/cloud/bigtable/internal/endian.cc
@@ -15,14 +15,8 @@
 #include "google/cloud/bigtable/internal/endian.h"
 #include "google/cloud/internal/big_endian.h"
 #include "google/cloud/internal/throw_delegate.h"
-
-#ifdef _MSC_VER
-#include <stdlib.h>
-#elif defined(__APPLE__)
-#include <libkern/OSByteOrder.h>
-#elif defined(__GNUC__) || defined(__clang__)
-#include <byteswap.h>
-#endif
+#include <cstring>
+#include <limits>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -4,6 +4,7 @@ google_cloud_cpp_common_HDRS = [
     "iam_bindings.h",
     "iam_policy.h",
     "internal/backoff_policy.h",
+    "internal/big_endian.h",
     "internal/build_info.h",
     "internal/getenv.h",
     "internal/make_unique.h",

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -2,6 +2,7 @@
 google_cloud_cpp_common_unit_tests = [
     "iam_bindings_test.cc",
     "internal/backoff_policy_test.cc",
+    "internal/big_endian_test.cc",
     "internal/random_test.cc",
     "internal/invoke_result_test.cc",
     "internal/retry_policy_test.cc",

--- a/google/cloud/internal/big_endian.h
+++ b/google/cloud/internal/big_endian.h
@@ -55,10 +55,10 @@ struct EndianTransform<false> {
 #elif defined(__GNUC__) || defined(__clang__)
     return __builtin_bswap16(value);
 #else
-  std::int16_t return_value = ((((num_value)&0xff00u) >> 8) |
-                               (((num_value)&0x00ffu) << 8));
+    std::int16_t return_value =
+        ((((num_value)&0xff00u) >> 8) | (((num_value)&0x00ffu) << 8));
 
-  return return_value;
+    return return_value;
 #endif
   }
 
@@ -70,12 +70,12 @@ struct EndianTransform<false> {
 #elif defined(__GNUC__) || defined(__clang__)
     return __builtin_bswap32(value);
 #else
-  std::int32_t return_value = ((((num_value)&0xff000000ul) >> 24) |
-                               (((num_value)&0x00ff0000ul) >> 8) |
-                               (((num_value)&0x0000ff00ul) << 8) |
-                               (((num_value)&0x000000fful) << 24));
+    std::int32_t return_value =
+        ((((num_value)&0xff000000ul) >> 24) |
+         (((num_value)&0x00ff0000ul) >> 8) | (((num_value)&0x0000ff00ul) << 8) |
+         (((num_value)&0x000000fful) << 24));
 
-  return return_value;
+    return return_value;
 #endif
   }
 
@@ -87,16 +87,16 @@ struct EndianTransform<false> {
 #elif defined(__GNUC__) || defined(__clang__)
     return __builtin_bswap64(value);
 #else
-  std::int64_t return_value = ((((num_value)&0xff00000000000000ull) >> 56) |
-                               (((num_value)&0x00ff000000000000ull) >> 40) |
-                               (((num_value)&0x0000ff0000000000ull) >> 24) |
-                               (((num_value)&0x000000ff00000000ull) >> 8) |
-                               (((num_value)&0x00000000ff000000ull) << 8) |
-                               (((num_value)&0x0000000000ff0000ull) << 24) |
-                               (((num_value)&0x000000000000ff00ull) << 40) |
-                               (((num_value)&0x00000000000000ffull) << 56));
+    std::int64_t return_value = ((((num_value)&0xff00000000000000ull) >> 56) |
+                                 (((num_value)&0x00ff000000000000ull) >> 40) |
+                                 (((num_value)&0x0000ff0000000000ull) >> 24) |
+                                 (((num_value)&0x000000ff00000000ull) >> 8) |
+                                 (((num_value)&0x00000000ff000000ull) << 8) |
+                                 (((num_value)&0x0000000000ff0000ull) << 24) |
+                                 (((num_value)&0x000000000000ff00ull) << 40) |
+                                 (((num_value)&0x00000000000000ffull) << 56));
 
-  return return_value;
+    return return_value;
 #endif
   }
 
@@ -108,10 +108,10 @@ struct EndianTransform<false> {
 #elif defined(__GNUC__) || defined(__clang__)
     return __builtin_bswap16(value);
 #else
-  std::uint16_t return_value = ((((num_value)&0xff00u) >> 8) |
-                                (((num_value)&0x00ffu) << 8));
+    std::uint16_t return_value =
+        ((((num_value)&0xff00u) >> 8) | (((num_value)&0x00ffu) << 8));
 
-  return return_value;
+    return return_value;
 #endif
   }
 
@@ -123,12 +123,12 @@ struct EndianTransform<false> {
 #elif defined(__GNUC__) || defined(__clang__)
     return __builtin_bswap32(value);
 #else
-  std::uint32_t return_value = ((((num_value)&0xff000000ul) >> 24) |
-                                (((num_value)&0x00ff0000ul) >> 8) |
-                                (((num_value)&0x0000ff00ul) << 8) |
-                                (((num_value)&0x000000fful) << 24));
+    std::uint32_t return_value =
+        ((((num_value)&0xff000000ul) >> 24) |
+         (((num_value)&0x00ff0000ul) >> 8) | (((num_value)&0x0000ff00ul) << 8) |
+         (((num_value)&0x000000fful) << 24));
 
-  return return_value;
+    return return_value;
 #endif
   }
 
@@ -140,16 +140,16 @@ struct EndianTransform<false> {
 #elif defined(__GNUC__) || defined(__clang__)
     return __builtin_bswap64(value);
 #else
-  std::uint64_t return_value = ((((num_value)&0xff00000000000000ull) >> 56) |
-                                (((num_value)&0x00ff000000000000ull) >> 40) |
-                                (((num_value)&0x0000ff0000000000ull) >> 24) |
-                                (((num_value)&0x000000ff00000000ull) >> 8) |
-                                (((num_value)&0x00000000ff000000ull) << 8) |
-                                (((num_value)&0x0000000000ff0000ull) << 24) |
-                                (((num_value)&0x000000000000ff00ull) << 40) |
-                                (((num_value)&0x00000000000000ffull) << 56));
+    std::uint64_t return_value = ((((num_value)&0xff00000000000000ull) >> 56) |
+                                  (((num_value)&0x00ff000000000000ull) >> 40) |
+                                  (((num_value)&0x0000ff0000000000ull) >> 24) |
+                                  (((num_value)&0x000000ff00000000ull) >> 8) |
+                                  (((num_value)&0x00000000ff000000ull) << 8) |
+                                  (((num_value)&0x0000000000ff0000ull) << 24) |
+                                  (((num_value)&0x000000000000ff00ull) << 40) |
+                                  (((num_value)&0x00000000000000ffull) << 56));
 
-  return return_value;
+    return return_value;
 #endif
   }
 

--- a/google/cloud/internal/big_endian.h
+++ b/google/cloud/internal/big_endian.h
@@ -1,0 +1,182 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_BIG_ENDIAN_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_BIG_ENDIAN_H_
+
+#include "google/cloud/version.h"
+#ifdef _MSC_VER
+#include <stdlib.h>
+#elif defined(__APPLE__)
+#include <libkern/OSByteOrder.h>
+#elif defined(__GNUC__) || defined(__clang__)
+#include <byteswap.h>
+#endif
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+constexpr char ENDIAN_DETECTOR[sizeof(int)] = {1};
+constexpr bool IsBigEndian() {
+  return ENDIAN_DETECTOR[0] != 1;  // ignore different type comparison
+}
+
+template <bool is_native_bigendian>
+struct EndianTransform {
+  template <typename IntegralType>
+  static constexpr IntegralType as_big_endian(IntegralType native) {
+    return native;
+  }
+  template <typename IntegralType>
+  static constexpr IntegralType as_native(IntegralType big_endian) {
+    return big_endian;
+  }
+};
+
+template <>
+struct EndianTransform<false> {
+  static constexpr std::int16_t byte_swap(std::int16_t value) {
+#ifdef _MSC_VER
+    return _byteswap_int16(value);
+#elif defined(__APPLE__)
+    return OSSwapInt16(value);
+#elif defined(__GNUC__) || defined(__clang__)
+    return __builtin_bswap16(value);
+#else
+  std::int16_t return_value = ((((num_value)&0xff00u) >> 8) |
+                               (((num_value)&0x00ffu) << 8));
+
+  return return_value;
+#endif
+  }
+
+  static constexpr std::int32_t byte_swap(std::int32_t value) {
+#ifdef _MSC_VER
+    return _byteswap_int32(value);
+#elif defined(__APPLE__)
+    return OSSwapInt32(value);
+#elif defined(__GNUC__) || defined(__clang__)
+    return __builtin_bswap32(value);
+#else
+  std::int32_t return_value = ((((num_value)&0xff000000ul) >> 24) |
+                               (((num_value)&0x00ff0000ul) >> 8) |
+                               (((num_value)&0x0000ff00ul) << 8) |
+                               (((num_value)&0x000000fful) << 24));
+
+  return return_value;
+#endif
+  }
+
+  static constexpr std::int64_t byte_swap(std::int64_t value) {
+#ifdef _MSC_VER
+    return _byteswap_int64(value);
+#elif defined(__APPLE__)
+    return OSSwapInt64(value);
+#elif defined(__GNUC__) || defined(__clang__)
+    return __builtin_bswap64(value);
+#else
+  std::int64_t return_value = ((((num_value)&0xff00000000000000ull) >> 56) |
+                               (((num_value)&0x00ff000000000000ull) >> 40) |
+                               (((num_value)&0x0000ff0000000000ull) >> 24) |
+                               (((num_value)&0x000000ff00000000ull) >> 8) |
+                               (((num_value)&0x00000000ff000000ull) << 8) |
+                               (((num_value)&0x0000000000ff0000ull) << 24) |
+                               (((num_value)&0x000000000000ff00ull) << 40) |
+                               (((num_value)&0x00000000000000ffull) << 56));
+
+  return return_value;
+#endif
+  }
+
+  static constexpr std::uint16_t byte_swap(std::uint16_t value) {
+#ifdef _MSC_VER
+    return _byteswap_int16(value);
+#elif defined(__APPLE__)
+    return OSSwapInt16(value);
+#elif defined(__GNUC__) || defined(__clang__)
+    return __builtin_bswap16(value);
+#else
+  std::uint16_t return_value = ((((num_value)&0xff00u) >> 8) |
+                                (((num_value)&0x00ffu) << 8));
+
+  return return_value;
+#endif
+  }
+
+  static constexpr std::uint32_t byte_swap(std::uint32_t value) {
+#ifdef _MSC_VER
+    return _byteswap_int32(value);
+#elif defined(__APPLE__)
+    return OSSwapInt32(value);
+#elif defined(__GNUC__) || defined(__clang__)
+    return __builtin_bswap32(value);
+#else
+  std::uint32_t return_value = ((((num_value)&0xff000000ul) >> 24) |
+                                (((num_value)&0x00ff0000ul) >> 8) |
+                                (((num_value)&0x0000ff00ul) << 8) |
+                                (((num_value)&0x000000fful) << 24));
+
+  return return_value;
+#endif
+  }
+
+  static constexpr std::uint64_t byte_swap(std::uint64_t value) {
+#ifdef _MSC_VER
+    return _byteswap_int64(value);
+#elif defined(__APPLE__)
+    return OSSwapInt64(value);
+#elif defined(__GNUC__) || defined(__clang__)
+    return __builtin_bswap64(value);
+#else
+  std::uint64_t return_value = ((((num_value)&0xff00000000000000ull) >> 56) |
+                                (((num_value)&0x00ff000000000000ull) >> 40) |
+                                (((num_value)&0x0000ff0000000000ull) >> 24) |
+                                (((num_value)&0x000000ff00000000ull) >> 8) |
+                                (((num_value)&0x00000000ff000000ull) << 8) |
+                                (((num_value)&0x0000000000ff0000ull) << 24) |
+                                (((num_value)&0x000000000000ff00ull) << 40) |
+                                (((num_value)&0x00000000000000ffull) << 56));
+
+  return return_value;
+#endif
+  }
+
+  template <typename IntegralType>
+  static constexpr IntegralType as_big_endian(IntegralType native) {
+    return byte_swap(native);
+  }
+
+  template <typename IntegralType>
+  static constexpr IntegralType as_native(IntegralType big_endian) {
+    return byte_swap(big_endian);
+  }
+};
+
+template <typename IntegralType>
+constexpr IntegralType ToBigEndian(IntegralType native) {
+  return EndianTransform<IsBigEndian()>::as_big_endian(native);
+}
+
+template <typename IntegralType>
+constexpr IntegralType FromBigEndian(IntegralType big_endian) {
+  return EndianTransform<IsBigEndian()>::as_native(big_endian);
+}
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_BIG_ENDIAN_H_

--- a/google/cloud/internal/big_endian.h
+++ b/google/cloud/internal/big_endian.h
@@ -49,7 +49,7 @@ template <>
 struct EndianTransform<false> {
   static constexpr std::int16_t byte_swap(std::int16_t value) {
 #ifdef _MSC_VER
-    return _byteswap_int16(value);
+    return _byteswap_ushort(value);
 #elif defined(__APPLE__)
     return OSSwapInt16(value);
 #elif defined(__GNUC__) || defined(__clang__)
@@ -64,7 +64,7 @@ struct EndianTransform<false> {
 
   static constexpr std::int32_t byte_swap(std::int32_t value) {
 #ifdef _MSC_VER
-    return _byteswap_int32(value);
+    return _byteswap_ulong(value);
 #elif defined(__APPLE__)
     return OSSwapInt32(value);
 #elif defined(__GNUC__) || defined(__clang__)
@@ -81,7 +81,7 @@ struct EndianTransform<false> {
 
   static constexpr std::int64_t byte_swap(std::int64_t value) {
 #ifdef _MSC_VER
-    return _byteswap_int64(value);
+    return _byteswap_uint64(value);
 #elif defined(__APPLE__)
     return OSSwapInt64(value);
 #elif defined(__GNUC__) || defined(__clang__)
@@ -102,7 +102,7 @@ struct EndianTransform<false> {
 
   static constexpr std::uint16_t byte_swap(std::uint16_t value) {
 #ifdef _MSC_VER
-    return _byteswap_int16(value);
+    return _byteswap_ushort(value);
 #elif defined(__APPLE__)
     return OSSwapInt16(value);
 #elif defined(__GNUC__) || defined(__clang__)
@@ -117,7 +117,7 @@ struct EndianTransform<false> {
 
   static constexpr std::uint32_t byte_swap(std::uint32_t value) {
 #ifdef _MSC_VER
-    return _byteswap_int32(value);
+    return _byteswap_ulong(value);
 #elif defined(__APPLE__)
     return OSSwapInt32(value);
 #elif defined(__GNUC__) || defined(__clang__)
@@ -134,7 +134,7 @@ struct EndianTransform<false> {
 
   static constexpr std::uint64_t byte_swap(std::uint64_t value) {
 #ifdef _MSC_VER
-    return _byteswap_int64(value);
+    return _byteswap_uint64(value);
 #elif defined(__APPLE__)
     return OSSwapInt64(value);
 #elif defined(__GNUC__) || defined(__clang__)

--- a/google/cloud/internal/big_endian_test.cc
+++ b/google/cloud/internal/big_endian_test.cc
@@ -1,0 +1,82 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/big_endian.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+namespace {
+
+TEST(BigEndianTest, Int16) {
+  std::uint8_t buf[] = {0x01, 0x02};
+  std::int16_t value;
+  static_assert(sizeof(value) == sizeof(buf), "Mismatched sizes");
+  std::memcpy(&value, buf, sizeof(buf));
+  EXPECT_EQ(0x0102, FromBigEndian(value));
+  EXPECT_EQ(value, FromBigEndian(ToBigEndian(value)));
+}
+
+TEST(BigEndianTest, UInt16) {
+  std::uint8_t buf[] = {0x01, 0x02};
+  std::uint16_t value;
+  static_assert(sizeof(value) == sizeof(buf), "Mismatched sizes");
+  std::memcpy(&value, buf, sizeof(buf));
+  EXPECT_EQ(0x0102U, FromBigEndian(value));
+  EXPECT_EQ(value, FromBigEndian(ToBigEndian(value)));
+}
+
+TEST(BigEndianTest, Int32) {
+  std::uint8_t buf[] = {0x01, 0x02, 0x03, 0x04};
+  std::int32_t value;
+  static_assert(sizeof(value) == sizeof(buf), "Mismatched sizes");
+  std::memcpy(&value, buf, sizeof(buf));
+  EXPECT_EQ(0x01020304, FromBigEndian(value));
+  EXPECT_EQ(value, FromBigEndian(ToBigEndian(value)));
+}
+
+TEST(BigEndianTest, UInt32) {
+  std::uint8_t buf[] = {0x01, 0x02, 0x03, 0x04};
+  std::uint32_t value;
+  static_assert(sizeof(value) == sizeof(buf), "Mismatched sizes");
+  std::memcpy(&value, buf, sizeof(buf));
+  EXPECT_EQ(0x01020304U, FromBigEndian(value));
+  EXPECT_EQ(value, FromBigEndian(ToBigEndian(value)));
+}
+
+TEST(BigEndianTest, Int64) {
+  std::uint8_t buf[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+  std::int64_t value;
+  static_assert(sizeof(value) == sizeof(buf), "Mismatched sizes");
+  std::memcpy(&value, buf, sizeof(buf));
+  EXPECT_EQ(0x0102030405060708, FromBigEndian(value));
+  EXPECT_EQ(value, FromBigEndian(ToBigEndian(value)));
+}
+
+TEST(BigEndianTest, UInt64) {
+  std::uint8_t buf[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+  std::uint64_t value;
+  static_assert(sizeof(value) == sizeof(buf), "Mismatched sizes");
+  std::memcpy(&value, buf, sizeof(buf));
+  EXPECT_EQ(0x0102030405060708U, FromBigEndian(value));
+  EXPECT_EQ(value, FromBigEndian(ToBigEndian(value)));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/big_endian_test.cc
+++ b/google/cloud/internal/big_endian_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/internal/big_endian.h"
 #include <gmock/gmock.h>
+#include <cstring>
 
 namespace google {
 namespace cloud {


### PR DESCRIPTION
I need functions to convert 32-bit numbers to Big Endian for the
CRC32C hashes. We had something similar in Bigtable, but with 64-bit
numbers. I think it is better to have such code in one place. I also
added the functions for 16-bits because they are easy.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1314)
<!-- Reviewable:end -->
