### PR TITLE
Implement bucket lock features in BucketMetadata.

### DIFF
--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -642,6 +642,18 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
     retention_policy_ = std::move(v);
     return *this;
   }
+
+  /**
+   * Sets the retention period.
+   *
+   * The retention period is the only writable attribute in a retention policy.
+   * This function makes it easier to set the retention policy when the
+   * `BucketMetadata` object is used to update or patch the bucket.
+   */
+  BucketMetadata& set_retention_policy(std::chrono::seconds retention_period) {
+    return set_retention_policy(BucketRetentionPolicy{retention_period});
+  }
+
   BucketMetadata& reset_retention_policy() {
     retention_policy_.reset();
     return *this;

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -249,6 +249,58 @@ inline bool operator>=(BucketEncryption const& lhs,
 }
 
 /**
+ * The retention policy for a bucket.
+ *
+ * The Bucket Lock feature of Google Cloud Storage allows you to configure a
+ * data retention policy for a Cloud Storage bucket. This policy governs how
+ * long objects in the bucket must be retained. The feature also allows you to
+ * lock the data retention policy, permanently preventing the policy from from
+ * being reduced or removed.
+ *
+ * @see https://cloud.google.com/storage/docs/bucket-lock for a general
+ *     overview
+ */
+struct BucketRetentionPolicy {
+  std::chrono::seconds retention_period;
+  std::chrono::system_clock::time_point effective_time;
+  bool is_locked;
+};
+
+inline bool operator==(BucketRetentionPolicy const& lhs,
+                       BucketRetentionPolicy const& rhs) {
+  return std::tie(lhs.retention_period, lhs.effective_time, lhs.is_locked) ==
+         std::tie(rhs.retention_period, rhs.effective_time, rhs.is_locked);
+}
+
+inline bool operator<(BucketRetentionPolicy const& lhs,
+                      BucketRetentionPolicy const& rhs) {
+  return std::tie(lhs.retention_period, lhs.effective_time, lhs.is_locked) <
+         std::tie(rhs.retention_period, rhs.effective_time, rhs.is_locked);
+}
+
+inline bool operator!=(BucketRetentionPolicy const& lhs,
+                       BucketRetentionPolicy const& rhs) {
+  return std::rel_ops::operator!=(lhs, rhs);
+}
+
+inline bool operator>(BucketRetentionPolicy const& lhs,
+                      BucketRetentionPolicy const& rhs) {
+  return std::rel_ops::operator>(lhs, rhs);
+}
+
+inline bool operator<=(BucketRetentionPolicy const& lhs,
+                       BucketRetentionPolicy const& rhs) {
+  return std::rel_ops::operator<=(lhs, rhs);
+}
+
+inline bool operator>=(BucketRetentionPolicy const& lhs,
+                       BucketRetentionPolicy const& rhs) {
+  return std::rel_ops::operator>=(lhs, rhs);
+}
+
+std::ostream& operator<<(std::ostream& os, BucketRetentionPolicy const& rhs);
+
+/**
  * The versioning configuration for a Bucket.
  *
  * @see https://cloud.google.com/storage/docs/requester-pays for general
@@ -379,6 +431,31 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   }
   BucketMetadata& reset_billing() {
     billing_.reset();
+    return *this;
+  }
+  //@}
+
+  //@{
+  /**
+   * @name Get and set the default event based hold for the Bucket.
+   *
+   * Objects may have an event-based hold associated with them. If a Bucket
+   * has the `default_event_based_hold()` parameter set, and you create a new
+   * object in the bucket without specifying its event-event based hold then the
+   * object gets the value set in the bucket.
+   *
+   * @see https://cloud.google.com/storage/docs/bucket-lock for generation
+   *     information on retention policies.  The section on
+   *     [Object
+   * holds](https://cloud.google.com/storage/docs/bucket-lock#object-holds) is
+   * particularly relevant.
+   *
+   * @see https://cloud.google.com/storage/docs/holding-objects for examples
+   *    of using default event-based hold policy.
+   */
+  bool default_event_based_hold() const { return default_event_based_hold_; }
+  BucketMetadata& set_default_event_based_hold(bool v) {
+    default_event_based_hold_ = v;
     return *this;
   }
   //@}
@@ -551,6 +628,26 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
 
   using CommonMetadata::self_link;
 
+  //@{
+  /// @name Accessors and modifiers for retention policy configuration.
+  bool has_retention_policy() const { return retention_policy_.has_value(); }
+  BucketRetentionPolicy const& retention_policy() const {
+    return *retention_policy_;
+  }
+  google::cloud::optional<BucketRetentionPolicy> const&
+  retention_policy_as_optional() const {
+    return retention_policy_;
+  }
+  BucketMetadata& set_retention_policy(BucketRetentionPolicy v) {
+    retention_policy_ = std::move(v);
+    return *this;
+  }
+  BucketMetadata& reset_retention_policy() {
+    retention_policy_.reset();
+    return *this;
+  }
+  //@}
+
   using CommonMetadata::storage_class;
   BucketMetadata& set_storage_class(std::string v) {
     CommonMetadata::set_storage_class(std::move(v));
@@ -610,6 +707,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   std::vector<BucketAccessControl> acl_;
   google::cloud::optional<BucketBilling> billing_;
   std::vector<CorsEntry> cors_;
+  bool default_event_based_hold_ = false;
   std::vector<ObjectAccessControl> default_acl_;
   google::cloud::optional<BucketEncryption> encryption_;
   std::map<std::string, std::string> labels_;
@@ -617,6 +715,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   std::string location_;
   google::cloud::optional<BucketLogging> logging_;
   std::int64_t project_number_;
+  google::cloud::optional<BucketRetentionPolicy> retention_policy_;
   google::cloud::optional<BucketVersioning> versioning_;
   google::cloud::optional<BucketWebsite> website_;
 };
@@ -656,6 +755,9 @@ class BucketMetadataPatchBuilder {
   BucketMetadataPatchBuilder& SetCors(std::vector<CorsEntry> const& v);
   BucketMetadataPatchBuilder& ResetCors();
 
+  BucketMetadataPatchBuilder& SetDefaultEventBasedHold(bool v);
+  BucketMetadataPatchBuilder& ResetDefaultEventBasedHold();
+
   BucketMetadataPatchBuilder& SetDefaultAcl(
       std::vector<ObjectAccessControl> const& v);
 
@@ -682,6 +784,10 @@ class BucketMetadataPatchBuilder {
 
   BucketMetadataPatchBuilder& SetName(std::string const& v);
   BucketMetadataPatchBuilder& ResetName();
+
+  BucketMetadataPatchBuilder& SetRetentionPolicy(
+      BucketRetentionPolicy const& v);
+  BucketMetadataPatchBuilder& ResetRetentionPolicy();
 
   BucketMetadataPatchBuilder& SetStorageClass(std::string const& v);
   BucketMetadataPatchBuilder& ResetStorageClass();

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -97,6 +97,11 @@ PatchBucketRequest::PatchBucketRequest(std::string bucket,
     builder.SetCors(updated.cors());
   }
 
+  if (original.default_event_based_hold() !=
+      updated.default_event_based_hold()) {
+    builder.SetDefaultEventBasedHold(updated.default_event_based_hold());
+  }
+
   if (original.default_acl() != updated.default_acl()) {
     builder.SetDefaultAcl(updated.default_acl());
   }
@@ -155,6 +160,15 @@ PatchBucketRequest::PatchBucketRequest(std::string bucket,
 
   if (original.name() != updated.name()) {
     builder.SetName(updated.name());
+  }
+
+  if (original.retention_policy_as_optional() !=
+      updated.retention_policy_as_optional()) {
+    if (updated.has_retention_policy()) {
+      builder.SetRetentionPolicy(updated.retention_policy());
+    } else {
+      builder.ResetRetentionPolicy();
+    }
   }
 
   if (original.storage_class() != updated.storage_class()) {
@@ -274,7 +288,9 @@ std::ostream& operator<<(std::ostream& os,
   return os << "}";
 }
 
-TestBucketIamPermissionsResponse TestBucketIamPermissionsResponse::FromHttpResponse(HttpResponse const& response) {
+TestBucketIamPermissionsResponse
+TestBucketIamPermissionsResponse::FromHttpResponse(
+    HttpResponse const& response) {
   TestBucketIamPermissionsResponse result;
   auto json = nl::json::parse(response.payload);
   for (auto const& kv : json["permissions"].items()) {

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -256,6 +256,20 @@ TEST(PatchBucketRequestTest, DiffResetCors) {
   EXPECT_EQ(expected, patch);
 }
 
+TEST(PatchBucketRequestTest, DiffSetDefaultEventBasedHold) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.set_default_event_based_hold(false);
+  BucketMetadata updated = original;
+  updated.set_default_event_based_hold(true);
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({
+      "defaultEventBasedHold": true
+  })""");
+  EXPECT_EQ(expected, patch);
+}
+
 TEST(PatchBucketRequestTest, DiffSetDefaultAcl) {
   BucketMetadata original = CreateBucketMetadataForTest();
   original.set_default_acl({});
@@ -430,6 +444,34 @@ TEST(PatchBucketRequestTest, DiffResetName) {
 
   nl::json patch = nl::json::parse(request.payload());
   nl::json expected = nl::json::parse(R"""({"name": null})""");
+  EXPECT_EQ(expected, patch);
+}
+
+TEST(PatchBucketRequestTest, DiffSetRetentionPolicy) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.reset_logging();
+  BucketMetadata updated = original;
+  updated.set_retention_policy(std::chrono::seconds(60));
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({
+      "retentionPolicy": {
+          "retentionPeriod": 60
+      }
+  })""");
+  EXPECT_EQ(expected, patch);
+}
+
+TEST(PatchBucketRequestTest, DiffResetRetentionPolicy) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.set_retention_policy(std::chrono::seconds(60));
+  BucketMetadata updated = original;
+  updated.reset_retention_policy();
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({"retentionPolicy": null})""");
   EXPECT_EQ(expected, patch);
 }
 

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -449,7 +449,7 @@ TEST(PatchBucketRequestTest, DiffResetName) {
 
 TEST(PatchBucketRequestTest, DiffSetRetentionPolicy) {
   BucketMetadata original = CreateBucketMetadataForTest();
-  original.reset_logging();
+  original.reset_retention_policy();
   BucketMetadata updated = original;
   updated.set_retention_policy(std::chrono::seconds(60));
   PatchBucketRequest request("test-bucket", original, updated);


### PR DESCRIPTION
This adds the functionality to parse the bucket lock features, and the
code to prepare messages for `Buckets: patch` and `Buckets: update` that
include bucket lock features. I am not including integration tests yet
because those require changes to the testbench and I would rather send a
smaller PR first. Part of the changes for #1029.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1340)
<!-- Reviewable:end -->
