### PR TITLE
Improve credential testability and coverage.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -293,6 +293,7 @@ set(storage_client_unit_tests
     internal/binary_data_as_debug_string_test.cc
     internal/bucket_acl_requests_test.cc
     internal/bucket_requests_test.cc
+    internal/compute_engine_util_test.cc
     internal/default_object_acl_requests_test.cc
     internal/format_rfc3339_test.cc
     internal/generate_message_boundary_test.cc

--- a/google/cloud/storage/internal/compute_engine_util_test.cc
+++ b/google/cloud/storage/internal/compute_engine_util_test.cc
@@ -1,0 +1,60 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/compute_engine_util.h"
+#include "google/cloud/internal/setenv.h"
+#include "google/cloud/testing_util/environment_variable_restore.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+using ::google::cloud::internal::SetEnv;
+using ::google::cloud::testing_util::EnvironmentVariableRestore;
+
+class ComputeEngineUtilTest : public ::testing::Test {
+ public:
+  ComputeEngineUtilTest()
+      : gce_check_override_env_var_(GceCheckOverrideEnvVar()) {}
+
+ protected:
+  void SetUp() override {
+    gce_check_override_env_var_.SetUp();
+  }
+
+  void TearDown() override {
+    gce_check_override_env_var_.TearDown();
+  }
+
+ protected:
+  EnvironmentVariableRestore gce_check_override_env_var_;
+};
+
+/// @test Ensure we can override the return value for checking if we're on GCE.
+TEST_F(ComputeEngineUtilTest, CanOverrideRunningOnGceCheckViaEnvVar) {
+  SetEnv(GceCheckOverrideEnvVar(), "1");
+  EXPECT_TRUE(RunningOnComputeEngineVm());
+
+  SetEnv(GceCheckOverrideEnvVar(), "0");
+  EXPECT_FALSE(RunningOnComputeEngineVm());
+}
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/compute_engine_util_test.cc
+++ b/google/cloud/storage/internal/compute_engine_util_test.cc
@@ -32,13 +32,9 @@ class ComputeEngineUtilTest : public ::testing::Test {
       : gce_check_override_env_var_(GceCheckOverrideEnvVar()) {}
 
  protected:
-  void SetUp() override {
-    gce_check_override_env_var_.SetUp();
-  }
+  void SetUp() override { gce_check_override_env_var_.SetUp(); }
 
-  void TearDown() override {
-    gce_check_override_env_var_.TearDown();
-  }
+  void TearDown() override { gce_check_override_env_var_.TearDown(); }
 
  protected:
   EnvironmentVariableRestore gce_check_override_env_var_;

--- a/google/cloud/storage/oauth2/google_application_default_credentials_file.cc
+++ b/google/cloud/storage/oauth2/google_application_default_credentials_file.cc
@@ -46,6 +46,13 @@ std::string GoogleAdcFilePathFromEnvVarOrEmpty() {
 }
 
 std::string GoogleAdcFilePathFromWellKnownPathOrEmpty() {
+  // Allow mocking out this value for testing.
+  auto override_path =
+      google::cloud::internal::GetEnv(GoogleGcloudAdcFileEnvVar());
+  if (override_path.has_value()) {
+    return *override_path;
+  }
+
   // Search well known gcloud ADC path.
   auto adc_path_root = google::cloud::internal::GetEnv(GoogleAdcHomeEnvVar());
   if (adc_path_root.has_value()) {

--- a/google/cloud/storage/oauth2/google_application_default_credentials_file.h
+++ b/google/cloud/storage/oauth2/google_application_default_credentials_file.h
@@ -54,6 +54,17 @@ std::string GoogleAdcFilePathFromEnvVarOrEmpty();
 std::string GoogleAdcFilePathFromWellKnownPathOrEmpty();
 
 /**
+ * Returns the environment variable to override the gcloud ADC path.
+ *
+ * This environment variable is used for testing to override the path that
+ * should be searched for the gcloud Application Default Credentials file.
+ */
+inline char const* GoogleGcloudAdcFileEnvVar() {
+  static constexpr char kEnvVarName[] = "GOOGLE_GCLOUD_ADC_PATH_OVERRIDE";
+  return kEnvVarName;
+}
+
+/**
  * Returns the environment variable used to construct the well known ADC path.
  *
  * The directory containing a user's application configuration data, indicated

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/oauth2/google_credentials.h"
 #include "google/cloud/internal/filesystem.h"
+#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/internal/throw_delegate.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/oauth2/anonymous_credentials.h"
@@ -22,6 +23,7 @@
 #include "google/cloud/storage/oauth2/service_account_credentials.h"
 #include <fstream>
 #include <iterator>
+#include <memory>
 
 namespace google {
 namespace cloud {
@@ -29,50 +31,70 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 
+std::unique_ptr<Credentials> LoadCredsFromPath(std::string const& path) {
+  using google::cloud::internal::make_unique;
+  using google::cloud::internal::RaiseRuntimeError;
+  namespace nl = google::cloud::storage::internal::nl;
+
+  std::ifstream ifs(path);
+  if (not ifs.is_open()) {
+    RaiseRuntimeError("Cannot open credentials file " + path);
+  }
+  std::string contents(std::istreambuf_iterator<char>{ifs}, {});
+  auto cred_json = nl::json::parse(contents, nullptr, false);
+  if (cred_json.is_discarded()) {
+    RaiseRuntimeError("Invalid contents in credentials file " + path);
+  }
+  std::string cred_type = cred_json.value("type", "no type given");
+  if (cred_type == "authorized_user") {
+    return make_unique<AuthorizedUserCredentials<>>(contents, path);
+  }
+  if (cred_type == "service_account") {
+    return make_unique<ServiceAccountCredentials<>>(contents, path);
+  }
+  RaiseRuntimeError(
+      "Unsupported credential type (" + cred_type +
+      ") when reading Application Default Credentials file from " + path + ".");
+}
+
+std::unique_ptr<Credentials> MaybeLoadCredsFromAdcEnvVar() {
+  auto path = GoogleAdcFilePathFromEnvVarOrEmpty();
+  if (not path.empty()) {
+    // If the path was specified, try to load that file; explicitly fail if it
+    // doesn't exist or can't be read and parsed.
+    return LoadCredsFromPath(path);
+  }
+  return nullptr;
+}
+
+std::unique_ptr<Credentials> MaybeLoadCredsFromGcloudAdcFile() {
+  auto path = GoogleAdcFilePathFromWellKnownPathOrEmpty();
+  if (not path.empty()) {
+    // Just because we had the necessary information to build the path doesn't
+    // mean that a file exists there.
+    std::error_code ec;
+    auto adc_file_status = google::cloud::internal::status(path, ec);
+    if (google::cloud::internal::exists(adc_file_status)) {
+      return LoadCredsFromPath(path);
+    }
+  }
+  // Either we were unable to construct the well known path or no file existed
+  // at that path.
+  return nullptr;
+}
+
 std::shared_ptr<Credentials> GoogleDefaultCredentials() {
   // Check if the GOOGLE_APPLICATION_CREDENTIALS environment variable is set.
-  auto path = GoogleAdcFilePathFromEnvVarOrEmpty();
+  auto creds = MaybeLoadCredsFromAdcEnvVar();
+  if (creds) {
+    return std::move(creds);
+  }
 
   // If no path was specified via environment variable, check if the gcloud
   // ADC file exists.
-  if (path.empty()) {
-    // Just because we had the necessary information to build the path doesn't
-    // mean that a file exists there.
-    path = GoogleAdcFilePathFromWellKnownPathOrEmpty();
-    if (not path.empty()) {
-      std::error_code ec;
-      auto adc_file_status = google::cloud::internal::status(path, ec);
-      if (not google::cloud::internal::exists(adc_file_status)) {
-        path = "";
-      }
-    }
-  }
-
-  // If a file at either of the paths above was present, try to load it.
-  if (not path.empty()) {
-    std::ifstream is(path);
-    if (not is.is_open()) {
-      google::cloud::internal::RaiseRuntimeError(
-          "Cannot open credentials file " + path);
-    }
-    std::string contents(std::istreambuf_iterator<char>{is}, {});
-    auto cred_json =
-        storage::internal::nl::json::parse(contents, nullptr, false);
-    if (cred_json.is_discarded()) {
-      google::cloud::internal::RaiseRuntimeError(
-          "Invalid contents in credentials file " + path);
-    }
-    std::string cred_type = cred_json.value("type", "no type given");
-    if (cred_type == "authorized_user") {
-      return std::make_shared<AuthorizedUserCredentials<>>(contents, path);
-    }
-    if (cred_type == "service_account") {
-      return std::make_shared<ServiceAccountCredentials<>>(contents, path);
-    }
-    google::cloud::internal::RaiseRuntimeError(
-        "Unsupported credential type (" + cred_type +
-        ") when reading Application Default Credentials file from " + path +
-        ".");
+  creds = MaybeLoadCredsFromGcloudAdcFile();
+  if (creds) {
+    return std::move(creds);
   }
 
   // Check for implicit environment-based credentials.

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -32,7 +32,6 @@ inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 
 std::unique_ptr<Credentials> LoadCredsFromPath(std::string const& path) {
-  using google::cloud::internal::make_unique;
   using google::cloud::internal::RaiseRuntimeError;
   namespace nl = google::cloud::storage::internal::nl;
 
@@ -47,10 +46,12 @@ std::unique_ptr<Credentials> LoadCredsFromPath(std::string const& path) {
   }
   std::string cred_type = cred_json.value("type", "no type given");
   if (cred_type == "authorized_user") {
-    return make_unique<AuthorizedUserCredentials<>>(contents, path);
+    return google::cloud::internal::make_unique<AuthorizedUserCredentials<>>(
+        contents, path);
   }
   if (cred_type == "service_account") {
-    return make_unique<ServiceAccountCredentials<>>(contents, path);
+    return google::cloud::internal::make_unique<ServiceAccountCredentials<>>(
+        contents, path);
   }
   RaiseRuntimeError(
       "Unsupported credential type (" + cred_type +

--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/oauth2/google_credentials.h"
 #include "google/cloud/internal/setenv.h"
+#include "google/cloud/storage/internal/compute_engine_util.h"
 #include "google/cloud/storage/oauth2/anonymous_credentials.h"
 #include "google/cloud/storage/oauth2/authorized_user_credentials.h"
 #include "google/cloud/storage/oauth2/google_application_default_credentials_file.h"
@@ -30,6 +31,7 @@ namespace oauth2 {
 namespace {
 using ::google::cloud::internal::SetEnv;
 using ::google::cloud::internal::UnsetEnv;
+using ::google::cloud::storage::internal::GceCheckOverrideEnvVar;
 using ::google::cloud::testing_util::EnvironmentVariableRestore;
 using ::testing::HasSubstr;
 
@@ -38,16 +40,19 @@ class GoogleCredentialsTest : public ::testing::Test {
   GoogleCredentialsTest()
       : home_env_var_(GoogleAdcHomeEnvVar()),
         adc_env_var_(GoogleAdcEnvVar()),
-        gcloud_path_override_env_var_(GoogleGcloudAdcFileEnvVar()) {}
+        gcloud_path_override_env_var_(GoogleGcloudAdcFileEnvVar()),
+        gce_check_override_env_var_(GceCheckOverrideEnvVar()) {}
 
  protected:
   void SetUp() override {
     home_env_var_.SetUp();
     adc_env_var_.SetUp();
     gcloud_path_override_env_var_.SetUp();
+    gce_check_override_env_var_.SetUp();
   }
 
   void TearDown() override {
+    gce_check_override_env_var_.TearDown();
     gcloud_path_override_env_var_.TearDown();
     adc_env_var_.TearDown();
     home_env_var_.TearDown();
@@ -57,7 +62,22 @@ class GoogleCredentialsTest : public ::testing::Test {
   EnvironmentVariableRestore home_env_var_;
   EnvironmentVariableRestore adc_env_var_;
   EnvironmentVariableRestore gcloud_path_override_env_var_;
+  EnvironmentVariableRestore gce_check_override_env_var_;
 };
+
+std::string const AUTHORIZED_USER_CRED_FILENAME = "authorized-user.json";
+std::string const AUTHORIZED_USER_CRED_CONTENTS = R"""({
+  "client_id": "test-invalid-test-invalid.apps.googleusercontent.com",
+  "client_secret": "invalid-invalid-invalid",
+  "refresh_token": "1/test-test-test",
+  "type": "authorized_user"
+})""";
+
+void SetupAuthorizedUserCredentialsFileForTest() {
+  std::ofstream os(AUTHORIZED_USER_CRED_FILENAME);
+  os << AUTHORIZED_USER_CRED_CONTENTS;
+  os.close();
+}
 
 /**
  * @test Verify `GoogleDefaultCredentials()` loads authorized user credentials.
@@ -69,46 +89,44 @@ class GoogleCredentialsTest : public ::testing::Test {
  * requires valid keys and contacting Google's production servers, and would
  * make this an integration test.
  */
-TEST_F(GoogleCredentialsTest, LoadValidAuthorizedUserCredentials) {
-  char const filename[] = "authorized-user.json";
-  std::ofstream os(filename);
-  std::string contents_str = R"""({
-  "client_id": "test-invalid-test-invalid.apps.googleusercontent.com",
-  "client_secret": "invalid-invalid-invalid",
-  "refresh_token": "1/test-test-test",
-  "type": "authorized_user"
-})""";
-  os << contents_str;
-  os.close();
+TEST_F(GoogleCredentialsTest, LoadValidAuthorizedUserCredentialsViaEnvVar) {
+  SetupAuthorizedUserCredentialsFileForTest();
 
   // Test that the authorized user credentials are loaded as the default when
   // specified via the well known environment variable.
-  SetEnv(GoogleAdcEnvVar(), filename);
+  SetEnv(GoogleAdcEnvVar(), AUTHORIZED_USER_CRED_FILENAME.c_str());
   auto credentials = GoogleDefaultCredentials();
   // Need to create a temporary for the pointer because clang-tidy warns about
   // using expressions with (potential) side-effects inside typeid().
   auto ptr = credentials.get();
   EXPECT_EQ(typeid(*ptr), typeid(AuthorizedUserCredentials<>));
+}
 
+TEST_F(GoogleCredentialsTest, LoadValidAuthorizedUserCredentialsViaGcloudFile) {
+  SetupAuthorizedUserCredentialsFileForTest();
   // Test that the authorized user credentials are loaded as the default when
   // stored in the the well known gcloud ADC file path.
   UnsetEnv(GoogleAdcEnvVar());
-  SetEnv(GoogleGcloudAdcFileEnvVar(), filename);
-  credentials = GoogleDefaultCredentials();
-  ptr = credentials.get();
+  SetEnv(GoogleGcloudAdcFileEnvVar(), AUTHORIZED_USER_CRED_FILENAME.c_str());
+  auto credentials = GoogleDefaultCredentials();
+  auto ptr = credentials.get();
   EXPECT_EQ(typeid(*ptr), typeid(AuthorizedUserCredentials<>));
+}
 
-  UnsetEnv(GoogleGcloudAdcFileEnvVar());
-
-  // Test that the authorized user credentials are loaded from a file.
-  credentials = CreateAuthorizedUserCredentialsFromJsonFilePath(filename);
-  ptr = credentials.get();
+TEST_F(GoogleCredentialsTest, LoadValidAuthorizedUserCredentialsFromFilename) {
+  SetupAuthorizedUserCredentialsFileForTest();
+  auto credentials = CreateAuthorizedUserCredentialsFromJsonFilePath(
+      AUTHORIZED_USER_CRED_FILENAME);
+  auto ptr = credentials.get();
   EXPECT_EQ(typeid(*ptr), typeid(AuthorizedUserCredentials<>));
+}
 
+TEST_F(GoogleCredentialsTest, LoadValidAuthorizedUserCredentialsFromContents) {
   // Test that the authorized user credentials are loaded from a string
   // representing JSON contents.
-  credentials = CreateAuthorizedUserCredentialsFromJsonContents(contents_str);
-  ptr = credentials.get();
+  auto credentials = CreateAuthorizedUserCredentialsFromJsonContents(
+      AUTHORIZED_USER_CRED_CONTENTS);
+  auto ptr = credentials.get();
   EXPECT_EQ(typeid(*ptr), typeid(AuthorizedUserCredentials<>));
 }
 
@@ -122,10 +140,9 @@ TEST_F(GoogleCredentialsTest, LoadValidAuthorizedUserCredentials) {
  * requires valid keys and contacting Google's production servers, and would
  * make this an integration test.
  */
-TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentials) {
-  char const filename[] = "service-account.json";
-  std::ofstream os(filename);
-  std::string contents_str = R"""({
+
+std::string const SERVICE_ACCOUNT_CRED_FILENAME = "service-account.json";
+std::string const SERVICE_ACCOUNT_CRED_CONTENTS = R"""({
     "type": "service_account",
     "project_id": "foo-project",
     "private_key_id": "a1a111aa1111a11a11a11aa111a111a1a1111111",
@@ -137,46 +154,51 @@ TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentials) {
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
     "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/foo-email%40foo-project.iam.gserviceaccount.com"
 })""";
-  os << contents_str;
+
+void SetupServiceAccountCredentialsFileForTest() {
+  std::ofstream os(SERVICE_ACCOUNT_CRED_FILENAME);
+  os << SERVICE_ACCOUNT_CRED_CONTENTS;
   os.close();
+}
+
+TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsViaEnvVar) {
+  SetupServiceAccountCredentialsFileForTest();
 
   // Test that the service account credentials are loaded as the default when
   // specified via the well known environment variable.
-  SetEnv(GoogleAdcEnvVar(), filename);
+  SetEnv(GoogleAdcEnvVar(), SERVICE_ACCOUNT_CRED_FILENAME.c_str());
   auto credentials = GoogleDefaultCredentials();
   // Need to create a temporary for the pointer because clang-tidy warns about
   // using expressions with (potential) side-effects inside typeid().
   auto ptr = credentials.get();
   EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));
+}
 
+TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsViaGcloudFile) {
   // Test that the service account credentials are loaded as the default when
   // stored in the the well known gcloud ADC file path.
   UnsetEnv(GoogleAdcEnvVar());
-  SetEnv(GoogleGcloudAdcFileEnvVar(), filename);
-  credentials = GoogleDefaultCredentials();
-  ptr = credentials.get();
-  EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));
-
-  UnsetEnv(GoogleGcloudAdcFileEnvVar());
-
-  // Test that the service account credentials are loaded from a file.
-  credentials = CreateServiceAccountCredentialsFromJsonFilePath(filename);
-  ptr = credentials.get();
-  EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));
-
-  // Test that the service account credentials are loaded from a string
-  // representing JSON contents.
-  credentials = CreateServiceAccountCredentialsFromJsonContents(contents_str);
-  ptr = credentials.get();
+  SetEnv(GoogleGcloudAdcFileEnvVar(), SERVICE_ACCOUNT_CRED_FILENAME.c_str());
+  auto credentials = GoogleDefaultCredentials();
+  auto ptr = credentials.get();
   EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));
 }
 
-TEST_F(GoogleCredentialsTest, LoadValidAnonymousCredentials) {
-  auto credentials = CreateAnonymousCredentials();
-  // Need to create a temporary for the pointer because clang-tidy warns about
-  // using expressions with (potential) side-effects inside typeid().
+TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsFromFilename) {
+  // Test that the service account credentials are loaded from a file.
+  auto credentials = CreateServiceAccountCredentialsFromJsonFilePath(
+      SERVICE_ACCOUNT_CRED_FILENAME);
   auto ptr = credentials.get();
-  EXPECT_EQ(typeid(*ptr), typeid(AnonymousCredentials));
+  EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));
+}
+
+TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsFromContents) {
+  // Test that the service account credentials are loaded from a string
+  // representing JSON contents.
+  auto credentials = CreateServiceAccountCredentialsFromJsonContents(
+      SERVICE_ACCOUNT_CRED_CONTENTS);
+  auto ptr = credentials.get();
+  EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));
 }
 
 TEST_F(GoogleCredentialsTest, LoadUnknownTypeCredentials) {
@@ -225,7 +247,7 @@ TEST_F(GoogleCredentialsTest, LoadInvalidCredentials) {
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
-TEST_F(GoogleCredentialsTest, MissingCredentials) {
+TEST_F(GoogleCredentialsTest, MissingCredentialsViaEnvVar) {
   char const filename[] = "missing-credentials.json";
   SetEnv(GoogleAdcEnvVar(), filename);
 
@@ -234,6 +256,32 @@ TEST_F(GoogleCredentialsTest, MissingCredentials) {
                    std::runtime_error const& ex) {
     EXPECT_THAT(ex.what(), HasSubstr("Cannot open credentials file"));
     EXPECT_THAT(ex.what(), HasSubstr(filename));
+    throw;
+  },
+               std::runtime_error);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(GoogleDefaultCredentials(),
+                            "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST_F(GoogleCredentialsTest, MissingCredentialsViaGcloudFilePath) {
+  char const filename[] = "missing-credentials.json";
+
+  // Make sure other credentials (ADC env var, implicit environment-based creds)
+  // aren't found either.
+  UnsetEnv(GoogleAdcEnvVar());
+  SetEnv(GceCheckOverrideEnvVar(), "0");
+  // The method to create default credentials should see that no file exists at
+  // this path, then continue trying to load the other credential types,
+  // eventually finding no valid credentials and hitting a runtime error.
+  SetEnv(GoogleGcloudAdcFileEnvVar(), filename);
+
+  // Ensure we don't find any valid credential type.
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(try { auto credentials = GoogleDefaultCredentials(); } catch (
+                   std::runtime_error const& ex) {
+    EXPECT_THAT(ex.what(), HasSubstr("Could not automatically determine"));
     throw;
   },
                std::runtime_error);

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -15,6 +15,7 @@ storage_client_unit_tests = [
     "internal/binary_data_as_debug_string_test.cc",
     "internal/bucket_acl_requests_test.cc",
     "internal/bucket_requests_test.cc",
+    "internal/compute_engine_util_test.cc",
     "internal/default_object_acl_requests_test.cc",
     "internal/format_rfc3339_test.cc",
     "internal/generate_message_boundary_test.cc",


### PR DESCRIPTION
As mentioned in #1354, there was no test coverage for the ADC code path that loads credentials from the gcloud well known ADC file path.  This adds a couple environment variables to make testing other credential-loading paths possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1357)
<!-- Reviewable:end -->
