### PR TITLE
Implement the base class for the shared state.

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -77,6 +77,7 @@ add_library(google_cloud_cpp_common
             ${CMAKE_CURRENT_BINARY_DIR}/internal/build_info.cc
             internal/filesystem.h
             internal/filesystem.cc
+            internal/future_impl.h
             internal/getenv.h
             internal/getenv.cc
             internal/make_unique.h
@@ -137,6 +138,7 @@ set(google_cloud_cpp_common_unit_tests
     internal/backoff_policy_test.cc
     internal/big_endian_test.cc
     internal/filesystem_test.cc
+    internal/future_impl_test.cc
     internal/invoke_result_test.cc
     internal/random_test.cc
     internal/retry_policy_test.cc

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -7,6 +7,7 @@ google_cloud_cpp_common_HDRS = [
     "internal/big_endian.h",
     "internal/build_info.h",
     "internal/filesystem.h",
+    "internal/future_impl.h",
     "internal/getenv.h",
     "internal/make_unique.h",
     "internal/port_platform.h",

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -4,6 +4,7 @@ google_cloud_cpp_common_unit_tests = [
     "internal/backoff_policy_test.cc",
     "internal/big_endian_test.cc",
     "internal/filesystem_test.cc",
+    "internal/future_impl_test.cc",
     "internal/invoke_result_test.cc",
     "internal/random_test.cc",
     "internal/retry_policy_test.cc",

--- a/google/cloud/internal/future_impl.h
+++ b/google/cloud/internal/future_impl.h
@@ -1,0 +1,188 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_IMPL_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_IMPL_H_
+/**
+ * @file
+ *
+ * Define the implementation details for `google::cloud::future<T>`.
+ */
+
+#include "google/cloud/internal/port_platform.h"
+
+// C++ futures only make sense when exceptions are enabled.
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+#include "google/cloud/version.h"
+#include <condition_variable>
+#include <exception>
+#include <future>
+#include <mutex>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+/**
+ * Common base class for all shared state classes.
+ *
+ * The implementation of the shared state for future<T>, future<R&> and
+ * future<void> share a lot of code. This class refactors that code, it
+ * represents a shared state of unknown type.
+ *
+ * @note While most of the invariants for promises and futures are implemented
+ *   by this class, not all of them are. Notably, future values can only be
+ *   retrieved once, but this is enforced because calling .get() or .then() on a
+ *   future invalidates the future for further use. The shared state does not
+ *   record that state change.
+ */
+class future_shared_state_base {
+ public:
+  future_shared_state_base() : mu_(), cv_(), current_state_(state::not_ready) {}
+
+  /// Return true if the shared state has a value or an exception.
+  bool is_ready() const {
+    std::unique_lock<std::mutex> lk(mu_);
+    return is_ready_unlocked();
+  }
+
+  /// Block until is_ready() returns true ...
+  void wait() {
+    std::unique_lock<std::mutex> lk(mu_);
+    cv_.wait(lk, [this] { return is_ready_unlocked(); });
+  }
+
+  /**
+   * Block until `is_ready()` returns true or until @p duration time has
+   * elapsed.
+   *
+   * @param duration the maximum time to wait for `is_ready()`.
+   *
+   * @tparam Rep a placeholder to match the Rep tparam for @p duration's
+   *     type, the semantics of this template parameter are documented in
+   *     `std::chrono::duration<>` (in brief, the underlying arithmetic type
+   *     used to store the number of ticks), for our purposes it is simply a
+   *     formal parameter.
+   * @tparam Period a placeholder to match the Period tparam for @p duration's
+   *     type, the semantics of this template parameter are documented in
+   *     `std::chrono::duration<>` (in brief, the length of the tick in seconds,
+   *     expressed as a `std::ratio<>`), for our purposes it is simply a formal
+   *     parameter.
+   *
+   * @return `std::future_status::ready` if the shared state is satisfied.
+   *     `std::future_status::deferred` if the shared state is not satisfied and
+   *     there is a continuation ready to execute when it is satisfied.
+   *     `std::future_status::timeout` otherwise.
+   */
+  template <typename Rep, typename Period>
+  std::future_status wait_for(std::chrono::duration<Rep, Period> duration) {
+    std::unique_lock<std::mutex> lk(mu_);
+    if (not lk.owns_lock()) {
+      return std::future_status::timeout;
+    }
+    bool result =
+        cv_.wait_for(lk, duration, [this] { return is_ready_unlocked(); });
+    if (result) {
+      return std::future_status::ready;
+    }
+    return std::future_status::timeout;
+  }
+
+  /**
+   * Block until is_ready() returns true or until the @p deadline.
+   *
+   * @param deadline the maximum time to wait.
+   *
+   * @tparam Clock a placeholder to match the Clock tparam for @p tp's
+   *     type, the semantics of this template parameter are documented in
+   *     `std::chrono::time_point<>` (in brief, the underlying clock type
+   *     associated with the time point), for our purposes it is simply a
+   *     formal parameter.
+   *
+   * @return `std::future_status::ready` if the shared state is satisfied.
+   *     `std::future_status::deferred` if the shared state is not satisfied and
+   *     there is a continuation ready to execute when it is satisfied.
+   *     `std::future_status::timeout` otherwise.
+   */
+  template <typename Clock>
+  std::future_status wait_until(std::chrono::time_point<Clock> deadline) {
+    std::unique_lock<std::mutex> lk(mu_);
+    if (not lk.owns_lock()) {
+      return std::future_status::timeout;
+    }
+    bool result =
+        cv_.wait_until(lk, deadline, [this] { return is_ready_unlocked(); });
+    if (result) {
+      return std::future_status::ready;
+    }
+    return std::future_status::timeout;
+  }
+
+  /// Set the shared state to hold an exception and notify immediately.
+  void set_exception(std::exception_ptr ex) {
+    std::unique_lock<std::mutex> lk(mu_);
+    set_exception(std::move(ex), lk);
+    notify_now(lk);
+  }
+
+  /// Abandon the shared state
+  void abandon() {
+    std::unique_lock<std::mutex> lk(mu_);
+    if (is_ready_unlocked()) {
+      return;
+    }
+    set_exception(std::make_exception_ptr(
+                      std::future_error(std::future_errc::broken_promise)),
+                  lk);
+    notify_now(lk);
+  }
+
+ protected:
+  bool is_ready_unlocked() const { return current_state_ != state::not_ready; }
+
+  /// Satisfy the shared state using an exception.
+  void set_exception(std::exception_ptr ex, std::unique_lock<std::mutex>& lk) {
+    if (is_ready_unlocked()) {
+      throw std::future_error(std::future_errc::promise_already_satisfied);
+    }
+    exception_ = std::move(ex);
+    current_state_ = state::has_exception;
+  }
+
+  void notify_now(std::unique_lock<std::mutex>& lk) {
+    cv_.notify_all();
+    // Release the lock after the notification because otherwise the threads
+    // may lose the state change.
+    lk.unlock();
+  }
+
+  mutable std::mutex mu_;
+  std::condition_variable cv_;
+  enum class state {
+    not_ready,
+    has_exception,
+    has_value,
+  };
+  state current_state_;
+  std::exception_ptr exception_;
+};
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_IMPL_H_

--- a/google/cloud/internal/future_impl_test.cc
+++ b/google/cloud/internal/future_impl_test.cc
@@ -41,16 +41,28 @@ TEST(FutureImplBaseTest, WaitFor) {
   EXPECT_FALSE(shared_state.is_ready());
 }
 
+TEST(FutureImplBaseTest, WaitForReady) {
+  future_shared_state_base shared_state;
+  shared_state.set_exception(
+      std::make_exception_ptr(std::runtime_error("test_message")));
+  auto s = shared_state.wait_for(100_us);
+  EXPECT_EQ(std::future_status::ready, s);
+  EXPECT_TRUE(shared_state.is_ready());
+}
+
 TEST(FutureImplBaseTest, WaitUntil) {
   future_shared_state_base shared_state;
   EXPECT_FALSE(shared_state.is_ready());
   auto s = shared_state.wait_until(std::chrono::system_clock::now() + 100_us);
   EXPECT_EQ(static_cast<int>(s), static_cast<int>(std::future_status::timeout));
   EXPECT_FALSE(shared_state.is_ready());
+}
 
+TEST(FutureImplBaseTest, WaitUntilReady) {
+  future_shared_state_base shared_state;
   shared_state.set_exception(
       std::make_exception_ptr(std::runtime_error("test message")));
-  s = shared_state.wait_until(std::chrono::system_clock::now() + 100_us);
+  auto s = shared_state.wait_until(std::chrono::system_clock::now() + 100_us);
   EXPECT_EQ(static_cast<int>(s), static_cast<int>(std::future_status::ready));
   EXPECT_TRUE(shared_state.is_ready());
 }
@@ -80,6 +92,15 @@ TEST(FutureImplBaseTest, Abandon) {
   // TODO(#1345) - use future_shared_state<void> and call .get();
   future_shared_state_base shared_state;
   shared_state.abandon();
+  EXPECT_TRUE(shared_state.is_ready());
+}
+
+TEST(FutureImplBaseTest, AbandonReady) {
+  // TODO(#1345) - use future_shared_state<void> and call .get();
+  future_shared_state_base shared_state;
+  shared_state.set_exception(
+      std::make_exception_ptr(std::runtime_error("test message")));
+  EXPECT_NO_THROW(shared_state.abandon());
   EXPECT_TRUE(shared_state.is_ready());
 }
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS

--- a/google/cloud/internal/future_impl_test.cc
+++ b/google/cloud/internal/future_impl_test.cc
@@ -1,0 +1,91 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/future_impl.h"
+#include "google/cloud/internal/make_unique.h"
+#include "google/cloud/testing_util/chrono_literals.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+namespace {
+
+using ::testing::HasSubstr;
+
+using namespace google::cloud::testing_util::chrono_literals;
+
+// C++ futures only make sense when exceptions are enabled.
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+TEST(FutureImplBaseTest, Basic) {
+  future_shared_state_base shared_state;
+  EXPECT_FALSE(shared_state.is_ready());
+}
+
+TEST(FutureImplBaseTest, WaitFor) {
+  future_shared_state_base shared_state;
+  auto s = shared_state.wait_for(100_us);
+  EXPECT_EQ(static_cast<int>(s), static_cast<int>(std::future_status::timeout));
+  EXPECT_FALSE(shared_state.is_ready());
+}
+
+TEST(FutureImplBaseTest, WaitUntil) {
+  future_shared_state_base shared_state;
+  EXPECT_FALSE(shared_state.is_ready());
+  auto s = shared_state.wait_until(std::chrono::system_clock::now() + 100_us);
+  EXPECT_EQ(static_cast<int>(s), static_cast<int>(std::future_status::timeout));
+  EXPECT_FALSE(shared_state.is_ready());
+
+  shared_state.set_exception(
+      std::make_exception_ptr(std::runtime_error("test message")));
+  s = shared_state.wait_until(std::chrono::system_clock::now() + 100_us);
+  EXPECT_EQ(static_cast<int>(s), static_cast<int>(std::future_status::ready));
+  EXPECT_TRUE(shared_state.is_ready());
+}
+
+TEST(FutureImplBaseTest, SetExceptionCanBeCalledOnlyOnce) {
+  future_shared_state_base shared_state;
+  EXPECT_FALSE(shared_state.is_ready());
+
+  shared_state.set_exception(
+      std::make_exception_ptr(std::runtime_error("test message")));
+  EXPECT_TRUE(shared_state.is_ready());
+
+  EXPECT_THROW(
+      try {
+        shared_state.set_exception(
+            std::make_exception_ptr(std::runtime_error("blah")));
+      } catch (std::future_error const& ex) {
+        EXPECT_EQ(std::future_errc::promise_already_satisfied, ex.code());
+        throw;
+      },
+      std::future_error);
+
+  EXPECT_TRUE(shared_state.is_ready());
+}
+
+TEST(FutureImplBaseTest, Abandon) {
+  // TODO(#1345) - use future_shared_state<void> and call .get();
+  future_shared_state_base shared_state;
+  shared_state.abandon();
+  EXPECT_TRUE(shared_state.is_ready());
+}
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+
+}  // namespace
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/future_impl_test.cc
+++ b/google/cloud/internal/future_impl_test.cc
@@ -36,8 +36,11 @@ TEST(FutureImplBaseTest, Basic) {
 
 TEST(FutureImplBaseTest, WaitFor) {
   future_shared_state_base shared_state;
+  auto start = std::chrono::steady_clock::now();
   auto s = shared_state.wait_for(100_us);
+  auto elapsed = std::chrono::steady_clock::now() - start;
   EXPECT_EQ(static_cast<int>(s), static_cast<int>(std::future_status::timeout));
+  EXPECT_LE(100_us, elapsed);
   EXPECT_FALSE(shared_state.is_ready());
 }
 
@@ -53,8 +56,11 @@ TEST(FutureImplBaseTest, WaitForReady) {
 TEST(FutureImplBaseTest, WaitUntil) {
   future_shared_state_base shared_state;
   EXPECT_FALSE(shared_state.is_ready());
+  auto start = std::chrono::steady_clock::now();
   auto s = shared_state.wait_until(std::chrono::system_clock::now() + 100_us);
+  auto elapsed = std::chrono::steady_clock::now() - start;
   EXPECT_EQ(static_cast<int>(s), static_cast<int>(std::future_status::timeout));
+  EXPECT_LE(100_us, elapsed);
   EXPECT_FALSE(shared_state.is_ready());
 }
 


### PR DESCRIPTION
Futures and promises keep a shared state that tracks whether the promise
is satisfied, if the value has been retrieved, the exception (if any),
and hold the (type erased) continuation. In this PR we introduce this
base class and unit tests for it, as part of the work for #1345.

The class is incomplete, and there are a lot of support classes around
it that will be introduced in future PRs, as it is, this PR is getting
too large already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1351)
<!-- Reviewable:end -->
