### PR TITLE
Add ComputeEngineCredentials to google_credentials

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -193,6 +193,7 @@ add_library(storage_client
             oauth2/anonymous_credentials.cc
             oauth2/authorized_user_credentials.h
             oauth2/authorized_user_credentials.cc
+            oauth2/compute_engine_credentials.h
             oauth2/credential_constants.h
             oauth2/credentials.h
             oauth2/google_application_default_credentials_file.h

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -325,6 +325,7 @@ set(storage_client_unit_tests
     list_objects_reader_test.cc
     oauth2/anonymous_credentials_test.cc
     oauth2/authorized_user_credentials_test.cc
+    oauth2/compute_engine_credentials_test.cc
     oauth2/google_application_default_credentials_file_test.cc
     oauth2/google_credentials_test.cc
     oauth2/service_account_credentials_test.cc

--- a/google/cloud/storage/oauth2/compute_engine_credentials.h
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.h
@@ -1,0 +1,204 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_COMPUTE_ENGINE_CREDENTIALS_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_COMPUTE_ENGINE_CREDENTIALS_H_
+
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/storage/internal/compute_engine_util.h"
+#include "google/cloud/storage/internal/curl_request_builder.h"
+#include "google/cloud/storage/internal/nljson.h"
+#include "google/cloud/storage/internal/openssl_util.h"
+#include "google/cloud/storage/oauth2/credential_constants.h"
+#include "google/cloud/storage/oauth2/credentials.h"
+#include "google/cloud/storage/status.h"
+#include <chrono>
+#include <condition_variable>
+#include <ctime>
+#include <iostream>
+#include <mutex>
+#include <set>
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace oauth2 {
+
+/**
+ * A C++ wrapper for Google's Compute Engine Service Account Credentials.
+ *
+ * Takes a service account email address or alias (e.g. "default") and uses
+ * the Google Compute Engine VM instance's metadata server to obtain service
+ * account metadata and OAuth2 access tokens.
+ *
+ * @see
+ *   https://cloud.google.com/compute/docs/authentication#using
+ *
+ * @tparam HttpRequestBuilderType a dependency injection point. It makes it
+ *     possible to mock the libcurl wrappers.
+ */
+template <typename HttpRequestBuilderType =
+              storage::internal::CurlRequestBuilder>
+class ComputeEngineCredentials : public Credentials {
+ public:
+  explicit ComputeEngineCredentials() : ComputeEngineCredentials("default") {}
+
+  explicit ComputeEngineCredentials(std::string const& service_account_email)
+      : expiration_time_(), service_account_email_(service_account_email) {}
+
+  std::string AuthorizationHeader() override {
+    std::unique_lock<std::mutex> lk(mu_);
+    cv_.wait(lk, [this]() { return Refresh().ok(); });
+    return authorization_header_;
+  }
+
+  /**
+   * Returns the email or alias of this credential's service account.
+   *
+   * Note that this class must query the Compute Engine instance's metadata
+   * server to fetch service account metadata. Because of this, if an alias
+   * (e.g. "default") was supplied in place of an actual email address when
+   * initializing this credential, that alias is returned as this credential's
+   * email address if the credential has not been refreshed yet.
+   */
+  std::string service_account_email() { return service_account_email_; }
+
+  /**
+   * Returns the set of scopes granted to this credential's service account.
+   *
+   * Note that because this class must query the Compute Engine instance's
+   * metadata server to fetch service account metadata, this method will return
+   * an empty set if the credential has not been refreshed yet.
+   */
+  std::set<std::string> scopes() { return scopes_; }
+
+ private:
+  storage::internal::HttpResponse DoMetadataServerGetRequest(std::string path,
+                                                             bool recursive) {
+    std::string metadata_server_hostname;
+    auto maybe_hostname =
+        ::google::cloud::internal::GetEnv("GCE_METADATA_ROOT");
+    if (maybe_hostname.has_value()) {
+      metadata_server_hostname = *maybe_hostname;
+    } else {
+      metadata_server_hostname = "metadata.google.internal";
+    }
+
+    HttpRequestBuilderType request_builder(
+        std::move("http://" + metadata_server_hostname + path),
+        storage::internal::GetDefaultCurlHandleFactory());
+    request_builder.AddHeader("metadata-flavor: Google");
+    if (recursive) {
+      request_builder.AddQueryParameter("recursive", "true");
+    }
+    return request_builder.BuildRequest().MakeRequest("");
+  }
+
+  storage::Status RetrieveServiceAccountInfo() {
+    namespace nl = storage::internal::nl;
+    auto response = DoMetadataServerGetRequest(
+        "/computeMetadata/v1/instance/service-accounts/" +
+            service_account_email_ + "/",
+        true);
+    if (response.status_code >= 300) {
+      return storage::Status(response.status_code, std::move(response.payload));
+    }
+
+    nl::json response_body = nl::json::parse(response.payload, nullptr, false);
+    // Note that the "scopes" attribute will always be present and contain a
+    // JSON array. At minimum, for the request to succeed, the instance must
+    // have been granted the scope that allows it to retrieve info from the
+    // metadata server.
+    if (response_body.is_discarded() or response_body.count("email") == 0U or
+        response_body.count("scopes") == 0U) {
+      return storage::Status(
+          response.status_code, std::move(response.payload),
+          "Could not find all required fields in response (email, scopes).");
+    }
+
+    std::string email = response_body.value("email", "");
+    std::set<std::string> scopes_set = response_body["scopes"];
+
+    // Do not update any state until all potential exceptions are raised.
+    service_account_email_ = email;
+    scopes_ = scopes_set;
+    return storage::Status();
+  }
+
+  storage::Status Refresh() {
+    namespace nl = storage::internal::nl;
+    if (std::chrono::system_clock::now() < expiration_time_) {
+      return storage::Status();
+    }
+
+    auto status = RetrieveServiceAccountInfo();
+    if (!status.ok()) {
+      // TODO(#516) - use retry policies.
+      return status;
+    }
+
+    auto response = DoMetadataServerGetRequest(
+        "/computeMetadata/v1/instance/service-accounts/" +
+            service_account_email_ + "/token",
+        false);
+    // TODO(#516) - use retry policies to refresh the credentials.
+    if (response.status_code >= 300) {
+      return storage::Status(response.status_code, std::move(response.payload));
+    }
+
+    // Response should have the attributes "access_token", "expires_in", and
+    // "token_type".
+    nl::json access_token = nl::json::parse(response.payload, nullptr, false);
+    if (access_token.is_discarded() or
+        access_token.count("access_token") == 0U or
+        access_token.count("expires_in") == 0U or
+        access_token.count("token_type") == 0U) {
+      return storage::Status(
+          response.status_code, std::move(response.payload),
+          "Could not find all required fields in response (access_token,"
+          " expires_in, token_type).");
+    }
+    std::string header = "Authorization: ";
+    header += access_token.value("token_type", "");
+    header += ' ';
+    header += access_token.value("access_token", "");
+    auto expires_in =
+        std::chrono::seconds(access_token.value("expires_in", int(0)));
+    auto new_expiration = std::chrono::system_clock::now() + expires_in -
+                          GoogleOAuthAccessTokenExpirationSlack();
+
+    // Do not update any state until all potential exceptions are raised.
+    authorization_header_ = std::move(header);
+    expiration_time_ = new_expiration;
+    return storage::Status();
+  }
+
+  std::mutex mu_;
+  std::condition_variable cv_;
+  // Credential attributes
+  std::string authorization_header_;
+  std::chrono::system_clock::time_point expiration_time_;
+  std::set<std::string> scopes_;
+  std::string service_account_email_;
+};
+
+}  // namespace oauth2
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_COMPUTE_ENGINE_CREDENTIALS_H_

--- a/google/cloud/storage/oauth2/compute_engine_credentials.h
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.h
@@ -26,7 +26,6 @@
 #include <chrono>
 #include <condition_variable>
 #include <ctime>
-#include <iostream>
 #include <mutex>
 #include <set>
 #include <string>
@@ -116,7 +115,6 @@ class ComputeEngineCredentials : public Credentials {
     // JSON array. At minimum, for the request to succeed, the instance must
     // have been granted the scope that allows it to retrieve info from the
     // metadata server.
-    std::cout << "Resp: " << response_body << std::endl;
     if (response_body.is_discarded() or response_body.count("email") == 0U or
         response_body.count("scopes") == 0U) {
       return storage::Status(

--- a/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
@@ -86,25 +86,23 @@ TEST_F(ComputeEngineCredentialsTest,
       }));
 
   // Both requests add this header.
-  EXPECT_CALL(*mock_req_builder,
-      AddHeader(StrEq("metadata-flavor: Google"))).Times(2);
+  EXPECT_CALL(*mock_req_builder, AddHeader(StrEq("metadata-flavor: Google")))
+      .Times(2);
   EXPECT_CALL(
       *mock_req_builder,
-      Constructor(
-          StrEq(std::string("http://") + hostname +
-                "/computeMetadata/v1/instance/service-accounts/" + email +
-                "/token")))
+      Constructor(StrEq(std::string("http://") + hostname +
+                        "/computeMetadata/v1/instance/service-accounts/" +
+                        email + "/token")))
       .Times(1);
   // Only the call to retrieve service account info sends this query param.
+  EXPECT_CALL(*mock_req_builder,
+              AddQueryParameter(StrEq("recursive"), StrEq("true")))
+      .Times(1);
   EXPECT_CALL(
       *mock_req_builder,
-      AddQueryParameter(StrEq("recursive"), StrEq("true"))).Times(1);
-  EXPECT_CALL(
-      *mock_req_builder,
-      Constructor(
-          StrEq(std::string("http://") + hostname +
-                "/computeMetadata/v1/instance/service-accounts/" + alias +
-                "/")))
+      Constructor(StrEq(std::string("http://") + hostname +
+                        "/computeMetadata/v1/instance/service-accounts/" +
+                        alias + "/")))
       .Times(1);
 
   ComputeEngineCredentials<MockHttpRequestBuilder> credentials(alias);
@@ -114,7 +112,6 @@ TEST_F(ComputeEngineCredentialsTest,
   // Make sure we obtain the scopes and email from the metadata server.
   EXPECT_EQ(email, credentials.service_account_email());
   EXPECT_THAT(credentials.scopes(), UnorderedElementsAre("scope1", "scope2"));
-
 }
 
 }  // namespace

--- a/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
@@ -1,0 +1,125 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/oauth2/compute_engine_credentials.h"
+#include "google/cloud/internal/setenv.h"
+#include "google/cloud/storage/internal/compute_engine_util.h"
+#include "google/cloud/storage/internal/nljson.h"
+#include "google/cloud/storage/oauth2/credential_constants.h"
+#include "google/cloud/storage/testing/mock_http_request.h"
+#include <gmock/gmock.h>
+#include <chrono>
+#include <cstring>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace oauth2 {
+namespace {
+using ::google::cloud::storage::internal::GceMetadataHostname;
+using ::google::cloud::storage::internal::HttpResponse;
+using ::google::cloud::storage::testing::MockHttpRequest;
+using ::google::cloud::storage::testing::MockHttpRequestBuilder;
+using ::testing::_;
+using ::testing::An;
+using ::testing::HasSubstr;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::StrEq;
+using ::testing::UnorderedElementsAre;
+
+class ComputeEngineCredentialsTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    MockHttpRequestBuilder::mock =
+        std::make_shared<MockHttpRequestBuilder::Impl>();
+  }
+  void TearDown() override { MockHttpRequestBuilder::mock.reset(); }
+};
+
+/// @test Verify that we can create and refresh ComputeEngineCredentials.
+TEST_F(ComputeEngineCredentialsTest,
+       RefreshingSendsCorrectRequestBodyAndParsesResponse) {
+  std::string alias = "default";
+  std::string email = "foo@bar.baz";
+  std::string hostname = GceMetadataHostname();
+  std::string svc_acct_info_resp = R"""({
+      "email": ")""" + email + R"""(",
+      "scopes": ["scope1","scope2"]
+  })""";
+  std::string token_info_resp = R"""({
+      "access_token": "mysupersecrettoken",
+      "expires_in": 3600,
+      "token_type": "tokentype"
+  })""";
+
+  auto first_mock_req_impl = std::make_shared<MockHttpRequest::Impl>();
+  EXPECT_CALL(*first_mock_req_impl, MakeRequest(_))
+      .WillOnce(Return(HttpResponse{200, svc_acct_info_resp, {}}));
+  auto second_mock_req_impl = std::make_shared<MockHttpRequest::Impl>();
+  EXPECT_CALL(*second_mock_req_impl, MakeRequest(_))
+      .WillOnce(Return(HttpResponse{200, token_info_resp, {}}));
+
+  auto mock_req_builder = MockHttpRequestBuilder::mock;
+  EXPECT_CALL(*mock_req_builder, BuildRequest())
+      .WillOnce(Invoke([first_mock_req_impl] {
+        MockHttpRequest mock_request;
+        mock_request.mock = first_mock_req_impl;
+        return mock_request;
+      }))
+      .WillOnce(Invoke([second_mock_req_impl] {
+        MockHttpRequest mock_request;
+        mock_request.mock = second_mock_req_impl;
+        return mock_request;
+      }));
+
+  // Both requests add this header.
+  EXPECT_CALL(*mock_req_builder,
+      AddHeader(StrEq("metadata-flavor: Google"))).Times(2);
+  EXPECT_CALL(
+      *mock_req_builder,
+      Constructor(
+          StrEq(std::string("http://") + hostname +
+                "/computeMetadata/v1/instance/service-accounts/" + email +
+                "/token")))
+      .Times(1);
+  // Only the call to retrieve service account info sends this query param.
+  EXPECT_CALL(
+      *mock_req_builder,
+      AddQueryParameter(StrEq("recursive"), StrEq("true"))).Times(1);
+  EXPECT_CALL(
+      *mock_req_builder,
+      Constructor(
+          StrEq(std::string("http://") + hostname +
+                "/computeMetadata/v1/instance/service-accounts/" + alias +
+                "/")))
+      .Times(1);
+
+  ComputeEngineCredentials<MockHttpRequestBuilder> credentials(alias);
+  // Calls Refresh to obtain the access token for our authorization header.
+  EXPECT_EQ("Authorization: tokentype mysupersecrettoken",
+            credentials.AuthorizationHeader());
+  // Make sure we obtain the scopes and email from the metadata server.
+  EXPECT_EQ(email, credentials.service_account_email());
+  EXPECT_THAT(UnorderedElementsAre("scope1", "scope2"));
+
+}
+
+}  // namespace
+}  // namespace oauth2
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
@@ -113,7 +113,7 @@ TEST_F(ComputeEngineCredentialsTest,
             credentials.AuthorizationHeader());
   // Make sure we obtain the scopes and email from the metadata server.
   EXPECT_EQ(email, credentials.service_account_email());
-  EXPECT_THAT(UnorderedElementsAre("scope1", "scope2"));
+  EXPECT_THAT(credentials.scopes(), UnorderedElementsAre("scope1", "scope2"));
 
 }
 

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/oauth2/anonymous_credentials.h"
 #include "google/cloud/storage/oauth2/authorized_user_credentials.h"
+#include "google/cloud/storage/oauth2/compute_engine_credentials.h"
 #include "google/cloud/storage/oauth2/google_application_default_credentials_file.h"
 #include "google/cloud/storage/oauth2/service_account_credentials.h"
 #include <fstream>
@@ -102,7 +103,9 @@ std::shared_ptr<Credentials> GoogleDefaultCredentials() {
 
   // TODO(#579): Check if running on App Engine flexible environment.
 
-  // TODO(#579): Check if running on Compute Engine.
+  if (storage::internal::RunningOnComputeEngineVm()) {
+    return std::make_shared<ComputeEngineCredentials<>>();
+  }
 
   // We've exhausted all search points, thus credentials cannot be constructed.
   std::string adc_link =

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -103,7 +103,9 @@ std::shared_ptr<Credentials> GoogleDefaultCredentials() {
 
   // TODO(#579): Check if running on App Engine flexible environment.
 
-  // TODO(#579): Check if running on App Engine flexible environment.
+  if (storage::internal::RunningOnComputeEngineVm()) {
+    return std::make_shared<ComputeEngineCredentials<>>();
+  }
 
   // We've exhausted all search points, thus credentials cannot be constructed.
   std::string adc_link =

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -103,9 +103,7 @@ std::shared_ptr<Credentials> GoogleDefaultCredentials() {
 
   // TODO(#579): Check if running on App Engine flexible environment.
 
-  if (storage::internal::RunningOnComputeEngineVm()) {
-    return std::make_shared<ComputeEngineCredentials<>>();
-  }
+  // TODO(#579): Check if running on App Engine flexible environment.
 
   // We've exhausted all search points, thus credentials cannot be constructed.
   std::string adc_link =

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -143,6 +143,15 @@ std::shared_ptr<Credentials> CreateServiceAccountCredentialsFromJsonContents(
   return std::make_shared<ServiceAccountCredentials<>>(contents, "memory");
 }
 
+std::shared_ptr<Credentials> CreateComputeEngineCredentials() {
+  return std::make_shared<ComputeEngineCredentials<>>();
+}
+
+std::shared_ptr<Credentials> CreateComputeEngineCredentials(
+    std::string const& service_account_email) {
+  return std::make_shared<ComputeEngineCredentials<>>(service_account_email);
+}
+
 }  // namespace oauth2
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/oauth2/google_credentials.h
+++ b/google/cloud/storage/oauth2/google_credentials.h
@@ -69,6 +69,12 @@ std::shared_ptr<Credentials> CreateServiceAccountCredentialsFromJsonFilePath(
 std::shared_ptr<Credentials> CreateServiceAccountCredentialsFromJsonContents(
     std::string const&);
 
+/// Creates a Google Compute Engine credential for the default service account.
+std::shared_ptr<Credentials> CreateComputeEngineCredentials();
+
+/// Creates a Google Compute Engine credential for the given service account.
+std::shared_ptr<Credentials> CreateComputeEngineCredentials(std::string const&);
+
 // TODO(#1193): Should we support loading service account credentials from a P12
 // file too? Other libraries do, but the JSON format is strongly preferred.
 

--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -202,6 +202,20 @@ TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsFromContents) {
   EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));
 }
 
+TEST_F(GoogleCredentialsTest, LoadComputeEngineCredentialsFromADCFlow) {
+  // Make sure other higher-precedence credentials (ADC env var, gcloud ADC from
+  // well-known path) aren't loaded.
+  UnsetEnv(GoogleAdcEnvVar());
+  UnsetEnv(GoogleGcloudAdcFileEnvVar());
+  // If the ADC flow thinks we're on a GCE instance, it should return
+  // ComputeEngineCredentials.
+  SetEnv(GceCheckOverrideEnvVar(), "1");
+
+  auto credentials = GoogleDefaultCredentials();
+  auto ptr = credentials.get();
+  EXPECT_EQ(typeid(*ptr), typeid(ComputeEngineCredentials<>));
+}
+
 TEST_F(GoogleCredentialsTest, CreateComputeEngineCredentialsWithDefaultEmail) {
   auto credentials = CreateComputeEngineCredentials();
   auto ptr = credentials.get();

--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/storage/internal/compute_engine_util.h"
 #include "google/cloud/storage/oauth2/anonymous_credentials.h"
 #include "google/cloud/storage/oauth2/authorized_user_credentials.h"
+#include "google/cloud/storage/oauth2/compute_engine_credentials.h"
 #include "google/cloud/storage/oauth2/google_application_default_credentials_file.h"
 #include "google/cloud/storage/oauth2/service_account_credentials.h"
 #include "google/cloud/testing_util/environment_variable_restore.h"
@@ -199,6 +200,24 @@ TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsFromContents) {
       SERVICE_ACCOUNT_CRED_CONTENTS);
   auto ptr = credentials.get();
   EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));
+}
+
+TEST_F(GoogleCredentialsTest, CreateComputeEngineCredentialsWithDefaultEmail) {
+  auto credentials = CreateComputeEngineCredentials();
+  auto ptr = credentials.get();
+  EXPECT_EQ(typeid(*ptr), typeid(ComputeEngineCredentials<>));
+  EXPECT_EQ(
+      std::string("default"),
+      dynamic_cast<ComputeEngineCredentials<>*>(ptr)->service_account_email());
+}
+
+TEST_F(GoogleCredentialsTest, CreateComputeEngineCredentialsWithExplicitEmail) {
+  auto credentials = CreateComputeEngineCredentials("foo@bar.baz");
+  auto ptr = credentials.get();
+  EXPECT_EQ(typeid(*ptr), typeid(ComputeEngineCredentials<>));
+  EXPECT_EQ(
+      std::string("foo@bar.baz"),
+      dynamic_cast<ComputeEngineCredentials<>*>(ptr)->service_account_email());
 }
 
 TEST_F(GoogleCredentialsTest, LoadUnknownTypeCredentials) {

--- a/google/cloud/storage/storage_client.bzl
+++ b/google/cloud/storage/storage_client.bzl
@@ -52,6 +52,7 @@ storage_client_HDRS = [
     "notification_payload_format.h",
     "oauth2/anonymous_credentials.h",
     "oauth2/authorized_user_credentials.h",
+    "oauth2/compute_engine_credentials.h",
     "oauth2/credential_constants.h",
     "oauth2/credentials.h",
     "oauth2/google_application_default_credentials_file.h",

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -37,6 +37,7 @@ storage_client_unit_tests = [
     "list_objects_reader_test.cc",
     "oauth2/anonymous_credentials_test.cc",
     "oauth2/authorized_user_credentials_test.cc",
+    "oauth2/compute_engine_credentials_test.cc",
     "oauth2/google_application_default_credentials_file_test.cc",
     "oauth2/google_credentials_test.cc",
     "oauth2/service_account_credentials_test.cc",


### PR DESCRIPTION
Add ComputeEngineCredentials support to the functionality in google_credentials.{h,cc}.  These changes are applied on top of those in #1380 (only the two most recent commits are new / specific to this PR), that PR should be reviewed first -- just wanted to get this PR out before the end of the day.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1381)
<!-- Reviewable:end -->
