### PR TITLE
Implement CompositeHashValidator.

### DIFF
--- a/google/cloud/storage/internal/curl_streambuf.cc
+++ b/google/cloud/storage/internal/curl_streambuf.cc
@@ -43,11 +43,9 @@ CurlReadStreambuf::int_type CurlReadStreambuf::underflow() {
     current_ios_buffer_.push_back('\0');
     char* data = &current_ios_buffer_[0];
     setg(data, data + 1, data + 1);
-    hash_validator_result_ =
-        std::move(*hash_validator_)
-            .Finish(
-                __func__ +
-                std::string(" mismatched hashes reading from closed stream"));
+    hash_validator_result_ = HashValidator::FinishAndCheck(
+        __func__ + std::string(" mismatched hashes reading from closed stream"),
+        std::move(*hash_validator_));
     return traits_type::eof();
   }
 
@@ -69,10 +67,9 @@ CurlReadStreambuf::int_type CurlReadStreambuf::underflow() {
   current_ios_buffer_.push_back('\0');
   char* data = &current_ios_buffer_[0];
   setg(data, data + 1, data + 1);
-  hash_validator_result_ =
-      std::move(*hash_validator_)
-          .Finish(__func__ +
-                  std::string(" mismatched hashes at end of download"));
+  hash_validator_result_ = HashValidator::FinishAndCheck(
+      __func__ + std::string(" mismatched hashes at end of download"),
+      std::move(*hash_validator_));
   return traits_type::eof();
 }
 
@@ -89,7 +86,8 @@ bool CurlStreambuf::IsOpen() const { return upload_.IsOpen(); }
 
 void CurlStreambuf::ValidateHash(ObjectMetadata const& meta) {
   hash_validator_->ProcessMetadata(meta);
-  hash_validator_result_ = std::move(*hash_validator_).Finish(__func__);
+  hash_validator_result_ =
+      HashValidator::FinishAndCheck(__func__, std::move(*hash_validator_));
 }
 
 CurlStreambuf::int_type CurlStreambuf::overflow(int_type ch) {

--- a/google/cloud/storage/internal/hash_validator_test.cc
+++ b/google/cloud/storage/internal/hash_validator_test.cc
@@ -103,7 +103,7 @@ TEST(HashValidator, FinishAndCheckMismatch) {
       std::ios::failure);
 #else
   auto result = HashValidator::FinishAndCheck("test-msg", std::move(validator));
-  EXPECT_EQ(EMPTY_STING_MD5_HASH, result.received);
+  EXPECT_EQ(EMPTY_STRING_MD5_HASH, result.received);
   EXPECT_EQ(QUICK_FOX_MD5_HASH, result.computed);
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }


### PR DESCRIPTION
A CompositeHashValidator can apply two hashes, such as MD5 and CRC32C,
to the same data. It could be generalized to compute N hashes, but we do
not need more than two, so keep it simple for now (YAGNI).

We are not using this yet, I thought it would be better to keep the PR smaller.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1337)
<!-- Reviewable:end -->
