### PR TITLE
Separate ADC logic to differentiate env var vs gcloud well known path

### DIFF
--- a/google/cloud/storage/oauth2/google_application_default_credentials_file.cc
+++ b/google/cloud/storage/oauth2/google_application_default_credentials_file.cc
@@ -37,11 +37,15 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 
-std::string GoogleAdcFilePathOrEmpty() {
+std::string GoogleAdcFilePathFromEnvVarOrEmpty() {
   auto override_value = google::cloud::internal::GetEnv(GoogleAdcEnvVar());
   if (override_value.has_value()) {
     return *override_value;
   }
+  return "";
+}
+
+std::string GoogleAdcFilePathFromWellKnownPathOrEmpty() {
   // Search well known gcloud ADC path.
   auto adc_path_root = google::cloud::internal::GetEnv(GoogleAdcHomeEnvVar());
   if (adc_path_root.has_value()) {

--- a/google/cloud/storage/oauth2/google_application_default_credentials_file.h
+++ b/google/cloud/storage/oauth2/google_application_default_credentials_file.h
@@ -42,7 +42,16 @@ inline char const* GoogleAdcEnvVar() {
  * the path specified by its value for a file containing ADCs. Returns an
  * empty string if no such path exists or the environment variable is not set.
  */
-std::string GoogleAdcFilePathOrEmpty();
+std::string GoogleAdcFilePathFromEnvVarOrEmpty();
+
+/**
+ * Returns the path to the Application Default Credentials file, if set.
+ *
+ * If the gcloud utility has configured an Application Default Credentials file,
+ * the path to that file is returned. Returns an empty string if no such file
+ * exists at the well known path.
+ */
+std::string GoogleAdcFilePathFromWellKnownPathOrEmpty();
 
 /**
  * Returns the environment variable used to construct the well known ADC path.

--- a/google/cloud/storage/oauth2/google_application_default_credentials_file_test.cc
+++ b/google/cloud/storage/oauth2/google_application_default_credentials_file_test.cc
@@ -50,7 +50,7 @@ class DefaultServiceAccountFileTest : public ::testing::Test {
 /// @test Verify that the application can override the default credentials.
 TEST_F(DefaultServiceAccountFileTest, EnvironmentVariableSet) {
   SetEnv(GoogleAdcEnvVar(), "/foo/bar/baz");
-  auto actual = GoogleAdcFilePathOrEmpty();
+  auto actual = GoogleAdcFilePathFromEnvVarOrEmpty();
   EXPECT_EQ("/foo/bar/baz", actual);
 }
 
@@ -59,7 +59,7 @@ TEST_F(DefaultServiceAccountFileTest, HomeSet) {
   UnsetEnv(GoogleAdcEnvVar());
   char const* home = GoogleAdcHomeEnvVar();
   SetEnv(home, "/foo/bar/baz");
-  auto actual = GoogleAdcFilePathOrEmpty();
+  auto actual = GoogleAdcFilePathFromWellKnownPathOrEmpty();
   using testing::HasSubstr;
   EXPECT_THAT(actual, HasSubstr("/foo/bar/baz"));
   EXPECT_THAT(actual, HasSubstr(".json"));
@@ -70,7 +70,7 @@ TEST_F(DefaultServiceAccountFileTest, HomeNotSet) {
   UnsetEnv(GoogleAdcEnvVar());
   char const* home = GoogleAdcHomeEnvVar();
   UnsetEnv(home);
-  EXPECT_EQ(GoogleAdcFilePathOrEmpty(), "");
+  EXPECT_EQ(GoogleAdcFilePathFromWellKnownPathOrEmpty(), "");
 }
 
 }  // namespace

--- a/google/cloud/storage/oauth2/google_application_default_credentials_file_test.cc
+++ b/google/cloud/storage/oauth2/google_application_default_credentials_file_test.cc
@@ -26,50 +26,55 @@ namespace {
 using ::google::cloud::internal::SetEnv;
 using ::google::cloud::internal::UnsetEnv;
 using ::google::cloud::testing_util::EnvironmentVariableRestore;
+using ::testing::HasSubstr;
 
 class DefaultServiceAccountFileTest : public ::testing::Test {
  public:
   DefaultServiceAccountFileTest()
-      : home_(GoogleAdcHomeEnvVar()), override_variable_(GoogleAdcEnvVar()) {}
+      : home_env_var_(GoogleAdcHomeEnvVar()), adc_env_var_(GoogleAdcEnvVar()) {}
 
  protected:
   void SetUp() override {
-    home_.SetUp();
-    override_variable_.SetUp();
+    home_env_var_.SetUp();
+    adc_env_var_.SetUp();
   }
   void TearDown() override {
-    override_variable_.TearDown();
-    home_.TearDown();
+    adc_env_var_.TearDown();
+    home_env_var_.TearDown();
   }
 
  protected:
-  EnvironmentVariableRestore home_;
-  EnvironmentVariableRestore override_variable_;
+  EnvironmentVariableRestore home_env_var_;
+  EnvironmentVariableRestore adc_env_var_;
 };
 
-/// @test Verify that the application can override the default credentials.
-TEST_F(DefaultServiceAccountFileTest, EnvironmentVariableSet) {
+/// @test Verify that the specified path is given when the ADC env var is set.
+TEST_F(DefaultServiceAccountFileTest, AdcEnvironmentVariableSet) {
   SetEnv(GoogleAdcEnvVar(), "/foo/bar/baz");
-  auto actual = GoogleAdcFilePathFromEnvVarOrEmpty();
-  EXPECT_EQ("/foo/bar/baz", actual);
+  EXPECT_EQ("/foo/bar/baz", GoogleAdcFilePathFromEnvVarOrEmpty());
 }
 
-/// @test Verify that the file path works as expected when using HOME.
-TEST_F(DefaultServiceAccountFileTest, HomeSet) {
+/// @test Verify that an empty string is given when the ADC env var is unset.
+TEST_F(DefaultServiceAccountFileTest, AdcEnvironmentVariableNotSet) {
   UnsetEnv(GoogleAdcEnvVar());
-  char const* home = GoogleAdcHomeEnvVar();
-  SetEnv(home, "/foo/bar/baz");
+  EXPECT_EQ(GoogleAdcFilePathFromEnvVarOrEmpty(), "");
+}
+
+/// @test Verify that the gcloud ADC file path is given when HOME is set.
+TEST_F(DefaultServiceAccountFileTest, HomeSet) {
+  SetEnv(GoogleAdcHomeEnvVar(), "/foo/bar/baz");
+
   auto actual = GoogleAdcFilePathFromWellKnownPathOrEmpty();
-  using testing::HasSubstr;
+
   EXPECT_THAT(actual, HasSubstr("/foo/bar/baz"));
+  // The rest of the path differs depending on the OS; just make sure that we
+  // appended the path to some JSON file to the path prefix set above.
   EXPECT_THAT(actual, HasSubstr(".json"));
 }
 
-/// @test Verify that the service account file path fails when HOME is not set.
+/// @test Verify that the gcloud ADC file path is not given when HOME is unset.
 TEST_F(DefaultServiceAccountFileTest, HomeNotSet) {
-  UnsetEnv(GoogleAdcEnvVar());
-  char const* home = GoogleAdcHomeEnvVar();
-  UnsetEnv(home);
+  UnsetEnv(GoogleAdcHomeEnvVar());
   EXPECT_EQ(GoogleAdcFilePathFromWellKnownPathOrEmpty(), "");
 }
 

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -82,35 +82,40 @@ std::shared_ptr<Credentials> GoogleDefaultCredentials() {
   // TODO(#579): Check if running on Compute Engine.
 
   // We've exhausted all search points, thus credentials cannot be constructed.
+  std::string adc_link =
+      "https://developers.google.com/identity/protocols"
+      "/application-default-credentials";
   google::cloud::internal::RaiseRuntimeError(
-      "No eligible credential types were found to use as default credentials.");
+      "Could not automatically determine credentials. For more information,"
+      " please see " +
+      adc_link);
 }
 
 std::shared_ptr<Credentials> CreateAnonymousCredentials() {
   return std::make_shared<AnonymousCredentials>();
 }
 
-std::shared_ptr<Credentials>
-CreateAuthorizedUserCredentialsFromJsonFilePath(std::string const& path) {
+std::shared_ptr<Credentials> CreateAuthorizedUserCredentialsFromJsonFilePath(
+    std::string const& path) {
   std::ifstream is(path);
   std::string contents(std::istreambuf_iterator<char>{is}, {});
   return std::make_shared<AuthorizedUserCredentials<>>(contents, path);
 }
 
-std::shared_ptr<Credentials>
-CreateAuthorizedUserCredentialsFromJsonContents(std::string const& contents) {
+std::shared_ptr<Credentials> CreateAuthorizedUserCredentialsFromJsonContents(
+    std::string const& contents) {
   return std::make_shared<AuthorizedUserCredentials<>>(contents, "memory");
 }
 
-std::shared_ptr<Credentials>
-CreateServiceAccountCredentialsFromJsonFilePath(std::string const& path) {
+std::shared_ptr<Credentials> CreateServiceAccountCredentialsFromJsonFilePath(
+    std::string const& path) {
   std::ifstream is(path);
   std::string contents(std::istreambuf_iterator<char>{is}, {});
   return std::make_shared<ServiceAccountCredentials<>>(contents, path);
 }
 
-std::shared_ptr<Credentials>
-CreateServiceAccountCredentialsFromJsonContents(std::string const& contents) {
+std::shared_ptr<Credentials> CreateServiceAccountCredentialsFromJsonContents(
+    std::string const& contents) {
   return std::make_shared<ServiceAccountCredentials<>>(contents, "memory");
 }
 

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -30,23 +30,14 @@ inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 
 std::shared_ptr<Credentials> GoogleDefaultCredentials() {
-  // Check if the GOOGLE_APPLICATION_CREDENTIALS environment variable is set,
-  // and if so, make sure the file exists.
+  // Check if the GOOGLE_APPLICATION_CREDENTIALS environment variable is set.
   auto path = GoogleAdcFilePathFromEnvVarOrEmpty();
-  if (not path.empty()) {
-    std::error_code ec;
-    auto adc_file_status = google::cloud::internal::status(path, ec);
-    if (not google::cloud::internal::exists(adc_file_status)) {
-      GCP_LOG(WARNING) << "The GOOGLE_APPLICATION_CREDENTIALS environment"
-                       << " variable was set to " << path << " but that file"
-                       << " does not exist.";
-      path = "";
-    }
-  }
 
   // If no path was specified via environment variable, check if the gcloud
   // ADC file exists.
   if (path.empty()) {
+    // Just because we had the necessary information to build the path doesn't
+    // mean that a file exists there.
     path = GoogleAdcFilePathFromWellKnownPathOrEmpty();
     if (not path.empty()) {
       std::error_code ec;

--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -28,60 +28,30 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 namespace {
-using google::cloud::internal::SetEnv;
-using google::cloud::internal::UnsetEnv;
-using google::cloud::testing_util::EnvironmentVariableRestore;
+using ::google::cloud::internal::SetEnv;
+using ::google::cloud::internal::UnsetEnv;
+using ::google::cloud::testing_util::EnvironmentVariableRestore;
 using ::testing::HasSubstr;
-
-char const VAR_NAME[] = "GOOGLE_APPLICATION_CREDENTIALS";
 
 class GoogleCredentialsTest : public ::testing::Test {
  public:
   GoogleCredentialsTest()
-      : home_(GoogleAdcHomeEnvVar()),
-        override_variable_("GOOGLE_APPLICATION_CREDENTIALS") {}
+      : home_env_var_(GoogleAdcHomeEnvVar()), adc_env_var_(GoogleAdcEnvVar()) {}
 
  protected:
   void SetUp() override {
-    home_.SetUp();
-    override_variable_.SetUp();
+    home_env_var_.SetUp();
+    adc_env_var_.SetUp();
   }
   void TearDown() override {
-    override_variable_.TearDown();
-    home_.TearDown();
+    adc_env_var_.TearDown();
+    home_env_var_.TearDown();
   }
 
  protected:
-  EnvironmentVariableRestore home_;
-  EnvironmentVariableRestore override_variable_;
+  EnvironmentVariableRestore home_env_var_;
+  EnvironmentVariableRestore adc_env_var_;
 };
-
-/// @test Verify that the application can override the default credentials.
-TEST_F(GoogleCredentialsTest, EnvironmentVariableSet) {
-  SetEnv(GoogleAdcEnvVar(), "/foo/bar/baz");
-  std::string actual = GoogleAdcFilePathFromEnvVarOrEmpty();
-  EXPECT_EQ("/foo/bar/baz", actual);
-}
-
-/// @test Verify that the file path works as expected when using HOME.
-TEST_F(GoogleCredentialsTest, HomeSet) {
-  UnsetEnv(GoogleAdcEnvVar());
-  char const* home = GoogleAdcHomeEnvVar();
-  SetEnv(home, "/foo/bar/baz");
-  std::string actual = GoogleAdcFilePathFromWellKnownPathOrEmpty();
-  using testing::HasSubstr;
-  EXPECT_THAT(actual, HasSubstr("/foo/bar/baz"));
-  EXPECT_THAT(actual, HasSubstr(".json"));
-}
-
-/// @test Verify that the ADC file path returns empty when HOME is not set.
-TEST_F(GoogleCredentialsTest, HomeNotSet) {
-  UnsetEnv(GoogleAdcEnvVar());
-  char const* home = GoogleAdcHomeEnvVar();
-  UnsetEnv(home);
-  EXPECT_EQ(GoogleAdcFilePathFromEnvVarOrEmpty(), "");
-  EXPECT_EQ(GoogleAdcFilePathFromWellKnownPathOrEmpty(), "");
-}
 
 /**
  * @test Verify `GoogleDefaultCredentials()` loads authorized user credentials.
@@ -104,7 +74,7 @@ TEST_F(GoogleCredentialsTest, LoadValidAuthorizedUserCredentials) {
 })""";
   os << contents_str;
   os.close();
-  SetEnv(VAR_NAME, filename);
+  SetEnv(GoogleAdcEnvVar(), filename);
 
   // Test that the service account credentials are loaded as the default when
   // specified via the well known environment variable.
@@ -153,7 +123,7 @@ TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentials) {
 })""";
   os << contents_str;
   os.close();
-  SetEnv(VAR_NAME, filename);
+  SetEnv(GoogleAdcEnvVar(), filename);
 
   // Test that the service account credentials are loaded as the default when
   // specified via the well known environment variable.
@@ -191,19 +161,19 @@ TEST_F(GoogleCredentialsTest, LoadUnknownTypeCredentials) {
 })""";
   os << contents_str;
   os.close();
-  SetEnv(VAR_NAME, filename);
+  SetEnv(GoogleAdcEnvVar(), filename);
 
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(try {
-    auto credentials = GoogleDefaultCredentials();
-  } catch(std::runtime_error const& ex) {
+  EXPECT_THROW(try { auto credentials = GoogleDefaultCredentials(); } catch (
+                   std::runtime_error const& ex) {
     EXPECT_THAT(ex.what(), HasSubstr("Unsupported credential type"));
     EXPECT_THAT(ex.what(), HasSubstr(filename));
     throw;
-  }, std::runtime_error);
+  },
+               std::runtime_error);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      GoogleDefaultCredentials(), "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(GoogleDefaultCredentials(),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -213,37 +183,37 @@ TEST_F(GoogleCredentialsTest, LoadInvalidCredentials) {
   std::string contents_str = R"""( not-a-json-object-string )""";
   os << contents_str;
   os.close();
-  SetEnv(VAR_NAME, filename);
+  SetEnv(GoogleAdcEnvVar(), filename);
 
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(try {
-    auto credentials = GoogleDefaultCredentials();
-  } catch(std::exception const& ex) {
+  EXPECT_THROW(try { auto credentials = GoogleDefaultCredentials(); } catch (
+                   std::exception const& ex) {
     EXPECT_THAT(ex.what(), HasSubstr("Invalid contents in credentials file"));
     EXPECT_THAT(ex.what(), HasSubstr(filename));
     throw;
-  }, std::runtime_error);
+  },
+               std::runtime_error);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      GoogleDefaultCredentials(), "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(GoogleDefaultCredentials(),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST_F(GoogleCredentialsTest, MissingCredentials) {
   char const filename[] = "missing-credentials.json";
-  SetEnv(VAR_NAME, filename);
+  SetEnv(GoogleAdcEnvVar(), filename);
 
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(try {
-    auto credentials = GoogleDefaultCredentials();
-  } catch(std::runtime_error const& ex) {
+  EXPECT_THROW(try { auto credentials = GoogleDefaultCredentials(); } catch (
+                   std::runtime_error const& ex) {
     EXPECT_THAT(ex.what(), HasSubstr("Cannot open credentials file"));
     EXPECT_THAT(ex.what(), HasSubstr(filename));
     throw;
-  }, std::runtime_error);
+  },
+               std::runtime_error);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(
-      GoogleDefaultCredentials(), "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(GoogleDefaultCredentials(),
+                            "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 

--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -59,7 +59,7 @@ class GoogleCredentialsTest : public ::testing::Test {
 /// @test Verify that the application can override the default credentials.
 TEST_F(GoogleCredentialsTest, EnvironmentVariableSet) {
   SetEnv(GoogleAdcEnvVar(), "/foo/bar/baz");
-  std::string actual = GoogleAdcFilePathOrEmpty();
+  std::string actual = GoogleAdcFilePathFromEnvVarOrEmpty();
   EXPECT_EQ("/foo/bar/baz", actual);
 }
 
@@ -68,7 +68,7 @@ TEST_F(GoogleCredentialsTest, HomeSet) {
   UnsetEnv(GoogleAdcEnvVar());
   char const* home = GoogleAdcHomeEnvVar();
   SetEnv(home, "/foo/bar/baz");
-  std::string actual = GoogleAdcFilePathOrEmpty();
+  std::string actual = GoogleAdcFilePathFromWellKnownPathOrEmpty();
   using testing::HasSubstr;
   EXPECT_THAT(actual, HasSubstr("/foo/bar/baz"));
   EXPECT_THAT(actual, HasSubstr(".json"));
@@ -79,7 +79,8 @@ TEST_F(GoogleCredentialsTest, HomeNotSet) {
   UnsetEnv(GoogleAdcEnvVar());
   char const* home = GoogleAdcHomeEnvVar();
   UnsetEnv(home);
-  EXPECT_EQ(GoogleAdcFilePathOrEmpty(), "");
+  EXPECT_EQ(GoogleAdcFilePathFromEnvVarOrEmpty(), "");
+  EXPECT_EQ(GoogleAdcFilePathFromWellKnownPathOrEmpty(), "");
 }
 
 /**


### PR DESCRIPTION
Split out logic for finding ADC file path.
    
This makes our ADC loading logic more consistent with other libraries,
e.g google-auth - specifically the logic/methods in this file:
https://github.com/googleapis/google-auth-library-python/blob/f1028252b262baee67a294b27ff831182ac645d3/google/auth/_default.py#L209
    
It's also needed to more easily test the GCE credential functionality
I've finished prototyping, but these changes deserved to be split out
into their own PR.
    
The only notable behavior change this brings is that we now check if
a file exists at the gcloud well known ADC path before trying to load it
(and potentially failing).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1354)
<!-- Reviewable:end -->
