### PR TITLE
Refactor testing types to library.

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -154,7 +154,9 @@ add_library(google_cloud_cpp_testing
             testing_util/environment_variable_restore.cc
             testing_util/custom_google_mock_main.cc
             testing_util/init_google_mock.h
-            testing_util/init_google_mock.cc)
+            testing_util/init_google_mock.cc
+            testing_util/testing_types.h
+            testing_util/testing_types.cc)
 target_link_libraries(google_cloud_cpp_testing
                       PUBLIC google_cloud_cpp_common GTest::gmock)
 

--- a/google/cloud/google_cloud_cpp_testing.bzl
+++ b/google/cloud/google_cloud_cpp_testing.bzl
@@ -5,6 +5,7 @@ google_cloud_cpp_testing_HDRS = [
     "testing_util/chrono_literals.h",
     "testing_util/environment_variable_restore.h",
     "testing_util/init_google_mock.h",
+    "testing_util/testing_types.h",
 ]
 
 google_cloud_cpp_testing_SRCS = [
@@ -12,4 +13,5 @@ google_cloud_cpp_testing_SRCS = [
     "testing_util/environment_variable_restore.cc",
     "testing_util/custom_google_mock_main.cc",
     "testing_util/init_google_mock.cc",
+    "testing_util/testing_types.cc",
 ]

--- a/google/cloud/optional_test.cc
+++ b/google/cloud/optional_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/optional.h"
+#include "google/cloud/testing_util/testing_types.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -20,82 +21,8 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 /// Helper types to test google::cloud::optional<T>
 namespace {
-class Observable {
- public:
-  static int default_constructor;
-  static int value_constructor;
-  static int copy_constructor;
-  static int move_constructor;
-  static int copy_assignment;
-  static int move_assignment;
-  static int destructor;
 
-  static void reset_counters() {
-    default_constructor = 0;
-    value_constructor = 0;
-    copy_constructor = 0;
-    move_constructor = 0;
-    copy_assignment = 0;
-    move_assignment = 0;
-    destructor = 0;
-  }
-
-  Observable() { ++default_constructor; }
-  explicit Observable(std::string s) : str_(std::move(s)) {
-    ++value_constructor;
-  }
-  Observable(Observable const& rhs) : str_(rhs.str_) { ++copy_constructor; }
-  Observable(Observable&& rhs) noexcept : str_(std::move(rhs.str_)) {
-    rhs.str_ = "moved-out";
-    ++move_constructor;
-  }
-
-  Observable& operator=(Observable const& rhs) {
-    str_ = rhs.str_;
-    ++copy_assignment;
-    return *this;
-  }
-  Observable& operator=(Observable&& rhs) noexcept {
-    str_ = std::move(rhs.str_);
-    rhs.str_ = "moved-out";
-    ++move_assignment;
-    return *this;
-  }
-  ~Observable() { ++destructor; }
-
-  std::string const& str() const { return str_; }
-
- private:
-  std::string str_;
-};
-
-int Observable::default_constructor = 0;
-int Observable::value_constructor = 0;
-int Observable::copy_constructor = 0;
-int Observable::move_constructor = 0;
-int Observable::copy_assignment = 0;
-int Observable::move_assignment = 0;
-int Observable::destructor = 0;
-
-// A class without a default constructor to verify optional<> can handle that.
-class NoDefaultConstructor {
- public:
-  NoDefaultConstructor() = delete;
-  explicit NoDefaultConstructor(std::string x) : str_(std::move(x)) {}
-
-  bool operator==(NoDefaultConstructor const& rhs) const {
-    return str_ == rhs.str_;
-  }
-  bool operator!=(NoDefaultConstructor const& rhs) const {
-    return !(*this == rhs);
-  }
-
-  std::string str() const { return str_; }
-
- private:
-  std::string str_;
-};
-
+using testing_util::Observable;
 using OptionalObservable = optional<Observable>;
 
 TEST(OptionalTest, Simple) {
@@ -393,11 +320,11 @@ TEST(OptionalTest, MoveValueOr) {
 }
 
 TEST(OptionalTest, WithNoDefaultConstructor) {
-  using TestedOptional = optional<NoDefaultConstructor>;
+  using TestedOptional = optional<testing_util::NoDefaultConstructor>;
   TestedOptional empty;
   EXPECT_FALSE(empty.has_value());
 
-  TestedOptional actual(NoDefaultConstructor(std::string("foo")));
+  TestedOptional actual(testing_util::NoDefaultConstructor(std::string("foo")));
   EXPECT_TRUE(actual.has_value());
   EXPECT_EQ(actual->str(), "foo");
 }

--- a/google/cloud/testing_util/testing_types.cc
+++ b/google/cloud/testing_util/testing_types.cc
@@ -1,0 +1,33 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/testing_util/testing_types.h"
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace testing_util {
+
+int Observable::default_constructor = 0;
+int Observable::value_constructor = 0;
+int Observable::copy_constructor = 0;
+int Observable::move_constructor = 0;
+int Observable::copy_assignment = 0;
+int Observable::move_assignment = 0;
+int Observable::destructor = 0;
+
+}  // namespace testing_util
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/testing_util/testing_types.h
+++ b/google/cloud/testing_util/testing_types.h
@@ -1,0 +1,112 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_TESTING_TYPES_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_TESTING_TYPES_H_
+/**
+ * @file
+ *
+ * Implement types useful to test the behavior of template classes.
+ *
+ * Just like a function should be tested with different inputs, template classes
+ * should be tested with types that have different characteristics. For example,
+ * it is often interesting to test a template with a type that lacks a default
+ * constructor. This file implements some types that we have found useful for
+ * testing template classes.
+ */
+
+#include "google/cloud/log.h"
+#include <vector>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace testing_util {
+/// A class without a default constructor.
+class NoDefaultConstructor {
+ public:
+  NoDefaultConstructor() = delete;
+  explicit NoDefaultConstructor(std::string x) : str_(std::move(x)) {}
+
+  bool operator==(NoDefaultConstructor const& rhs) const {
+    return str_ == rhs.str_;
+  }
+  bool operator!=(NoDefaultConstructor const& rhs) const {
+    return !(*this == rhs);
+  }
+
+  std::string str() const { return str_; }
+
+ private:
+  std::string str_;
+};
+
+/**
+ * A class that counts calls to its constructors.
+ */
+class Observable {
+ public:
+  static int default_constructor;
+  static int value_constructor;
+  static int copy_constructor;
+  static int move_constructor;
+  static int copy_assignment;
+  static int move_assignment;
+  static int destructor;
+
+  static void reset_counters() {
+    default_constructor = 0;
+    value_constructor = 0;
+    copy_constructor = 0;
+    move_constructor = 0;
+    copy_assignment = 0;
+    move_assignment = 0;
+    destructor = 0;
+  }
+
+  Observable() { ++default_constructor; }
+  explicit Observable(std::string s) : str_(std::move(s)) {
+    ++value_constructor;
+  }
+  Observable(Observable const& rhs) : str_(rhs.str_) { ++copy_constructor; }
+  Observable(Observable&& rhs) noexcept : str_(std::move(rhs.str_)) {
+    rhs.str_ = "moved-out";
+    ++move_constructor;
+  }
+
+  Observable& operator=(Observable const& rhs) {
+    str_ = rhs.str_;
+    ++copy_assignment;
+    return *this;
+  }
+  Observable& operator=(Observable&& rhs) noexcept {
+    str_ = std::move(rhs.str_);
+    rhs.str_ = "moved-out";
+    ++move_assignment;
+    return *this;
+  }
+  ~Observable() { ++destructor; }
+
+  std::string const& str() const { return str_; }
+
+ private:
+  std::string str_;
+};
+
+}  // namespace testing_util
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_TESTING_TYPES_H_


### PR DESCRIPTION
We should test future<T> with interesting types, e.g., classes that lack
a default constructor. This refactors some types that we already had in
the tests for optional<T> to the testing_util library. Part of the work
for #1345.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1400)
<!-- Reviewable:end -->
