### PR TITLE
Remove Disposition and AsyncUnaryRpcResult (#1308)

### DIFF
--- a/google/cloud/bigtable/async_operation.h
+++ b/google/cloud/bigtable/async_operation.h
@@ -37,22 +37,7 @@ class CompletionQueue;
  */
 struct AsyncTimerResult {
   std::chrono::system_clock::time_point deadline;
-};
-
-/**
- * The result of a unary asynchronous RPC operation.
- *
- * Applications provide a callback to be invoked when an asynchronous RPC
- * completes. The callback receives this parameter as the result of the
- * operation.
- *
- * @tparam Response
- */
-template <typename Response>
-struct AsyncUnaryRpcResult {
-  Response response;
-  grpc::Status status;
-  std::unique_ptr<grpc::ClientContext> context;
+  bool cancelled;
 };
 
 /**
@@ -77,11 +62,6 @@ class AsyncOperation {
    */
   virtual void Cancel() = 0;
 
-  enum Disposition {
-    CANCELLED,
-    COMPLETED,
-  };
-
  private:
   friend class internal::CompletionQueueImpl;
   /**
@@ -92,12 +72,12 @@ class AsyncOperation {
    *
    * @param cq the completion queue sending the notification, this is useful in
    *   case the callback needs to retry the operation.
-   * @param disposition `COMPLETED` if the operation completed, `CANCELED` if
-   *   the operation were canceled. Note that errors are a "normal" completion.
+   * @param ok opaque parameter returned by grpc::CompletionQueue; different
+   *   operations interpret it differently
    * @return Whether the operation is completed (e.g. in case of streaming
    *   response, it would return true only after the stream is finished).
    */
-  virtual bool Notify(CompletionQueue& cq, Disposition disposition) = 0;
+  virtual bool Notify(CompletionQueue& cq, bool ok) = 0;
 };
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/google/cloud/bigtable/async_operation.h
+++ b/google/cloud/bigtable/async_operation.h
@@ -72,8 +72,9 @@ class AsyncOperation {
    *
    * @param cq the completion queue sending the notification, this is useful in
    *   case the callback needs to retry the operation.
-   * @param ok opaque parameter returned by grpc::CompletionQueue; different
-   *   operations interpret it differently
+   * @param ok opaque parameter returned by grpc::CompletionQueue.  The
+   *   semantics defined by gRPC depend on the type of operation, therefore the
+   *   operation needs to interpret this parameter based on those semantics.
    * @return Whether the operation is completed (e.g. in case of streaming
    *   response, it would return true only after the stream is finished).
    */

--- a/google/cloud/bigtable/internal/async_bulk_apply.h
+++ b/google/cloud/bigtable/internal/async_bulk_apply.h
@@ -149,15 +149,14 @@ class AsyncRetryBulkApply
 
     auto delay = rpc_backoff_policy_->OnCompletion(status);
     auto self = this->shared_from_this();
-    cq.MakeRelativeTimer(
-        delay,
-        [self](CompletionQueue& cq, AsyncTimerResult timer,
-               AsyncOperation::Disposition d) { self->OnTimer(cq, timer, d); });
+    cq.MakeRelativeTimer(delay,
+                         [self](CompletionQueue& cq, AsyncTimerResult result) {
+                           self->OnTimer(cq, result);
+                         });
   }
 
-  void OnTimer(CompletionQueue& cq, AsyncTimerResult& timer,
-               AsyncOperation::Disposition d) {
-    if (d == AsyncOperation::CANCELLED) {
+  void OnTimer(CompletionQueue& cq, AsyncTimerResult& timer) {
+    if (timer.cancelled) {
       // Cancelled, no more action to take.
       auto res = impl_.ExtractFinalFailures();
       grpc::Status res_status(grpc::StatusCode::CANCELLED,

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -475,21 +475,20 @@ TEST(MultipleRowsMutatorTest, SimpleAsync) {
   auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
   bool mutator_finished = false;
   using bigtable::AsyncOperation;
-  using bigtable::AsyncUnaryRpcResult;
   mutator.Start(cq, std::move(context),
-                [&](CompletionQueue&, grpc::Status &status) {
+                [&](CompletionQueue&, grpc::Status& status) {
                   EXPECT_TRUE(status.ok());
                   EXPECT_EQ("mocked-status", status.error_message());
                   mutator_finished = true;
                 });
-  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  impl->SimulateCompletion(cq, true);
   // state == PROCESSING
-  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  impl->SimulateCompletion(cq, true);
   // state == PROCESSING, 1 read
-  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  impl->SimulateCompletion(cq, false);
   // state == FINISHING
   EXPECT_FALSE(mutator_finished);
-  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  impl->SimulateCompletion(cq, false);
   // callback fired
   EXPECT_TRUE(mutator_finished);
 }
@@ -532,17 +531,16 @@ TEST(MultipleRowsMutatorTest, SimpleAsyncFailure) {
   auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
   bool mutator_finished = false;
   using bigtable::AsyncOperation;
-  using bigtable::AsyncUnaryRpcResult;
   mutator.Start(cq, std::move(context),
-                [&](CompletionQueue&, grpc::Status &status) {
+                [&](CompletionQueue&, grpc::Status& status) {
                   EXPECT_FALSE(status.ok());
                   EXPECT_EQ("mocked-status", status.error_message());
                   mutator_finished = true;
                 });
-  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  impl->SimulateCompletion(cq, false);
   // state == FINISHING
   EXPECT_FALSE(mutator_finished);
-  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  impl->SimulateCompletion(cq, false);
   // callback fired
   EXPECT_TRUE(mutator_finished);
 }

--- a/google/cloud/bigtable/internal/table_async_bulk_apply_test.cc
+++ b/google/cloud/bigtable/internal/table_async_bulk_apply_test.cc
@@ -132,24 +132,24 @@ TEST_F(NoexTableAsyncBulkApplyTest, IdempotencyAndRetries) {
                         });
 
   using bigtable::AsyncOperation;
-  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  impl->SimulateCompletion(cq, true);
   // state == PROCESSING
-  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  impl->SimulateCompletion(cq, true);
   // state == PROCESSING, 1 read
-  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  impl->SimulateCompletion(cq, false);
   // state == FINISHING
-  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  impl->SimulateCompletion(cq, false);
   // FinishTimer
-  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  impl->SimulateCompletion(cq, true);
   // Second attempt
-  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  impl->SimulateCompletion(cq, true);
   // state == PROCESSING
-  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  impl->SimulateCompletion(cq, true);
   // state == PROCESSING, 1 read
-  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  impl->SimulateCompletion(cq, false);
   // state == FINISHING
   EXPECT_FALSE(mutator_finished);
-  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  impl->SimulateCompletion(cq, false);
   EXPECT_TRUE(mutator_finished);
 }
 
@@ -195,12 +195,12 @@ TEST_F(NoexTableAsyncBulkApplyTest, Cancelled) {
                         });
 
   using bigtable::AsyncOperation;
-  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  impl->SimulateCompletion(cq, false);
   // state == FINISHING
   EXPECT_FALSE(mutator_finished);
-  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  impl->SimulateCompletion(cq, false);
   // callback fired
-  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  impl->SimulateCompletion(cq, false);
   EXPECT_TRUE(mutator_finished);
 }
 
@@ -248,12 +248,12 @@ TEST_F(NoexTableAsyncBulkApplyTest, PermanentError) {
                         });
 
   using bigtable::AsyncOperation;
-  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  impl->SimulateCompletion(cq, false);
   // state == FINISHING
   EXPECT_FALSE(mutator_finished);
-  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  impl->SimulateCompletion(cq, false);
   // callback fired
-  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  impl->SimulateCompletion(cq, false);
   EXPECT_TRUE(mutator_finished);
 }
 
@@ -320,16 +320,16 @@ TEST_F(NoexTableAsyncBulkApplyTest, CancelledInTimer) {
                         });
 
   using bigtable::AsyncOperation;
-  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  impl->SimulateCompletion(cq, true);
   // state == PROCESSING
-  impl->SimulateCompletion(cq, AsyncOperation::COMPLETED);
+  impl->SimulateCompletion(cq, true);
   // state == PROCESSING, 1 read
-  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  impl->SimulateCompletion(cq, false);
   // state == FINISHING
-  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  impl->SimulateCompletion(cq, false);
   EXPECT_FALSE(mutator_finished);
   // FinishTimer
-  impl->SimulateCompletion(cq, AsyncOperation::CANCELLED);
+  impl->SimulateCompletion(cq, false);
   EXPECT_TRUE(mutator_finished);
 }
 


### PR DESCRIPTION
The disposition was only meaningful for timers. It wasn't used in unary
RPCs with streaming responses and for those non-streaming it erroneously
indicated whether an operation got cancelled.

"This fixes #1308".

The documentation states that "ok" (obtained from AsyncNext) should
always be true for Finish() operation.

After this change:
- disposition is removed from the codebase,
- if an operation is cancelled, we trust that grpc status indicates that
  and pass it to the user,
- if a timer is cancelled, AsyncTimerResult has a bool to reflect it,
- AsyncUnaryRpcResult is removed too, because it doesn't make much sense
  after the removal of disposition,
- if my understanding of the documentation is wrong or gRPC is buggy and
  AsyncNext does return false for a Finish() operation, we translate it
  into an grpc::UNKNOWN.

The change required a modification of a test which assumed that upon
request cancellation AsyncNext returns ok == false.

A test is added to check the newly added behaviour on Finish() returning
ok == false.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1341)
<!-- Reviewable:end -->
