### PR TITLE
Implement StrictIdempotentPolicy for *Acl.

### DIFF
--- a/google/cloud/storage/idempotency_policy.cc
+++ b/google/cloud/storage/idempotency_policy.cc
@@ -331,95 +331,92 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::ListBucketAclRequest const& request) const {
-  // TODO(#714) - determine if the request is idempotent and return accordingly.
   return true;
 }
+
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::CreateBucketAclRequest const& request) const {
-  // TODO(#714) - determine if the request is idempotent and return accordingly.
-  return true;
+  return request.HasOption<IfMatchEtag>();
 }
+
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::DeleteBucketAclRequest const& request) const {
-  // TODO(#714) - determine if the request is idempotent and return accordingly.
-  return true;
+  return request.HasOption<IfMatchEtag>();
 }
+
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::GetBucketAclRequest const& request) const {
-  // TODO(#714) - determine if the request is idempotent and return accordingly.
   return true;
 }
+
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::UpdateBucketAclRequest const& request) const {
-  // TODO(#714) - determine if the request is idempotent and return accordingly.
-  return true;
+  return request.HasOption<IfMatchEtag>();
 }
+
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::PatchBucketAclRequest const& request) const {
-  // TODO(#714) - determine if the request is idempotent and return accordingly.
-  return true;
+  return request.HasOption<IfMatchEtag>();
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::ListObjectAclRequest const& request) const {
-  // TODO(#714) - determine if the request is idempotent and return accordingly.
-  return true;
-}
-bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::CreateObjectAclRequest const& request) const {
-  // TODO(#714) - determine if the request is idempotent and return accordingly.
-  return true;
-}
-bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::DeleteObjectAclRequest const& request) const {
-  // TODO(#714) - determine if the request is idempotent and return accordingly.
-  return true;
-}
-bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::GetObjectAclRequest const& request) const {
-  // TODO(#714) - determine if the request is idempotent and return accordingly.
-  return true;
-}
-bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::UpdateObjectAclRequest const& request) const {
-  // TODO(#714) - determine if the request is idempotent and return accordingly.
-  return true;
-}
-bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::PatchObjectAclRequest const& request) const {
-  // TODO(#714) - determine if the request is idempotent and return accordingly.
   return true;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::ListDefaultObjectAclRequest const& request) const {
-  // TODO(#714) - determine if the request is idempotent and return accordingly.
+    internal::CreateObjectAclRequest const& request) const {
+  return request.HasOption<IfMatchEtag>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::DeleteObjectAclRequest const& request) const {
+  return request.HasOption<IfMatchEtag>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::GetObjectAclRequest const& request) const {
   return true;
 }
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::UpdateObjectAclRequest const& request) const {
+  return request.HasOption<IfMatchEtag>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::PatchObjectAclRequest const& request) const {
+  return request.HasOption<IfMatchEtag>();
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::ListDefaultObjectAclRequest const& request) const {
+  return true;
+}
+
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::CreateDefaultObjectAclRequest const& request) const {
-  // TODO(#714) - determine if the request is idempotent and return accordingly.
-  return true;
+  return request.HasOption<IfMatchEtag>();
 }
+
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::DeleteDefaultObjectAclRequest const& request) const {
-  // TODO(#714) - determine if the request is idempotent and return accordingly.
-  return true;
+  return request.HasOption<IfMatchEtag>();
 }
+
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::GetDefaultObjectAclRequest const& request) const {
-  // TODO(#714) - determine if the request is idempotent and return accordingly.
   return true;
 }
+
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::UpdateDefaultObjectAclRequest const& request) const {
-  // TODO(#714) - determine if the request is idempotent and return accordingly.
-  return true;
+  return request.HasOption<IfMatchEtag>();
 }
+
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::PatchDefaultObjectAclRequest const& request) const {
-  // TODO(#714) - determine if the request is idempotent and return accordingly.
-  return true;
+  return request.HasOption<IfMatchEtag>();
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(

--- a/google/cloud/storage/idempotency_policy_test.cc
+++ b/google/cloud/storage/idempotency_policy_test.cc
@@ -285,6 +285,231 @@ TEST(StrictIdempotencyPolicyTest, RewriteObjectIfGenerationMatch) {
   EXPECT_TRUE(policy.IsIdempotent(request));
 }
 
+TEST(StrictIdempotencyPolicyTest, ListBucketAcl) {
+  StrictIdempotencyPolicy policy;
+  internal::ListBucketAclRequest request("test-bucket-name");
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, CreateBucketAcl) {
+  StrictIdempotencyPolicy policy;
+  internal::CreateBucketAclRequest request("test-bucket-name",
+                                           "test-entity-name", "READER");
+  EXPECT_FALSE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, CreateBucketAclIfMatchEtag) {
+  StrictIdempotencyPolicy policy;
+  internal::CreateBucketAclRequest request("test-bucket-name",
+                                           "test-entity-name", "READER");
+  request.set_option(IfMatchEtag("ABC123="));
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, DeleteBucketAcl) {
+  StrictIdempotencyPolicy policy;
+  internal::DeleteBucketAclRequest request("test-bucket-name",
+                                           "test-entity-name");
+  EXPECT_FALSE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, DeleteBucketAclIfMatchEtag) {
+  StrictIdempotencyPolicy policy;
+  internal::DeleteBucketAclRequest request("test-bucket-name",
+                                           "test-entity-name");
+  request.set_option(IfMatchEtag("ABC123="));
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, GetBucketAcl) {
+  StrictIdempotencyPolicy policy;
+  internal::GetBucketAclRequest request("test-bucket-name", "test-entity-name");
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, UpdateBucketAcl) {
+  StrictIdempotencyPolicy policy;
+  internal::UpdateBucketAclRequest request("test-bucket-name",
+                                           "test-entity-name", "READER");
+  EXPECT_FALSE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, UpdateBucketAclIfMatchEtag) {
+  StrictIdempotencyPolicy policy;
+  internal::UpdateBucketAclRequest request("test-bucket-name",
+                                           "test-entity-name", "READER");
+  request.set_option(IfMatchEtag("ABC123="));
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, PatchBucketAcl) {
+  StrictIdempotencyPolicy policy;
+  internal::PatchBucketAclRequest request("test-bucket-name",
+                                          "test-entity-name",
+                                          BucketAccessControlPatchBuilder());
+  EXPECT_FALSE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, PatchBucketAclIfMatchEtag) {
+  StrictIdempotencyPolicy policy;
+  internal::PatchBucketAclRequest request("test-bucket-name",
+                                          "test-entity-name",
+                                          BucketAccessControlPatchBuilder());
+  request.set_option(IfMatchEtag("ABC123="));
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, ListObjectAcl) {
+  StrictIdempotencyPolicy policy;
+  internal::ListObjectAclRequest request("test-bucket-name",
+                                         "test-object-name");
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, CreateObjectAcl) {
+  StrictIdempotencyPolicy policy;
+  internal::CreateObjectAclRequest request(
+      "test-bucket-name", "test-object-name", "test-entity-name", "READER");
+  EXPECT_FALSE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, CreateObjectAclIfMatchEtag) {
+  StrictIdempotencyPolicy policy;
+  internal::CreateObjectAclRequest request(
+      "test-bucket-name", "test-object-name", "test-entity-name", "READER");
+  request.set_option(IfMatchEtag("ABC123="));
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, DeleteObjectAcl) {
+  StrictIdempotencyPolicy policy;
+  internal::DeleteObjectAclRequest request(
+      "test-bucket-name", "test-object-name", "test-entity-name");
+  EXPECT_FALSE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, DeleteObjectAclIfMatchEtag) {
+  StrictIdempotencyPolicy policy;
+  internal::DeleteObjectAclRequest request(
+      "test-bucket-name", "test-object-name", "test-entity-name");
+  request.set_option(IfMatchEtag("ABC123="));
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, GetObjectAcl) {
+  StrictIdempotencyPolicy policy;
+  internal::GetObjectAclRequest request("test-bucket-name", "test-object-name",
+                                        "test-entity-name");
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, UpdateObjectAcl) {
+  StrictIdempotencyPolicy policy;
+  internal::UpdateObjectAclRequest request(
+      "test-bucket-name", "test-object-name", "test-entity-name", "READER");
+  EXPECT_FALSE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, UpdateObjectAclIfMatchEtag) {
+  StrictIdempotencyPolicy policy;
+  internal::UpdateObjectAclRequest request(
+      "test-bucket-name", "test-object-name", "test-entity-name", "READER");
+  request.set_option(IfMatchEtag("ABC123="));
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, PatchObjectAcl) {
+  StrictIdempotencyPolicy policy;
+  internal::PatchObjectAclRequest request(
+      "test-bucket-name", "test-object-name", "test-entity-name",
+      ObjectAccessControlPatchBuilder());
+  EXPECT_FALSE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, PatchObjectAclIfMatchEtag) {
+  StrictIdempotencyPolicy policy;
+  internal::PatchObjectAclRequest request(
+      "test-bucket-name", "test-object-name", "test-entity-name",
+      ObjectAccessControlPatchBuilder());
+  request.set_option(IfMatchEtag("ABC123="));
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, ListDefaultObjectAcl) {
+  StrictIdempotencyPolicy policy;
+  internal::ListDefaultObjectAclRequest request("test-bucket-name");
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, CreateDefaultObjectAcl) {
+  StrictIdempotencyPolicy policy;
+  internal::CreateDefaultObjectAclRequest request("test-bucket-name",
+                                                  "test-entity-name", "READER");
+  EXPECT_FALSE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, CreateDefaultObjectAclIfMatchEtag) {
+  StrictIdempotencyPolicy policy;
+  internal::CreateDefaultObjectAclRequest request("test-bucket-name",
+                                                  "test-entity-name", "READER");
+  request.set_option(IfMatchEtag("ABC123="));
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, DeleteDefaultObjectAcl) {
+  StrictIdempotencyPolicy policy;
+  internal::DeleteDefaultObjectAclRequest request("test-bucket-name",
+                                                  "test-entity-name");
+  EXPECT_FALSE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, DeleteDefaultObjectAclIfMatchEtag) {
+  StrictIdempotencyPolicy policy;
+  internal::DeleteDefaultObjectAclRequest request("test-bucket-name",
+                                                  "test-entity-name");
+  request.set_option(IfMatchEtag("ABC123="));
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, GetDefaultObjectAcl) {
+  StrictIdempotencyPolicy policy;
+  internal::GetDefaultObjectAclRequest request("test-bucket-name",
+                                               "test-entity-name");
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, UpdateDefaultObjectAcl) {
+  StrictIdempotencyPolicy policy;
+  internal::UpdateDefaultObjectAclRequest request("test-bucket-name",
+                                                  "test-entity-name", "READER");
+  EXPECT_FALSE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, UpdateDefaultObjectAclIfMatchEtag) {
+  StrictIdempotencyPolicy policy;
+  internal::UpdateDefaultObjectAclRequest request("test-bucket-name",
+                                                  "test-entity-name", "READER");
+  request.set_option(IfMatchEtag("ABC123="));
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, PatchDefaultObjectAcl) {
+  StrictIdempotencyPolicy policy;
+  internal::PatchDefaultObjectAclRequest request(
+      "test-bucket-name", "test-entity-name",
+      ObjectAccessControlPatchBuilder());
+  EXPECT_FALSE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, PatchDefaultObjectAclIfMatchEtag) {
+  StrictIdempotencyPolicy policy;
+  internal::PatchDefaultObjectAclRequest request(
+      "test-bucket-name", "test-entity-name",
+      ObjectAccessControlPatchBuilder());
+  request.set_option(IfMatchEtag("ABC123="));
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
 }  // namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage


### PR DESCRIPTION
This is part of the work for #714. Sorry for the larger PR, I think it
should be Okay since all the *Acl requests have the same behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1395)
<!-- Reviewable:end -->
