### PR TITLE
Implement BulkAsyncRetry

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -145,6 +145,7 @@ add_library(bigtable_client
             instance_config.cc
             instance_update_config.h
             instance_update_config.cc
+            internal/async_bulk_apply.h
             internal/async_retry_unary_rpc.h
             internal/bulk_mutator.h
             internal/bulk_mutator.cc
@@ -288,6 +289,7 @@ set(bigtable_client_unit_tests
     internal/prefix_range_end_test.cc
     internal/table_admin_test.cc
     internal/table_async_apply_test.cc
+    internal/table_async_bulk_apply_test.cc
     internal/table_test.cc
     mutations_test.cc
     table_admin_test.cc

--- a/google/cloud/bigtable/bigtable_client.bzl
+++ b/google/cloud/bigtable/bigtable_client.bzl
@@ -16,6 +16,7 @@ bigtable_client_HDRS = [
     "instance_admin.h",
     "instance_config.h",
     "instance_update_config.h",
+    "internal/async_bulk_apply.h",
     "internal/async_retry_unary_rpc.h",
     "internal/bulk_mutator.h",
     "internal/completion_queue_impl.h",

--- a/google/cloud/bigtable/bigtable_client_unit_tests.bzl
+++ b/google/cloud/bigtable/bigtable_client_unit_tests.bzl
@@ -22,6 +22,7 @@ bigtable_client_unit_tests = [
     "internal/prefix_range_end_test.cc",
     "internal/table_admin_test.cc",
     "internal/table_async_apply_test.cc",
+    "internal/table_async_bulk_apply_test.cc",
     "internal/table_test.cc",
     "mutations_test.cc",
     "table_admin_test.cc",

--- a/google/cloud/bigtable/data_client.cc
+++ b/google/cloud/bigtable/data_client.cc
@@ -101,6 +101,13 @@ class DefaultDataClient : public DataClient {
              btproto::MutateRowsRequest const& request) override {
     return impl_.Stub()->MutateRows(context, request);
   }
+  std::unique_ptr<::grpc::ClientAsyncReaderInterface<
+      ::google::bigtable::v2::MutateRowsResponse>>
+  AsyncMutateRows(::grpc::ClientContext* context,
+                  const ::google::bigtable::v2::MutateRowsRequest& request,
+                  ::grpc::CompletionQueue* cq, void* tag) {
+    return impl_.Stub()->AsyncMutateRows(context, request, cq, tag);
+  }
 
  private:
   std::string project_;

--- a/google/cloud/bigtable/data_client.cc
+++ b/google/cloud/bigtable/data_client.cc
@@ -105,7 +105,7 @@ class DefaultDataClient : public DataClient {
       ::google::bigtable::v2::MutateRowsResponse>>
   AsyncMutateRows(::grpc::ClientContext* context,
                   const ::google::bigtable::v2::MutateRowsRequest& request,
-                  ::grpc::CompletionQueue* cq, void* tag) {
+                  ::grpc::CompletionQueue* cq, void* tag) override {
     return impl_.Stub()->AsyncMutateRows(context, request, cq, tag);
   }
 

--- a/google/cloud/bigtable/data_client.h
+++ b/google/cloud/bigtable/data_client.h
@@ -113,6 +113,11 @@ class DataClient {
       grpc::ClientReaderInterface<google::bigtable::v2::MutateRowsResponse>>
   MutateRows(grpc::ClientContext* context,
              google::bigtable::v2::MutateRowsRequest const& request) = 0;
+  virtual std::unique_ptr<::grpc::ClientAsyncReaderInterface<
+      ::google::bigtable::v2::MutateRowsResponse>>
+  AsyncMutateRows(::grpc::ClientContext* context,
+                  const ::google::bigtable::v2::MutateRowsRequest& request,
+                  ::grpc::CompletionQueue* cq, void* tag) = 0;
   //@}
 };
 

--- a/google/cloud/bigtable/data_client.h
+++ b/google/cloud/bigtable/data_client.h
@@ -28,6 +28,7 @@ namespace noex {
 class Table;
 }  // namespace noex
 namespace internal {
+class AsyncBulkMutator;
 class BulkMutator;
 }  // namespace internal
 
@@ -80,6 +81,7 @@ class DataClient {
  protected:
   friend class Table;
   friend class noex::Table;
+  friend class internal::AsyncBulkMutator;
   friend class internal::BulkMutator;
   friend class RowReader;
   //@{

--- a/google/cloud/bigtable/internal/async_bulk_apply.h
+++ b/google/cloud/bigtable/internal/async_bulk_apply.h
@@ -1,0 +1,159 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_BULK_APPLY_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_BULK_APPLY_H
+
+#include "google/cloud/bigtable/async_operation.h"
+#include "google/cloud/bigtable/bigtable_strong_types.h"
+#include "google/cloud/bigtable/completion_queue.h"
+#include "google/cloud/bigtable/data_client.h"
+#include "google/cloud/bigtable/internal/bulk_mutator.h"
+#include "google/cloud/bigtable/metadata_update_policy.h"
+#include "google/cloud/bigtable/rpc_backoff_policy.h"
+#include "google/cloud/bigtable/rpc_retry_policy.h"
+#include "google/cloud/bigtable/table_strong_types.h"
+#include "google/cloud/internal/invoke_result.h"
+#include "google/cloud/internal/make_unique.h"
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
+
+template <typename Functor,
+          typename std::enable_if<
+              google::cloud::internal::is_invocable<
+                  Functor, CompletionQueue&, std::vector<FailedMutation>&,
+                  grpc::Status&>::value,
+              int>::type valid_callback_type = 0>
+class AsyncRetryBulkApply
+    : public std::enable_shared_from_this<AsyncRetryBulkApply<Functor>> {
+ public:
+  AsyncRetryBulkApply(std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
+                      std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
+                      IdempotentMutationPolicy& idempotent_policy,
+                      MetadataUpdatePolicy metadata_update_policy,
+                      std::shared_ptr<bigtable::DataClient> client,
+                      bigtable::AppProfileId const& app_profile_id,
+                      bigtable::TableId const& table_name, BulkMutation&& mut,
+                      Functor&& callback)
+      : impl_(client, std::move(app_profile_id), std::move(table_name),
+              idempotent_policy, std::forward<BulkMutation>(mut)),
+        rpc_retry_policy_(std::move(rpc_retry_policy)),
+        rpc_backoff_policy_(std::move(rpc_backoff_policy)),
+        metadata_update_policy_(std::move(metadata_update_policy)),
+        callback_(std::forward<Functor>(callback)) {}
+  /**
+   * Kick off the asynchronous request.
+   *
+   * @param cq the completion queue to run the asynchronous operations.
+   */
+  void Start(CompletionQueue& cq) {
+    auto self = this->shared_from_this();
+    auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
+    rpc_retry_policy_->Setup(*context);
+    rpc_backoff_policy_->Setup(*context);
+    metadata_update_policy_.Setup(*context);
+
+    impl_.Start(cq, std::move(context),
+                [self](CompletionQueue& cq, grpc::Status& status) {
+                  self->OnCompletion(cq, status);
+                });
+  }
+
+ private:
+  std::string FullErrorMessage(char const* where) {
+    std::string full_message =
+        "AsyncBulkApply(" + metadata_update_policy_.value() + ") ";
+    full_message += where;
+    return full_message;
+  }
+
+  std::string FullErrorMessage(char const* where, grpc::Status const& status) {
+    std::string full_message = FullErrorMessage(where);
+    full_message += ", last error=";
+    full_message += status.error_message();
+    return full_message;
+  }
+
+  /// The callback to handle one asynchronous request completing.
+  void OnCompletion(CompletionQueue& cq, grpc::Status& status) {
+    if (status.error_code() == grpc::StatusCode::CANCELLED) {
+      // Cancelled, no retry necessary.
+      auto res = impl_.ExtractFinalFailures();
+      grpc::Status res_status(
+          grpc::StatusCode::CANCELLED,
+          FullErrorMessage("pending operation cancelled", status),
+          status.error_details());
+      callback_(cq, res, res_status);
+      return;
+    }
+    if (status.ok()) {
+      // Success, just report the result.
+      auto res = impl_.ExtractFinalFailures();
+      callback_(cq, res, status);
+      return;
+    }
+    if (not rpc_retry_policy_->OnFailure(status)) {
+      std::string full_message =
+          FullErrorMessage(RPCRetryPolicy::IsPermanentFailure(status)
+                               ? "permanent error"
+                               : "too many transient errors",
+                           status);
+      auto res = impl_.ExtractFinalFailures();
+      grpc::Status res_status(status.error_code(), full_message,
+                              status.error_details());
+      callback_(cq, res, res_status);
+      return;
+    }
+    // BulkMutator keeps track of idempotency of the mutations it holds, so
+    // we'll just keep retrying if the policy says so.
+
+    auto delay = rpc_backoff_policy_->OnCompletion(status);
+    auto self = this->shared_from_this();
+    cq.MakeRelativeTimer(
+        delay,
+        [self](CompletionQueue& cq, AsyncTimerResult timer,
+               AsyncOperation::Disposition d) { self->OnTimer(cq, timer, d); });
+  }
+
+  void OnTimer(CompletionQueue& cq, AsyncTimerResult& timer,
+               AsyncOperation::Disposition d) {
+    if (d == AsyncOperation::CANCELLED) {
+      // Cancelled, no more action to take.
+      auto res = impl_.ExtractFinalFailures();
+      grpc::Status res_status(grpc::StatusCode::CANCELLED,
+                              FullErrorMessage("pending timer cancelled"));
+      callback_(cq, res, res_status);
+      return;
+    }
+    Start(cq);
+  }
+
+  AsyncBulkMutator impl_;
+  std::unique_ptr<RPCRetryPolicy> rpc_retry_policy_;
+  std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy_;
+  MetadataUpdatePolicy metadata_update_policy_;
+  Functor callback_;
+};
+
+}  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_BULK_APPLY_H

--- a/google/cloud/bigtable/internal/async_bulk_apply.h
+++ b/google/cloud/bigtable/internal/async_bulk_apply.h
@@ -123,12 +123,15 @@ class AsyncRetryBulkApply
       callback_(cq, res, res_status);
       return;
     }
-    if (status.ok() && !impl_.HasPendingMutations()) {
+    if (status.ok() and not impl_.HasPendingMutations()) {
       // Success, just report the result.
       auto res = impl_.ExtractFinalFailures();
       callback_(cq, res, status);
       return;
     }
+    // It might happen that status.ok() is true here, but there are pending
+    // mutations. Due to that, RPCRetryPolicy shouldn't consider status.ok() as
+    // permanent errors.
     if (not rpc_retry_policy_->OnFailure(status)) {
       std::string full_message =
           FullErrorMessage(RPCRetryPolicy::IsPermanentFailure(status)

--- a/google/cloud/bigtable/internal/async_bulk_apply.h
+++ b/google/cloud/bigtable/internal/async_bulk_apply.h
@@ -33,7 +33,6 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
 
-
 /**
  * Perform an AsyncBulkApply operation request with retries.
  *
@@ -78,6 +77,7 @@ class AsyncRetryBulkApply
         rpc_backoff_policy_(std::move(rpc_backoff_policy)),
         metadata_update_policy_(std::move(metadata_update_policy)),
         callback_(std::forward<Functor>(callback)) {}
+
   /**
    * Kick off the asynchronous request.
    *
@@ -123,7 +123,7 @@ class AsyncRetryBulkApply
       callback_(cq, res, res_status);
       return;
     }
-    if (status.ok()) {
+    if (status.ok() && !impl_.HasPendingMutations()) {
       // Success, just report the result.
       auto res = impl_.ExtractFinalFailures();
       callback_(cq, res, status);

--- a/google/cloud/bigtable/internal/async_bulk_apply.h
+++ b/google/cloud/bigtable/internal/async_bulk_apply.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,6 +33,28 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
 
+
+/**
+ * Perform an AsyncBulkApply operation request with retries.
+ *
+ * @tparam Client the class implementing the asynchronous operation, examples
+ *     include `DataClient`, `AdminClient`, and `InstanceAdminClient`.
+ *
+ * @tparam MemberFunctionType the type of the member function to call on the
+ *     `Client` object. This type must meet the requirements of
+ *     `internal::CheckAsyncUnaryRpcSignature`, the `AsyncRetryUnaryRpc`
+ *     template is disabled otherwise.
+ *
+ * @tparam Functor the type of the function-like object that will receive the
+ *     results. It must satisfy (using C++17 types):
+ *     static_assert(std::is_invocable_v<
+ *         Functor, CompletionQueue&, std::vector<FailedMutation>&,
+ *             grpc::Status&>);
+ *
+ * @tparam valid_callback_type a format parameter, uses `std::enable_if<>` to
+ *     disable this template if the functor does not match the expected
+ *     signature.
+ */
 template <typename Functor,
           typename std::enable_if<
               google::cloud::internal::is_invocable<

--- a/google/cloud/bigtable/internal/async_bulk_apply.h
+++ b/google/cloud/bigtable/internal/async_bulk_apply.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_BULK_APPLY_H
-#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_BULK_APPLY_H
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_BULK_APPLY_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_BULK_APPLY_H_
 
 #include "google/cloud/bigtable/async_operation.h"
 #include "google/cloud/bigtable/bigtable_strong_types.h"
@@ -181,4 +181,4 @@ class AsyncRetryBulkApply
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_BULK_APPLY_H
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_BULK_APPLY_H_

--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -134,9 +134,8 @@ class AsyncBulkMutator : protected BulkMutator {
              std::unique_ptr<grpc::ClientContext>&& context,
              Functor&& callback) {
     PrepareForRequest();
-    rpc_ = cq.MakeUnaryStreamRpc(
-        *client_, &DataClient::AsyncMutateRows, pending_mutations_,
-        std::move(context),
+    cq.MakeUnaryStreamRpc(
+        *client_, &DataClient::AsyncMutateRows, mutations_, std::move(context),
         [this](CompletionQueue&, const grpc::ClientContext&,
                google::bigtable::v2::MutateRowsResponse& response) {
           ProcessResponse(response);

--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -15,10 +15,15 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_BULK_MUTATOR_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_BULK_MUTATOR_H_
 
+#include "google/cloud/bigtable/async_operation.h"
 #include "google/cloud/bigtable/bigtable_strong_types.h"
+#include "google/cloud/bigtable/completion_queue.h"
 #include "google/cloud/bigtable/data_client.h"
 #include "google/cloud/bigtable/idempotent_mutation_policy.h"
+#include "google/cloud/bigtable/internal/async_retry_op.h"
 #include "google/cloud/bigtable/table_strong_types.h"
+#include "google/cloud/internal/invoke_result.h"
+#include "google/cloud/internal/make_unique.h"
 
 namespace google {
 namespace cloud {
@@ -37,14 +42,14 @@ class BulkMutator {
     return pending_mutations_.entries_size() != 0;
   }
 
-  /// Send one batch request to the given stub.
+  /// Synchronously send one batch request to the given stub.
   grpc::Status MakeOneRequest(bigtable::DataClient& client,
                               grpc::ClientContext& client_context);
 
   /// Give up on any pending mutations, move them to the failures array.
   std::vector<FailedMutation> ExtractFinalFailures();
 
- private:
+ protected:
   /// Get ready for a new request.
   void PrepareForRequest();
 
@@ -54,7 +59,6 @@ class BulkMutator {
   /// A request has finished and we have processed all the responses.
   void FinishRequest();
 
- private:
   /// Accumulate any permanent failures and the list of mutations we gave up on.
   std::vector<FailedMutation> failures_;
 
@@ -90,6 +94,92 @@ class BulkMutator {
   /// Accumulate annotations for the next request.
   std::vector<Annotations> pending_annotations_;
 };
+
+/**
+ * Async-friendly version BulkMutator.
+ *
+ * It satisfies the requirements to be used in AsyncRetryOp.
+ *
+ * It extends the normal BulkMutator with logic to do its job asynchronously.
+ * Conceptually it reimplements MakeOneRequest in an async way.
+ */
+class AsyncBulkMutator : protected BulkMutator {
+ public:
+  AsyncBulkMutator(std::shared_ptr<bigtable::DataClient> client,
+                   bigtable::AppProfileId const& app_profile_id,
+                   bigtable::TableId const& table_name,
+                   IdempotentMutationPolicy& idempotent_policy,
+                   BulkMutation&& mut)
+      : BulkMutator(app_profile_id, table_name, idempotent_policy,
+                    std::move(mut)),
+        client_(std::move(client)) {}
+
+  // For AsyncRetryOp
+  using Request = google::bigtable::v2::MutateRowsRequest;
+  // We don't want to make AsyncRetryOp return the last response because
+  // we care about the accumulated result from all retries, not the last
+  // response. Due to that, we accumulate and process the responses in this
+  // object and forge a dummy int result to AsyncRetryOp. Eventually, after all
+  // retries are done, the user will call ExtractFinalFailures to get to know
+  // the actual response.
+  using Response = int;
+  using AsyncResult = AsyncUnaryRpcResult<int>;
+
+  template <typename Functor,
+            typename std::enable_if<google::cloud::internal::is_invocable<
+                                        Functor, CompletionQueue&, AsyncResult&,
+                                        AsyncOperation::Disposition>::value,
+                                    int>::type valid_callback_type = 0>
+  void Start(CompletionQueue& cq,
+             std::unique_ptr<grpc::ClientContext>&& context,
+             Functor&& callback) {
+    PrepareForRequest();
+    rpc_ = cq.MakeUnaryStreamRpc(
+        *client_, &DataClient::AsyncMutateRows, pending_mutations_,
+        std::move(context),
+        [this](CompletionQueue&, const grpc::ClientContext&,
+               google::bigtable::v2::MutateRowsResponse& response) {
+          ProcessResponse(response);
+        },
+        FinishedCallback<Functor>(*this, std::forward<Functor>(callback)));
+  }
+  using BulkMutator::ExtractFinalFailures;
+
+ private:
+  template <typename Functor,
+            typename std::enable_if<google::cloud::internal::is_invocable<
+                                        Functor, CompletionQueue&, AsyncResult&,
+                                        AsyncOperation::Disposition>::value,
+                                    int>::type valid_callback_type = 0>
+  struct FinishedCallback {
+    FinishedCallback(AsyncBulkMutator& parent, Functor&& callback)
+        : parent_(parent), callback_(callback) {}
+
+    void operator()(CompletionQueue& cq, grpc::ClientContext& context,
+                    grpc::Status& status) {
+      parent_.FinishRequest();
+
+      if (parent_.HasPendingMutations() && status.ok()) {
+        // Can this even happen? Sounds like it would be a bug.
+        status = grpc::Status(grpc::StatusCode::UNAVAILABLE,
+                              "Some mutations were not confirmed");
+      }
+      // TODO(#1308) - the context is wrong here, but deferring the fix until
+      // the API is changed as a part of Disposition removal.
+      AsyncResult res{
+          0, std::move(status),
+          google::cloud::internal::make_unique<grpc::ClientContext>()};
+      callback_(cq, res, AsyncOperation::COMPLETED);
+    }
+    AsyncBulkMutator& parent_;
+    Functor callback_;
+  };
+
+ private:
+  std::shared_ptr<bigtable::DataClient> client_;
+  std::shared_ptr<AsyncOperation> rpc_;
+};
+
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -176,7 +176,6 @@ class AsyncBulkMutator : protected BulkMutator {
 
  private:
   std::shared_ptr<bigtable::DataClient> client_;
-  std::shared_ptr<AsyncOperation> rpc_;
 };
 
 }  // namespace internal

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -477,18 +477,15 @@ TEST(MultipleRowsMutatorTest, SimpleAsync) {
   using bigtable::AsyncOperation;
   using bigtable::AsyncUnaryRpcResult;
   mutator.Start(cq, std::move(context),
-                [&](CompletionQueue&, AsyncUnaryRpcResult<int>& res,
-                    AsyncOperation::Disposition d) {
-                  EXPECT_EQ(d, AsyncOperation::COMPLETED);
-                  EXPECT_EQ(0, res.response);
-                  EXPECT_TRUE(res.status.ok());
-                  EXPECT_EQ("mocked-status", res.status.error_message());
+                [&](CompletionQueue&, grpc::Status &status) {
+                  EXPECT_TRUE(status.ok());
+                  EXPECT_EQ("mocked-status", status.error_message());
                   mutator_finished = true;
                 });
   impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
   // state == PROCESSING
   impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
-  // state == PROCESSING, 1 rea
+  // state == PROCESSING, 1 read
   impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
   // state == FINISHING
   EXPECT_FALSE(mutator_finished);
@@ -537,12 +534,9 @@ TEST(MultipleRowsMutatorTest, SimpleAsyncFailure) {
   using bigtable::AsyncOperation;
   using bigtable::AsyncUnaryRpcResult;
   mutator.Start(cq, std::move(context),
-                [&](CompletionQueue&, AsyncUnaryRpcResult<int>& res,
-                    AsyncOperation::Disposition d) {
-                  EXPECT_EQ(d, AsyncOperation::COMPLETED);
-                  EXPECT_EQ(0, res.response);
-                  EXPECT_FALSE(res.status.ok());
-                  EXPECT_EQ("mocked-status", res.status.error_message());
+                [&](CompletionQueue&, grpc::Status &status) {
+                  EXPECT_FALSE(status.ok());
+                  EXPECT_EQ("mocked-status", status.error_message());
                   mutator_finished = true;
                 });
   impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);

--- a/google/cloud/bigtable/internal/table.h
+++ b/google/cloud/bigtable/internal/table.h
@@ -202,6 +202,21 @@ class Table {
     retry->Start(cq);
   }
 
+  /**
+   * Make an asynchronous request to mutate a multiple rows.
+   *
+   * @param mut the bulk mutation to apply.
+   * @param cq the completion queue that will execute the asynchronous calls,
+   *     the application must ensure that one or more threads are blocked on
+   *     `cq.Run()`.
+   * @param callback a functor to be called when the operation completes. It
+   *     must satisfy (using C++17 types):
+   *     static_assert(std::is_invocable_v<
+   *         Functor, CompletionQueue&, std::vector<FailedMutation>&,
+   *             grpc::Status&>);
+   *
+   * @tparam Functor the type of the callback.
+   */
   template <typename Functor,
             typename std::enable_if<
                 google::cloud::internal::is_invocable<

--- a/google/cloud/bigtable/internal/table_async_bulk_apply_test.cc
+++ b/google/cloud/bigtable/internal/table_async_bulk_apply_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/bigtable/internal/table_async_bulk_apply_test.cc
+++ b/google/cloud/bigtable/internal/table_async_bulk_apply_test.cc
@@ -1,0 +1,265 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/internal/table.h"
+#include "google/cloud/bigtable/testing/internal_table_test_fixture.h"
+#include "google/cloud/bigtable/testing/mock_completion_queue.h"
+#include "google/cloud/bigtable/testing/mock_mutate_rows_reader.h"
+#include "google/cloud/testing_util/chrono_literals.h"
+#include <gmock/gmock.h>
+#include <thread>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace noex {
+namespace {
+
+namespace bt = ::google::cloud::bigtable;
+namespace btproto = google::bigtable::v2;
+using namespace google::cloud::testing_util::chrono_literals;
+using namespace ::testing;
+
+class NoexTableAsyncBulkApplyTest
+    : public bigtable::testing::internal::TableTestFixture {};
+
+/// @test Verify that noex::Table::AsyncBulkApply() works in a simple case.
+TEST_F(NoexTableAsyncBulkApplyTest, IdempotencyAndRetries) {
+  // This test creates 3 mutations. First one will succeed straight away, second
+  // on retry and third never, because it's not idempotent.
+  bt::BulkMutation mut(
+      bt::SingleRowMutation("foo", {bt::SetCell("fam", "col", 0_ms, "baz")}),
+      bt::SingleRowMutation("bar", {bt::SetCell("fam", "col", 0_ms, "qux")}),
+      bt::SingleRowMutation("baz", {bt::SetCell("fam", "col", "qux")}));
+
+  using bigtable::testing::MockClientAsyncReaderInterface;
+
+  // reader1 will confirm only the first mutation and return UNAVAILABLE to
+  // others.
+  MockClientAsyncReaderInterface<btproto::MutateRowsResponse>* reader1 =
+      new MockClientAsyncReaderInterface<btproto::MutateRowsResponse>;
+  std::unique_ptr<MockClientAsyncReaderInterface<btproto::MutateRowsResponse>>
+      reader_deleter1(reader1);
+  EXPECT_CALL(*reader1, Read(_, _))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r, void*) {
+        {
+          auto& e = *r->add_entries();
+          e.set_index(0);
+          e.mutable_status()->set_code(grpc::StatusCode::OK);
+        }
+        {
+          auto& e = *r->add_entries();
+          e.set_index(1);
+          e.mutable_status()->set_code(grpc::StatusCode::UNAVAILABLE);
+        }
+        {
+          auto& e = *r->add_entries();
+          e.set_index(2);
+          e.mutable_status()->set_code(grpc::StatusCode::UNAVAILABLE);
+        }
+      }))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r, void*) {}));
+
+  EXPECT_CALL(*reader1, Finish(_, _))
+      .WillOnce(Invoke([](grpc::Status* status, void*) {
+        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+      }));
+
+  // reader2 will confirm only the first mutation (the only one); the mutation
+  // which used to be first should now be confirmed and the mutation which used
+  // to be third is not idempotent, so should not be retried.
+  MockClientAsyncReaderInterface<btproto::MutateRowsResponse>* reader2 =
+      new MockClientAsyncReaderInterface<btproto::MutateRowsResponse>;
+  std::unique_ptr<MockClientAsyncReaderInterface<btproto::MutateRowsResponse>>
+      reader_deleter2(reader2);
+  EXPECT_CALL(*reader2, Read(_, _))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r, void*) {
+        {
+          auto& e = *r->add_entries();
+          e.set_index(0);
+          e.mutable_status()->set_code(grpc::StatusCode::OK);
+        }
+      }))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r, void*) {}));
+
+  EXPECT_CALL(*reader2, Finish(_, _))
+      .WillOnce(Invoke([](grpc::Status* status, void*) {
+        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+      }));
+
+  EXPECT_CALL(*client_, AsyncMutateRows(_, _, _, _))
+      .WillOnce(Invoke([&reader_deleter1](grpc::ClientContext*,
+                                          btproto::MutateRowsRequest const& r,
+                                          grpc::CompletionQueue*, void*) {
+        EXPECT_EQ(3, r.entries_size());
+        return std::move(reader_deleter1);
+      }))
+      .WillOnce(Invoke([&reader_deleter2](grpc::ClientContext*,
+                                          btproto::MutateRowsRequest const& r,
+                                          grpc::CompletionQueue*, void*) {
+        // Second invocation should only contain the second mutation.
+        EXPECT_EQ(1, r.entries_size());
+        EXPECT_EQ("bar", r.entries(0).row_key());
+        return std::move(reader_deleter2);
+      }));
+
+  auto policy = bt::DefaultIdempotentMutationPolicy();
+  auto impl = std::make_shared<bigtable::testing::MockCompletionQueue>();
+  using bigtable::CompletionQueue;
+  bigtable::CompletionQueue cq(impl);
+
+  bool mutator_finished = false;
+  table_.AsyncBulkApply(std::move(mut), cq,
+                        [&mutator_finished](CompletionQueue& cq,
+                                            std::vector<FailedMutation>& failed,
+                                            grpc::Status& status) {
+                          EXPECT_EQ(1U, failed.size());
+                          EXPECT_EQ("baz", failed[0].mutation().row_key());
+                          EXPECT_TRUE(status.ok());
+                          mutator_finished = true;
+                        });
+
+  using bigtable::AsyncOperation;
+  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  // state == PROCESSING
+  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  // state == PROCESSING, 1 read
+  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  // state == FINISHING
+  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  // FinishTimer
+  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  // Second attempt
+  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  // state == PROCESSING
+  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  // state == PROCESSING, 1 read
+  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  // state == FINISHING
+  EXPECT_FALSE(mutator_finished);
+  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  EXPECT_TRUE(mutator_finished);
+}
+
+/// @test Verify that noex::Table::AsyncBulkApply() works when cancelled
+TEST_F(NoexTableAsyncBulkApplyTest, Cancelled) {
+  // This test creates 3 mutations. First one will succeed straight away, second
+  // on retry and third never, because it's not idempotent.
+  bt::BulkMutation mut(
+      bt::SingleRowMutation("baz", {bt::SetCell("fam", "col", "qux")}));
+
+  using bigtable::testing::MockClientAsyncReaderInterface;
+
+  MockClientAsyncReaderInterface<btproto::MutateRowsResponse>* reader1 =
+      new MockClientAsyncReaderInterface<btproto::MutateRowsResponse>;
+  std::unique_ptr<MockClientAsyncReaderInterface<btproto::MutateRowsResponse>>
+      reader_deleter1(reader1);
+  EXPECT_CALL(*reader1, Finish(_, _))
+      .WillOnce(Invoke([](grpc::Status* status, void*) {
+        *status = grpc::Status(grpc::StatusCode::CANCELLED, "mocked-status");
+      }));
+
+  EXPECT_CALL(*client_, AsyncMutateRows(_, _, _, _))
+      .WillOnce(Invoke([&reader_deleter1](grpc::ClientContext*,
+                                          btproto::MutateRowsRequest const&,
+                                          grpc::CompletionQueue*, void*) {
+        return std::move(reader_deleter1);
+      }));
+
+  auto policy = bt::DefaultIdempotentMutationPolicy();
+  auto impl = std::make_shared<bigtable::testing::MockCompletionQueue>();
+  using bigtable::CompletionQueue;
+  bigtable::CompletionQueue cq(impl);
+
+  bool mutator_finished = false;
+  table_.AsyncBulkApply(std::move(mut), cq,
+                        [&mutator_finished](CompletionQueue& cq,
+                                            std::vector<FailedMutation>& failed,
+                                            grpc::Status& status) {
+                          EXPECT_FALSE(status.ok());
+                          EXPECT_EQ(grpc::StatusCode::CANCELLED,
+                                    status.error_code());
+                          mutator_finished = true;
+                        });
+
+  using bigtable::AsyncOperation;
+  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  // state == FINISHING
+  EXPECT_FALSE(mutator_finished);
+  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  // callback fired
+  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  EXPECT_TRUE(mutator_finished);
+}
+
+/// @test Verify that noex::Table::AsyncBulkApply() works when permanent error
+//  occurs
+TEST_F(NoexTableAsyncBulkApplyTest, PermanentError) {
+  // This test creates 3 mutations. First one will succeed straight away, second
+  // on retry and third never, because it's not idempotent.
+  bt::BulkMutation mut(
+      bt::SingleRowMutation("baz", {bt::SetCell("fam", "col", "qux")}));
+
+  using bigtable::testing::MockClientAsyncReaderInterface;
+
+  MockClientAsyncReaderInterface<btproto::MutateRowsResponse>* reader1 =
+      new MockClientAsyncReaderInterface<btproto::MutateRowsResponse>;
+  std::unique_ptr<MockClientAsyncReaderInterface<btproto::MutateRowsResponse>>
+      reader_deleter1(reader1);
+  EXPECT_CALL(*reader1, Finish(_, _))
+      .WillOnce(Invoke([](grpc::Status* status, void*) {
+        *status =
+            grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "mocked-status");
+      }));
+
+  EXPECT_CALL(*client_, AsyncMutateRows(_, _, _, _))
+      .WillOnce(Invoke([&reader_deleter1](grpc::ClientContext*,
+                                          btproto::MutateRowsRequest const&,
+                                          grpc::CompletionQueue*, void*) {
+        return std::move(reader_deleter1);
+      }));
+
+  auto policy = bt::DefaultIdempotentMutationPolicy();
+  auto impl = std::make_shared<bigtable::testing::MockCompletionQueue>();
+  using bigtable::CompletionQueue;
+  bigtable::CompletionQueue cq(impl);
+
+  bool mutator_finished = false;
+  table_.AsyncBulkApply(std::move(mut), cq,
+                        [&mutator_finished](CompletionQueue& cq,
+                                            std::vector<FailedMutation>& failed,
+                                            grpc::Status& status) {
+                          EXPECT_FALSE(status.ok());
+                          EXPECT_EQ(grpc::StatusCode::PERMISSION_DENIED,
+                                    status.error_code());
+                          mutator_finished = true;
+                        });
+
+  using bigtable::AsyncOperation;
+  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  // state == FINISHING
+  EXPECT_FALSE(mutator_finished);
+  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  // callback fired
+  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  EXPECT_TRUE(mutator_finished);
+}
+
+}  // namespace
+}  // namespace noex
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/testing/inprocess_data_client.cc
+++ b/google/cloud/bigtable/testing/inprocess_data_client.cc
@@ -71,6 +71,15 @@ InProcessDataClient::MutateRows(grpc::ClientContext* context,
   return Stub()->MutateRows(context, request);
 }
 
+std::unique_ptr<::grpc::ClientAsyncReaderInterface<
+    ::google::bigtable::v2::MutateRowsResponse>>
+InProcessDataClient::AsyncMutateRows(
+    ::grpc::ClientContext* context,
+    const ::google::bigtable::v2::MutateRowsRequest& request,
+    ::grpc::CompletionQueue* cq, void* tag) {
+  return Stub()->AsyncMutateRows(context, request, cq, tag);
+}
+
 }  // namespace testing
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/testing/inprocess_data_client.h
+++ b/google/cloud/bigtable/testing/inprocess_data_client.h
@@ -84,6 +84,11 @@ class InProcessDataClient : public bigtable::DataClient {
       grpc::ClientReaderInterface<google::bigtable::v2::MutateRowsResponse>>
   MutateRows(grpc::ClientContext* context,
              google::bigtable::v2::MutateRowsRequest const& request) override;
+  std::unique_ptr<::grpc::ClientAsyncReaderInterface<
+      ::google::bigtable::v2::MutateRowsResponse>>
+  AsyncMutateRows(::grpc::ClientContext* context,
+                  const ::google::bigtable::v2::MutateRowsRequest& request,
+                  ::grpc::CompletionQueue* cq, void* tag) override;
   //@}
 
  private:

--- a/google/cloud/bigtable/testing/mock_data_client.h
+++ b/google/cloud/bigtable/testing/mock_data_client.h
@@ -69,6 +69,12 @@ class MockDataClient : public bigtable::DataClient {
                    google::bigtable::v2::MutateRowsResponse>>(
                    grpc::ClientContext* context,
                    google::bigtable::v2::MutateRowsRequest const& request));
+  MOCK_METHOD4(AsyncMutateRows,
+               std::unique_ptr<grpc::ClientAsyncReaderInterface<
+                   google::bigtable::v2::MutateRowsResponse>>(
+                   grpc::ClientContext*,
+                   const google::bigtable::v2::MutateRowsRequest&,
+                   grpc::CompletionQueue*, void*));
 };
 
 }  // namespace testing

--- a/google/cloud/bigtable/testing/mock_response_reader.h
+++ b/google/cloud/bigtable/testing/mock_response_reader.h
@@ -104,6 +104,16 @@ class MockAsyncResponseReader
   MOCK_METHOD3_T(Finish, void(Response*, grpc::Status*, void*));
 };
 
+template <typename Response>
+class MockClientAsyncReaderInterface
+    : public grpc::ClientAsyncReaderInterface<Response> {
+ public:
+  MOCK_METHOD1(StartCall, void(void*));
+  MOCK_METHOD1(ReadInitialMetadata, void(void*));
+  MOCK_METHOD2(Finish, void(grpc::Status*, void*));
+  MOCK_METHOD2_T(Read, void(Response*, void*));
+};
+
 }  // namespace testing
 }  // namespace bigtable
 }  // namespace cloud


### PR DESCRIPTION
It adds AsyncBulkMutator - an async version of BulkMutator which it then uses in AsyncRetryBulkApply - a reimplementation of AsyncRetryUnaryOp.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1336)
<!-- Reviewable:end -->
