### PR TITLE
Limit ccache size

### DIFF
--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -151,9 +151,7 @@ if [ "${TEST_INSTALL:-}" = "yes" -o "${SCAN_BUILD:-}" = "yes" ]; then
   (cd /var/tmp/build-dependencies; install_c_ares)
   (cd /var/tmp/build-dependencies; install_grpc)
   (cd /var/tmp/build-dependencies; install_googletest)
-  # DEBUG REMOVE BEFORE MERGE
   ${ccache_command} --show-stats
-  # END DEBUG REMOVE BEFORE MERGE
   echo
   echo "${COLOR_YELLOW}Finished dependency install at: $(date)${COLOR_RESET}"
   echo
@@ -211,7 +209,7 @@ if [ -n "${ccache_command}" ]; then
   echo
   echo "${COLOR_YELLOW}Print and clearing ccache stats: $(date)${COLOR_RESET}"
   ${ccache_command} --show-stats
-  ${ccache_command} --zero-stats
+  ${ccache_command} --zero-stats --cleanup --max-size=1Gi
 fi
 
 # Run the tests and output any failures.


### PR DESCRIPTION
The cache can grow over time, some of our builds have 5.0GiB caches,
while a clean builds creates a cache that only takes about 200MiB.
Reducing the size speeds up the download and upload of the cache, and
therefore the overall build time.

My measurements about 40 seconds of savings, which is not nothing considering
some of the builds are under 10 minutes with a hot cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1326)
<!-- Reviewable:end -->
