### PR TITLE
Implement examples for bucket retention policy.

### DIFF
--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -799,6 +799,12 @@ class BucketMetadataPatchBuilder {
 
   BucketMetadataPatchBuilder& SetRetentionPolicy(
       BucketRetentionPolicy const& v);
+  BucketMetadataPatchBuilder& SetRetentionPolicy(
+      std::chrono::seconds retention_period) {
+    // This is the only parameter that the application can set, so make it easy
+    // for them to set it.
+    return SetRetentionPolicy(BucketRetentionPolicy{retention_period});
+  }
   BucketMetadataPatchBuilder& ResetRetentionPolicy();
 
   BucketMetadataPatchBuilder& SetStorageClass(std::string const& v);

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -110,6 +110,56 @@ run_all_requester_pays_examples() {
 }
 
 ################################################
+# Run all examples showing how to use default event based holds.
+# Globals:
+#   COLOR_*: colorize output messages, defined in colors.sh
+#   EXIT_STATUS: control the final exit status for the program.
+#   PROJECT_ID: the Google Cloud Project used for the test.
+# Arguments:
+#   None
+# Returns:
+#   None
+################################################
+run_default_event_based_hold_examples() {
+  local bucket_name="cloud-cpp-test-bucket-$(date +%s)-${RANDOM}-${RANDOM}"
+
+  run_example ./storage_bucket_samples create-bucket-for-project \
+      "${bucket_name}" "${PROJECT_ID}"
+  run_example ./storage_bucket_samples get-default-event-based-hold \
+      "${bucket_name}"
+  run_example ./storage_bucket_samples enable-default-event-based-hold \
+      "${bucket_name}"
+  run_example ./storage_bucket_samples disable-default-event-based-hold \
+      "${bucket_name}"
+  run_example ./storage_bucket_samples delete-bucket "${bucket_name}"
+}
+
+################################################
+# Run all examples showing how to use retention policies.
+# Globals:
+#   COLOR_*: colorize output messages, defined in colors.sh
+#   EXIT_STATUS: control the final exit status for the program.
+#   PROJECT_ID: the Google Cloud Project used for the test.
+# Arguments:
+#   None
+# Returns:
+#   None
+################################################
+run_retention_policy_examples() {
+  local bucket_name="cloud-cpp-test-bucket-$(date +%s)-${RANDOM}-${RANDOM}"
+
+  run_example ./storage_bucket_samples create-bucket-for-project \
+      "${bucket_name}" "${PROJECT_ID}"
+  run_example ./storage_bucket_samples get-retention-policy \
+      "${bucket_name}"
+  run_example ./storage_bucket_samples set-retention-policy \
+      "${bucket_name}" 30
+  run_example ./storage_bucket_samples remove-retention-policy \
+      "${bucket_name}"
+  run_example ./storage_bucket_samples delete-bucket "${bucket_name}"
+}
+
+################################################
 # Run all Bucket ACL examples.
 # Globals:
 #   COLOR_*: colorize output messages, defined in colors.sh
@@ -679,6 +729,8 @@ run_all_storage_examples() {
   EMULATOR_LOG="testbench.log"
   run_quickstart
   run_all_bucket_examples
+  run_default_event_based_hold_examples
+  run_retention_policy_examples
   run_all_bucket_acl_examples "${BUCKET_NAME}"
   run_all_default_object_acl_examples "${BUCKET_NAME}"
   run_all_requester_pays_examples

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -548,6 +548,156 @@ void GetServiceAccountForProject(google::cloud::storage::Client client,
   //! [get service account for project]
   (std::move(client), project_id);
 }
+
+void GetDefaultEventBasedHold(google::cloud::storage::Client client, int& argc,
+                              char* argv[]) {
+  if (argc != 2) {
+    throw Usage{"get-default-event-based-hold <bucket-name>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  //! [get default event based hold]
+  // [START storage_get_default_event_based_hold]
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string bucket_name) {
+    gcs::BucketMetadata metadata = client.GetBucketMetadata(bucket_name);
+    std::cout << "The default event-based hold for objects in bucket "
+              << bucket_name << " is "
+              << (metadata.default_event_based_hold() ? "enabled" : "disabled")
+              << std::endl;
+  }
+  // [END storage_get_default_event_based_hold]
+  //! [get default event based hold]
+  (std::move(client), bucket_name);
+}
+
+void EnableDefaultEventBasedHold(google::cloud::storage::Client client,
+                                 int& argc, char* argv[]) {
+  if (argc != 2) {
+    throw Usage{"enable-default-event-based-hold <bucket-name>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  //! [enable default event based hold]
+  // [START storage_enable_default_event_based_hold]
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string bucket_name) {
+    gcs::BucketMetadata original = client.GetBucketMetadata(bucket_name);
+    gcs::BucketMetadata metadata = client.PatchBucket(
+        bucket_name,
+        gcs::BucketMetadataPatchBuilder().SetDefaultEventBasedHold(true),
+        gcs::IfMetagenerationMatch(original.metageneration()));
+    std::cout << "The default event-based hold for objects in bucket "
+              << bucket_name << " is "
+              << (metadata.default_event_based_hold() ? "enabled" : "disabled")
+              << std::endl;
+  }
+  // [END storage_enable_default_event_based_hold]
+  //! [enable default event based hold]
+  (std::move(client), bucket_name);
+}
+
+void DisableDefaultEventBasedHold(google::cloud::storage::Client client,
+                                  int& argc, char* argv[]) {
+  if (argc != 2) {
+    throw Usage{"disable-default-event-based-hold <bucket-name>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  //! [disable default event based hold]
+  // [START storage_disable_default_event_based_hold]
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string bucket_name) {
+    gcs::BucketMetadata metadata = client.PatchBucket(
+        bucket_name,
+        gcs::BucketMetadataPatchBuilder().SetDefaultEventBasedHold(true));
+    std::cout << "The default event-based hold for objects in bucket "
+              << bucket_name << " is "
+              << (metadata.default_event_based_hold() ? "enabed" : "disabled")
+              << std::endl;
+  }
+  // [END storage_disable_default_event_based_hold]
+  //! [disable default event based hold]
+  (std::move(client), bucket_name);
+}
+
+void GetRetentionPolicy(google::cloud::storage::Client client, int& argc,
+                        char* argv[]) {
+  if (argc != 2) {
+    throw Usage{"get-retention-policy <bucket-name>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  //! [get retention policy]
+  // [START storage_get_retention_policy]
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string bucket_name) {
+    gcs::BucketMetadata metadata = client.GetBucketMetadata(bucket_name);
+    if (not metadata.has_retention_policy()) {
+      std::cout << "The bucket " << bucket_name
+                << " does not have a retention policy set." << std::endl;
+      return;
+    }
+    std::cout << "The bucket " << bucket_name << " retention policy is set to "
+              << metadata.retention_policy() << std::endl;
+  }
+  // [END storage_get_retention_policy]
+  //! [get retention policy]
+  (std::move(client), bucket_name);
+}
+
+void SetRetentionPolicy(google::cloud::storage::Client client, int& argc,
+                        char* argv[]) {
+  if (argc != 3) {
+    throw Usage{"set-retention-policy <bucket-name> <period>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  auto period = std::stol(ConsumeArg(argc, argv));
+  //! [set retention policy]
+  // [START storage_set_retention_policy]
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string bucket_name, std::chrono::seconds period) {
+    gcs::BucketMetadata original = client.GetBucketMetadata(bucket_name);
+    gcs::BucketMetadata metadata = client.PatchBucket(
+        bucket_name,
+        gcs::BucketMetadataPatchBuilder().SetRetentionPolicy(period),
+        gcs::IfMetagenerationMatch(original.metageneration()));
+    if (not metadata.has_retention_policy()) {
+      std::cout << "The bucket " << bucket_name
+                << " does not have a retention policy set." << std::endl;
+      return;
+    }
+    std::cout << "The bucket " << bucket_name << " retention policy is set to "
+              << metadata.retention_policy() << std::endl;
+  }
+  // [END storage_set_retention_policy]
+  //! [set retention policy]
+  (std::move(client), bucket_name, std::chrono::seconds(period));
+}
+
+void RemoveRetentionPolicy(google::cloud::storage::Client client, int& argc,
+                        char* argv[]) {
+  if (argc != 2) {
+    throw Usage{"remove-retention-policy <bucket-name>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  //! [remove retention policy]
+  // [START storage_remove_retention_policy]
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string bucket_name) {
+    gcs::BucketMetadata original = client.GetBucketMetadata(bucket_name);
+    gcs::BucketMetadata metadata = client.PatchBucket(
+        bucket_name,
+        gcs::BucketMetadataPatchBuilder().ResetRetentionPolicy());
+    if (not metadata.has_retention_policy()) {
+      std::cout << "The bucket " << bucket_name
+                << " does not have a retention policy set." << std::endl;
+      return;
+    }
+    std::cout << "The bucket " << bucket_name << " retention policy is set to "
+              << metadata.retention_policy() << std::endl;
+  }
+  // [END storage_remove_retention_policy]
+  //! [remove retention policy]
+  (std::move(client), bucket_name);
+}
+
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) try {
@@ -582,6 +732,12 @@ int main(int argc, char* argv[]) try {
       {"read-object-requester-pays", &ReadObjectRequesterPays},
       {"get-service-account", &GetServiceAccount},
       {"get-service-account-for-project", &GetServiceAccountForProject},
+      {"get-default-event-based-hold", &GetDefaultEventBasedHold},
+      {"enable-default-event-based-hold", &EnableDefaultEventBasedHold},
+      {"disable-default-event-based-hold", &DisableDefaultEventBasedHold},
+      {"get-retention-policy", &GetRetentionPolicy},
+      {"set-retention-policy", &SetRetentionPolicy},
+      {"remove-retention-policy", &RemoveRetentionPolicy},
   };
   for (auto&& kv : commands) {
     try {

--- a/google/cloud/storage/testbench/gcs_bucket.py
+++ b/google/cloud/storage/testbench/gcs_bucket.py
@@ -19,6 +19,7 @@ import base64
 import error_response
 import json
 import testbench_utils
+import time
 
 
 class GcsBucket(object):
@@ -123,6 +124,13 @@ class GcsBucket(object):
         :param patch:dict a dictionary with metadata changes.
         """
         patch = GcsBucket._remove_non_writable_keys(patch)
+        retention_policy = patch.get('retentionPolicy')
+        if retention_policy is not None:
+            retention_policy.pop('isLocked', None)
+            now = time.gmtime(time.time())
+            timestamp = time.strftime('%Y-%m-%dT%H:%M:%SZ', now)
+            retention_policy['effectiveTime'] = timestamp
+            patch['retentionPolicy'] = retention_policy
         patched = testbench_utils.json_api_patch(self.metadata, patch, recurse_on={'labels'})
         self.metadata = patched
         self.increase_metageneration()

--- a/google/cloud/storage/testbench/gcs_bucket.py
+++ b/google/cloud/storage/testbench/gcs_bucket.py
@@ -103,6 +103,14 @@ class GcsBucket(object):
 
         :param metadata:dict a dictionary with new metadata values.
         """
+        retention_policy = metadata.get('retentionPolicy')
+        if retention_policy:
+            # Ignore any values set for 'isLocked' or 'effectiveTime'.
+            retention_policy.pop('isLocked', None)
+            now = time.gmtime(time.time())
+            timestamp = time.strftime('%Y-%m-%dT%H:%M:%SZ', now)
+            retention_policy['effectiveTime'] = timestamp
+            metadata['retentionPolicy'] = retention_policy
         tmp = self.metadata.copy()
         metadata = GcsBucket._remove_non_writable_keys(metadata)
         tmp.update(metadata)
@@ -125,7 +133,8 @@ class GcsBucket(object):
         """
         patch = GcsBucket._remove_non_writable_keys(patch)
         retention_policy = patch.get('retentionPolicy')
-        if retention_policy is not None:
+        if retention_policy:
+            # Ignore any values set for 'isLocked' or 'effectiveTime'.
             retention_policy.pop('isLocked', None)
             now = time.gmtime(time.time())
             timestamp = time.strftime('%Y-%m-%dT%H:%M:%SZ', now)


### PR DESCRIPTION
Part of the work for #1029. This includes the examples to set the bucket
default event based hold, as well as the examples to query and set the
retention policy. The examples to lock the retention policy will come
later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1347)
<!-- Reviewable:end -->
