### PR TITLE
Make BulkMutator async friendly.

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -145,6 +145,7 @@ add_library(bigtable_client
             instance_config.cc
             instance_update_config.h
             instance_update_config.cc
+            internal/async_bulk_apply.h
             internal/async_retry_op.h
             internal/async_retry_unary_rpc.h
             internal/bulk_mutator.h
@@ -289,6 +290,7 @@ set(bigtable_client_unit_tests
     internal/prefix_range_end_test.cc
     internal/table_admin_test.cc
     internal/table_async_apply_test.cc
+    internal/table_async_bulk_apply_test.cc
     internal/table_test.cc
     mutations_test.cc
     table_admin_test.cc

--- a/google/cloud/bigtable/bigtable_client.bzl
+++ b/google/cloud/bigtable/bigtable_client.bzl
@@ -16,6 +16,7 @@ bigtable_client_HDRS = [
     "instance_admin.h",
     "instance_config.h",
     "instance_update_config.h",
+    "internal/async_bulk_apply.h",
     "internal/async_retry_op.h",
     "internal/async_retry_unary_rpc.h",
     "internal/bulk_mutator.h",

--- a/google/cloud/bigtable/bigtable_client_unit_tests.bzl
+++ b/google/cloud/bigtable/bigtable_client_unit_tests.bzl
@@ -22,6 +22,7 @@ bigtable_client_unit_tests = [
     "internal/prefix_range_end_test.cc",
     "internal/table_admin_test.cc",
     "internal/table_async_apply_test.cc",
+    "internal/table_async_bulk_apply_test.cc",
     "internal/table_test.cc",
     "mutations_test.cc",
     "table_admin_test.cc",

--- a/google/cloud/bigtable/data_client.cc
+++ b/google/cloud/bigtable/data_client.cc
@@ -101,6 +101,13 @@ class DefaultDataClient : public DataClient {
              btproto::MutateRowsRequest const& request) override {
     return impl_.Stub()->MutateRows(context, request);
   }
+  std::unique_ptr<::grpc::ClientAsyncReaderInterface<
+      ::google::bigtable::v2::MutateRowsResponse>>
+  AsyncMutateRows(::grpc::ClientContext* context,
+                  const ::google::bigtable::v2::MutateRowsRequest& request,
+                  ::grpc::CompletionQueue* cq, void* tag) {
+    return impl_.Stub()->AsyncMutateRows(context, request, cq, tag);
+  }
 
  private:
   std::string project_;

--- a/google/cloud/bigtable/data_client.h
+++ b/google/cloud/bigtable/data_client.h
@@ -113,6 +113,11 @@ class DataClient {
       grpc::ClientReaderInterface<google::bigtable::v2::MutateRowsResponse>>
   MutateRows(grpc::ClientContext* context,
              google::bigtable::v2::MutateRowsRequest const& request) = 0;
+  virtual std::unique_ptr<::grpc::ClientAsyncReaderInterface<
+      ::google::bigtable::v2::MutateRowsResponse>>
+  AsyncMutateRows(::grpc::ClientContext* context,
+                  const ::google::bigtable::v2::MutateRowsRequest& request,
+                  ::grpc::CompletionQueue* cq, void* tag) = 0;
   //@}
 };
 

--- a/google/cloud/bigtable/internal/async_bulk_apply.h
+++ b/google/cloud/bigtable/internal/async_bulk_apply.h
@@ -1,0 +1,70 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_BULK_APPLY_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_BULK_APPLY_H
+
+#include "google/cloud/bigtable/async_operation.h"
+#include "google/cloud/bigtable/bigtable_strong_types.h"
+#include "google/cloud/bigtable/completion_queue.h"
+#include "google/cloud/bigtable/data_client.h"
+#include "google/cloud/bigtable/idempotent_mutation_policy.h"
+#include "google/cloud/bigtable/internal/async_retry_op.h"
+#include "google/cloud/bigtable/internal/bulk_mutator.h"
+#include "google/cloud/bigtable/table_strong_types.h"
+#include "google/cloud/internal/invoke_result.h"
+#include "google/cloud/internal/make_unique.h"
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
+
+template <typename Functor,
+          typename std::enable_if<
+              google::cloud::internal::is_invocable<
+                  Functor, CompletionQueue&, std::vector<FailedMutation>&,
+                  grpc::Status&>::value,
+              int>::type valid_callback_type = 0>
+class AsyncRetryBulkApply : public AsyncRetryOp<ConstantIdempotencyPolicy,
+                                                Functor, AsyncBulkMutator> {
+ public:
+  AsyncRetryBulkApply(char const* error_message,
+                      std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
+                      std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
+                      IdempotentMutationPolicy& idempotent_policy,
+                      MetadataUpdatePolicy metadata_update_policy,
+                      std::shared_ptr<bigtable::DataClient> client,
+                      bigtable::AppProfileId const& app_profile_id,
+                      bigtable::TableId const& table_name, BulkMutation&& mut,
+                      Functor&& callback)
+      : AsyncRetryOp<ConstantIdempotencyPolicy, Functor, AsyncBulkMutator>(
+            error_message, std::move(rpc_retry_policy),
+            // BulkMutator is idempotent because it keeps track of idempotency
+            // of the mutations it holds.
+            std::move(rpc_backoff_policy), ConstantIdempotencyPolicy(true),
+            std::move(metadata_update_policy), std::forward<Functor>(callback),
+            AsyncBulkMutator(client, std::move(app_profile_id),
+                             std::move(table_name), idempotent_policy,
+                             std::forward<BulkMutation>(mut))) {}
+};
+
+}  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_BULK_APPLY_H

--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -15,10 +15,15 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_BULK_MUTATOR_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_BULK_MUTATOR_H_
 
+#include "google/cloud/bigtable/async_operation.h"
 #include "google/cloud/bigtable/bigtable_strong_types.h"
+#include "google/cloud/bigtable/completion_queue.h"
 #include "google/cloud/bigtable/data_client.h"
 #include "google/cloud/bigtable/idempotent_mutation_policy.h"
+#include "google/cloud/bigtable/internal/async_retry_op.h"
 #include "google/cloud/bigtable/table_strong_types.h"
+#include "google/cloud/internal/invoke_result.h"
+#include "google/cloud/internal/make_unique.h"
 
 namespace google {
 namespace cloud {
@@ -37,14 +42,14 @@ class BulkMutator {
     return pending_mutations_.entries_size() != 0;
   }
 
-  /// Send one batch request to the given stub.
+  /// Synchronously send one batch request to the given stub.
   grpc::Status MakeOneRequest(bigtable::DataClient& client,
                               grpc::ClientContext& client_context);
 
   /// Give up on any pending mutations, move them to the failures array.
   std::vector<FailedMutation> ExtractFinalFailures();
 
- private:
+ protected:
   /// Get ready for a new request.
   void PrepareForRequest();
 
@@ -54,7 +59,6 @@ class BulkMutator {
   /// A request has finished and we have processed all the responses.
   void FinishRequest();
 
- private:
   /// Accumulate any permanent failures and the list of mutations we gave up on.
   std::vector<FailedMutation> failures_;
 
@@ -90,6 +94,92 @@ class BulkMutator {
   /// Accumulate annotations for the next request.
   std::vector<Annotations> pending_annotations_;
 };
+
+/**
+ * Async-friendly version BulkMutator.
+ *
+ * It satisfies the requirements to be used in AsyncRetryOp.
+ *
+ * It extends the normal BulkMutator with logic to do its job asynchronously.
+ * Conceptually it reimplements MakeOneRequest in an async way.
+ */
+class AsyncBulkMutator : protected BulkMutator {
+ public:
+  AsyncBulkMutator(std::shared_ptr<bigtable::DataClient> client,
+                   bigtable::AppProfileId const& app_profile_id,
+                   bigtable::TableId const& table_name,
+                   IdempotentMutationPolicy& idempotent_policy,
+                   BulkMutation&& mut)
+      : BulkMutator(app_profile_id, table_name, idempotent_policy,
+                    std::move(mut)),
+        client_(std::move(client)) {}
+
+  // For AsyncRetryOp
+  using Request = google::bigtable::v2::MutateRowsRequest;
+  // We don't want to make AsyncRetryOp return the last response because
+  // we care about the accumulated result from all retries, not the last
+  // response. Due to that, we accumulate and process the responses in this
+  // object and forge a dummy int result to AsyncRetryOp. Eventually, after all
+  // retries are done, the user will call ExtractFinalFailures to get to know
+  // the actual response.
+  using Response = int;
+  using AsyncResult = AsyncUnaryRpcResult<int>;
+
+  template <typename Functor,
+            typename std::enable_if<google::cloud::internal::is_invocable<
+                                        Functor, CompletionQueue&, AsyncResult&,
+                                        AsyncOperation::Disposition>::value,
+                                    int>::type valid_callback_type = 0>
+  void Start(CompletionQueue& cq,
+             std::unique_ptr<grpc::ClientContext>&& context,
+             Functor&& callback) {
+    PrepareForRequest();
+    rpc_ = cq.MakeUnaryStreamRpc(
+        *client_, &DataClient::AsyncMutateRows, pending_mutations_,
+        std::move(context),
+        [this](CompletionQueue&, const grpc::ClientContext&,
+               google::bigtable::v2::MutateRowsResponse& response) {
+          ProcessResponse(response);
+        },
+        FinishedCallback<Functor>(*this, std::forward<Functor>(callback)));
+  }
+  using BulkMutator::ExtractFinalFailures;
+
+ private:
+  template <typename Functor,
+            typename std::enable_if<google::cloud::internal::is_invocable<
+                                        Functor, CompletionQueue&, AsyncResult&,
+                                        AsyncOperation::Disposition>::value,
+                                    int>::type valid_callback_type = 0>
+  struct FinishedCallback {
+    FinishedCallback(AsyncBulkMutator& parent, Functor&& callback)
+        : parent_(parent), callback_(callback) {}
+
+    void operator()(CompletionQueue& cq, grpc::ClientContext& context,
+                    grpc::Status& status) {
+      parent_.FinishRequest();
+
+      if (parent_.HasPendingMutations() && status.ok()) {
+        // Can this even happen? Sounds like it would be a bug.
+        status = grpc::Status(grpc::StatusCode::UNAVAILABLE,
+                              "Some mutations were not confirmed");
+      }
+      // TODO(#1308) - the context is wrong here, but deferring the fix until
+      // the API is changed as a part of Disposition removal.
+      AsyncResult res{
+          0, std::move(status),
+          google::cloud::internal::make_unique<grpc::ClientContext>()};
+      callback_(cq, res, AsyncOperation::COMPLETED);
+    }
+    AsyncBulkMutator& parent_;
+    Functor callback_;
+  };
+
+ private:
+  std::shared_ptr<bigtable::DataClient> client_;
+  std::shared_ptr<AsyncOperation> rpc_;
+};
+
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -133,9 +133,8 @@ class AsyncBulkMutator : protected BulkMutator {
              std::unique_ptr<grpc::ClientContext>&& context,
              Functor&& callback) {
     PrepareForRequest();
-    rpc_ = cq.MakeUnaryStreamRpc(
-        *client_, &DataClient::AsyncMutateRows, pending_mutations_,
-        std::move(context),
+    cq.MakeUnaryStreamRpc(
+        *client_, &DataClient::AsyncMutateRows, mutations_, std::move(context),
         [this](CompletionQueue&, const grpc::ClientContext&,
                google::bigtable::v2::MutateRowsResponse& response) {
           ProcessResponse(response);

--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -173,7 +173,6 @@ class AsyncBulkMutator : protected BulkMutator {
 
  private:
   std::shared_ptr<bigtable::DataClient> client_;
-  std::shared_ptr<AsyncOperation> rpc_;
 };
 
 }  // namespace internal

--- a/google/cloud/bigtable/internal/table.h
+++ b/google/cloud/bigtable/internal/table.h
@@ -20,7 +20,9 @@
 #include "google/cloud/bigtable/data_client.h"
 #include "google/cloud/bigtable/filters.h"
 #include "google/cloud/bigtable/idempotent_mutation_policy.h"
+#include "google/cloud/bigtable/internal/async_bulk_apply.h"
 #include "google/cloud/bigtable/internal/async_retry_unary_rpc.h"
+#include "google/cloud/bigtable/internal/bulk_mutator.h"
 #include "google/cloud/bigtable/metadata_update_policy.h"
 #include "google/cloud/bigtable/mutations.h"
 #include "google/cloud/bigtable/read_modify_write_rule.h"
@@ -197,6 +199,29 @@ class Table {
         internal::ConstantIdempotencyPolicy(is_idempotent),
         metadata_update_policy_, client_, &DataClient::AsyncMutateRow,
         std::move(request), std::forward<Functor>(callback));
+    retry->Start(cq);
+  }
+
+  template <typename Functor,
+            typename std::enable_if<
+                google::cloud::internal::is_invocable<
+                    Functor, CompletionQueue&, std::vector<FailedMutation>&,
+                    grpc::Status&>::value,
+                int>::type valid_callback_type = 0>
+  void AsyncBulkApply(BulkMutation&& mut, CompletionQueue& cq,
+                      Functor&& callback) {
+    google::bigtable::v2::MutateRowsRequest request;
+    internal::SetCommonTableOperationRequest<
+        google::bigtable::v2::MutateRowsRequest>(request, app_profile_id_.get(),
+                                                 table_name_.get());
+    using Retry = bigtable::internal::AsyncRetryBulkApply<Functor>;
+
+    auto retry = std::make_shared<Retry>(
+        __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
+        *idempotent_mutation_policy_, metadata_update_policy_, client_,
+        app_profile_id_, table_name_, std::move(mut),
+        std::forward<Functor>(callback));
+
     retry->Start(cq);
   }
 

--- a/google/cloud/bigtable/internal/table_async_bulk_apply_test.cc
+++ b/google/cloud/bigtable/internal/table_async_bulk_apply_test.cc
@@ -1,0 +1,161 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/internal/table.h"
+#include "google/cloud/bigtable/testing/internal_table_test_fixture.h"
+#include "google/cloud/bigtable/testing/mock_completion_queue.h"
+#include "google/cloud/bigtable/testing/mock_mutate_rows_reader.h"
+#include "google/cloud/testing_util/chrono_literals.h"
+#include <gmock/gmock.h>
+#include <thread>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace noex {
+namespace {
+
+namespace bt = ::google::cloud::bigtable;
+namespace btproto = google::bigtable::v2;
+using namespace google::cloud::testing_util::chrono_literals;
+using namespace ::testing;
+
+class NoexTableAsyncBulkApplyTest
+    : public bigtable::testing::internal::TableTestFixture {};
+
+/// @test Verify that noex::Table::AsyncBulkApply() works in a simple case.
+TEST_F(NoexTableAsyncBulkApplyTest, IdempotencyAndRetries) {
+  // This test creates 3 mutations. First one will succeed straight away, second
+  // on retry and third never, because it's not idempotent.
+  bt::BulkMutation mut(
+      bt::SingleRowMutation("foo", {bt::SetCell("fam", "col", 0_ms, "baz")}),
+      bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0_ms, "qux")}),
+      bt::SingleRowMutation("baz", {bt::SetCell("fam", "col", "qux")}));
+
+  using bigtable::testing::MockClientAsyncReaderInterface;
+
+  // reader1 will confirm only the first mutation and return UNAVAILABLE to
+  // others.
+  MockClientAsyncReaderInterface<btproto::MutateRowsResponse>* reader1 =
+      new MockClientAsyncReaderInterface<btproto::MutateRowsResponse>;
+  std::unique_ptr<MockClientAsyncReaderInterface<btproto::MutateRowsResponse>>
+      reader_deleter1(reader1);
+  EXPECT_CALL(*reader1, Read(_, _))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r, void*) {
+        {
+          auto& e = *r->add_entries();
+          e.set_index(0);
+          e.mutable_status()->set_code(grpc::StatusCode::OK);
+        }
+        {
+          auto& e = *r->add_entries();
+          e.set_index(1);
+          e.mutable_status()->set_code(grpc::StatusCode::UNAVAILABLE);
+        }
+        {
+          auto& e = *r->add_entries();
+          e.set_index(2);
+          e.mutable_status()->set_code(grpc::StatusCode::UNAVAILABLE);
+        }
+      }))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r, void*) {}));
+
+  EXPECT_CALL(*reader1, Finish(_, _))
+      .WillOnce(Invoke([](grpc::Status* status, void*) {
+        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+      }));
+
+  // reader2 will confirm only the first mutation (the only one); the mutation
+  // which used to be first should now be confirmed and the mutation which used
+  // to be third is not idempotent, so should not be retried.
+  MockClientAsyncReaderInterface<btproto::MutateRowsResponse>* reader2 =
+      new MockClientAsyncReaderInterface<btproto::MutateRowsResponse>;
+  std::unique_ptr<MockClientAsyncReaderInterface<btproto::MutateRowsResponse>>
+      reader_deleter2(reader2);
+  EXPECT_CALL(*reader2, Read(_, _))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r, void*) {
+        {
+          auto& e = *r->add_entries();
+          e.set_index(0);
+          e.mutable_status()->set_code(grpc::StatusCode::OK);
+        }
+      }))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r, void*) {}));
+
+  EXPECT_CALL(*reader2, Finish(_, _))
+      .WillOnce(Invoke([](grpc::Status* status, void*) {
+        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+      }));
+
+  EXPECT_CALL(*client_, AsyncMutateRows(_, _, _, _))
+      .WillOnce(Invoke([&reader_deleter1](grpc::ClientContext*,
+                                          btproto::MutateRowsRequest const& r,
+                                          grpc::CompletionQueue*, void*) {
+        EXPECT_EQ(3, r.entries_size());
+        return std::move(reader_deleter1);
+      }))
+      .WillOnce(Invoke([&reader_deleter2](grpc::ClientContext*,
+                                          btproto::MutateRowsRequest const& r,
+                                          grpc::CompletionQueue*, void*) {
+        // Second invocation should only contain the second mutation.
+        EXPECT_EQ(1, r.entries_size());
+        EXPECT_EQ("bar", r.entries(0).row_key());
+        return std::move(reader_deleter2);
+      }));
+
+  auto policy = bt::DefaultIdempotentMutationPolicy();
+  auto impl = std::make_shared<bigtable::testing::MockCompletionQueue>();
+  using bigtable::CompletionQueue;
+  bigtable::CompletionQueue cq(impl);
+
+  bool mutator_finished = false;
+  table_.AsyncBulkApply(std::move(mut), cq,
+                        [&mutator_finished](CompletionQueue& cq,
+                                            std::vector<FailedMutation>& failed,
+                                            grpc::Status& status) {
+                          EXPECT_EQ(1U, failed.size());
+                          EXPECT_EQ("baz", failed[0].mutation().row_key());
+                          EXPECT_TRUE(status.ok());
+                          mutator_finished = true;
+                        });
+
+  using bigtable::AsyncOperation;
+  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  // state == PROCESSING
+  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  // state == PROCESSING, 1 read
+  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  // state == FINISHING
+  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  // FinishTimer
+  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  // Second attempt
+  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  // state == PROCESSING
+  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  // state == PROCESSING, 1 read
+  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  // state == FINISHING
+  EXPECT_FALSE(mutator_finished);
+  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  EXPECT_TRUE(mutator_finished);
+}
+
+}  // namespace
+}  // namespace noex
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/testing/inprocess_data_client.cc
+++ b/google/cloud/bigtable/testing/inprocess_data_client.cc
@@ -71,6 +71,15 @@ InProcessDataClient::MutateRows(grpc::ClientContext* context,
   return Stub()->MutateRows(context, request);
 }
 
+std::unique_ptr<::grpc::ClientAsyncReaderInterface<
+    ::google::bigtable::v2::MutateRowsResponse>>
+InProcessDataClient::AsyncMutateRows(
+    ::grpc::ClientContext* context,
+    const ::google::bigtable::v2::MutateRowsRequest& request,
+    ::grpc::CompletionQueue* cq, void* tag) {
+  return Stub()->AsyncMutateRows(context, request, cq, tag);
+}
+
 }  // namespace testing
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/testing/inprocess_data_client.h
+++ b/google/cloud/bigtable/testing/inprocess_data_client.h
@@ -84,6 +84,11 @@ class InProcessDataClient : public bigtable::DataClient {
       grpc::ClientReaderInterface<google::bigtable::v2::MutateRowsResponse>>
   MutateRows(grpc::ClientContext* context,
              google::bigtable::v2::MutateRowsRequest const& request) override;
+  std::unique_ptr<::grpc::ClientAsyncReaderInterface<
+      ::google::bigtable::v2::MutateRowsResponse>>
+  AsyncMutateRows(::grpc::ClientContext* context,
+                  const ::google::bigtable::v2::MutateRowsRequest& request,
+                  ::grpc::CompletionQueue* cq, void* tag) override;
   //@}
 
  private:

--- a/google/cloud/bigtable/testing/mock_data_client.h
+++ b/google/cloud/bigtable/testing/mock_data_client.h
@@ -69,6 +69,12 @@ class MockDataClient : public bigtable::DataClient {
                    google::bigtable::v2::MutateRowsResponse>>(
                    grpc::ClientContext* context,
                    google::bigtable::v2::MutateRowsRequest const& request));
+  MOCK_METHOD4(AsyncMutateRows,
+               std::unique_ptr<grpc::ClientAsyncReaderInterface<
+                   google::bigtable::v2::MutateRowsResponse>>(
+                   grpc::ClientContext*,
+                   const google::bigtable::v2::MutateRowsRequest&,
+                   grpc::CompletionQueue*, void*));
 };
 
 }  // namespace testing

--- a/google/cloud/bigtable/testing/mock_response_reader.h
+++ b/google/cloud/bigtable/testing/mock_response_reader.h
@@ -104,6 +104,16 @@ class MockAsyncResponseReader
   MOCK_METHOD3_T(Finish, void(Response*, grpc::Status*, void*));
 };
 
+template <typename Response>
+class MockClientAsyncReaderInterface
+    : public grpc::ClientAsyncReaderInterface<Response> {
+ public:
+  MOCK_METHOD1(StartCall, void(void*));
+  MOCK_METHOD1(ReadInitialMetadata, void(void*));
+  MOCK_METHOD2(Finish, void(grpc::Status*, void*));
+  MOCK_METHOD2_T(Read, void(Response*, void*));
+};
+
 }  // namespace testing
 }  // namespace bigtable
 }  // namespace cloud


### PR DESCRIPTION
This PR adds `AsyncBulkMutator`, which implements the async counterpart of
`AsyncBulkMutator` of `MakeOneRequest`. It is suitable for using with
`AsyncRetryOp`.
    
This is the last missing piece to implement AsyncMutateRows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1327)
<!-- Reviewable:end -->
