### PR TITLE
Implement future<T> and promise<T>.

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -108,6 +108,7 @@ add_library(google_cloud_cpp_common
             internal/future_fwd.h
             internal/future_impl.h
             internal/future_then_meta.h
+            internal/future_generic.h
             internal/future_void.h
             internal/getenv.h
             internal/getenv.cc
@@ -171,6 +172,7 @@ set(google_cloud_cpp_common_unit_tests
     internal/big_endian_test.cc
     internal/filesystem_test.cc
     internal/future_impl_test.cc
+    internal/future_generic_test.cc
     internal/future_void_test.cc
     internal/future_void_then_test.cc
     internal/invoke_result_test.cc

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -11,6 +11,7 @@ google_cloud_cpp_common_HDRS = [
     "internal/future_fwd.h",
     "internal/future_impl.h",
     "internal/future_then_meta.h",
+    "internal/future_generic.h",
     "internal/future_void.h",
     "internal/getenv.h",
     "internal/make_unique.h",

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -5,6 +5,7 @@ google_cloud_cpp_common_unit_tests = [
     "internal/big_endian_test.cc",
     "internal/filesystem_test.cc",
     "internal/future_impl_test.cc",
+    "internal/future_generic_test.cc",
     "internal/future_void_test.cc",
     "internal/future_void_then_test.cc",
     "internal/invoke_result_test.cc",

--- a/google/cloud/internal/future_generic.h
+++ b/google/cloud/internal/future_generic.h
@@ -1,0 +1,157 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_GENERIC_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_GENERIC_H_
+/**
+ * @file
+ *
+ * Fully specialize `future<void>` and `promise<R>` for void.
+ */
+
+#include "google/cloud/internal/port_platform.h"
+
+// C++ futures only make sense when exceptions are enabled.
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+#include "google/cloud/internal/future_base.h"
+#include "google/cloud/internal/future_fwd.h"
+#include "google/cloud/internal/future_impl.h"
+#include "google/cloud/internal/future_then_meta.h"
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+/**
+ * Implement ISO/IEC TS 19571:2016 `future<T>`.
+ */
+template <typename T>
+class future final : private internal::future_base<T> {
+ public:
+  future() noexcept = default;
+
+  // TODO(#1345) - implement the unwrapping constructor.
+  // future(future<future<T>>&& f) noexcept;
+  // future& operator=(future<future<T>>&& f) noexcept;
+
+  /**
+   * Waits until the shared state becomes ready, then retrieves the value stored
+   * in the shared state.
+   *
+   * @note This operation invalidates the future, subsequent calls will fail,
+   *   the application should capture the returned value because it would.
+   *
+   * @throws any exceptions stored in the shared state.
+   * @throws std::future_error with std::no_state if the future does not have
+   *   a shared state.
+   */
+  T get() {
+    this->check_valid();
+    std::shared_ptr<shared_state_type> tmp;
+    tmp.swap(this->shared_state_);
+    return tmp->get();
+  }
+
+  using internal::future_base<T>::valid;
+  using internal::future_base<T>::wait;
+  using internal::future_base<T>::wait_for;
+  using internal::future_base<T>::wait_until;
+
+ private:
+  /// Shorthand to refer to the shared state type.
+  using shared_state_type = internal::future_shared_state<T>;
+
+  friend class promise<T>;
+  explicit future(std::shared_ptr<shared_state_type> state)
+      : internal::future_base<T>(std::move(state)) {}
+};
+
+/**
+ * Implement `promise<T>` as defined in ISO/IEC TS 19571:2016.
+ */
+template <typename T>
+class promise final : private internal::promise_base<T> {
+ public:
+  /// Creates a promise with an unsatisfied shared state.
+  promise() = default;
+
+  /// Constructs a new promise and transfer any shared state from @p rhs.
+  promise(promise&& rhs) noexcept = default;
+
+  /// Abandons the shared state in `*this`, if any, and transfers the shared
+  /// state from @p rhs.
+  promise& operator=(promise&& rhs) noexcept {
+    promise tmp(std::move(rhs));
+    this->swap(tmp);
+    return *this;
+  }
+
+  /**
+   * Abandons any shared state.
+   *
+   * If the shared state was not already satisfied it becomes satisfied with
+   * a `std::future_error` exception. The error code in this exception is
+   * `std::future_errc::broken_promise`.
+   */
+  ~promise() = default;
+
+  promise(promise const&) = delete;
+  promise& operator=(promise const&) = delete;
+
+  /// Swaps the shared state in `*this` with @p rhs.
+  void swap(promise& other) noexcept {
+    std::swap(this->shared_state_, other.shared_state_);
+  }
+
+  /**
+   * Creates the `future<T>` using the same shared state as `*this`.
+   */
+  future<T> get_future() {
+    internal::future_shared_state<T>::mark_retrieved(this->shared_state_);
+    return future<T>(this->shared_state_);
+  }
+
+  /**
+   * Satisfies the shared state.
+   *
+   * @throws std::future_error with std::future_errc::promise_already_satisfied
+   *   if the shared state is already satisfied.
+   * @throws std::future_error with std::no_state if the promise does not have
+   *   a shared state.
+   */
+  void set_value(T&& value) {
+    if (not this->shared_state_) {
+      throw std::future_error(std::future_errc::no_state);
+    }
+    this->shared_state_->set_value(std::forward<T>(value));
+  }
+
+  /**
+   * Satisfies the shared state.
+   *
+   * @throws std::future_error with std::future_errc::promise_already_satisfied
+   *   if the shared state is already satisfied.
+   * @throws std::future_error with std::no_state if the promise does not have
+   *   a shared state.
+   */
+  void set_value(T const& value) { set_value(T(value)); }
+
+  using internal::promise_base<T>::set_exception;
+};
+
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_GENERIC_H_

--- a/google/cloud/internal/future_generic_test.cc
+++ b/google/cloud/internal/future_generic_test.cc
@@ -1,0 +1,654 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/future_generic.h"
+#include "google/cloud/testing_util/chrono_literals.h"
+#include <gmock/gmock.h>
+
+// C++ futures only make sense when exceptions are enabled.
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace {
+using ::testing::HasSubstr;
+using namespace testing_util::chrono_literals;
+
+/// @test Verify conformance with section 30.6.5 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_5_3) {
+  // TODO(coryan) - allocators are not supported for now.
+  static_assert(
+      not std::uses_allocator<promise<int>, std::allocator<int>>::value,
+      "promise<int> should use allocators if provided");
+}
+
+/// @test Verify conformance with section 30.6.5 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_5_4_default) {
+  promise<int> p0;
+  auto f0 = p0.get_future();
+  p0.set_value(42);
+  ASSERT_EQ(std::future_status::ready, f0.wait_for(0_ms));
+  EXPECT_NO_THROW(f0.get());
+}
+
+/// @test Verify conformance with section 30.6.5 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_5_5) {
+  // promise<R> move constructor clears the shared state on the moved-from
+  // promise.
+  promise<int> p0;
+
+  promise<int> p1(std::move(p0));
+  auto f1 = p1.get_future();
+  p1.set_value(42);
+  ASSERT_EQ(std::future_status::ready, f1.wait_for(0_ms));
+  EXPECT_NO_THROW(f1.get());
+
+  // Verify 30.6.5.6
+  EXPECT_THROW(  // NOLINT
+      try {
+        p0.set_value(42);  // NOLINT
+      } catch (std::future_error const& ex) {
+        EXPECT_EQ(std::future_errc::no_state, ex.code());
+        throw;
+      },
+      std::future_error);
+}
+
+/// @test Verify conformance with section 30.6.5 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_5_7) {
+  // promise<R> destructor abandons the shared state, the associated future
+  // becomes satisfied with an exception.
+  future<int> f0;
+  {
+    promise<int> p0;
+    f0 = p0.get_future();
+    ASSERT_NE(std::future_status::ready, f0.wait_for(0_ms));
+    EXPECT_TRUE(f0.valid());
+  }
+  EXPECT_TRUE(f0.valid());
+  ASSERT_EQ(std::future_status::ready, f0.wait_for(0_ms));
+  EXPECT_THROW(  // NOLINT
+      try { f0.get(); } catch (std::future_error const& ex) {
+        EXPECT_EQ(std::future_errc::broken_promise, ex.code());
+        throw;
+      },
+      std::future_error);
+}
+
+/// @test Verify conformance with section 30.6.5 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_5_8) {
+  // promise<R> move assignment clears the shared state in the moved-from
+  // promise.
+  promise<int> p0;
+
+  promise<int> p1;
+  p1 = std::move(p0);
+  auto f1 = p1.get_future();
+  p1.set_value(42);
+  ASSERT_EQ(std::future_status::ready, f1.wait_for(0_ms));
+  EXPECT_NO_THROW(f1.get());
+
+  EXPECT_THROW(  // NOLINT
+      try {
+        p0.set_value(42);  // NOLINT
+      } catch (std::future_error const& ex) {
+        EXPECT_EQ(std::future_errc::no_state, ex.code());
+        throw;
+      },
+      std::future_error);
+}
+
+/// @test Verify conformance with section 30.6.5 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_5_10) {
+  // promise<R>::swap() actually swaps shared states.
+  promise<int> p0;
+  promise<int> p1;
+  p0.set_value(42);
+  p0.swap(p1);
+
+  auto f0 = p0.get_future();
+  auto f1 = p1.get_future();
+  ASSERT_NE(std::future_status::ready, f0.wait_for(0_ms));
+  ASSERT_EQ(std::future_status::ready, f1.wait_for(0_ms));
+  EXPECT_NO_THROW(f1.get());
+  EXPECT_NO_THROW(p0.set_value(42));
+  ASSERT_EQ(std::future_status::ready, f0.wait_for(0_ms));
+}
+
+/// @test Verify conformance with section 30.6.5 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_5_14_1) {
+  // promise<R>::get_future() raises if future was already retrieved.
+  promise<int> p0;
+  auto f0 = p0.get_future();
+
+  EXPECT_THROW(  // NOLINT
+      try { p0.get_future(); } catch (std::future_error const& ex) {
+        EXPECT_EQ(std::future_errc::future_already_retrieved, ex.code());
+        throw;
+      },
+      std::future_error);
+}
+
+/// @test Verify conformance with section 30.6.5 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_5_14_2) {
+  // promise<R>::get_future() raises if there is no shared state.
+  promise<int> p0;
+  promise<int> p1(std::move(p0));
+
+  EXPECT_THROW(  // NOLINT
+      try {
+        p0.get_future();  // NOLINT
+      } catch (std::future_error const& ex) {
+        EXPECT_EQ(std::future_errc::no_state, ex.code());
+        throw;
+      },
+      std::future_error);
+}
+
+/// @test Verify conformance with section 30.6.5 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_5_15) {
+  // promise<R>::set_value() stores the value in the shared state and makes it
+  // ready.
+  promise<int> p0;
+  auto f0 = p0.get_future();
+  ASSERT_NE(std::future_status::ready, f0.wait_for(0_ms));
+  p0.set_value(42);
+  ASSERT_EQ(std::future_status::ready, f0.wait_for(0_ms));
+  EXPECT_NO_THROW(f0.get());
+}
+
+/// @test Verify conformance with section 30.6.5 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_5_16_1) {
+  // promise<R>::set_value() raises if there is a value in the shared state.
+  promise<int> p0;
+  p0.set_value(42);
+  EXPECT_THROW(  // NOLINT
+      try { p0.set_value(42); } catch (std::future_error const& ex) {
+        EXPECT_EQ(std::future_errc::promise_already_satisfied, ex.code());
+        throw;
+      },
+      std::future_error);
+}
+
+/// @test Verify conformance with section 30.6.5 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_5_17_2) {
+  // promise<R>::set_value() raises if there is no shared state.
+  promise<int> p0;
+  promise<int> p1(std::move(p0));
+  EXPECT_THROW(  // NOLINT
+      try {
+        p0.set_value(42);  // NOLINT
+      } catch (std::future_error const& ex) {
+        EXPECT_EQ(std::future_errc::no_state, ex.code());
+        throw;
+      },
+      std::future_error);
+}
+
+/// @test Verify conformance with section 30.6.5 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_5_18) {
+  // promise<R>::set_exception() sets an exception and makes the shared state
+  // ready.
+  promise<int> p0;
+  auto f0 = p0.get_future();
+  ASSERT_NE(std::future_status::ready, f0.wait_for(0_ms));
+  p0.set_exception(std::make_exception_ptr(std::runtime_error("testing")));
+  ASSERT_EQ(std::future_status::ready, f0.wait_for(0_ms));
+  EXPECT_THROW(  // NOLINT
+      try { f0.get(); } catch (std::runtime_error const& ex) {
+        EXPECT_EQ(std::string("testing"), ex.what());
+        throw;
+      },
+      std::runtime_error);
+}
+
+/// @test Verify conformance with section 30.6.5 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_5_20_1_value) {
+  // promise<R>::set_exception() raises if the shared state is already storing
+  // a value.
+  promise<int> p0;
+  p0.set_value(42);
+  EXPECT_THROW(
+      try {
+        p0.set_exception(
+            std::make_exception_ptr(std::runtime_error("testing")));
+      } catch (std::future_error const& ex) {
+        EXPECT_EQ(std::future_errc::promise_already_satisfied, ex.code());
+        throw;
+      },
+      std::future_error);
+}
+
+/// @test Verify conformance with section 30.6.5 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_5_20_1_exception) {
+  // promise<R>::set_exception() raises if the shared state is already storing
+  // an exception.
+  promise<int> p0;
+  p0.set_exception(std::make_exception_ptr(std::runtime_error("original ex")));
+  EXPECT_THROW(
+      try {
+        p0.set_exception(
+            std::make_exception_ptr(std::runtime_error("testing")));
+      } catch (std::future_error const& ex) {
+        EXPECT_EQ(std::future_errc::promise_already_satisfied, ex.code());
+        throw;
+      },
+      std::future_error);
+}
+
+/// @test Verify conformance with section 30.6.5 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_5_20_2) {
+  // promise<R>::set_exception() raises if the promise does not have a shared
+  // state.
+  promise<int> p0;
+  promise<int> p1(std::move(p0));
+  EXPECT_THROW(  // NOLINT
+      try {
+        p0.set_exception(  // NOLINT
+            std::make_exception_ptr(std::runtime_error("testing")));
+      } catch (std::future_error const& ex) {
+        EXPECT_EQ(std::future_errc::no_state, ex.code());
+        throw;
+      },
+      std::future_error);
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_3_a) {
+  // Calling get() on a future with `valid() == false` is undefined, but the
+  // implementation is encouraged to raise `future_error` with an error code
+  // of `future_errc::no_state`
+  future<int> f;
+  EXPECT_FALSE(f.valid());
+  EXPECT_THROW(try { f.get(); } catch (std::future_error const& ex) {
+    EXPECT_EQ(std::future_errc::no_state, ex.code());
+    throw;
+  },
+               std::future_error);
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_3_b) {
+  // Calling wait() on a future with `valid() == false` is undefined, but the
+  // implementation is encouraged to raise `future_error` with an error code
+  // of `future_errc::no_state`
+  future<int> f;
+  EXPECT_FALSE(f.valid());
+  EXPECT_THROW(try { f.wait(); } catch (std::future_error const& ex) {
+    EXPECT_EQ(std::future_errc::no_state, ex.code());
+    throw;
+  },
+               std::future_error);
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_3_c) {
+  // Calling wait_for() on a future with `valid() == false` is undefined, but
+  // the implementation is encouraged to raise `future_error` with an error code
+  // of `future_errc::no_state`
+  future<int> f;
+  EXPECT_FALSE(f.valid());
+  EXPECT_THROW(try { f.wait_for(3_ms); } catch (std::future_error const& ex) {
+    EXPECT_EQ(std::future_errc::no_state, ex.code());
+    throw;
+  },
+               std::future_error);
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_3_d) {
+  // Calling wait_until() on a future with `valid() == false` is undefined, but
+  // the implementation is encouraged to raise `future_error` with an error code
+  // of `future_errc::no_state`
+  future<int> f;
+  EXPECT_FALSE(f.valid());
+  EXPECT_THROW(
+      try {
+        f.wait_until(std::chrono::system_clock::now() + 3_ms);
+      } catch (std::future_error const& ex) {
+        EXPECT_EQ(std::future_errc::no_state, ex.code());
+        throw;
+      },
+      std::future_error);
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_5) {
+  // future<int>::future() constructs an empty future with no shared state.
+  future<int> f;
+  EXPECT_FALSE(f.valid());
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_7) {
+  // future<int> move constructor is `noexcept`.
+  future<int> f0;
+  EXPECT_TRUE(noexcept(future<int>(std::move(f0))));
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_8_a) {
+  // future<int> move constructor transfers futures with valid state.
+  promise<int> p;
+  future<int> f0 = p.get_future();
+  EXPECT_TRUE(f0.valid());
+
+  future<int> f1(std::move(f0));
+  EXPECT_FALSE(f0.valid());
+  EXPECT_TRUE(f1.valid());
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_8_b) {
+  // future<int> move constructor transfers futures with no state.
+  future<int> f0;
+  EXPECT_FALSE(f0.valid());
+
+  future<int> f1(std::move(f0));
+  EXPECT_FALSE(f0.valid());
+  EXPECT_FALSE(f1.valid());
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_9) {
+  // future<int> destructor releases the shared state.
+  promise<int> p;
+  future<int> f0 = p.get_future();
+  EXPECT_TRUE(f0.valid());
+  // This behavior is not observable, but any violation should be detected by
+  // the ASAN builds.
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_10) {
+  // Move assignment is noexcept.
+  promise<int> p;
+  future<int> f0 = p.get_future();
+  EXPECT_TRUE(f0.valid());
+
+  future<int> f1;
+  EXPECT_TRUE(noexcept(f1 = std::move(f0)));
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_11_a) {
+  // future<int> move assignment transfers futures with valid state.
+  promise<int> p;
+  future<int> f0 = p.get_future();
+  EXPECT_TRUE(f0.valid());
+
+  future<int> f1;
+  f1 = std::move(f0);
+  EXPECT_FALSE(f0.valid());
+  EXPECT_TRUE(f1.valid());
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_11_b) {
+  // future<int> move assignment transfers futures with invalid state.
+  future<int> f0;
+  EXPECT_FALSE(f0.valid());
+
+  future<int> f1;
+  f1 = std::move(f0);
+  EXPECT_FALSE(f0.valid());
+  EXPECT_FALSE(f1.valid());
+}
+
+// Paragraphs 30.6.6.{12,13,14} are about shared_futures which we are
+// not implementing yet.
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_15) {
+  // future<int>::get() only returns once the promise is satisfied.
+  promise<int> p;
+
+  // We use std::promise<> and std::future<> to test our promises and futures.
+  // This test uses a number of promises to track progress in a separate thread,
+  // and checks the expected conditions in each one.
+  std::promise<void> p_get_future_called;
+  std::promise<void> f_get_called;
+
+  std::thread t([&] {
+    future<int> f = p.get_future();
+    p_get_future_called.set_value();
+    EXPECT_NO_THROW(f.get());
+    f_get_called.set_value();
+  });
+
+  p_get_future_called.get_future().get();
+  auto waiter = f_get_called.get_future();
+  // thread `t` cannot make progress until we set the promise value.
+  EXPECT_EQ(std::future_status::timeout, waiter.wait_for(2_ms));
+
+  p.set_value(42);
+  // now thread `t` can make progress.
+  EXPECT_EQ(std::future_status::ready, waiter.wait_for(20_ms));
+
+  waiter.get();
+  t.join();
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_16_3) {
+  // future<int>::get() returns void.
+  promise<int> p;
+  future<int> f = p.get_future();
+  EXPECT_TRUE((std::is_same<decltype(f.get()), int>::value));
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_17) {
+  // future<int>::get() throws if an exception was set in the promise.
+  promise<int> p;
+
+  future<int> f = p.get_future();
+  p.set_exception(std::make_exception_ptr(std::runtime_error("test message")));
+  EXPECT_THROW(try { f.get(); } catch (std::runtime_error const& ex) {
+    EXPECT_THAT(ex.what(), HasSubstr("test message"));
+    throw;
+  },
+               std::runtime_error);
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_18_a) {
+  // future<int>::get() releases the shared state.
+  promise<int> p;
+  future<int> f = p.get_future();
+  p.set_value(42);
+  EXPECT_NO_THROW(f.get());
+  EXPECT_FALSE(f.valid());
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_18_b) {
+  // future<int>::get() throws releases the shared state.
+  promise<int> p;
+  future<int> f = p.get_future();
+  p.set_exception(std::make_exception_ptr(std::runtime_error("unused")));
+  EXPECT_THROW(f.get(), std::runtime_error);
+  EXPECT_FALSE(f.valid());
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_19_a) {
+  // future<int>::valid() returns true when the future has a shared state.
+  promise<int> p;
+  future<int> const f = p.get_future();
+  EXPECT_TRUE(noexcept(f.valid()));
+  EXPECT_TRUE(f.valid());
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_19_b) {
+  // future<int>::valid() returns false when the future has no shared state.
+  future<int> const f;
+  EXPECT_TRUE(noexcept(f.valid()));
+  EXPECT_FALSE(f.valid());
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_20) {
+  // future<int>::wait() blocks until state is ready.
+  promise<int> p;
+  future<int> const f = p.get_future();
+
+  // We use std::promise<> and std::future<> to test our promises and futures.
+  // This test uses a number of promises to track progress in a separate thread,
+  // and checks the expected conditions in each one.
+  std::promise<void> thread_started;
+  std::promise<void> f_wait_returned;
+
+  std::thread t([&] {
+    thread_started.set_value();
+    f.wait();
+    f_wait_returned.set_value();
+  });
+
+  thread_started.get_future().get();
+
+  auto waiter = f_wait_returned.get_future();
+  EXPECT_EQ(std::future_status::timeout, waiter.wait_for(2_ms));
+  p.set_value(42);
+  EXPECT_EQ(std::future_status::ready, waiter.wait_for(10_ms));
+
+  t.join();
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_21) {
+  // future<int>::wait_for() blocks until state is ready.
+  promise<int> p;
+  future<int> const f = p.get_future();
+
+  // We use std::promise<> and std::future<> to test our promises and futures.
+  // This test uses a number of promises to track progress in a separate thread,
+  // and checks the expected conditions in each one.
+  std::promise<void> thread_started;
+  std::promise<void> f_wait_returned;
+
+  std::thread t([&] {
+    thread_started.set_value();
+    f.wait_for(100_ms);
+    f_wait_returned.set_value();
+  });
+
+  thread_started.get_future().get();
+
+  auto waiter = f_wait_returned.get_future();
+  EXPECT_EQ(std::future_status::timeout, waiter.wait_for(2_ms));
+  p.set_value(42);
+  EXPECT_EQ(std::future_status::ready, waiter.wait_for(10_ms));
+
+  t.join();
+}
+
+// Paragraph 30.6.6.22.1 refers to futures that hold a deferred function (like
+// those returned by std::async()), we are not implement those, so there is no
+// test needed.
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_22_2) {
+  // wait_for() returns std::future_status::ready if the future is ready.
+  promise<int> p0;
+  auto f0 = p0.get_future();
+
+  p0.set_value(42);
+  auto s = f0.wait_for(0_ms);
+  EXPECT_EQ(std::future_status::ready, s);
+  EXPECT_NO_THROW(f0.get());
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_22_3) {
+  // wait_for() returns std::future_status::timeout if the future is not ready.
+  promise<int> p0;
+  auto f0 = p0.get_future();
+
+  auto s = f0.wait_for(0_ms);
+  EXPECT_EQ(std::future_status::timeout, s);
+  ASSERT_NE(std::future_status::ready, f0.wait_for(0_ms));
+}
+
+// Paragraph 30.6.6.23 asserts that if the clock raises then wait_for() might
+// raise too. We do not need to test for that, exceptions are always propagated,
+// this is just giving implementors freedom.
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_24) {
+  // future<int>::wait_until() blocks until state is ready.
+  promise<int> p;
+  future<int> const f = p.get_future();
+
+  // We use std::promise<> and std::future<> to test our promises and futures.
+  // This test uses a number of promises to track progress in a separate thread,
+  // and checks the expected conditions in each one.
+  std::promise<void> thread_started;
+  std::promise<void> f_wait_returned;
+
+  std::thread t([&] {
+    thread_started.set_value();
+    f.wait_until(std::chrono::system_clock::now() + 100_ms);
+    f_wait_returned.set_value();
+  });
+
+  thread_started.get_future().get();
+
+  auto waiter = f_wait_returned.get_future();
+  EXPECT_EQ(std::future_status::timeout, waiter.wait_for(2_ms));
+  p.set_value(42);
+  EXPECT_EQ(std::future_status::ready, waiter.wait_for(10_ms));
+
+  t.join();
+}
+
+// Paragraph 30.6.6.25.1 refers to futures that hold a deferred function (like
+// those returned by std::async()), we are not implement those, so there is no
+// test needed.
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_25_2) {
+  // wait_until() returns std::future_status::ready if the future is ready.
+  promise<int> p0;
+  auto f0 = p0.get_future();
+
+  p0.set_value(42);
+  auto s = f0.wait_until(std::chrono::system_clock::now());
+  EXPECT_EQ(std::future_status::ready, s);
+  ASSERT_EQ(std::future_status::ready, f0.wait_for(0_ms));
+  EXPECT_NO_THROW(f0.get());
+}
+
+/// @test Verify conformance with section 30.6.6 of the C++14 spec.
+TEST(FutureTestInt, conform_30_6_6_25_3) {
+  // wait_until() returns std::future_status::timeout if the future is not ready.
+  promise<int> p0;
+  auto f0 = p0.get_future();
+
+  auto s = f0.wait_until(std::chrono::system_clock::now());
+  EXPECT_EQ(std::future_status::timeout, s);
+  ASSERT_NE(std::future_status::ready, f0.wait_for(0_ms));
+}
+
+// Paragraph 30.6.6.26 asserts that if the clock raises then wait_until() might
+// raise too. We do not need to test for that, exceptions are always propagated,
+// this is just giving implementors freedom.
+
+}  // namespace
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS


### PR DESCRIPTION
This is part of the work for #1345. It implements the basic
functionality for `future<T>` and `promise<T>`, excluding `then()` and
`is_ready()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1408)
<!-- Reviewable:end -->
