### PR TITLE
Better management for the cached packages.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,7 +32,7 @@ environment:
       APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
 cache:
-  - c:\projects\vcpkg\installed -> ci\appveyor\install-windows.ps1
+  - c:\projects\vcpkg\installed
 
 install:
   - choco install -y ninja

--- a/ci/appveyor/install-windows.ps1
+++ b/ci/appveyor/install-windows.ps1
@@ -70,6 +70,12 @@ if ($LastExitCode) {
     throw "vcpkg integrate failed with exit code $LastExitCode"
 }
 
+# Remove old versions of the packages.
+& .\vcpkg.exe remove --outdated --recurse
+if ($LastExitCode) {
+    throw "vcpkg remove --outdated failed with exit code $LastExitCode"
+}
+
 # AppVeyor limits builds to 60 minutes. Building all the dependencies takes
 # longer than that. Cache the dependencies to work around the build time
 # restrictions. Explicitly install each dependency because if we run out of


### PR DESCRIPTION
Under AppVeyor we were destroying the full vcpkg cache cache every
time the install script changed.  That often destroyed too much, and
the builds cannot complete with an empty cache (sometimes we are
lucky).  Furthermore, sometimes the vcpkg definition of the cached
packages changes, and the dependency trick did not catch that problem.

I think the new approach, where only the packages in the cache that need
rebuilding are cleared, is probably going to give us better build times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1328)
<!-- Reviewable:end -->
