### PR TITLE
Capture compiler version in Bazel.

### DIFF
--- a/google/cloud/BUILD
+++ b/google/cloud/BUILD
@@ -29,9 +29,10 @@ genrule(
     srcs = ["internal/build_info.cc.in"],
     outs = ["internal/build_info.cc"],
     cmd = """
-V=`git rev-parse --short HEAD 2>/dev/null || echo "unknown"`;
+CC_COMPILER_VERSION=$$($(CC) --version | head -1);
+V=$$(git rev-parse --short HEAD 2>/dev/null || echo "unknown");
 sed -e "s;@CMAKE_CXX_COMPILER_ID@;$(C_COMPILER);" \
-    -e "s;@CMAKE_CXX_COMPILER_VERSION@;unknown-bazel;" \
+    -e "s;@CMAKE_CXX_COMPILER_VERSION@;$${CC_COMPILER_VERSION};" \
     -e "s;@CMAKE_CXX_FLAGS@;$(CC_FLAGS);" \
     -e "s;\\$${CMAKE_CXX_FLAGS_.*};$(COMPILATION_MODE);" \
     -e "s;@GOOGLE_CLOUD_CPP_IS_RELEASE@;%s;" \


### PR DESCRIPTION
I finally figured out how to do this with Bazel. I never created a bug, but
clearly this is a deficiency in our Bazel builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1368)
<!-- Reviewable:end -->
