### PR TITLE
Introduce StrictIdempotencyPolicy.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -297,6 +297,7 @@ set(storage_client_unit_tests
     client_test.cc
     client_write_object_test.cc
     hashing_options_test.cc
+    idempotency_policy_test.cc
     internal/access_control_common_test.cc
     internal/binary_data_as_debug_string_test.cc
     internal/bucket_acl_requests_test.cc

--- a/google/cloud/storage/idempotency_policy.cc
+++ b/google/cloud/storage/idempotency_policy.cc
@@ -204,6 +204,246 @@ bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
   return true;
 }
 
+std::unique_ptr<IdempotencyPolicy> StrictIdempotencyPolicy::clone() const {
+  return google::cloud::internal::make_unique<StrictIdempotencyPolicy>(*this);
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::ListBucketsRequest const& request) const {
+  // Read operations are always idempotent.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::CreateBucketRequest const& request) const {
+  // Creating a bucket is idempotent because you cannot create a new version
+  // of a bucket, it succeeds only once.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::GetBucketMetadataRequest const& request) const {
+  // Read operations are always idempotent.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::DeleteBucketRequest const& request) const {
+  return (request.HasOption<IfMatchEtag>() or
+          request.HasOption<IfMetagenerationMatch>());
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::UpdateBucketRequest const& request) const {
+  return (request.HasOption<IfMatchEtag>() or
+          request.HasOption<IfMetagenerationMatch>());
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::PatchBucketRequest const& request) const {
+  return (request.HasOption<IfMatchEtag>() or
+      request.HasOption<IfMetagenerationMatch>());
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::GetBucketIamPolicyRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::SetBucketIamPolicyRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::TestBucketIamPermissionsRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::InsertObjectMediaRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::CopyObjectRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::GetObjectMetadataRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::ReadObjectRangeRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::InsertObjectStreamingRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::ListObjectsRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::DeleteObjectRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::UpdateObjectRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::PatchObjectRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::ComposeObjectRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::RewriteObjectRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::ListBucketAclRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::CreateBucketAclRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::DeleteBucketAclRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::GetBucketAclRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::UpdateBucketAclRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::PatchBucketAclRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::ListObjectAclRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::CreateObjectAclRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::DeleteObjectAclRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::GetObjectAclRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::UpdateObjectAclRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::PatchObjectAclRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::ListDefaultObjectAclRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::CreateDefaultObjectAclRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::DeleteDefaultObjectAclRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::GetDefaultObjectAclRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::UpdateDefaultObjectAclRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::PatchDefaultObjectAclRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::GetProjectServiceAccountRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::ListNotificationsRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::CreateNotificationRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::GetNotificationRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::DeleteNotificationRequest const& request) const {
+  // TODO(#714) - determine if the request is idempotent and return accordingly.
+  return true;
+}
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/idempotency_policy.h
+++ b/google/cloud/storage/idempotency_policy.h
@@ -282,6 +282,123 @@ class AlwaysRetryIdempotencyPolicy : public IdempotencyPolicy {
   //@}
 };
 
+/**
+ * A IdempotencyPolicy that only retries strictly idempotent requests.
+ */
+class StrictIdempotencyPolicy : public IdempotencyPolicy {
+ public:
+  StrictIdempotencyPolicy() = default;
+
+  std::unique_ptr<IdempotencyPolicy> clone() const override;
+
+  //@{
+  /// @name Bucket resource operations
+  bool IsIdempotent(internal::ListBucketsRequest const& request) const override;
+  bool IsIdempotent(
+      internal::CreateBucketRequest const& request) const override;
+  bool IsIdempotent(
+      internal::GetBucketMetadataRequest const& request) const override;
+  bool IsIdempotent(
+      internal::DeleteBucketRequest const& request) const override;
+  bool IsIdempotent(
+      internal::UpdateBucketRequest const& request) const override;
+  bool IsIdempotent(internal::PatchBucketRequest const& request) const override;
+  bool IsIdempotent(
+      internal::GetBucketIamPolicyRequest const& request) const override;
+  bool IsIdempotent(
+      internal::SetBucketIamPolicyRequest const& request) const override;
+  bool IsIdempotent(
+      internal::TestBucketIamPermissionsRequest const& request) const override;
+  //@}
+
+  //@{
+  /// @name Object resource operations
+  bool IsIdempotent(
+      internal::InsertObjectMediaRequest const& request) const override;
+  bool IsIdempotent(internal::CopyObjectRequest const& request) const override;
+  bool IsIdempotent(
+      internal::GetObjectMetadataRequest const& request) const override;
+  bool IsIdempotent(
+      internal::ReadObjectRangeRequest const& request) const override;
+  bool IsIdempotent(
+      internal::InsertObjectStreamingRequest const& request) const override;
+  bool IsIdempotent(internal::ListObjectsRequest const& request) const override;
+  bool IsIdempotent(
+      internal::DeleteObjectRequest const& request) const override;
+  bool IsIdempotent(
+      internal::UpdateObjectRequest const& request) const override;
+  bool IsIdempotent(internal::PatchObjectRequest const& request) const override;
+  bool IsIdempotent(
+      internal::ComposeObjectRequest const& request) const override;
+  bool IsIdempotent(
+      internal::RewriteObjectRequest const& request) const override;
+  //@}
+
+  //@{
+  /// @name BucketAccessControls resource operations
+  bool IsIdempotent(
+      internal::ListBucketAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::CreateBucketAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::DeleteBucketAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::GetBucketAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::UpdateBucketAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::PatchBucketAclRequest const& request) const override;
+  //@}
+
+  //@{
+  /// @name ObjectAccessControls operations
+  bool IsIdempotent(
+      internal::ListObjectAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::CreateObjectAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::DeleteObjectAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::GetObjectAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::UpdateObjectAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::PatchObjectAclRequest const& request) const override;
+  //@}
+
+  //@{
+  /// @name DefaultObjectAccessControls operations.
+  bool IsIdempotent(
+      internal::ListDefaultObjectAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::CreateDefaultObjectAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::DeleteDefaultObjectAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::GetDefaultObjectAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::UpdateDefaultObjectAclRequest const& request) const override;
+  bool IsIdempotent(
+      internal::PatchDefaultObjectAclRequest const& request) const override;
+  //@}
+
+  //@{
+  bool IsIdempotent(
+      internal::GetProjectServiceAccountRequest const& request) const override;
+  //@}
+
+  //@{
+  bool IsIdempotent(
+      internal::ListNotificationsRequest const& request) const override;
+  bool IsIdempotent(
+      internal::CreateNotificationRequest const& request) const override;
+  bool IsIdempotent(
+      internal::GetNotificationRequest const& request) const override;
+  bool IsIdempotent(
+      internal::DeleteNotificationRequest const& request) const override;
+  //@}
+};
+
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/idempotency_policy_test.cc
+++ b/google/cloud/storage/idempotency_policy_test.cc
@@ -1,0 +1,113 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/idempotency_policy.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+
+TEST(StrictIdempotencyPolicyTest, ListBuckets) {
+  StrictIdempotencyPolicy policy;
+  internal::ListBucketsRequest request("test-project");
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, CreateBucket) {
+  StrictIdempotencyPolicy policy;
+  internal::CreateBucketRequest request(
+      "test-project", BucketMetadata().set_name("test-bucket-name"));
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, GetBucketMetadata) {
+  StrictIdempotencyPolicy policy;
+  internal::GetBucketMetadataRequest request("test-bucket-name");
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, DeleteBucket) {
+  StrictIdempotencyPolicy policy;
+  internal::DeleteBucketRequest request("test-bucket-name");
+  EXPECT_FALSE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, DeleteBucketIfEtag) {
+  StrictIdempotencyPolicy policy;
+  internal::DeleteBucketRequest request("test-bucket-name");
+  request.set_option(IfMatchEtag("ABC123="));
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, DeleteBucketIfMetagenerationMatch) {
+  StrictIdempotencyPolicy policy;
+  internal::DeleteBucketRequest request("test-bucket-name");
+  request.set_option(IfMetagenerationMatch(7));
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, UpdateBucket) {
+  StrictIdempotencyPolicy policy;
+  internal::UpdateBucketRequest request(
+      BucketMetadata().set_name("test-bucket-name"));
+  EXPECT_FALSE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, UpdateBucketIfEtag) {
+  StrictIdempotencyPolicy policy;
+  internal::UpdateBucketRequest request(
+      BucketMetadata().set_name("test-bucket-name"));
+  request.set_option(IfMatchEtag("ABC123="));
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, UpdateBucketIfMetagenerationMatch) {
+  StrictIdempotencyPolicy policy;
+  internal::UpdateBucketRequest request(
+      BucketMetadata().set_name("test-bucket-name"));
+  request.set_option(IfMetagenerationMatch(7));
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, PatchBucket) {
+  StrictIdempotencyPolicy policy;
+  internal::PatchBucketRequest request("test-bucket-name",
+                                       BucketMetadataPatchBuilder());
+  EXPECT_FALSE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, PatchBucketIfEtag) {
+  StrictIdempotencyPolicy policy;
+  internal::PatchBucketRequest request("test-bucket-name",
+                                       BucketMetadataPatchBuilder());
+  request.set_option(IfMatchEtag("ABC123="));
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, PatchBucketIfMetagenerationMatch) {
+  StrictIdempotencyPolicy policy;
+  internal::PatchBucketRequest request("test-bucket-name",
+                                       BucketMetadataPatchBuilder());
+  request.set_option(IfMetagenerationMatch(7));
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -11,6 +11,7 @@ storage_client_unit_tests = [
     "client_test.cc",
     "client_write_object_test.cc",
     "hashing_options_test.cc",
+    "idempotency_policy_test.cc",
     "internal/access_control_common_test.cc",
     "internal/binary_data_as_debug_string_test.cc",
     "internal/bucket_acl_requests_test.cc",


### PR DESCRIPTION
This is part of the work for #714. It introduces a new (partially
implemented) idempotency policy that only labels as idempotent the
operations that are idempotent in all circumstances. In this PR only the
CRUD operations for buckets are implemented, I plan to create one PR per
resource type to keep the PRs reasonably sized. Because the policy is
not fully implemented there are no integration tests yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1365)
<!-- Reviewable:end -->
