### PR TITLE
Implement CRC32C-based HashValidator.

### DIFF
--- a/google/cloud/storage/internal/hash_validator.cc
+++ b/google/cloud/storage/internal/hash_validator.cc
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/hash_validator.h"
+#include "google/cloud/internal/big_endian.h"
 #include "google/cloud/storage/internal/openssl_util.h"
 #include "google/cloud/storage/object_metadata.h"
 #include "google/cloud/storage/status.h"
-#include <openssl/md5.h>
+#include <crc32c/crc32c.h>
 
 namespace google {
 namespace cloud {
@@ -49,12 +50,70 @@ void MD5HashValidator::ProcessHeader(std::string const& key,
   if (pos == std::string::npos) {
     return;
   }
-  received_hash_ = value.substr(pos + 4);
+  auto end = value.find(',', pos);
+  if (end == std::string::npos) {
+    received_hash_ = value.substr(pos + 4);
+    return;
+  }
+  received_hash_ = value.substr(pos + 4, end - pos - 4);
 }
 
 HashValidator::Result MD5HashValidator::Finish(std::string const& msg) && {
   std::string hash(MD5_DIGEST_LENGTH, ' ');
   MD5_Final(reinterpret_cast<unsigned char*>(&hash[0]), &context_);
+  auto computed = OpenSslUtils::Base64Encode(hash);
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  // Sometimes the server simply does not have a MD5 hash to send us, the most
+  // common case is a composed object, particularly one formed from encrypted
+  // components, where computing the MD5 would require decrypting and re-reading
+  // all the components. In that case we just do not raise an exception even if
+  // there is a mismatch.
+  if (not received_hash_.empty() and received_hash_ != computed) {
+    throw HashMismatchError(msg, std::move(received_hash_),
+                            std::move(computed));
+  }
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  return Result{std::move(received_hash_), std::move(computed)};
+}
+
+Crc32cHashValidator::Crc32cHashValidator() : current_(0) {}
+
+void Crc32cHashValidator::Update(std::string const& payload) {
+  current_ = crc32c::Extend(current_, reinterpret_cast<std::uint8_t const*>(payload.data()), payload.size());
+}
+
+void Crc32cHashValidator::ProcessMetadata(ObjectMetadata const& meta) {
+  if (meta.crc32c().empty()) {
+    // When using the XML API the metadata is empty, but the headers are not. In
+    // that case we do not want to replace the received hash with an empty
+    // value.
+    return;
+  }
+  received_hash_ = meta.crc32c();
+
+}
+
+void Crc32cHashValidator::ProcessHeader(std::string const& key, std::string const& value) {
+  if (key != "x-goog-hash") {
+    return;
+  }
+  auto pos = value.find("crc32c=");
+  if (pos == std::string::npos) {
+    return;
+  }
+  auto end = value.find(',', pos);
+  if (end == std::string::npos) {
+    received_hash_ = value.substr(pos + 7);
+    return;
+  }
+  received_hash_ = value.substr(pos + 7, end - pos - 7);
+}
+
+HashValidator::Result Crc32cHashValidator::Finish(std::string const& msg) && {
+  std::uint32_t big_endian = google::cloud::internal::ToBigEndian(current_);
+  std::string hash;
+  hash.resize(sizeof(big_endian));
+  std::memcpy(&hash[0], &big_endian, sizeof(big_endian));
   auto computed = OpenSslUtils::Base64Encode(hash);
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   // Sometimes the server simply does not have a MD5 hash to send us, the most

--- a/google/cloud/storage/internal/hash_validator.h
+++ b/google/cloud/storage/internal/hash_validator.h
@@ -96,6 +96,26 @@ class MD5HashValidator : public HashValidator {
   std::string received_hash_;
 };
 
+/**
+ * A validator based on CRC32C checksums.
+ */
+class Crc32cHashValidator : public HashValidator {
+ public:
+  Crc32cHashValidator();
+
+  Crc32cHashValidator(Crc32cHashValidator const&) = delete;
+  Crc32cHashValidator& operator=(Crc32cHashValidator const&) = delete;
+
+  void Update(std::string const& payload) override;
+  void ProcessMetadata(ObjectMetadata const& meta) override;
+  void ProcessHeader(std::string const& key, std::string const& value) override;
+  Result Finish(std::string const& msg) && override;
+
+ private:
+  std::uint32_t current_;
+  std::string received_hash_;
+};
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage


### PR DESCRIPTION
This will be used to validate the CRC32C checksums in both uploads and
downloads, just like we do for MD5 hashes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1330)
<!-- Reviewable:end -->
