### PR TITLE
Break up decl and impl in GCE util files.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -123,6 +123,7 @@ add_library(storage_client
             internal/complex_option.h
             internal/common_metadata.h
             internal/compute_engine_util.h
+            internal/compute_engine_util.cc
             internal/curl_handle.h
             internal/curl_handle.cc
             internal/curl_handle_factory.h

--- a/google/cloud/storage/internal/compute_engine_util.cc
+++ b/google/cloud/storage/internal/compute_engine_util.cc
@@ -1,0 +1,110 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/compute_engine_util.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/log.h"
+#include <string>
+#if _WIN32
+#include <Windows.h>
+#else  // On Linux
+#include <fstream>
+#endif  // _WIN32
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+
+std::string GceMetadataHostname() {
+  auto maybe_hostname =
+      google::cloud::internal::GetEnv(GceMetadataHostnameEnvVar());
+  if (maybe_hostname.has_value()) {
+    return *maybe_hostname;
+  }
+  return "metadata.google.internal";
+}
+
+bool RunningOnComputeEngineVm() {
+  // Allow overriding this value for integration tests.
+  auto override_val = google::cloud::internal::GetEnv(GceCheckOverrideEnvVar());
+  if (override_val.has_value()) {
+    return std::string("1") == *override_val;
+  }
+
+#if _WIN32
+  // These values came from a GCE VM running Windows Server 2012 R2.
+  std::wstring const REG_KEY_PATH = L"SYSTEM\\HardwareConfig\\Current\\";
+  std::wstring const REG_KEY_NAME = L"SystemProductName";
+  std::wstring const GCE_PRODUCT_NAME = L"Google Compute Engine";
+
+  // Get the size of the string first to allocate our buffer. This includes
+  // enough space for the trailing NUL character that will be included.
+  DWORD buffer_size{};
+  auto rc = ::RegGetValueW(
+      HKEY_LOCAL_MACHINE, REG_KEY_PATH.c_str(), REG_KEY_NAME.c_str(),
+      RRF_RT_REG_SZ,
+      nullptr,        // We know the type will be REG_SZ.
+      nullptr,        // We're only fetching the size; no buffer given yet.
+      &buffer_size);  // Fetch the size in bytes of the value, if it exists.
+  if (rc != 0) {
+    return false;
+  }
+
+  // Allocate the buffer size and retrieve the product name string.
+  std::wstring buffer;
+  buffer.resize(static_cast<std::size_t>(buffer_size) / sizeof(wchar_t));
+  rc = ::RegGetValueW(
+      HKEY_LOCAL_MACHINE, REG_KEY_PATH.c_str(), REG_KEY_NAME.c_str(),
+      RRF_RT_REG_SZ,
+      nullptr,                         // We know the type will be REG_SZ.
+      static_cast<void*>(&buffer[0]),  // Fetch the string value this time.
+      &buffer_size);  // The wstring size in bytes, not including trailing NUL.
+  if (rc != 0) {
+    return false;
+  }
+
+  // Account for the trailing NUL character in the retrieved value, along with
+  // the additional NUL char appended to all wstring objects.
+  buffer_size = static_cast<std::size_t>(buffer_size) / sizeof(wchar_t);
+  if (buffer_size == 0) {
+    return false;
+  }
+  buffer_size--;
+  buffer.resize(static_cast<std::size_t>(buffer_size));
+
+  return buffer == GCE_PRODUCT_NAME;
+#else   // Running on Linux
+  // On Linux GCE VMs, we expect to see "Google Compute Engine" as the contents
+  // of the file at /sys/class/dmi/id/product_name.
+  std::string const GCE_PRODUCT_NAME = "Google Compute Engine";
+  std::string const PRODUCT_NAME_FILE = "/sys/class/dmi/id/product_name";
+  std::ifstream is(PRODUCT_NAME_FILE);
+  if (not is.is_open()) {
+    GCP_LOG(WARNING) << "Could not find file '" << PRODUCT_NAME_FILE
+                     << "' when checking if running on GCE, returning false";
+    return false;
+  }
+  std::string first_line;
+  std::getline(is, first_line);
+  return first_line == GCE_PRODUCT_NAME;
+#endif  // _WIN32
+}
+
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/compute_engine_util.h
+++ b/google/cloud/storage/internal/compute_engine_util.h
@@ -15,15 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_COMPUTE_ENGINE_UTIL_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_COMPUTE_ENGINE_UTIL_H_
 
-#include "google/cloud/internal/getenv.h"
-#include "google/cloud/log.h"
 #include "google/cloud/storage/version.h"
-#include <string>
-#if _WIN32
-#include <Windows.h>
-#else  // On Linux
-#include <fstream>
-#endif  // _WIN32
 
 namespace google {
 namespace cloud {
@@ -48,6 +40,14 @@ inline char const* GceCheckOverrideEnvVar() {
   return kEnvVarName;
 }
 
+/// Returns the hostname for a GCE instance's metadata server.
+std::string GceMetadataHostname();
+
+inline char const* GceMetadataHostnameEnvVar() {
+  static constexpr char kEnvVarName[] = "GCE_METADATA_ROOT";
+  return kEnvVarName;
+}
+
 /**
  * Returns true if the program is running on a Compute Engine VM.
  *
@@ -56,71 +56,7 @@ inline char const* GceCheckOverrideEnvVar() {
  * GCE metadata server (e.g. the metadata server may be temporarily unavailable,
  * the VM may be experiencing network issues, etc.).
  */
-bool RunningOnComputeEngineVm() {
-  // Allow overriding this value for integration tests.
-  auto override_val = google::cloud::internal::GetEnv(GceCheckOverrideEnvVar());
-  if (override_val.has_value()) {
-    return std::string("1") == *override_val;
-  }
-
-#if _WIN32
-  // These values came from a GCE VM running Windows Server 2012 R2.
-  std::wstring const REG_KEY_PATH = L"SYSTEM\\HardwareConfig\\Current\\";
-  std::wstring const REG_KEY_NAME = L"SystemProductName";
-  std::wstring const GCE_PRODUCT_NAME = L"Google Compute Engine";
-
-  // Get the size of the string first to allocate our buffer. This includes
-  // enough space for the trailing NUL character that will be included.
-  DWORD buffer_size{};
-  auto rc = ::RegGetValueW(
-      HKEY_LOCAL_MACHINE, REG_KEY_PATH.c_str(), REG_KEY_NAME.c_str(),
-      RRF_RT_REG_SZ,
-      nullptr,        // We know the type will be REG_SZ.
-      nullptr,        // We're only fetching the size; no buffer given yet.
-      &buffer_size);  // Fetch the size in bytes of the value, if it exists.
-  if (rc != 0) {
-    return false;
-  }
-
-  // Allocate the buffer size and retrieve the product name string.
-  std::wstring buffer;
-  buffer.resize(static_cast<std::size_t>(buffer_size) / sizeof(wchar_t));
-  rc = ::RegGetValueW(
-      HKEY_LOCAL_MACHINE, REG_KEY_PATH.c_str(), REG_KEY_NAME.c_str(),
-      RRF_RT_REG_SZ,
-      nullptr,                         // We know the type will be REG_SZ.
-      static_cast<void*>(&buffer[0]),  // Fetch the string value this time.
-      &buffer_size);  // The wstring size in bytes, not including trailing NUL.
-  if (rc != 0) {
-    return false;
-  }
-
-  // Account for the trailing NUL character in the retrieved value, along with
-  // the additional NUL char appended to all wstring objects.
-  buffer_size = static_cast<std::size_t>(buffer_size) / sizeof(wchar_t);
-  if (buffer_size == 0) {
-    return false;
-  }
-  buffer_size--;
-  buffer.resize(static_cast<std::size_t>(buffer_size));
-
-  return buffer == GCE_PRODUCT_NAME;
-#else   // Running on Linux
-  // On Linux GCE VMs, we expect to see "Google Compute Engine" as the contents
-  // of the file at /sys/class/dmi/id/product_name.
-  std::string const GCE_PRODUCT_NAME = "Google Compute Engine";
-  std::string const PRODUCT_NAME_FILE = "/sys/class/dmi/id/product_name";
-  std::ifstream is(PRODUCT_NAME_FILE);
-  if (not is.is_open()) {
-    GCP_LOG(WARNING) << "Could not find file '" << PRODUCT_NAME_FILE
-                     << "' when checking if running on GCE, returning false";
-    return false;
-  }
-  std::string first_line;
-  std::getline(is, first_line);
-  return first_line == GCE_PRODUCT_NAME;
-#endif  // _WIN32
-}
+bool RunningOnComputeEngineVm();
 
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/internal/compute_engine_util_test.cc
+++ b/google/cloud/storage/internal/compute_engine_util_test.cc
@@ -24,20 +24,29 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 using ::google::cloud::internal::SetEnv;
+using ::google::cloud::internal::UnsetEnv;
 using ::google::cloud::testing_util::EnvironmentVariableRestore;
 
 class ComputeEngineUtilTest : public ::testing::Test {
  public:
   ComputeEngineUtilTest()
-      : gce_check_override_env_var_(GceCheckOverrideEnvVar()) {}
+      : gce_check_override_env_var_(GceCheckOverrideEnvVar()),
+        gce_metadata_hostname_env_var_(GceMetadataHostnameEnvVar()) {}
 
  protected:
-  void SetUp() override { gce_check_override_env_var_.SetUp(); }
+  void SetUp() override {
+    gce_check_override_env_var_.SetUp();
+    gce_metadata_hostname_env_var_.SetUp();
+  }
 
-  void TearDown() override { gce_check_override_env_var_.TearDown(); }
+  void TearDown() override {
+    gce_check_override_env_var_.TearDown();
+    gce_metadata_hostname_env_var_.TearDown();
+  }
 
  protected:
   EnvironmentVariableRestore gce_check_override_env_var_;
+  EnvironmentVariableRestore gce_metadata_hostname_env_var_;
 };
 
 /// @test Ensure we can override the return value for checking if we're on GCE.
@@ -48,6 +57,17 @@ TEST_F(ComputeEngineUtilTest, CanOverrideRunningOnGceCheckViaEnvVar) {
   SetEnv(GceCheckOverrideEnvVar(), "0");
   EXPECT_FALSE(RunningOnComputeEngineVm());
 }
+
+/// @test Ensure we can override the value for the GCE metadata hostname.
+TEST_F(ComputeEngineUtilTest, CanOverrideGceMetadataHostname) {
+  SetEnv(GceMetadataHostnameEnvVar(), "foo.bar");
+  EXPECT_EQ(std::string("foo.bar"), GceMetadataHostname());
+
+  // If not overridden for testing, we should get the actual hostname.
+  UnsetEnv(GceMetadataHostnameEnvVar());
+  EXPECT_EQ(std::string("metadata.google.internal"), GceMetadataHostname());
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/storage_client.bzl
+++ b/google/cloud/storage/storage_client.bzl
@@ -81,6 +81,7 @@ storage_client_SRCS = [
     "internal/binary_data_as_debug_string.cc",
     "internal/bucket_acl_requests.cc",
     "internal/bucket_requests.cc",
+    "internal/compute_engine_util.cc",
     "internal/curl_handle.cc",
     "internal/curl_handle_factory.cc",
     "internal/curl_download_request.cc",


### PR DESCRIPTION
This change is needed as part of the GCE credentials being added in one
of the next PRs in this chain; after putting those changes together,
this one was large and modular enough to split into its own PR.