### PR TITLE
Add async operations with streaming responses.

### DIFF
--- a/google/cloud/bigtable/async_operation.h
+++ b/google/cloud/bigtable/async_operation.h
@@ -94,8 +94,10 @@ class AsyncOperation {
    *   case the callback needs to retry the operation.
    * @param disposition `COMPLETED` if the operation completed, `CANCELED` if
    *   the operation were canceled. Note that errors are a "normal" completion.
+   * @return Whether the operation is completed (e.g. in case of streaming
+   *   response, it would return true only after the stream is finished).
    */
-  virtual void Notify(CompletionQueue& cq, Disposition disposition) = 0;
+  virtual bool Notify(CompletionQueue& cq, Disposition disposition) = 0;
 };
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/google/cloud/bigtable/completion_queue_test.cc
+++ b/google/cloud/bigtable/completion_queue_test.cc
@@ -83,8 +83,24 @@ class MockClient {
           grpc::ClientAsyncResponseReaderInterface<btproto::MutateRowResponse>>(
           grpc::ClientContext*, btproto::MutateRowRequest const&,
           grpc::CompletionQueue* cq));
+  MOCK_METHOD4(
+      AsyncMutateRows,
+      std::unique_ptr<
+          grpc::ClientAsyncReaderInterface<btproto::MutateRowsResponse>>(
+          grpc::ClientContext* context,
+          const ::google::bigtable::v2::MutateRowsRequest& request,
+          grpc::CompletionQueue* cq, void* tag));
 };
 
+template <typename Response>
+class MockClientAsyncReaderInterface
+    : public grpc::ClientAsyncReaderInterface<Response> {
+ public:
+  MOCK_METHOD1(StartCall, void(void*));
+  MOCK_METHOD1(ReadInitialMetadata, void(void*));
+  MOCK_METHOD2(Finish, void(grpc::Status*, void*));
+  MOCK_METHOD2_T(Read, void(Response*, void*));
+};
 /// @test Verify that completion queues can create async operations.
 TEST(CompletionQueueTest, AyncRpcSimple) {
   MockClient client;
@@ -130,6 +146,151 @@ TEST(CompletionQueueTest, AyncRpcSimple) {
 
   EXPECT_TRUE(impl->empty());
 }
+
+/// @test Verify that completion queues can create async operations with
+//        streamed responses.
+TEST(CompletionQueueTest, AsyncRpcSimpleStream) {
+  MockClient client;
+
+  // Normally, reader is created by the client and returned as unique_ptr, but I
+  // want to mock it, so I create it here. Eventually, I'll return it as a
+  // unique_ptr from the client, but before that, I hold it in reader_deleter in
+  // case something goes wrong.
+  MockClientAsyncReaderInterface<btproto::MutateRowsResponse>* reader =
+      new MockClientAsyncReaderInterface<btproto::MutateRowsResponse>;
+  std::unique_ptr<MockClientAsyncReaderInterface<btproto::MutateRowsResponse>>
+      reader_deleter(reader);
+
+  EXPECT_CALL(*reader, Read(_, _))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r, void*) {
+        r->add_entries()->set_index(0);
+      }))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r, void*) {
+        r->add_entries()->set_index(1);
+      }))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r, void*) {
+        r->add_entries()->set_index(2);
+      }));
+  EXPECT_CALL(*reader, Finish(_, _))
+      .WillOnce(Invoke([](grpc::Status* status, void*) {
+        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+      }));
+
+  EXPECT_CALL(client, AsyncMutateRows(_, _, _, _))
+      .WillOnce(Invoke([&reader_deleter](grpc::ClientContext*,
+                                         btproto::MutateRowsRequest const&,
+                                         grpc::CompletionQueue*, void*) {
+        auto tmp = google::cloud::internal::make_unique<
+            MockClientAsyncReaderInterface<btproto::MutateRowsResponse>>();
+        return std::move(reader_deleter);
+      }));
+
+  auto impl = std::make_shared<testing::MockCompletionQueue>();
+  bigtable::CompletionQueue cq(impl);
+
+  // In this unit test we do not need to initialize the request parameter.
+  btproto::MutateRowsRequest request;
+  auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
+
+  bool completion_called = false;
+  int cur_idx = 0;
+  auto op = cq.MakeUnaryStreamRpc(
+      client, &MockClient::AsyncMutateRows, request, std::move(context),
+      [&cur_idx](CompletionQueue&, const grpc::ClientContext&,
+                 btproto::MutateRowsResponse& resp) {
+        EXPECT_EQ(1, resp.entries().size());
+        EXPECT_EQ(cur_idx++, resp.entries(0).index());
+      },
+      [&completion_called](CompletionQueue&, grpc::ClientContext&,
+                           grpc::Status& result) {
+        EXPECT_TRUE(result.ok());
+        EXPECT_EQ("mocked-status", result.error_message());
+        completion_called = true;
+      });
+  // Initially stream is in CREATING state
+  EXPECT_EQ(1U, impl->size());
+  impl->SimulateCompletion(cq, op.get(), AsyncOperation::COMPLETED);
+  // Now the stream should now be in PROCESSING state
+  EXPECT_EQ(0, cur_idx);
+  EXPECT_EQ(1U, impl->size());
+  impl->SimulateCompletion(cq, op.get(), AsyncOperation::COMPLETED);
+  EXPECT_EQ(1, cur_idx);
+  EXPECT_EQ(1U, impl->size());
+  impl->SimulateCompletion(cq, op.get(), AsyncOperation::COMPLETED);
+  EXPECT_EQ(2, cur_idx);
+  EXPECT_EQ(1U, impl->size());
+  impl->SimulateCompletion(cq, op.get(), AsyncOperation::CANCELLED);
+  // Stream should now be in FINISHING state, the next completion should be
+  // translated into calling the "finished" callback.
+  EXPECT_EQ(2, cur_idx);
+  EXPECT_EQ(1U, impl->size());
+  EXPECT_FALSE(completion_called);
+  impl->SimulateCompletion(cq, op.get(), AsyncOperation::CANCELLED);
+  EXPECT_EQ(2, cur_idx);
+  EXPECT_TRUE(impl->empty());
+  EXPECT_TRUE(completion_called);
+}
+
+/// @test Verify that async streams which fail to get created are properly
+//        handled.
+TEST(CompletionQueueTest, AsyncRpcStreamNotCreated) {
+  MockClient client;
+
+  // Normally, reader is created by the client and returned as unique_ptr, but I
+  // want to mock it, so I create it here. Eventually, I'll return it as a
+  // unique_ptr from the client, but before that, I hold it in reader_deleter in
+  // case something goes wrong.
+  MockClientAsyncReaderInterface<btproto::MutateRowsResponse>* reader =
+      new MockClientAsyncReaderInterface<btproto::MutateRowsResponse>;
+  std::unique_ptr<MockClientAsyncReaderInterface<btproto::MutateRowsResponse>>
+      reader_deleter(reader);
+
+  EXPECT_CALL(*reader, Finish(_, _))
+      .WillOnce(Invoke([](grpc::Status* status, void*) {
+        *status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "mocked-status");
+      }));
+
+  EXPECT_CALL(client, AsyncMutateRows(_, _, _, _))
+      .WillOnce(Invoke([&reader_deleter](grpc::ClientContext*,
+                                         btproto::MutateRowsRequest const&,
+                                         grpc::CompletionQueue*, void*) {
+        auto tmp = google::cloud::internal::make_unique<
+            MockClientAsyncReaderInterface<btproto::MutateRowsResponse>>();
+        return std::move(reader_deleter);
+      }));
+
+  auto impl = std::make_shared<testing::MockCompletionQueue>();
+  bigtable::CompletionQueue cq(impl);
+
+  // In this unit test we do not need to initialize the request parameter.
+  btproto::MutateRowsRequest request;
+  auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
+
+  bool completion_called = false;
+  auto op = cq.MakeUnaryStreamRpc(
+      client, &MockClient::AsyncMutateRows, request, std::move(context),
+      [](CompletionQueue&, const grpc::ClientContext&,
+                 btproto::MutateRowsResponse& resp) {
+        EXPECT_TRUE(false);
+      },
+      [&completion_called](CompletionQueue&, grpc::ClientContext&,
+                           grpc::Status& result) {
+        EXPECT_FALSE(result.ok());
+        EXPECT_EQ("mocked-status", result.error_message());
+        completion_called = true;
+      });
+  // Initially stream is in CREATING state
+  EXPECT_EQ(1U, impl->size());
+  impl->SimulateCompletion(cq, op.get(), AsyncOperation::CANCELLED);
+  // Now the stream should now be in FINISHING state
+  EXPECT_EQ(1U, impl->size());
+  EXPECT_FALSE(completion_called);
+  impl->SimulateCompletion(cq, op.get(), AsyncOperation::CANCELLED);
+  EXPECT_TRUE(impl->empty());
+  EXPECT_TRUE(completion_called);
+}
+
+
 
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/google/cloud/bigtable/internal/completion_queue_impl.cc
+++ b/google/cloud/bigtable/internal/completion_queue_impl.cc
@@ -86,9 +86,9 @@ std::shared_ptr<AsyncOperation> CompletionQueueImpl::FindOperation(void* tag) {
 
 void CompletionQueueImpl::ForgetOperation(void* tag) {
   std::lock_guard<std::mutex> lk(mu_);
-  const int num_erased =
+  auto const num_erased =
       pending_ops_.erase(reinterpret_cast<std::intptr_t>(tag));
-  if (1 != num_erased) {
+  if (1U != num_erased) {
     google::cloud::internal::RaiseRuntimeError(
         "assertion failure: searching for async op tag when trying to "
         "unregister");

--- a/google/cloud/bigtable/internal/completion_queue_impl.h
+++ b/google/cloud/bigtable/internal/completion_queue_impl.h
@@ -199,7 +199,7 @@ class AsyncUnaryStreamRpcFunctor : public AsyncOperation {
   void Cancel() override { context_->TryCancel(); }
 
  private:
-  enum State { CREATING = 4525, PROCESSING = 21345, FINISHING = 82553 };
+  enum State { CREATING, PROCESSING, FINISHING };
   bool Notify(CompletionQueue& cq, Disposition d) override {
     // TODO(#1308) - the disposition types do not quite work for streaming
     // requests, that will be fixed in a future PR.


### PR DESCRIPTION
It is needed to implement the AsyncMutateRows (#1217). A preview of where I'm
going with it is available here:
https://github.com/dopiera/google-cloud-cpp/commit/17a36d5301d40c9042d238b8816a0ab5741c03dc

This is implemented by adding a AsyncUnaryStreamRpcFunctor, which
implements the stream lifecycle state machine. In order to achieve that,
enqueued async operations had to start reporting to the completion
queue, whether it should keep them or remove them on a notification
event. AsyncUnaryStreamRpcFunctor indicates to the queue that it should
be removed after the whole stream is finished.

Disposition is handled differently in the streamed version of the
functor than it is in the single-RPC. The assumption I made (which I
will double check in integration tests) is that if a stream is
cancelled, the final gRPC status will hold that information. Due to
that, the callbacks for the streaming API don't use AsyncResult. I'd like to
homogenize the non-streaming API later to resemble this one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1321)
<!-- Reviewable:end -->
