### PR TITLE
Make retriable operations return an AsyncOperation

### DIFF
--- a/google/cloud/bigtable/internal/async_retry_op.h
+++ b/google/cloud/bigtable/internal/async_retry_op.h
@@ -87,6 +87,8 @@ struct HasAccumulatedResult<
  *    `std::unique_ptr<grpc::ClientContext>&&` and `Functor&&`, where `Functor`
  *    is invokable with `CompletionQueue&` and `grpc::Status&`,
  *  - the `AccumulatedResult` is invocable with no arguments,
+ *  - the `Start` function returns a
+ *        std::shared_ptr<::google::cloud::bigtable::AsyncOperation>
  *  - the `AccumulatedResult` function has the same return type as
  *    `Operation::Response`.
  */
@@ -102,7 +104,14 @@ struct MeetsAsyncOperationRequirements
               decltype(&Operation::AccumulatedResult), Operation&>,
           std::is_same<google::cloud::internal::invoke_result_t<
                            decltype(&Operation::AccumulatedResult), Operation&>,
-                       typename Operation::Response>> {};
+                       typename Operation::Response>,
+          std::is_same<
+              google::cloud::internal::invoke_result_t<
+                  decltype(&Operation::template Start<PrototypeStartCallback>),
+                  Operation&, CompletionQueue&,
+                  std::unique_ptr<grpc::ClientContext>&&,
+                  PrototypeStartCallback&&>,
+              std::shared_ptr<::google::cloud::bigtable::AsyncOperation>>> {};
 
 /**
  * Perform an asynchronous operation, with retries.

--- a/google/cloud/bigtable/internal/async_retry_op.h
+++ b/google/cloud/bigtable/internal/async_retry_op.h
@@ -87,8 +87,7 @@ struct HasAccumulatedResult<
  *    `std::unique_ptr<grpc::ClientContext>&&` and `Functor&&`, where `Functor`
  *    is invokable with `CompletionQueue&` and `grpc::Status&`,
  *  - the `AccumulatedResult` is invocable with no arguments,
- *  - the `Start` function returns a
- *        std::shared_ptr<::google::cloud::bigtable::AsyncOperation>
+ *  - the `Start` function returns a std::shared_ptr<AsyncOperation>
  *  - the `AccumulatedResult` function has the same return type as
  *    `Operation::Response`.
  */
@@ -111,7 +110,7 @@ struct MeetsAsyncOperationRequirements
                   Operation&, CompletionQueue&,
                   std::unique_ptr<grpc::ClientContext>&&,
                   PrototypeStartCallback&&>,
-              std::shared_ptr<::google::cloud::bigtable::AsyncOperation>>> {};
+              std::shared_ptr<AsyncOperation>>> {};
 
 /**
  * Perform an asynchronous operation, with retries.

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc.h
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc.h
@@ -92,15 +92,16 @@ class AsyncUnaryRpc {
                 google::cloud::internal::is_invocable<Functor, CompletionQueue&,
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
-  void Start(CompletionQueue& cq,
-             std::unique_ptr<grpc::ClientContext>&& context,
-             Functor&& callback) {
-    cq.MakeUnaryRpc(*client_, call_, request_, std::move(context),
-                    [this, callback](CompletionQueue& cq, Response& response,
-                                     grpc::Status& status) {
-                      response_ = std::move(response);
-                      callback(cq, status);
-                    });
+  std::shared_ptr<AsyncOperation> Start(
+      CompletionQueue& cq, std::unique_ptr<grpc::ClientContext>&& context,
+      Functor&& callback) {
+    return cq.MakeUnaryRpc(
+        *client_, call_, request_, std::move(context),
+        [this, callback](CompletionQueue& cq, Response& response,
+                         grpc::Status& status) {
+          response_ = std::move(response);
+          callback(cq, status);
+        });
   }
 
   Response AccumulatedResult() { return response_; }

--- a/google/cloud/bigtable/internal/async_sample_row_keys.h
+++ b/google/cloud/bigtable/internal/async_sample_row_keys.h
@@ -72,10 +72,10 @@ class AsyncSampleRowKeys {
                 google::cloud::internal::is_invocable<Functor, CompletionQueue&,
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
-  void Start(CompletionQueue& cq,
-             std::unique_ptr<grpc::ClientContext>&& context,
-             Functor&& callback) {
-    cq.MakeUnaryStreamRpc(
+  std::shared_ptr<::google::cloud::bigtable::AsyncOperation> Start(
+      CompletionQueue& cq, std::unique_ptr<grpc::ClientContext>&& context,
+      Functor&& callback) {
+    return cq.MakeUnaryStreamRpc(
         *client_, &DataClient::AsyncSampleRowKeys, request_, std::move(context),
         [this](CompletionQueue&, const grpc::ClientContext&,
                google::bigtable::v2::SampleRowKeysResponse& response) {

--- a/google/cloud/bigtable/internal/async_sample_row_keys.h
+++ b/google/cloud/bigtable/internal/async_sample_row_keys.h
@@ -72,7 +72,7 @@ class AsyncSampleRowKeys {
                 google::cloud::internal::is_invocable<Functor, CompletionQueue&,
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
-  std::shared_ptr<::google::cloud::bigtable::AsyncOperation> Start(
+  std::shared_ptr<AsyncOperation> Start(
       CompletionQueue& cq, std::unique_ptr<grpc::ClientContext>&& context,
       Functor&& callback) {
     return cq.MakeUnaryStreamRpc(

--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -121,11 +121,11 @@ class AsyncBulkMutator : private BulkMutator {
                 google::cloud::internal::is_invocable<Functor, CompletionQueue&,
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
-  void Start(CompletionQueue& cq,
-             std::unique_ptr<grpc::ClientContext>&& context,
-             Functor&& callback) {
+  std::shared_ptr<::google::cloud::bigtable::AsyncOperation> Start(
+      CompletionQueue& cq, std::unique_ptr<grpc::ClientContext>&& context,
+      Functor&& callback) {
     PrepareForRequest();
-    cq.MakeUnaryStreamRpc(
+    return cq.MakeUnaryStreamRpc(
         *client_, &DataClient::AsyncMutateRows, mutations_, std::move(context),
         [this](CompletionQueue&, const grpc::ClientContext&,
                google::bigtable::v2::MutateRowsResponse& response) {

--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -121,7 +121,7 @@ class AsyncBulkMutator : private BulkMutator {
                 google::cloud::internal::is_invocable<Functor, CompletionQueue&,
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
-  std::shared_ptr<::google::cloud::bigtable::AsyncOperation> Start(
+  std::shared_ptr<AsyncOperation> Start(
       CompletionQueue& cq, std::unique_ptr<grpc::ClientContext>&& context,
       Functor&& callback) {
     PrepareForRequest();


### PR DESCRIPTION
This is a part of #1305.

AsyncRetryOp will need to be cancellable and in order to achieve it, in
needs to keep an AsyncOperation of the underlaying operations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1388)
<!-- Reviewable:end -->
