### PR TITLE
Add support for detecting if running on GCE.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -113,6 +113,7 @@ add_library(storage_client
             internal/bucket_requests.cc
             internal/complex_option.h
             internal/common_metadata.h
+            internal/compute_engine_util.h
             internal/curl_handle.h
             internal/curl_handle.cc
             internal/curl_handle_factory.h

--- a/google/cloud/storage/internal/compute_engine_util.h
+++ b/google/cloud/storage/internal/compute_engine_util.h
@@ -1,0 +1,104 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_COMPUTE_ENGINE_UTIL_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_COMPUTE_ENGINE_UTIL_H_
+
+#include "google/cloud/storage/version.h"
+#include <string>
+#if _WIN32
+#include <Windows.h>
+#else  // On Linux
+#include <fstream>
+#endif  // _WIN32
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+
+/**
+ * Returns true if the program is running on a Compute Engine VM.
+ *
+ * This method checks the system BIOS information to determine if the program
+ * is running on a GCE VM. This has proven to be more reliable than pinging the
+ * GCE metadata server (e.g. the metadata server may be temporarily unavailable,
+ * the VM may be experiencing network issues, etc.).
+ */
+bool RunningOnComputeEngineVm() {
+#if _WIN32
+  // These values came from a GCE VM running Windows Server 2012 R2.
+  std::wstring const REG_KEY_PATH = L"SYSTEM\\HardwareConfig\\Current\\";
+  std::wstring const REG_KEY_NAME = L"SystemProductName";
+  std::wstring const GCE_PRODUCT_NAME = L"Google Compute Engine";
+
+  // Get the size of the string first to allocate our buffer. This includes
+  // enough space for the trailing NUL character that will be included.
+  DWORD buffer_size{};
+  auto rc = ::RegGetValueW(
+      HKEY_LOCAL_MACHINE, REG_KEY_PATH.c_str(), REG_KEY_NAME.c_str(),
+      RRF_RT_REG_SZ,
+      nullptr,        // We know the type will be REG_SZ.
+      nullptr,        // We're only fetching the size; no buffer given yet.
+      &buffer_size);  // Fetch the size in bytes of the value, if it exists.
+  if (rc != 0) {  // 0 means success.
+    return false;
+  }
+
+  // Allocate the buffer size and retrieve the product name string.
+  std::wstring buffer;
+  buffer.resize(static_cast<std::size_t>(buffer_size) / sizeof(wchar_t));
+  rc = ::RegGetValueW(
+      HKEY_LOCAL_MACHINE, REG_KEY_PATH.c_str(), REG_KEY_NAME.c_str(),
+      RRF_RT_REG_SZ,
+      nullptr,                         // We know the type will be REG_SZ.
+      static_cast<void*>(&buffer[0]),  // Fetch the string value this time.
+      &buffer_size);  // The wstring size in bytes, not including trailing NUL.
+  if (rc != 0) {
+    return false;
+  }
+
+  // Account for the trailing NUL character in the retrieved value, along with
+  // the additional NUL char appended to all wstring objects.
+  buffer_size = static_cast<std::size_t>(buffer_size) / sizeof(wchar_t);
+  if (buffer_size == 0) {
+    return false;
+  }
+  buffer_size--;
+  buffer.resize(static_cast<std::size_t>(buffer_size));
+
+  return buffer == GCE_PRODUCT_NAME;
+#else   // Running on Linux
+  // On Linux GCE VMs, we expect to see "Google Compute Engine" as the contents
+  // of the file at /sys/class/dmi/id/product_name.
+  std::string const GCE_PRODUCT_NAME = "Google Compute Engine";
+  std::string const PRODUCT_NAME_FILE = "/sys/class/dmi/id/product_name";
+  std::ifstream is(PRODUCT_NAME_FILE);
+  if (not is.is_open()) {
+    return false;
+  }
+  std::string first_line;
+  std::getline(is, first_line);
+  return first_line == GCE_PRODUCT_NAME;
+#endif  // _WIN32
+}
+
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_COMPUTE_ENGINE_UTIL_H_

--- a/google/cloud/storage/internal/compute_engine_util.h
+++ b/google/cloud/storage/internal/compute_engine_util.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_COMPUTE_ENGINE_UTIL_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_COMPUTE_ENGINE_UTIL_H_
 
+#include "google/cloud/log.h"
 #include "google/cloud/storage/version.h"
 #include <string>
 #if _WIN32
@@ -87,6 +88,8 @@ bool RunningOnComputeEngineVm() {
   std::string const PRODUCT_NAME_FILE = "/sys/class/dmi/id/product_name";
   std::ifstream is(PRODUCT_NAME_FILE);
   if (not is.is_open()) {
+    GCP_LOG(WARNING) << "Could not find file '" << PRODUCT_NAME_FILE
+                      << "' when checking if running on GCE, returning false";
     return false;
   }
   std::string first_line;

--- a/google/cloud/storage/internal/compute_engine_util.h
+++ b/google/cloud/storage/internal/compute_engine_util.h
@@ -53,7 +53,7 @@ bool RunningOnComputeEngineVm() {
       nullptr,        // We know the type will be REG_SZ.
       nullptr,        // We're only fetching the size; no buffer given yet.
       &buffer_size);  // Fetch the size in bytes of the value, if it exists.
-  if (rc != 0) {  // 0 means success.
+  if (rc != 0) {
     return false;
   }
 

--- a/google/cloud/storage/internal/compute_engine_util.h
+++ b/google/cloud/storage/internal/compute_engine_util.h
@@ -89,7 +89,7 @@ bool RunningOnComputeEngineVm() {
   std::ifstream is(PRODUCT_NAME_FILE);
   if (not is.is_open()) {
     GCP_LOG(WARNING) << "Could not find file '" << PRODUCT_NAME_FILE
-                      << "' when checking if running on GCE, returning false";
+                     << "' when checking if running on GCE, returning false";
     return false;
   }
   std::string first_line;

--- a/google/cloud/storage/storage_client.bzl
+++ b/google/cloud/storage/storage_client.bzl
@@ -11,6 +11,7 @@ storage_client_HDRS = [
     "internal/bucket_requests.h",
     "internal/complex_option.h",
     "internal/common_metadata.h",
+    "internal/compute_engine_util.h",
     "internal/curl_handle.h",
     "internal/curl_handle_factory.h",
     "internal/curl_download_request.h",


### PR DESCRIPTION
This implements the recommended approach for detecting whether the
program is running on a Google Compute Engine VM instance. It follows
the approach taken by the grpc library for Linux, but for Windows
machines, it checks the registry rather than launching a subshell and
querying WMI, e.g. `Get-WMIObject -Query "SELECT ... FROM Win32_BIOS"`.
The grpc approaches can be seen in their repository:
    https://github.com/grpc/grpc/blob/master/src/core/lib/security/credentials/alts/check_gcp_environment_linux.cc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1335)
<!-- Reviewable:end -->
