### PR TITLE
Implement LockBucketRetentionPolicyRequest.

### DIFF
--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -310,6 +310,14 @@ std::ostream& operator<<(std::ostream& os,
   return os << "]}";
 }
 
+std::ostream& operator<<(std::ostream& os,
+                         LockBucketRetentionPolicyRequest const& r) {
+  os << "LockBucketRetentionPolicyRequest={bucket_name=" << r.bucket_name()
+     << ", metageneration=" << r.metageneration();
+  r.DumpOptions(os, ", ");
+  return os << "}";
+};
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/bucket_requests.h
+++ b/google/cloud/storage/internal/bucket_requests.h
@@ -254,6 +254,28 @@ struct TestBucketIamPermissionsResponse {
 std::ostream& operator<<(std::ostream& os,
                          TestBucketIamPermissionsResponse const& r);
 
+/**
+ * Represents a request to the `Buckets: lockRetentionPolicy` API.
+ */
+class LockBucketRetentionPolicyRequest
+    : public GenericRequest<LockBucketRetentionPolicyRequest, UserProject> {
+ public:
+  LockBucketRetentionPolicyRequest() = default;
+  explicit LockBucketRetentionPolicyRequest(std::string bucket_name,
+                                            std::uint64_t metageneration)
+      : bucket_name_(std::move(bucket_name)), metageneration_(metageneration) {}
+
+  std::string const& bucket_name() const { return bucket_name_; }
+  std::uint64_t metageneration() const { return metageneration_; }
+
+ private:
+  std::string bucket_name_;
+  std::uint64_t metageneration_;
+};
+
+std::ostream& operator<<(std::ostream& os,
+                         LockBucketRetentionPolicyRequest const& r);
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -818,6 +818,20 @@ TEST(BucketRequestsTest, TestIamPermissionsResponseEmpty) {
       HttpResponse{200, text, {}});
   EXPECT_TRUE(actual.permissions.empty());
 }
+
+TEST(BucketRequestsTest, LockBucketRetentionPolicyRequest) {
+  LockBucketRetentionPolicyRequest request("test-bucket", 12345U);
+  request.set_multiple_options(UserProject("project-for-billing"));
+  EXPECT_EQ("test-bucket", request.bucket_name());
+  EXPECT_EQ(12345U, request.metageneration());
+
+  std::ostringstream os;
+  os << request;
+  auto actual = os.str();
+  EXPECT_THAT(actual, HasSubstr("test-bucket"));
+  EXPECT_THAT(actual, HasSubstr("project-for-billing"));
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS


### PR DESCRIPTION
This is part of the work for #1029. It implements the request class for
`Buckets: lockRetentionPolicy`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1366)
<!-- Reviewable:end -->
