### PR TITLE
Fixes #1404.

### DIFF
--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -206,7 +206,7 @@ TEST_F(GoogleCredentialsTest, LoadComputeEngineCredentialsFromADCFlow) {
   // Make sure other higher-precedence credentials (ADC env var, gcloud ADC from
   // well-known path) aren't loaded.
   UnsetEnv(GoogleAdcEnvVar());
-  UnsetEnv(GoogleGcloudAdcFileEnvVar());
+  SetEnv(GoogleGcloudAdcFileEnvVar(), "");
   // If the ADC flow thinks we're on a GCE instance, it should return
   // ComputeEngineCredentials.
   SetEnv(GceCheckOverrideEnvVar(), "1");


### PR DESCRIPTION
Ensures that if gcloud has configured ADCs at its well known path, this
affected unit test should not load those credentials.