### PR TITLE
Call AsyncRetryOp::Start() in ctor.

### DIFF
--- a/google/cloud/bigtable/internal/async_bulk_apply.h
+++ b/google/cloud/bigtable/internal/async_bulk_apply.h
@@ -69,7 +69,7 @@ class AsyncRetryBulkApply : public AsyncRetryOp<ConstantIdempotencyPolicy,
                       std::shared_ptr<bigtable::DataClient> client,
                       bigtable::AppProfileId const& app_profile_id,
                       bigtable::TableId const& table_name, BulkMutation&& mut,
-                      Functor&& callback)
+                      Functor&& callback, CompletionQueue& cq)
       : AsyncRetryOp<ConstantIdempotencyPolicy, Functor, AsyncBulkMutator>(
             __func__, std::move(rpc_retry_policy),
             // BulkMutator is idempotent because it keeps track of idempotency
@@ -78,7 +78,8 @@ class AsyncRetryBulkApply : public AsyncRetryOp<ConstantIdempotencyPolicy,
             std::move(metadata_update_policy), std::forward<Functor>(callback),
             AsyncBulkMutator(client, std::move(app_profile_id),
                              std::move(table_name), idempotent_policy,
-                             std::forward<BulkMutation>(mut))) {}
+                             std::forward<BulkMutation>(mut)),
+            cq) {}
 };
 
 }  // namespace internal

--- a/google/cloud/bigtable/internal/async_retry_op.h
+++ b/google/cloud/bigtable/internal/async_retry_op.h
@@ -152,15 +152,19 @@ class AsyncRetryOp : public std::enable_shared_from_this<
                         std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
                         IdempotencyPolicy idempotent_policy,
                         MetadataUpdatePolicy metadata_update_policy,
-                        Functor&& callback, Operation&& operation)
+                        Functor&& callback, Operation&& operation,
+                        CompletionQueue& cq)
       : error_message_(error_message),
         rpc_retry_policy_(std::move(rpc_retry_policy)),
         rpc_backoff_policy_(std::move(rpc_backoff_policy)),
         idempotent_policy_(std::move(idempotent_policy)),
         metadata_update_policy_(std::move(metadata_update_policy)),
         callback_(std::forward<Functor>(callback)),
-        operation_(std::move(operation)) {}
+        operation_(std::move(operation)) {
+    Start(cq);
+  }
 
+ private:
   /**
    * Kick off the asynchronous request.
    *
@@ -179,7 +183,6 @@ class AsyncRetryOp : public std::enable_shared_from_this<
                      });
   }
 
- private:
   std::string FullErrorMessage(char const* where) {
     std::string full_message = error_message_;
     full_message += "(" + metadata_update_policy_.value() + ") ";

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc.h
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc.h
@@ -136,14 +136,15 @@ class AsyncRetryUnaryRpc
       IdempotencyPolicy idempotent_policy,
       MetadataUpdatePolicy metadata_update_policy,
       std::shared_ptr<Client> client, MemberFunctionType Client::*call,
-      Request&& request, Functor&& callback)
+      Request&& request, Functor&& callback, CompletionQueue& cq)
       : AsyncRetryOp<IdempotencyPolicy, Functor,
                      AsyncUnaryRpc<Client, MemberFunctionType>>(
             error_message, std::move(rpc_retry_policy),
             std::move(rpc_backoff_policy), std::move(idempotent_policy),
             std::move(metadata_update_policy), std::forward<Functor>(callback),
             AsyncUnaryRpc<Client, MemberFunctionType>(
-                std::move(client), std::move(call), std::move(request))) {}
+                std::move(client), std::move(call), std::move(request)),
+            cq) {}
 };
 
 }  // namespace internal

--- a/google/cloud/bigtable/internal/async_sample_row_keys.h
+++ b/google/cloud/bigtable/internal/async_sample_row_keys.h
@@ -151,7 +151,7 @@ class AsyncRetrySampleRowKeys
                           std::shared_ptr<bigtable::DataClient> client,
                           bigtable::AppProfileId const& app_profile_id,
                           bigtable::TableId const& table_name,
-                          Functor&& callback)
+                          Functor&& callback, CompletionQueue& cq)
       : AsyncRetryOp<ConstantIdempotencyPolicy, Functor, AsyncSampleRowKeys>(
             error_message, std::move(rpc_retry_policy),
             // BulkMutator is idempotent because it keeps track of idempotency
@@ -159,7 +159,8 @@ class AsyncRetrySampleRowKeys
             std::move(rpc_backoff_policy), ConstantIdempotencyPolicy(true),
             std::move(metadata_update_policy), std::forward<Functor>(callback),
             AsyncSampleRowKeys(client, std::move(app_profile_id),
-                               std::move(table_name))) {}
+                               std::move(table_name)),
+            cq) {}
 };
 
 }  // namespace internal

--- a/google/cloud/bigtable/internal/instance_admin.h
+++ b/google/cloud/bigtable/internal/instance_admin.h
@@ -157,12 +157,11 @@ class InstanceAdmin {
                                      internal::ConstantIdempotencyPolicy,
                                      Functor>;
 
-    auto retry = std::make_shared<Retry>(
+    std::make_shared<Retry>(
         __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
         internal::ConstantIdempotencyPolicy(true), metadata_update_policy_,
         client_, &InstanceAdminClient::AsyncGetInstance, std::move(request),
-        std::forward<Functor>(callback));
-    retry->Start(cq);
+        std::forward<Functor>(callback), cq);
   }
 
   void DeleteInstance(std::string const& instance_id, grpc::Status& status);
@@ -208,12 +207,11 @@ class InstanceAdmin {
                                      internal::ConstantIdempotencyPolicy,
                                      Functor>;
 
-    auto retry = std::make_shared<Retry>(
+    std::make_shared<Retry>(
         __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
         internal::ConstantIdempotencyPolicy(true), metadata_update_policy_,
         client_, &InstanceAdminClient::AsyncDeleteInstance, std::move(request),
-        std::forward<Functor>(callback));
-    retry->Start(cq);
+        std::forward<Functor>(callback), cq);
   }
 
   std::vector<google::bigtable::admin::v2::Cluster> ListClusters(
@@ -266,12 +264,11 @@ class InstanceAdmin {
                                      internal::ConstantIdempotencyPolicy,
                                      Functor>;
 
-    auto retry = std::make_shared<Retry>(
+    std::make_shared<Retry>(
         __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
         internal::ConstantIdempotencyPolicy(true), metadata_update_policy_,
         client_, &InstanceAdminClient::AsyncDeleteCluster, std::move(request),
-        std::forward<Functor>(callback));
-    retry->Start(cq);
+        std::forward<Functor>(callback), cq);
   }
 
   google::bigtable::admin::v2::Cluster GetCluster(
@@ -321,12 +318,11 @@ class InstanceAdmin {
                                      internal::ConstantIdempotencyPolicy,
                                      Functor>;
 
-    auto retry = std::make_shared<Retry>(
+    std::make_shared<Retry>(
         __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
         internal::ConstantIdempotencyPolicy(true), metadata_update_policy_,
         client_, &InstanceAdminClient::AsyncGetCluster, std::move(request),
-        std::forward<Functor>(callback));
-    retry->Start(cq);
+        std::forward<Functor>(callback), cq);
   }
 
   google::longrunning::Operation UpdateAppProfile(
@@ -378,12 +374,11 @@ class InstanceAdmin {
                                      internal::ConstantIdempotencyPolicy,
                                      Functor>;
 
-    auto retry = std::make_shared<Retry>(
+    std::make_shared<Retry>(
         __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
         internal::ConstantIdempotencyPolicy(true), metadata_update_policy_,
         client_, &InstanceAdminClient::AsyncCreateAppProfile,
-        std::move(request), std::forward<Functor>(callback));
-    retry->Start(cq);
+        std::move(request), std::forward<Functor>(callback), cq);
   }
 
   google::bigtable::admin::v2::AppProfile GetAppProfile(
@@ -435,12 +430,11 @@ class InstanceAdmin {
                                      internal::ConstantIdempotencyPolicy,
                                      Functor>;
 
-    auto retry = std::make_shared<Retry>(
+    std::make_shared<Retry>(
         __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
         internal::ConstantIdempotencyPolicy(true), metadata_update_policy_,
         client_, &InstanceAdminClient::AsyncGetAppProfile, std::move(request),
-        std::forward<Functor>(callback));
-    retry->Start(cq);
+        std::forward<Functor>(callback), cq);
   }
 
   std::vector<google::bigtable::admin::v2::AppProfile> ListAppProfiles(
@@ -494,12 +488,11 @@ class InstanceAdmin {
                                      internal::ConstantIdempotencyPolicy,
                                      Functor>;
 
-    auto retry = std::make_shared<Retry>(
+    std::make_shared<Retry>(
         __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
         internal::ConstantIdempotencyPolicy(true), metadata_update_policy_,
         client_, &InstanceAdminClient::AsyncDeleteAppProfile,
-        std::move(request), std::forward<Functor>(callback));
-    retry->Start(cq);
+        std::move(request), std::forward<Functor>(callback), cq);
   }
 
   google::cloud::IamPolicy GetIamPolicy(std::string const& instance_id,

--- a/google/cloud/bigtable/internal/table.h
+++ b/google/cloud/bigtable/internal/table.h
@@ -194,8 +194,7 @@ class Table {
         __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
         internal::ConstantIdempotencyPolicy(is_idempotent),
         metadata_update_policy_, client_, &DataClient::AsyncMutateRow,
-        std::move(request), std::forward<Functor>(callback));
-    retry->Start(cq);
+        std::move(request), std::forward<Functor>(callback), cq);
   }
 
   /**
@@ -221,14 +220,11 @@ class Table {
                 int>::type valid_callback_type = 0>
   void AsyncBulkApply(BulkMutation&& mut, CompletionQueue& cq,
                       Functor&& callback) {
-    auto op =
-        std::make_shared<bigtable::internal::AsyncRetryBulkApply<Functor>>(
-            rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
-            *idempotent_mutation_policy_, metadata_update_policy_, client_,
-            app_profile_id_, table_name_, std::move(mut),
-            std::forward<Functor>(callback));
-
-    op->Start(cq);
+    std::make_shared<bigtable::internal::AsyncRetryBulkApply<Functor>>(
+        rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
+        *idempotent_mutation_policy_, metadata_update_policy_, client_,
+        app_profile_id_, table_name_, std::move(mut),
+        std::forward<Functor>(callback), cq);
   }
 
   std::vector<FailedMutation> BulkApply(BulkMutation&& mut,
@@ -303,13 +299,10 @@ class Table {
                     grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
   void AsyncSampleRowKeys(CompletionQueue& cq, Functor&& callback) {
-    auto op =
-        std::make_shared<bigtable::internal::AsyncRetrySampleRowKeys<Functor>>(
-            __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
-            metadata_update_policy_, client_, app_profile_id_, table_name_,
-            std::forward<Functor>(callback));
-
-    op->Start(cq);
+    std::make_shared<bigtable::internal::AsyncRetrySampleRowKeys<Functor>>(
+        __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
+        metadata_update_policy_, client_, app_profile_id_, table_name_,
+        std::forward<Functor>(callback), cq);
   }
   //@}
 

--- a/google/cloud/bigtable/internal/table_admin.h
+++ b/google/cloud/bigtable/internal/table_admin.h
@@ -154,12 +154,11 @@ class TableAdmin {
                                      internal::ConstantIdempotencyPolicy,
                                      Functor>;
 
-    auto retry = std::make_shared<Retry>(
+    std::make_shared<Retry>(
         __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
         internal::ConstantIdempotencyPolicy(false), metadata_update_policy_,
         client_, &AdminClient::AsyncCreateTable, std::move(request),
-        std::forward<Functor>(callback));
-    retry->Start(cq);
+        std::forward<Functor>(callback), cq);
   }
 
   std::vector<google::bigtable::admin::v2::Table> ListTables(
@@ -210,12 +209,11 @@ class TableAdmin {
                                      internal::ConstantIdempotencyPolicy,
                                      Functor>;
 
-    auto retry = std::make_shared<Retry>(
+    std::make_shared<Retry>(
         __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
         internal::ConstantIdempotencyPolicy(true), metadata_update_policy_,
         client_, &AdminClient::AsyncGetTable, std::move(request),
-        std::forward<Functor>(callback));
-    retry->Start(cq);
+        std::forward<Functor>(callback), cq);
   }
 
   void DeleteTable(std::string const& table_id, grpc::Status& status);
@@ -309,12 +307,11 @@ class TableAdmin {
                                      internal::ConstantIdempotencyPolicy,
                                      Functor>;
 
-    auto retry = std::make_shared<Retry>(
+    std::make_shared<Retry>(
         __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
         internal::ConstantIdempotencyPolicy(false), metadata_update_policy,
         client_, &AdminClient::AsyncModifyColumnFamilies, std::move(request),
-        std::forward<Functor>(callback));
-    retry->Start(cq);
+        std::forward<Functor>(callback), cq);
   }
 
   /**
@@ -363,12 +360,11 @@ class TableAdmin {
                                      internal::ConstantIdempotencyPolicy,
                                      Functor>;
 
-    auto retry = std::make_shared<Retry>(
+    std::make_shared<Retry>(
         __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
         internal::ConstantIdempotencyPolicy(false), metadata_update_policy,
         client_, &AdminClient::AsyncDropRowRange, std::move(request),
-        std::forward<Functor>(callback));
-    retry->Start(cq);
+        std::forward<Functor>(callback), cq);
   }
 
   /**
@@ -414,12 +410,11 @@ class TableAdmin {
                                      internal::ConstantIdempotencyPolicy,
                                      Functor>;
 
-    auto retry = std::make_shared<Retry>(
+    std::make_shared<Retry>(
         __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
         internal::ConstantIdempotencyPolicy(false), metadata_update_policy,
         client_, &AdminClient::AsyncDropRowRange, std::move(request),
-        std::forward<Functor>(callback));
-    retry->Start(cq);
+        std::forward<Functor>(callback), cq);
   }
 
   /**
@@ -470,12 +465,11 @@ class TableAdmin {
                                      internal::ConstantIdempotencyPolicy,
                                      Functor>;
 
-    auto retry = std::make_shared<Retry>(
+    std::make_shared<Retry>(
         __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
         internal::ConstantIdempotencyPolicy(false), metadata_update_policy,
         client_, &AdminClient::AsyncGetSnapshot, std::move(request),
-        std::forward<Functor>(callback));
-    retry->Start(cq);
+        std::forward<Functor>(callback), cq);
   }
 
   /**
@@ -528,12 +522,11 @@ class TableAdmin {
                                      internal::ConstantIdempotencyPolicy,
                                      Functor>;
 
-    auto retry = std::make_shared<Retry>(
+    std::make_shared<Retry>(
         __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
         internal::ConstantIdempotencyPolicy(false), metadata_update_policy,
         client_, &AdminClient::AsyncDeleteSnapshot, std::move(request),
-        std::forward<Functor>(callback));
-    retry->Start(cq);
+        std::forward<Functor>(callback), cq);
   }
   //@}
 


### PR DESCRIPTION
By calling `Start()` straight away in `AsyncRetryOp` ctor, I'm removing
one state which tha object can be in (i.e. created, but not yet started).
That makes it easier to implement cancellation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1393)
<!-- Reviewable:end -->
