### PR TITLE
Simplify byproduct definition.

### DIFF
--- a/cmake/ExternalProjectHelper.cmake
+++ b/cmake/ExternalProjectHelper.cmake
@@ -49,12 +49,7 @@ function (set_library_properties_for_external_project _target _lib)
     # The alternative is to manually create "IMPORTED" libraries with the right
     # paths. Generally this is possible because we control how the external
     # projects are compiled and installed.
-    if (WIN32)
-        set(
-            _libfullname
-            "${CMAKE_STATIC_LIBRARY_PREFIX}${_lib}${CMAKE_LIB}${CMAKE_STATIC_LIBRARY_SUFFIX}"
-            )
-    elseif("${BUILD_SHARED_LIBS}" OR "${F_OPT_ALWAYS_SHARED}")
+    if ("${BUILD_SHARED_LIBS}" OR "${F_OPT_ALWAYS_SHARED}")
         set(
             _libfullname
             "${CMAKE_SHARED_LIBRARY_PREFIX}${_lib}${CMAKE_SHARED_LIBRARY_SUFFIX}"
@@ -110,4 +105,31 @@ function (set_executable_name_for_external_project _target _exe)
             IMPORTED_LOCATION
             "${PROJECT_BINARY_DIR}/external/bin/${_exe}${CMAKE_EXECUTABLE_SUFFIX}"
         )
+endfunction ()
+
+function (create_external_project_library_byproduct_list var_name)
+    cmake_parse_arguments(_BYPRODUCT_OPT "ALWAYS_SHARED" "" "" ${ARGN})
+    if ("${BUILD_SHARED_LIBS}" OR "${_BYPRODUCT_OPT_ALWAYS_SHARED}")
+        set(_byproduct_prefix "${CMAKE_SHARED_LIBRARY_PREFIX}")
+        set(_byproduct_suffix "${CMAKE_SHARED_LIBRARY_SUFFIX}")
+    else()
+        set(_byproduct_prefix "${CMAKE_STATIC_LIBRARY_PREFIX}")
+        set(_byproduct_suffix "${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    endif ()
+
+    set(_decorated_byproduct_names)
+    foreach (lib ${_BYPRODUCT_OPT_UNPARSED_ARGUMENTS})
+        list(
+            APPEND
+                _decorated_byproduct_names
+                "<INSTALL_DIR>/lib/${_byproduct_prefix}${lib}${_byproduct_suffix}"
+            )
+        list(
+            APPEND
+                _decorated_byproduct_names
+                "<INSTALL_DIR>/lib/${_byproduct_prefix}${lib}d${_byproduct_suffix}"
+            )
+    endforeach ()
+
+    set(${var_name} ${_decorated_byproduct_names} PARENT_SCOPE)
 endfunction ()

--- a/cmake/external/c-ares.cmake
+++ b/cmake/external/c-ares.cmake
@@ -33,29 +33,28 @@ if (NOT TARGET c_ares_project)
         set(PARALLEL "")
     endif ()
 
+    create_external_project_library_byproduct_list(c_ares_byproducts
+                                                   ALWAYS_SHARED "cares")
+
     include(ExternalProject)
-    externalproject_add(
-        c_ares_project
-        EXCLUDE_FROM_ALL ON
-        PREFIX "${CMAKE_BINARY_DIR}/external/c-ares"
-        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
-        URL ${GOOGLE_CLOUD_CPP_C_ARES_URL}
-        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_C_ARES_SHA256}
-        CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
-                   -DCMAKE_BUILD_TYPE=Release
-                   -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-        BUILD_COMMAND ${CMAKE_COMMAND}
-                      --build
-                      <BINARY_DIR>
-                      ${PARALLEL}
-        BUILD_BYPRODUCTS
-            <INSTALL_DIR>/lib/libcares${CMAKE_SHARED_LIBRARY_SUFFIX}
-            <INSTALL_DIR>/lib/libcares${CMAKE_STATIC_LIBRARY_SUFFIX}
-        LOG_DOWNLOAD ON
-        LOG_CONFIGURE ON
-        LOG_BUILD ON
-        LOG_INSTALL ON)
+    externalproject_add(c_ares_project
+                        EXCLUDE_FROM_ALL ON
+                        PREFIX "${CMAKE_BINARY_DIR}/external/c-ares"
+                        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
+                        URL ${GOOGLE_CLOUD_CPP_C_ARES_URL}
+                        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_C_ARES_SHA256}
+                        CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+                                   -DCMAKE_BUILD_TYPE=Release
+                                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                        BUILD_COMMAND ${CMAKE_COMMAND}
+                                      --build
+                                      <BINARY_DIR>
+                                      ${PARALLEL}
+                        BUILD_BYPRODUCTS ${c_ares_byproducts}
+                        LOG_DOWNLOAD ON
+                        LOG_CONFIGURE ON
+                        LOG_BUILD ON
+                        LOG_INSTALL ON)
 
     add_library(c-ares::cares INTERFACE IMPORTED)
     set_library_properties_for_external_project(c-ares::cares cares

--- a/cmake/external/crc32c.cmake
+++ b/cmake/external/crc32c.cmake
@@ -31,33 +31,32 @@ if (NOT TARGET crc32c_project)
         set(PARALLEL "")
     endif ()
 
+    create_external_project_library_byproduct_list(crc32c_byproducts "crc32c")
+
     include(ExternalProject)
-    externalproject_add(
-        crc32c_project
-        EXCLUDE_FROM_ALL ON
-        PREFIX "${CMAKE_BINARY_DIR}/external/crc32c"
-        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
-        URL ${GOOGLE_CLOUD_CPP_CRC32C_URL}
-        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_CRC32C_SHA256}
-        CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
-                   -DCMAKE_BUILD_TYPE=Release
-                   -DCRC32C_BUILD_TESTS=OFF
-                   -DCRC32C_BUILD_BENCHMARKS=OFF
-                   -DCRC32C_USE_GLOG=OFF
-                   -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-                   -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
-        BUILD_COMMAND ${CMAKE_COMMAND}
-                      --build
-                      <BINARY_DIR>
-                      ${PARALLEL}
-        BUILD_BYPRODUCTS
-            <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}crc32c${CMAKE_STATIC_LIBRARY_SUFFIX}
-            <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}crc32c${CMAKE_SHARED_LIBRARY_SUFFIX}
-        LOG_DOWNLOAD ON
-        LOG_CONFIGURE ON
-        LOG_BUILD ON
-        LOG_INSTALL ON)
+    externalproject_add(crc32c_project
+                        EXCLUDE_FROM_ALL ON
+                        PREFIX "${CMAKE_BINARY_DIR}/external/crc32c"
+                        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
+                        URL ${GOOGLE_CLOUD_CPP_CRC32C_URL}
+                        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_CRC32C_SHA256}
+                        CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+                                   -DCMAKE_BUILD_TYPE=Release
+                                   -DCRC32C_BUILD_TESTS=OFF
+                                   -DCRC32C_BUILD_BENCHMARKS=OFF
+                                   -DCRC32C_USE_GLOG=OFF
+                                   -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+                                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                                   -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
+                        BUILD_COMMAND ${CMAKE_COMMAND}
+                                      --build
+                                      <BINARY_DIR>
+                                      ${PARALLEL}
+                        BUILD_BYPRODUCTS ${crc32c_byproducts}
+                        LOG_DOWNLOAD ON
+                        LOG_CONFIGURE ON
+                        LOG_BUILD ON
+                        LOG_INSTALL ON)
 
     include(ExternalProjectHelper)
     add_library(Crc32c::crc32c INTERFACE IMPORTED)

--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -33,31 +33,32 @@ if (NOT TARGET googletest_project)
         set(PARALLEL "")
     endif ()
 
+    create_external_project_library_byproduct_list(googletest_byproducts
+                                                   "gtest"
+                                                   "gtest_main"
+                                                   "gmock"
+                                                   "gmock_main")
+
     include(ExternalProject)
-    externalproject_add(
-        googletest_project
-        EXCLUDE_FROM_ALL ON
-        PREFIX "${CMAKE_BINARY_DIR}/external/googletest"
-        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
-        URL ${GOOGLE_CLOUD_CPP_GOOGLETEST_URL}
-        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GOOGLETEST_SHA256}
-        CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
-                   -DCMAKE_BUILD_TYPE=Release
-                   -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-        BUILD_COMMAND ${CMAKE_COMMAND}
-                      --build
-                      <BINARY_DIR>
-                      ${PARALLEL}
-        BUILD_BYPRODUCTS
-            <INSTALL_DIR>/lib/libgtest${CMAKE_SHARED_LIBRARY_SUFFIX}
-            <INSTALL_DIR>/lib/libgmock${CMAKE_STATIC_LIBRARY_SUFFIX}
-            <INSTALL_DIR>/lib/libgtest_main${CMAKE_SHARED_LIBRARY_SUFFIX}
-            <INSTALL_DIR>/lib/libgmock_main${CMAKE_STATIC_LIBRARY_SUFFIX}
-        LOG_DOWNLOAD ON
-        LOG_CONFIGURE ON
-        LOG_BUILD ON
-        LOG_INSTALL ON)
+    externalproject_add(googletest_project
+                        EXCLUDE_FROM_ALL ON
+                        PREFIX "${CMAKE_BINARY_DIR}/external/googletest"
+                        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
+                        URL ${GOOGLE_CLOUD_CPP_GOOGLETEST_URL}
+                        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GOOGLETEST_SHA256}
+                        CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+                                   -DCMAKE_BUILD_TYPE=Release
+                                   -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+                                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                        BUILD_COMMAND ${CMAKE_COMMAND}
+                                      --build
+                                      <BINARY_DIR>
+                                      ${PARALLEL}
+                        BUILD_BYPRODUCTS ${googletest_byproducts}
+                        LOG_DOWNLOAD ON
+                        LOG_CONFIGURE ON
+                        LOG_BUILD ON
+                        LOG_INSTALL ON)
 
     # On Windows GTest uses library postfixes for debug versions, that is
     # gtest.lib becomes gtestd.lib when compiled with for debugging.  This ugly

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -35,6 +35,12 @@ if (NOT TARGET gprc_project)
         set(PARALLEL "")
     endif ()
 
+    create_external_project_library_byproduct_list(grpc_byproducts
+                                                   "grpc"
+                                                   "grpc++"
+                                                   "gpr"
+                                                   "address_sorting")
+
     include(ExternalProject)
     externalproject_add(
         grpc_project
@@ -59,14 +65,7 @@ if (NOT TARGET gprc_project)
                       <BINARY_DIR>
                       ${PARALLEL}
         BUILD_BYPRODUCTS
-            <INSTALL_DIR>/lib/libgrpc${CMAKE_STATIC_LIBRARY_SUFFIX}
-            <INSTALL_DIR>/lib/libgrpc${CMAKE_SHARED_LIBRARY_SUFFIX}
-            <INSTALL_DIR>/lib/libgrpc++${CMAKE_STATIC_LIBRARY_SUFFIX}
-            <INSTALL_DIR>/lib/libgrpc++${CMAKE_SHARED_LIBRARY_SUFFIX}
-            <INSTALL_DIR>/lib/libgpr${CMAKE_STATIC_LIBRARY_SUFFIX}
-            <INSTALL_DIR>/lib/libgpr${CMAKE_SHARED_LIBRARY_SUFFIX}
-            <INSTALL_DIR>/lib/libaddress_sorting${CMAKE_STATIC_LIBRARY_SUFFIX}
-            <INSTALL_DIR>/lib/libaddress_sorting${CMAKE_SHARED_LIBRARY_SUFFIX}
+            ${grpc_byproducts}
             <INSTALL_DIR>/bin/grpc_cpp_plugin${CMAKE_EXECUTABLE_SUFFIX}
         LOG_DOWNLOAD ON
         LOG_CONFIGURE ON

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -34,6 +34,9 @@ if (NOT TARGET protobuf_project)
         set(PARALLEL "")
     endif ()
 
+    create_external_project_library_byproduct_list(protobuf_byproducts
+                                                   "protobuf")
+
     include(ExternalProject)
     externalproject_add(
         protobuf_project
@@ -57,10 +60,8 @@ if (NOT TARGET protobuf_project)
                       --build
                       <BINARY_DIR>
                       ${PARALLEL}
-        BUILD_BYPRODUCTS
-            <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/libprotobuf${CMAKE_STATIC_LIBRARY_SUFFIX}
-            <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/libprotobuf${CMAKE_SHARED_LIBRARY_SUFFIX}
-            <INSTALL_DIR>/bin/protoc${CMAKE_EXECUTABLE_SUFFIX}
+        BUILD_BYPRODUCTS ${protobuf_byproducts}
+                         <INSTALL_DIR>/bin/protoc${CMAKE_EXECUTABLE_SUFFIX}
         LOG_DOWNLOAD ON
         LOG_CONFIGURE ON
         LOG_BUILD ON


### PR DESCRIPTION
When using external projects with Ninja we need to specify the
byproducts (or if you prefer, the artifacts produced by) of each
external project. It it somewhat tedious to manually type these
byproducts when they are libraries, this PR introduces a CMake function
to compute them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1329)
<!-- Reviewable:end -->
