### PR TITLE
Enable CRC32C checksums by default.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -613,9 +613,10 @@ class Client {
    * @param bucket_name the name of the bucket that contains the object.
    * @param object_name the name of the object to be read.
    * @param options a list of optional query parameters and/or request headers.
-   *     Valid types for this operation include
+   *     Valid types for this operation include `DisableCrc32cChecksum`,
+   *     `DisableMD5Hash`, `IfGenerationMatch`, `EncryptionKey`, `Generation`,
    *     `IfGenerationMatch`, `IfGenerationNotMatch`, `IfMetagenerationMatch`,
-   *     `IfMetagenerationNotMatch`, `Generation`, and `UserProject`.
+   *     `IfMetagenerationNotMatch`, and `UserProject`.
    *
    * @par Examples
    *
@@ -638,9 +639,11 @@ class Client {
    * @param bucket_name the name of the bucket that contains the object.
    * @param object_name the name of the object to be read.
    * @param options a list of optional query parameters and/or request headers.
-   *   Valid types for this operation include `IfGenerationMatch`,
-   *   `IfGenerationNotMatch`, `IfMetagenerationMatch`,
-   *   `IfMetagenerationNotMatch`, `Generation`, and `UserProject`.
+   *   Valid types for this operation include `ContentEncoding`, `ContentType`,
+   *   `Crc32cChecksumValue`, `DisableCrc32cChecksum`, `DisableMD5Hash`,
+   *   `EncryptionKey`, `IfGenerationMatch`, `IfGenerationNotMatch`,
+   *   `IfMetagenerationMatch`, `IfMetagenerationNotMatch`, `KmsKeyName`,
+   *   `MD5HashValue`, `PredefinedAcl`, `Projection`, and `UserProject`.
    *
    * @par Examples
    *
@@ -670,9 +673,11 @@ class Client {
    * @param bucket_name the name of the bucket that contains the object.
    * @param object_name the name of the object to be read.
    * @param options a list of optional query parameters and/or request headers.
-   *   Valid types for this operation include `IfGenerationMatch`,
-   *   `IfGenerationNotMatch`, `IfMetagenerationMatch`,
-   *   `IfMetagenerationNotMatch`, `Generation`, and `UserProject`.
+   *   Valid types for this operation include `ContentEncoding`, `ContentType`,
+   *   `Crc32cChecksumValue`, `DisableCrc32cChecksum`, `DisableMD5Hash`,
+   *   `EncryptionKey`, `IfGenerationMatch`, `IfGenerationNotMatch`,
+   *   `IfMetagenerationMatch`, `IfMetagenerationNotMatch`, `KmsKeyName`,
+   *   `MD5HashValue`, `PredefinedAcl`, `Projection`, and `UserProject`.
    *
    * @par Example
    * @snippet storage_object_samples.cc upload file

--- a/google/cloud/storage/internal/hash_validator.cc
+++ b/google/cloud/storage/internal/hash_validator.cc
@@ -27,15 +27,16 @@ namespace internal {
 
 void HashValidator::CheckResult(std::string const& msg,
                                 HashValidator::Result const& result) {
+  if (not result.is_mismatch) {
+    return;
+  }
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   // Sometimes the server simply does not have a MD5 hash to send us, the most
   // common case is a composed object, particularly one formed from encrypted
   // components, where computing the MD5 would require decrypting and re-reading
   // all the components. In that case we just do not raise an exception even if
   // there is a mismatch.
-  if (not result.received.empty() and result.received != result.computed) {
-    throw HashMismatchError(msg, result.received, result.computed);
-  }
+  throw HashMismatchError(msg, result.received, result.computed);
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -70,7 +71,8 @@ HashValidator::Result CompositeValidator::Finish() && {
   received += "," + right_->Name() + "=" + right_result.received;
   auto computed = left_->Name() + "=" + left_result.computed;
   computed += "," + right_->Name() + "=" + right_result.computed;
-  return Result{std::move(received), std::move(computed)};
+  bool is_mismatch = left_result.is_mismatch or right_result.is_mismatch;
+  return Result{std::move(received), std::move(computed), is_mismatch};
 }
 
 MD5HashValidator::MD5HashValidator() : context_{} { MD5_Init(&context_); }
@@ -110,7 +112,9 @@ HashValidator::Result MD5HashValidator::Finish() && {
   std::string hash(MD5_DIGEST_LENGTH, ' ');
   MD5_Final(reinterpret_cast<unsigned char*>(&hash[0]), &context_);
   auto computed = OpenSslUtils::Base64Encode(hash);
-  return Result{std::move(received_hash_), std::move(computed)};
+  bool is_mismatch =
+      not received_hash_.empty() and (received_hash_ != computed);
+  return Result{std::move(received_hash_), std::move(computed), is_mismatch};
 }
 
 Crc32cHashValidator::Crc32cHashValidator() : current_(0) {}
@@ -154,7 +158,9 @@ HashValidator::Result Crc32cHashValidator::Finish() && {
   hash.resize(sizeof(big_endian));
   std::memcpy(&hash[0], &big_endian, sizeof(big_endian));
   auto computed = OpenSslUtils::Base64Encode(hash);
-  return Result{std::move(received_hash_), std::move(computed)};
+  bool is_mismatch =
+      not received_hash_.empty() and (received_hash_ != computed);
+  return Result{std::move(received_hash_), std::move(computed), is_mismatch};
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/hash_validator.h
+++ b/google/cloud/storage/internal/hash_validator.h
@@ -52,6 +52,9 @@ class HashValidator {
     std::string received;
     /// The value computed locally, based on the calls to Update().
     std::string computed;
+    /// A flag indicating of this is considered a mismatch based on the rules
+    /// for the validator.
+    bool is_mismatch;
   };
 
   /**

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -117,9 +117,10 @@ std::ostream& operator<<(std::ostream& os, InsertObjectMediaRequest const& r);
 class InsertObjectStreamingRequest
     : public GenericObjectRequest<
           InsertObjectStreamingRequest, ContentEncoding, ContentType,
-          DisableMD5Hash, EncryptionKey, IfGenerationMatch,
-          IfGenerationNotMatch, IfMetagenerationMatch, IfMetagenerationNotMatch,
-          KmsKeyName, MD5HashValue, PredefinedAcl, Projection, UserProject> {
+          Crc32cChecksumValue, DisableCrc32cChecksum, DisableMD5Hash,
+          EncryptionKey, IfGenerationMatch, IfGenerationNotMatch,
+          IfMetagenerationMatch, IfMetagenerationNotMatch, KmsKeyName,
+          MD5HashValue, PredefinedAcl, Projection, UserProject> {
  public:
   using GenericObjectRequest::GenericObjectRequest;
 };
@@ -170,10 +171,10 @@ std::ostream& operator<<(std::ostream& os, CopyObjectRequest const& r);
  * Represents a request to the `Objects: get` API with `alt=media`.
  */
 class ReadObjectRangeRequest
-    : public GenericObjectRequest<ReadObjectRangeRequest, DisableMD5Hash,
-                                  EncryptionKey, Generation, IfGenerationMatch,
-                                  IfGenerationNotMatch, IfMetagenerationMatch,
-                                  IfMetagenerationNotMatch, UserProject> {
+    : public GenericObjectRequest<
+          ReadObjectRangeRequest, DisableCrc32cChecksum, DisableMD5Hash,
+          EncryptionKey, Generation, IfGenerationMatch, IfGenerationNotMatch,
+          IfMetagenerationMatch, IfMetagenerationNotMatch, UserProject> {
  public:
   ReadObjectRangeRequest() : GenericObjectRequest(), begin_(0), end_(0) {}
 

--- a/google/cloud/storage/testbench/gcs_object.py
+++ b/google/cloud/storage/testbench/gcs_object.py
@@ -324,6 +324,12 @@ class GcsObjectVersion(object):
             raise error_response.ErrorResponse('Missing role value')
         return self.insert_acl(entity, role)
 
+    def x_goog_hash_header(self):
+        """Return the value for the x-goog-hash header."""
+        hashes = {'md5': self.metadata.get('md5Hash', ''),
+                  'crc32c': self.metadata.get('crc32c', '')}
+        hashes = ['%s=%s' % (key, val) for key, val in hashes.iteritems() if val]
+        return ','.join(hashes)
 
 class GcsObject(object):
     """Represent a GCS Object, including all its revisions."""

--- a/google/cloud/storage/testbench/gcs_object.py
+++ b/google/cloud/storage/testbench/gcs_object.py
@@ -696,6 +696,10 @@ class GcsObject(object):
         payload = json.loads(request.data)
         if payload.get('destination') is not None:
             revision.update_from_metadata(payload.get('destination'))
+        # The server often discards the MD5 Hash when composing objects, we can
+        # easily maintain them in the testbench, but dropping them helps us
+        # detect bugs sooner.
+        revision.metadata.pop('md5Hash')
         self._insert_revision(revision)
         return revision
 

--- a/google/cloud/storage/testbench/testbench.py
+++ b/google/cloud/storage/testbench/testbench.py
@@ -444,7 +444,7 @@ def objects_get(bucket_name, object_name):
     response = flask.make_response(response_payload)
     length = len(response_payload)
     response.headers['Content-Range'] = 'bytes 0-%d/%d' % (length - 1, length)
-    response.headers['x-goog-hash'] = 'md5=%s,crc32c=%s' % (revision.metadata.get('md5Hash', ''), revision.metadata.get('crc32c', ''))
+    response.headers['x-goog-hash'] = revision.x_goog_hash_header()
     return response
 
 
@@ -674,7 +674,7 @@ def xmlapi_get_object(bucket_name, object_name):
     response = flask.make_response(response_payload)
     length = len(response_payload)
     response.headers['Content-Range'] = 'bytes 0-%d/%d' % (length - 1, length)
-    response.headers['x-goog-hash'] = 'md5=%s,crc32c=%s' % (revision.metadata.get('md5Hash', ''), revision.metadata.get('crc32c', ''))
+    response.headers['x-goog-hash'] = revision.x_goog_hash_header()
     return response
 
 
@@ -699,7 +699,7 @@ def xmlapi_put_object(bucket_name, object_name):
     revision = blob.insert_xml(gcs_url, flask.request)
     testbench_utils.insert_object(object_path, blob)
     response = flask.make_response('')
-    response.headers['x-goog-hash'] = 'md5=%s,crc32c=%s' % (revision.metadata.get('md5Hash', ''), revision.metadata.get('crc32c', ''))
+    response.headers['x-goog-hash'] = revision.x_goog_hash_header()
     return response
 
 

--- a/google/cloud/storage/testbench/testbench.py
+++ b/google/cloud/storage/testbench/testbench.py
@@ -354,6 +354,8 @@ def objects_list(bucket_name):
     """Implement the 'Objects: list' API: return the objects in a bucket."""
     # Lookup the bucket, if this fails the bucket does not exist, and this
     # function should return an error.
+    base_url = flask.url_for('gcs_index', _external=True)
+    insert_magic_bucket(base_url)
     _ = testbench_utils.lookup_bucket(bucket_name)
     result = {'next_page_token': '', 'items': []}
     versions_parameter = flask.request.args.get('versions')
@@ -442,7 +444,7 @@ def objects_get(bucket_name, object_name):
     response = flask.make_response(response_payload)
     length = len(response_payload)
     response.headers['Content-Range'] = 'bytes 0-%d/%d' % (length - 1, length)
-    response.headers['x-goog-hash'] = 'md5=%s' % revision.metadata.get('md5Hash', '')
+    response.headers['x-goog-hash'] = 'md5=%s,crc32c=%s' % (revision.metadata.get('md5Hash', ''), revision.metadata.get('crc32c', ''))
     return response
 
 
@@ -672,7 +674,7 @@ def xmlapi_get_object(bucket_name, object_name):
     response = flask.make_response(response_payload)
     length = len(response_payload)
     response.headers['Content-Range'] = 'bytes 0-%d/%d' % (length - 1, length)
-    response.headers['x-goog-hash'] = 'md5=%s' % revision.metadata.get('md5Hash', '')
+    response.headers['x-goog-hash'] = 'md5=%s,crc32c=%s' % (revision.metadata.get('md5Hash', ''), revision.metadata.get('crc32c', ''))
     return response
 
 
@@ -697,7 +699,7 @@ def xmlapi_put_object(bucket_name, object_name):
     revision = blob.insert_xml(gcs_url, flask.request)
     testbench_utils.insert_object(object_path, blob)
     response = flask.make_response('')
-    response.headers['x-goog-hash'] = 'md5=%s' % revision.metadata.get('md5Hash', '')
+    response.headers['x-goog-hash'] = 'md5=%s,crc32c=%s' % (revision.metadata.get('md5Hash', ''), revision.metadata.get('crc32c', ''))
     return response
 
 


### PR DESCRIPTION
With this PR the APIs to insert objects, upload objects, and download
objects compute the CRC32C checksum by default. This is in addition to
the MD5 hash, application developers can disable one or both of these.

I apologize for the large PR, mostly tests though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1344)
<!-- Reviewable:end -->
