### PR TITLE
Implement crc32c on insert media

### DIFF
--- a/ci/appveyor/build-windows.ps1
+++ b/ci/appveyor/build-windows.ps1
@@ -42,8 +42,6 @@ if ($env:PROVIDER -eq "vcpkg") {
     }
 
     $cmake_flags += "-DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=$env:PROVIDER"
-    # As of 2018-10-19 the vcpkg port of google/crc32c does not work, workaround that for now.
-    $cmake_flags += "-DGOOGLE_CLOUD_CPP_CRC32C_PROVIDER=external"
     $cmake_flags += "-DCMAKE_TOOLCHAIN_FILE=`"$dir\vcpkg\scripts\buildsystems\vcpkg.cmake`""
     $cmake_flags += "-DVCPKG_TARGET_TRIPLET=x64-windows-static"
     $cmake_flags += "-DCMAKE_C_COMPILER=cl.exe"

--- a/ci/test-install/Makefile
+++ b/ci/test-install/Makefile
@@ -44,7 +44,8 @@ bigtable_install_test: bigtable_install_test.cc
 GCS_DEPS := storage_client google_cloud_cpp_common libcurl openssl
 GCS_CXXFLAGS   := $(shell pkg-config $(GCS_DEPS) --cflags)
 GCS_CXXLDFLAGS := $(shell pkg-config $(GCS_DEPS) --libs-only-L)
-GCS_LIBS := $(shell pkg-config $(GCS_DEPS) --libs-only-l)
+# CRC32C does not have pkg-config(1) files, so link it explicitly.
+GCS_LIBS := $(shell pkg-config $(GCS_DEPS) --libs-only-l) -lcrc32c
 
 storage_install_test: storage_install_test.cc
 	$(CXXLD) $(GCS_CXXFLAGS) $(GCS_CXXLDFLAGS) -o $@ $^ $(GCS_LIBS)

--- a/ci/travis/Dockerfile.centos
+++ b/ci/travis/Dockerfile.centos
@@ -44,7 +44,7 @@ RUN yum makecache && yum install -y \
     zlib-devel
 
 RUN pip install --upgrade pip
-RUN pip install httpbin flask gevent gunicorn
+RUN pip install httpbin flask gevent gunicorn crc32c
 
 # Install cmake3 + ctest3 as cmake + ctest.
 RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && \

--- a/ci/travis/Dockerfile.fedora
+++ b/ci/travis/Dockerfile.fedora
@@ -46,7 +46,7 @@ RUN dnf makecache && dnf install -y \
     zlib-devel
 
 RUN pip install --upgrade pip
-RUN pip install httpbin flask gevent gunicorn
+RUN pip install httpbin flask gevent gunicorn crc32c
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.

--- a/ci/travis/Dockerfile.ubuntu
+++ b/ci/travis/Dockerfile.ubuntu
@@ -67,7 +67,7 @@ RUN pip install --upgrade pip
 RUN pip install numpy cmake_format==0.4.0
 
 # Install Python packages used in the integration tests.
-RUN pip install flask httpbin gevent gunicorn
+RUN pip install flask httpbin gevent gunicorn crc32c
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.

--- a/ci/travis/Dockerfile.ubuntu-trusty
+++ b/ci/travis/Dockerfile.ubuntu-trusty
@@ -51,7 +51,7 @@ RUN apt update && apt install -y software-properties-common && \
 # Install Python packages used in the integration tests.
 RUN apt update && apt install -y python-dev python-pip
 RUN pip install --upgrade pip
-RUN pip install flask httpbin gevent gunicorn
+RUN pip install flask httpbin gevent gunicorn crc32c
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.

--- a/google/cloud/storage/BUILD
+++ b/google/cloud/storage/BUILD
@@ -53,6 +53,7 @@ cc_library(
         "@boringssl//:crypto",
         "@boringssl//:ssl",
         "@com_github_curl_curl//:curl",
+        "@com_github_google_crc32c//:crc32c",
     ],
 )
 

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -211,6 +211,7 @@ add_library(storage_client
 target_link_libraries(storage_client
                       PUBLIC google_cloud_cpp_common
                              nlohmann_json
+                             Crc32c::crc32c
                              CURL::CURL
                              Threads::Threads
                              OpenSSL::SSL

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -482,7 +482,8 @@ class Client {
    * @param contents the contents (media) for the new object.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `ContentEncoding`,
-   *     `ContentType`, `DisableMD5Hash`, `EncryptionKey`, `IfGenerationMatch`,
+   *     `ContentType`, `Crc32cChecksumValue`, `DisableCrc32cChecksum`,
+   *     `DisableMD5Hash`, `EncryptionKey`, `IfGenerationMatch`,
    *     `IfGenerationNotMatch`, `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, `KmsKeyName`, `MD5HashValue`,
    *     `PredefinedAcl`, `Projection`, and `UserProject`.

--- a/google/cloud/storage/config.cmake.in
+++ b/google/cloud/storage/config.cmake.in
@@ -14,6 +14,7 @@
 
 include(CMakeFindDependencyMacro)
 find_dependency(CURL)
+find_dependency(Crc32c)
 find_dependency(google_cloud_cpp_common 0.1.0)
 
 # Some versions of FindCURL do not define CURL::CURL, so we define it ourselves.

--- a/google/cloud/storage/hashing_options.h
+++ b/google/cloud/storage/hashing_options.h
@@ -57,6 +57,42 @@ struct DisableMD5Hash : public internal::ComplexOption<DisableMD5Hash, bool> {
   static char const* name() { return "disable-md5-hash"; }
 };
 
+/**
+ * Provide a pre-computed MD5 hash value to an upload or download request.
+ *
+ * The application may know what the MD5 hash value of a particular object is,
+ * for example, because it was downloaded from GCS or some other cloud storage
+ * service. In these cases, the client can include the hash value in the
+ * request for better end-to-end validation.
+ */
+struct Crc32cChecksumValue
+    : public internal::ComplexOption<Crc32cChecksumValue, std::string> {
+  using ComplexOption<Crc32cChecksumValue, std::string>::ComplexOption;
+  static char const* name() { return "crc32c-checksum"; }
+};
+
+/**
+ * Compute the MD5 Hash of a string in the format preferred by GCS.
+ */
+std::string ComputeCrc32cChecksum(std::string const& payload);
+
+/**
+ * Disable MD5 Hashing computations.
+ *
+ * By default the GCS client library computes MD5 hashes in all
+ * `Client::InsertObject` calls. The application can disable the hash
+ * computation by passing this parameter.
+ *
+ * @warning Disabling MD5 hashing exposes your application to data corruption.
+ *   We recommend that all uploads to GCS are protected by the supported
+ *   checksums and/or hashes.
+ */
+struct DisableCrc32cChecksum
+    : public internal::ComplexOption<DisableCrc32cChecksum, bool> {
+  using ComplexOption<DisableCrc32cChecksum, bool>::ComplexOption;
+  static char const* name() { return "disable-crc32c-checksum"; }
+};
+
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/hashing_options_test.cc
+++ b/google/cloud/storage/hashing_options_test.cc
@@ -37,6 +37,22 @@ TEST(ComputeMD5HashTest, Simple) {
   EXPECT_EQ("nhB9nTcrtoJr2B01QqQZ1g==", actual);
 }
 
+TEST(ComputeCrc32cChecksumTest, Empty) {
+  std::string actual = ComputeCrc32cChecksum("");
+  // Use this command to get the expected value:
+  // echo -n '' > foo.txt && gsutil hash foo.txt
+  EXPECT_EQ("AAAAAA==", actual);
+}
+
+TEST(ComputeCrc32cChecksumTest, Simple) {
+  std::string actual = ComputeCrc32cChecksum(
+      "The quick brown fox jumps over the lazy dog");
+  // I used this command to get the expected value:
+  // /bin/echo -n "The quick brown fox jumps over the lazy dog" > foo.txt &&
+  // gsutil hash foo.txt
+  EXPECT_EQ("ImIEBA==", actual);
+}
+
 }  // namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -85,9 +85,10 @@ std::ostream& operator<<(std::ostream& os, GetObjectMetadataRequest const& r);
 class InsertObjectMediaRequest
     : public GenericObjectRequest<
           InsertObjectMediaRequest, ContentEncoding, ContentType,
-          DisableMD5Hash, EncryptionKey, IfGenerationMatch,
-          IfGenerationNotMatch, IfMetagenerationMatch, IfMetagenerationNotMatch,
-          KmsKeyName, MD5HashValue, PredefinedAcl, Projection, UserProject> {
+          Crc32cChecksumValue, DisableCrc32cChecksum, DisableMD5Hash,
+          EncryptionKey, IfGenerationMatch, IfGenerationNotMatch,
+          IfMetagenerationMatch, IfMetagenerationNotMatch, KmsKeyName,
+          MD5HashValue, PredefinedAcl, Projection, UserProject> {
  public:
   InsertObjectMediaRequest() : GenericObjectRequest(), contents_() {}
 


### PR DESCRIPTION
With this change the library sends (unless explicitly disabled by the
application developer) the CRC32C checksum of any data included in
InsertObjectMedia() calls. The integration tests in this change verify
that valid CRC32C checksums are accepted, and that invalid CRC32C
checksums are rejected by the testbench (and the service).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1323)
<!-- Reviewable:end -->
