### PR TITLE
Implement bucket lock features in ObjectMetadata.

### DIFF
--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -237,6 +237,9 @@ PatchObjectRequest::PatchObjectRequest(std::string bucket_name,
   if (original.content_type() != updated.content_type()) {
     builder.SetContentType(updated.content_type());
   }
+  if (original.event_based_hold() != updated.event_based_hold()) {
+    builder.SetEventBasedHold(updated.event_based_hold());
+  }
 
   if (original.metadata() != updated.metadata()) {
     if (updated.metadata().empty()) {
@@ -268,6 +271,10 @@ PatchObjectRequest::PatchObjectRequest(std::string bucket_name,
         builder.SetMetadata(d.first, d.second);
       }
     }
+  }
+
+  if (original.temporary_hold() != updated.temporary_hold()) {
+    builder.SetTemporaryHold(updated.temporary_hold());
   }
 
   payload_ = builder.BuildPatch();

--- a/google/cloud/storage/internal/object_requests_test.cc
+++ b/google/cloud/storage/internal/object_requests_test.cc
@@ -596,6 +596,19 @@ TEST(PatchObjectRequestTest, DiffResetContentType) {
   EXPECT_EQ(expected, patch);
 }
 
+TEST(PatchObjectRequestTest, DiffSetEventBasedHold) {
+  ObjectMetadata original = CreateObjectMetadataForTest();
+  original.set_event_based_hold(false);
+  ObjectMetadata updated = original;
+  updated.set_event_based_hold(true);
+  PatchObjectRequest request("test-bucket", "test-object", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected =
+      nl::json::parse(R"""({"eventBasedHold": true})""");
+  EXPECT_EQ(expected, patch);
+}
+
 TEST(PatchObjectRequestTest, DiffSetLabels) {
   ObjectMetadata original = CreateObjectMetadataForTest();
   original.mutable_metadata() = {
@@ -626,6 +639,19 @@ TEST(PatchObjectRequestTest, DiffResetLabels) {
 
   nl::json patch = nl::json::parse(request.payload());
   nl::json expected = nl::json::parse(R"""({"metadata": null})""");
+  EXPECT_EQ(expected, patch);
+}
+
+TEST(PatchObjectRequestTest, DiffSetTemporaryHold) {
+  ObjectMetadata original = CreateObjectMetadataForTest();
+  original.set_temporary_hold(false);
+  ObjectMetadata updated = original;
+  updated.set_temporary_hold(true);
+  PatchObjectRequest request("test-bucket", "test-object", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected =
+      nl::json::parse(R"""({"temporaryHold": true})""");
   EXPECT_EQ(expected, patch);
 }
 

--- a/google/cloud/storage/object_metadata.cc
+++ b/google/cloud/storage/object_metadata.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/object_metadata.h"
+#include "google/cloud/storage/internal/format_rfc3339.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include "google/cloud/storage/internal/nljson.h"
 
@@ -73,6 +74,7 @@ ObjectMetadata ObjectMetadata::ParseFromJson(internal::nl::json const& json) {
     e.key_sha256 = field.value("keySha256", "");
     result.customer_encryption_ = std::move(e);
   }
+  result.event_based_hold_ = internal::ParseBoolField(json, "eventBasedHold");
   result.generation_ = internal::ParseLongField(json, "generation");
   result.kms_key_name_ = json.value("kmsKeyName", "");
   result.md5_hash_ = json.value("md5Hash", "");
@@ -82,7 +84,10 @@ ObjectMetadata ObjectMetadata::ParseFromJson(internal::nl::json const& json) {
       result.metadata_.emplace(kv.key(), kv.value().get<std::string>());
     }
   }
+  result.retention_expiration_time_ =
+      internal::ParseTimestampField(json, "retentionExpirationTime");
   result.size_ = internal::ParseUnsignedLongField(json, "size");
+  result.temporary_hold_ = internal::ParseBoolField(json, "temporaryHold");
   result.time_deleted_ = internal::ParseTimestampField(json, "timeDeleted");
   result.time_storage_class_updated_ =
       internal::ParseTimestampField(json, "timeStorageClassUpdated");
@@ -126,6 +131,8 @@ internal::nl::json ObjectMetadata::JsonForUpdate() const {
   SetIfNotEmpty(metadata_as_json, "contentEncoding", content_encoding());
   SetIfNotEmpty(metadata_as_json, "contentLanguage", content_language());
   SetIfNotEmpty(metadata_as_json, "contentType", content_type());
+
+  metadata_as_json["eventBasedHold"] = event_based_hold();
 
   if (not metadata().empty()) {
     json meta_as_json;
@@ -182,16 +189,18 @@ bool ObjectMetadata::operator==(ObjectMetadata const& rhs) const {
          content_language_ == rhs.content_language_ and
          content_type_ == rhs.content_type_ and crc32c_ == rhs.crc32c_ and
          customer_encryption_ == customer_encryption_ and
+         event_based_hold_ == rhs.event_based_hold_ and
          generation_ == rhs.generation_ and
          kms_key_name_ == rhs.kms_key_name_ and md5_hash_ == rhs.md5_hash_ and
          media_link_ == rhs.media_link_ and metadata_ == rhs.metadata_ and
+         retention_expiration_time_ == rhs.retention_expiration_time_ and
+         temporary_hold_ == rhs.temporary_hold_ and
          time_deleted_ == rhs.time_deleted_ and
          time_storage_class_updated_ == rhs.time_storage_class_updated_ and
          size_ == rhs.size_;
 }
 
 std::ostream& operator<<(std::ostream& os, ObjectMetadata const& rhs) {
-  // TODO(#536) - convert back to JSON for a nicer format.
   os << "ObjectMetadata={name=" << rhs.name() << ", acl=[";
   char const* sep = "";
   for (auto const& acl : rhs.acl()) {
@@ -213,9 +222,10 @@ std::ostream& operator<<(std::ostream& os, ObjectMetadata const& rhs) {
        << rhs.customer_encryption().key_sha256;
   }
 
-  os << ", etag=" << rhs.etag() << ", generation=" << rhs.generation()
-     << ", id=" << rhs.id() << ", kind=" << rhs.kind()
-     << ", kms_key_name=" << rhs.kms_key_name()
+  os << ", etag=" << rhs.etag()
+     << ", event_based_hold=" << std::boolalpha << rhs.event_based_hold()
+     << ", generation=" << rhs.generation() << ", id=" << rhs.id()
+     << ", kind=" << rhs.kind() << ", kms_key_name=" << rhs.kms_key_name()
      << ", md5_hash=" << rhs.md5_hash() << ", media_link=" << rhs.media_link();
   sep = "metadata.";
   for (auto const& kv : rhs.metadata_) {
@@ -229,8 +239,11 @@ std::ostream& operator<<(std::ostream& os, ObjectMetadata const& rhs) {
        << ", owner.entity_id=" << rhs.owner().entity_id;
   }
 
-  os << ", self_link=" << rhs.self_link() << ", size=" << rhs.size()
+  os << ", retention_expiration_time="
+     << internal::FormatRfc3339(rhs.retention_expiration_time())
+     << ", self_link=" << rhs.self_link() << ", size=" << rhs.size()
      << ", storage_class=" << rhs.storage_class()
+     << ", temporary_hold=" << std::boolalpha << rhs.temporary_hold()
      << ", time_created=" << rhs.time_created().time_since_epoch().count()
      << ", time_deleted=" << rhs.time_deleted().time_since_epoch().count()
      << ", time_storage_class_updated="
@@ -341,6 +354,16 @@ ObjectMetadataPatchBuilder& ObjectMetadataPatchBuilder::SetContentType(
 
 ObjectMetadataPatchBuilder& ObjectMetadataPatchBuilder::ResetContentType() {
   impl_.RemoveField("contentType");
+  return *this;
+}
+
+ObjectMetadataPatchBuilder& ObjectMetadataPatchBuilder::SetEventBasedHold(bool v) {
+  impl_.SetBoolField("eventBasedHold", v);
+  return *this;
+}
+
+ObjectMetadataPatchBuilder& ObjectMetadataPatchBuilder::ResetEventBasedHold() {
+  impl_.RemoveField("eventBasedHold");
   return *this;
 }
 

--- a/google/cloud/storage/object_metadata.cc
+++ b/google/cloud/storage/object_metadata.cc
@@ -387,6 +387,16 @@ ObjectMetadataPatchBuilder& ObjectMetadataPatchBuilder::ResetMetadata() {
   return *this;
 }
 
+ObjectMetadataPatchBuilder& ObjectMetadataPatchBuilder::SetTemporaryHold(bool v) {
+  impl_.SetBoolField("temporaryHold", v);
+  return *this;
+}
+
+ObjectMetadataPatchBuilder& ObjectMetadataPatchBuilder::ResetTemporaryHold() {
+  impl_.RemoveField("temporaryHold");
+  return *this;
+}
+
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -161,6 +161,12 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
 
   using CommonMetadata::etag;
 
+  bool event_based_hold() const { return event_based_hold_; }
+  ObjectMetadata& set_event_based_hold(bool v) {
+    event_based_hold_ = v;
+    return *this;
+  }
+
   std::int64_t generation() const { return generation_; }
 
   using CommonMetadata::id;
@@ -210,11 +216,23 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
   using CommonMetadata::metageneration;
   using CommonMetadata::name;
   using CommonMetadata::owner;
+
+  std::chrono::system_clock::time_point retention_expiration_time() const {
+    return retention_expiration_time_;
+  }
+
   using CommonMetadata::self_link;
 
   std::uint64_t size() const { return size_; }
 
   using CommonMetadata::storage_class;
+
+  bool temporary_hold() const { return temporary_hold_; }
+  ObjectMetadata& set_temporary_hold(bool v) {
+    temporary_hold_ = v;
+    return *this;
+  }
+
   using CommonMetadata::time_created;
 
   std::chrono::system_clock::time_point time_deleted() const {
@@ -244,12 +262,15 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
   std::string content_type_;
   std::string crc32c_;
   google::cloud::optional<CustomerEncryption> customer_encryption_;
+  bool event_based_hold_ = false;
   std::int64_t generation_;
   std::string kms_key_name_;
   std::string md5_hash_;
   std::string media_link_;
   std::map<std::string, std::string> metadata_;
+  std::chrono::system_clock::time_point retention_expiration_time_;
   std::uint64_t size_;
+  bool temporary_hold_;
   std::chrono::system_clock::time_point time_deleted_;
   std::chrono::system_clock::time_point time_storage_class_updated_;
 };
@@ -293,6 +314,8 @@ class ObjectMetadataPatchBuilder {
   ObjectMetadataPatchBuilder& ResetContentLanguage();
   ObjectMetadataPatchBuilder& SetContentType(std::string const& v);
   ObjectMetadataPatchBuilder& ResetContentType();
+  ObjectMetadataPatchBuilder& SetEventBasedHold(bool v);
+  ObjectMetadataPatchBuilder& ResetEventBasedHold();
 
   ObjectMetadataPatchBuilder& SetMetadata(std::string const& key,
                                           std::string const& value);

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -270,7 +270,7 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
   std::map<std::string, std::string> metadata_;
   std::chrono::system_clock::time_point retention_expiration_time_;
   std::uint64_t size_;
-  bool temporary_hold_;
+  bool temporary_hold_ = false;
   std::chrono::system_clock::time_point time_deleted_;
   std::chrono::system_clock::time_point time_storage_class_updated_;
 };
@@ -321,6 +321,9 @@ class ObjectMetadataPatchBuilder {
                                           std::string const& value);
   ObjectMetadataPatchBuilder& ResetMetadata(std::string const& key);
   ObjectMetadataPatchBuilder& ResetMetadata();
+
+  ObjectMetadataPatchBuilder& SetTemporaryHold(bool v);
+  ObjectMetadataPatchBuilder& ResetTemporaryHold();
 
  private:
   internal::PatchBuilder impl_;

--- a/google/cloud/storage/object_metadata_test.cc
+++ b/google/cloud/storage/object_metadata_test.cc
@@ -500,6 +500,26 @@ TEST(ObjectMetadataPatchBuilder, Resetmetadata) {
   EXPECT_EQ(expected, actual_as_json) << actual;
 }
 
+TEST(ObjectMetadataPatchBuilder, SetTemporaryHold) {
+  ObjectMetadataPatchBuilder builder;
+  builder.SetTemporaryHold(true);
+
+  auto actual = builder.BuildPatch();
+  auto actual_as_json = internal::nl::json::parse(actual);
+  internal::nl::json expected{{"temporaryHold", true}};
+  EXPECT_EQ(expected, actual_as_json) << actual;
+}
+
+TEST(ObjectMetadataPatchBuilder, ResetTemporaryHold) {
+  ObjectMetadataPatchBuilder builder;
+  builder.ResetTemporaryHold();
+
+  auto actual = builder.BuildPatch();
+  auto actual_as_json = internal::nl::json::parse(actual);
+  internal::nl::json expected{{"temporaryHold", nullptr}};
+  EXPECT_EQ(expected, actual_as_json) << actual;
+}
+
 }  // namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/object_metadata_test.cc
+++ b/google/cloud/storage/object_metadata_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/object_metadata.h"
+#include "google/cloud/storage/internal/parse_rfc3339.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -74,6 +75,7 @@ ObjectMetadata CreateObjectMetadataForTest() {
         "keySha256": "abc123"
       },
       "etag": "XYZ=",
+      "eventBasedHold": true,
       "generation": "12345",
       "id": "foo-bar/baz/12345",
       "kind": "storage#object",
@@ -90,9 +92,11 @@ ObjectMetadata CreateObjectMetadataForTest() {
         "entity": "user-qux",
         "entityId": "user-qux-id-123"
       },
+      "retentionExpirationTime": "2019-01-01T00:00:00Z",
       "selfLink": "https://www.googleapis.com/storage/v1/b/foo-bar/o/baz",
       "size": 102400,
       "storageClass": "STANDARD",
+      "temporaryHold": true,
       "timeCreated": "2018-05-19T19:31:14Z",
       "timeDeleted": "2018-05-19T19:32:24Z",
       "timeStorageClassUpdated": "2018-05-19T19:31:34Z",
@@ -115,6 +119,7 @@ TEST(ObjectMetadataTest, Parse) {
   EXPECT_EQ("application/octet-stream", actual.content_type());
   EXPECT_EQ("deadbeef", actual.crc32c());
   EXPECT_EQ("XYZ=", actual.etag());
+  EXPECT_TRUE(actual.event_based_hold());
   EXPECT_EQ(12345, actual.generation());
   EXPECT_EQ("foo-bar/baz/12345", actual.id());
   EXPECT_EQ("storage#object", actual.kind());
@@ -131,6 +136,8 @@ TEST(ObjectMetadataTest, Parse) {
   EXPECT_EQ("baz", actual.name());
   EXPECT_EQ("user-qux", actual.owner().entity);
   EXPECT_EQ("user-qux-id-123", actual.owner().entity_id);
+  EXPECT_EQ(internal::ParseRfc3339("2019-01-01T00:00:00Z"),
+            actual.retention_expiration_time());
   EXPECT_EQ("https://www.googleapis.com/storage/v1/b/foo-bar/o/baz",
             actual.self_link());
   EXPECT_EQ(102400U, actual.size());
@@ -167,7 +174,11 @@ TEST(ObjectMetadataTest, IOStream) {
   EXPECT_THAT(actual, HasSubstr("acl-id-0"));
   EXPECT_THAT(actual, HasSubstr("name=baz"));
   EXPECT_THAT(actual, HasSubstr("metadata.foo=bar"));
+  EXPECT_THAT(actual, HasSubstr("event_based_hold=true"));
+  EXPECT_THAT(actual,
+              HasSubstr("retention_expiration_time=2019-01-01T00:00:00Z"));
   EXPECT_THAT(actual, HasSubstr("size=102400"));
+  EXPECT_THAT(actual, HasSubstr("temporary_hold=true"));
 }
 
 /// @test Verify we can convert a ObjectMetadata object to a JSON string.
@@ -191,6 +202,7 @@ TEST(ObjectMetadataTest, UpdatePayload) {
       {"contentEncoding", "an-encoding"},
       {"contentLanguage", "a-language"},
       {"contentType", "application/octet-stream"},
+      {"eventBasedHold", true},
       {"metadata",
        internal::nl::json{
            {"foo", "bar"},
@@ -266,6 +278,17 @@ TEST(ObjectMetadataTest, SetContentType) {
   auto copy = expected;
   copy.set_content_type("some-other-type");
   EXPECT_EQ("some-other-type", copy.content_type());
+  EXPECT_NE(expected, copy);
+}
+
+/// @test Verify we can change the eventBasedHold field.
+TEST(ObjectMetadataTest, SetEventBasedHold) {
+  // This has a event based hold and it is true.
+  auto expected = CreateObjectMetadataForTest();
+  ASSERT_TRUE(expected.event_based_hold());
+  auto copy = expected;
+  copy.set_event_based_hold(false);
+  EXPECT_FALSE(copy.event_based_hold());
   EXPECT_NE(expected, copy);
 }
 
@@ -425,6 +448,26 @@ TEST(ObjectMetadataPatchBuilder, ResetContentType) {
   auto actual = builder.BuildPatch();
   auto actual_as_json = internal::nl::json::parse(actual);
   internal::nl::json expected{{"contentType", nullptr}};
+  EXPECT_EQ(expected, actual_as_json) << actual;
+}
+
+TEST(ObjectMetadataPatchBuilder, SetEventBasedHold) {
+  ObjectMetadataPatchBuilder builder;
+  builder.SetEventBasedHold(true);
+
+  auto actual = builder.BuildPatch();
+  auto actual_as_json = internal::nl::json::parse(actual);
+  internal::nl::json expected{{"eventBasedHold", true}};
+  EXPECT_EQ(expected, actual_as_json) << actual;
+}
+
+TEST(ObjectMetadataPatchBuilder, ResetEventBasedHold) {
+  ObjectMetadataPatchBuilder builder;
+  builder.ResetEventBasedHold();
+
+  auto actual = builder.BuildPatch();
+  auto actual_as_json = internal::nl::json::parse(actual);
+  internal::nl::json expected{{"eventBasedHold", nullptr}};
   EXPECT_EQ(expected, actual_as_json) << actual;
 }
 

--- a/google/cloud/storage/object_test.cc
+++ b/google/cloud/storage/object_test.cc
@@ -281,11 +281,11 @@ TEST_F(ObjectTest, UpdateObject) {
             {"contentEncoding", "new-encoding"},
             {"contentLanguage", "new-language"},
             {"contentType", "new-type"},
+            {"eventBasedHold", false},
             {"metadata",
              internal::nl::json{
                  {"test-label", "test-value"},
              }},
-
         };
         EXPECT_EQ(expected_payload, actual_payload);
         return std::make_pair(Status(), expected);


### PR DESCRIPTION
This is part of the work for #1029. It changes the ObjectMetadata class
to support the bucket lock features. No integration tests yet, those
will need support in the testbench, and I would rather do that in a
separate PR (to keep the PRs small-ish).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1339)
<!-- Reviewable:end -->
