### PR TITLE
Refactor common future and promise functions.

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -103,6 +103,7 @@ add_library(google_cloud_cpp_common
             ${CMAKE_CURRENT_BINARY_DIR}/internal/build_info.cc
             internal/filesystem.h
             internal/filesystem.cc
+            internal/future_base.h
             internal/future_fwd.h
             internal/future_impl.h
             internal/future_then_meta.h

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -7,6 +7,7 @@ google_cloud_cpp_common_HDRS = [
     "internal/big_endian.h",
     "internal/build_info.h",
     "internal/filesystem.h",
+    "internal/future_base.h",
     "internal/future_fwd.h",
     "internal/future_impl.h",
     "internal/future_then_meta.h",

--- a/google/cloud/internal/future_base.h
+++ b/google/cloud/internal/future_base.h
@@ -1,0 +1,184 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_BASE_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_BASE_H_
+/**
+ * @file
+ *
+ * Define the implementation details for `google::cloud::future<T>`.
+ */
+
+#include "google/cloud/internal/port_platform.h"
+
+// C++ futures only make sense when exceptions are enabled.
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+#include "google/cloud/internal/future_impl.h"
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+/**
+ * Refactor common functions to `future<T>`, `future<R&>` and `future<void>`.
+ * @tparam T
+ */
+template <typename T>
+class future_base {
+ public:
+  future_base() noexcept = default;
+  future_base(future_base&&) noexcept = default;
+  future_base& operator=(future_base&&) noexcept = default;
+
+  future_base(future_base const& rhs) = delete;
+  future_base& operator=(future_base const& rhs) = delete;
+
+  /// Returns true if the future has a shared state.
+  bool valid() const noexcept { return static_cast<bool>(shared_state_); }
+
+  /**
+   * Blocks until the shared state is ready.
+   *
+   * @throws std::future_error with std::future_errc::no_state if the future has
+   *     no shared state.
+   */
+  void wait() const {
+    check_valid();
+    shared_state_->wait();
+  }
+
+  /**
+   * Blocks until the shared state is ready, or until @p duration time has
+   * elapsed.
+   *
+   * @param duration the maximum time to wait for the shared state to become
+   *     ready.
+   *
+   * @tparam Rep a placeholder to match the Rep tparam for @p duration's
+   *     type, the semantics of this template parameter are documented in
+   *     `std::chrono::duration<>` (in brief, the underlying arithmetic type
+   *     used to store the number of ticks), for our purposes it is simply a
+   *     formal parameter.
+   * @tparam Period a placeholder to match the Period tparam for @p duration's
+   *     type, the semantics of this template parameter are documented in
+   *     `std::chrono::duration<>` (in brief, the length of the tick in seconds,
+   *     expressed as a `std::ratio<>`), for our purposes it is simply a formal
+   *     parameter.
+   *
+   * @return `std::future_status::ready` if the shared state is satisfied.
+   *     `std::future_status::deferred` if the shared state is not satisfied and
+   *     there is a continuation ready to execute when it is satisfied.
+   *     `std::future_status::timeout` otherwise.
+   *
+   * @throws std::future_error with std::future_errc::no_state if the future has
+   *     no shared state.
+   */
+  template <typename Rep, typename Period>
+  std::future_status wait_for(
+      std::chrono::duration<Rep, Period> const& rel_time) const {
+    check_valid();
+    return shared_state_->wait_for(rel_time);
+  }
+
+  /**
+   * Blocks until the shared state is ready, or until @p deadline expires.
+   *
+   * @param deadline a time point after which this function no longer waits.
+   *
+   * @tparam Clock a placeholder to match the Clock tparam for @p tp's
+   *     type, the semantics of this template parameter are documented in
+   *     `std::chrono::time_point<>` (in brief, the underlying clock type
+   *     associated with the time point), for our purposes it is simply a
+   *     formal parameter.
+   *
+   * @return `std::future_status::ready` if the shared state is satisfied.
+   *     `std::future_status::deferred` if the shared state is not satisfied and
+   *     there is a continuation ready to execute when it is satisfied.
+   *     `std::future_status::timeout` otherwise.
+   *
+   * @throws std::future_error with std::future_errc::no_state if the future has
+   *     no shared state.
+   */
+  template <typename Rep, typename Period>
+  std::future_status wait_until(
+      std::chrono::time_point<Rep, Period> const& abs_time) const {
+    check_valid();
+    return shared_state_->wait_until(abs_time);
+  }
+
+ protected:
+  /// Shorthand to refer to the shared state type.
+  using shared_state_type = internal::future_shared_state<T>;
+
+  /// Creates a future from a shared state.
+  explicit future_base(std::shared_ptr<shared_state_type> state)
+      : shared_state_(std::move(state)) {}
+
+  /// Raises an exception if the shared state is not valid.
+  void check_valid() const {
+    if (not shared_state_) {
+      throw std::future_error(std::future_errc::no_state);
+    }
+  }
+
+  std::shared_ptr<shared_state_type> shared_state_;
+};
+
+template <typename T>
+class promise_base {
+ public:
+  promise_base() : shared_state_(std::make_shared<shared_state_type>()) {}
+  promise_base(promise_base&&) noexcept = default;
+
+  ~promise_base() {
+    if (shared_state_) {
+      shared_state_->abandon();
+    }
+  }
+
+  // Delete the operators we do not want. Note that the move operator is deleted
+  // because the implementation must call the destructor (or at least abandon)
+  // on *this.
+  promise_base& operator=(promise_base&&) noexcept = delete;
+  promise_base(promise_base const&) = delete;
+  promise_base& operator=(promise_base const&) = delete;
+
+  /**
+   * Satisfies the shared state using the exception @p ex.
+   *
+   * @throws std::future_error with std::future_errc::promise_already_satisfied
+   *   if the shared state is already satisfied.
+   * @throws std::future_error with std::no_state if the promise does not have
+   *   a shared state.
+   */
+  void set_exception(std::exception_ptr ex) {
+    if (not shared_state_) {
+      throw std::future_error(std::future_errc::no_state);
+    }
+    shared_state_->set_exception(std::move(ex));
+  }
+
+ protected:
+  /// Shorthand to refer to the shared state type.
+  using shared_state_type = internal::future_shared_state<T>;
+  std::shared_ptr<shared_state_type> shared_state_;
+};
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_BASE_H_

--- a/google/cloud/internal/future_then_meta.h
+++ b/google/cloud/internal/future_then_meta.h
@@ -17,7 +17,7 @@
 /**
  * @file
  *
- * Define metafunctions used in the implementation for `future<T>::then()`.
+ * Define metafunctions used in the implementation for `future<T>::%then()`.
  */
 
 #include "google/cloud/internal/future_fwd.h"
@@ -47,7 +47,7 @@ struct unwrap_then<future<U>> {
 };
 
 /**
- * A metafunction to implement `continuation<Functor, T>::execute()`.
+ * A metafunction to implement `internal::continuation<Functor,T>`.
  *
  * This metafunction implements a number of useful results given a functor type
  * @p Functor, and the value type @p T of a `future_shared_state<T>`.
@@ -68,7 +68,7 @@ struct unwrap_then<future<U>> {
  * * It determines if the resulting type requires implicit unwrapping because it
  *   is a `future<U>`.
  * * It computes the type of the shared state needed to implement
- *   `future<T>::then()`.
+ *   `future<T>::%then()`.
  *
  * @tparam Functor the functor to call. Note that this is a functor wrapped by
  *   `future<T>`. It must accept a `std::shared_ptr<future_shared_state<T>>` as


### PR DESCRIPTION
We expect that all 3 versions (`future<T>`, `future<R&>`, and
`future<void>`) will have identical implementations for some
functions, like `wait_for()`, or `wait_until()`. Refactor now to make
future changes smaller. Part of the work for #1345.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1376)
<!-- Reviewable:end -->
