### PR TITLE
Initial support for continuations.

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -105,6 +105,7 @@ add_library(google_cloud_cpp_common
             internal/filesystem.cc
             internal/future_fwd.h
             internal/future_impl.h
+            internal/future_then_meta.h
             internal/future_void.h
             internal/getenv.h
             internal/getenv.cc

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -9,6 +9,7 @@ google_cloud_cpp_common_HDRS = [
     "internal/filesystem.h",
     "internal/future_fwd.h",
     "internal/future_impl.h",
+    "internal/future_then_meta.h",
     "internal/future_void.h",
     "internal/getenv.h",
     "internal/make_unique.h",

--- a/google/cloud/internal/future_then_meta.h
+++ b/google/cloud/internal/future_then_meta.h
@@ -52,6 +52,14 @@ struct unwrap_then<future<U>> {
  * This metafunction implements a number of useful results given a functor type
  * @p Functor, and the value type @p T of a `future_shared_state<T>`.
  *
+ * @note The `Functor` in this metafunction is *not* the template parameter
+ * passed to `.then()`.  It is a functor, created by `.then()`, that wraps the
+ * original argument but operates directly on `future_shared_state<T>`. Without
+ * this wrapper the implementation of the continuation classes would need to
+ * know about the full definition of `future<T>`, and we could too easily create
+ * a cycle where the definition of `future_shared_state<T>` needs the definition
+ * of `future<T>` which needs the definition of `future_shared_state<T>.
+ *
  * * First it determines if `Functor` meets the requirements, i.e., that it can
  *   be invoked with an object of type `future_shared_state<T>` as its only
  *   argument.

--- a/google/cloud/internal/future_then_meta.h
+++ b/google/cloud/internal/future_then_meta.h
@@ -1,0 +1,97 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_THEN_META_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_THEN_META_H_
+/**
+ * @file
+ *
+ * Define metafunctions used in the implementation for `future<T>::then()`.
+ */
+
+#include "google/cloud/internal/future_fwd.h"
+#include "google/cloud/internal/invoke_result.h"
+#include <memory>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+template <typename T>
+class future_shared_state;
+
+/// Compute the return type for a future<T>::then()
+template <typename FunctorReturn>
+struct unwrap_then {
+  using type = FunctorReturn;
+  using requires_unwrap_t = std::false_type;
+};
+
+/// Specialize the unwrap_then<> for functors that return future<U>
+template <typename U>
+struct unwrap_then<future<U>> {
+  using type = U;
+  using requires_unwrap_t = std::true_type;
+};
+
+/**
+ * A metafunction to implement `continuation<Functor, T>::execute()`.
+ *
+ * This metafunction implements a number of useful results given a functor type
+ * @p Functor, and the value type @p T of a `future_shared_state<T>`.
+ *
+ * * First it determines if `Functor` meets the requirements, i.e., that it can
+ *   be invoked with an object of type `future_shared_state<T>` as its only
+ *   argument.
+ * * Then in computes the type of the expression `functor(fut)`, where `functor`
+ *   is of type `Functor` and `fut` is of type `future<T>`.
+ * * It determines if the resulting type requires implicit unwrapping because it
+ *   is a `future<U>`.
+ * * It computes the type of the shared state needed to implement
+ *   `future<T>::then()`.
+ *
+ * @tparam Functor the functor to call. Note that this is a functor wrapped by
+ *   `future<T>`. It must accept a `std::shared_ptr<future_shared_state<T>>` as
+ *   its single input parameter.
+ * @tparam T the type contained in the input future.
+ */
+template <
+    typename Functor, typename T,
+    typename std::enable_if<
+        is_invocable<Functor, std::shared_ptr<future_shared_state<T>>>::value,
+        int>::type = 0>
+struct continuation_helper {
+  /// The type returned by calling the functor with the given future type.
+  using functor_result_t =
+      invoke_result_t<Functor, std::shared_ptr<future_shared_state<T>>>;
+
+  /// The type returned by `.then()`, which is a `future<U>`.
+  using result_t = typename unwrap_then<functor_result_t>::type;
+
+  /// `std::true_type` if `functor_result_t` is a `future<R>`, `std::false_type`
+  /// otherwise.
+  using requires_unwrap_t =
+      typename unwrap_then<functor_result_t>::requires_unwrap_t;
+
+  /// The type of the shared state created by `.then()`.
+  using state_t = future_shared_state<result_t>;
+};
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_THEN_META_H_


### PR DESCRIPTION
This is part of the work for #1345. It implements support for
continuations in the shared state. Continuations are implemented as a
type-erased object associated with the source shared state. They hold
both the functor and the destination shared state. When the source
shared state is satisfied the continuation is invoked, they call the
functor with the source shared state input, and store the results (if
any) into the output shared state.

In this PR this is only implemented for `void` as the shared state, so
it is a bit boring, but it is a good start, and more code would make the
PR even larger than it already is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1373)
<!-- Reviewable:end -->
