### PR TITLE
Update manual formatting instructions [skip ci].

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,16 +73,19 @@ $ find google/cloud -o -name '*.h' -o -name '*.cc' -print0 \
     | xargs -0 clang-format -i
 ```
 
-You might find it convenient to reformat only the files which you actually
-touched:
+You might find it convenient to reformat only the files that you added or
+modified:
 ```console
-$ git status -s | awk 'NF>1{print $NF}' | grep -E '.*\.(cc|h)$' \
+$ git status -s \
+    | awk 'NF>1{print $NF}' \
+    | grep -E '.*\.(cc|h)$' \
+    | while read fpath; do if [ -f "$fpath" ]; then echo "$fpath"; fi; done \
     | xargs clang-format -i
 ```
 
 If you need to reformat one of the files to match the Google style.  Please be
 advised that `clang-format` has been known to generate slightly different
-formatting in different versions, we use version 4.0, use the same version if
+formatting in different versions. We use version 6.0; use the same version if
 you run into problems.
 
 If you have prepared a Docker image for `ubuntu:18.04` (see below), you can


### PR DESCRIPTION
The instructions for manually running clang-format did not take into
account files that had been removed (passing these to clang-format would
fail), and recommended using an old version of clang-format (we've moved
from 4.0 to 6.0).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1378)
<!-- Reviewable:end -->
