### PR TITLE
Fix a race condition in AsyncUnaryStreamRpcFunctor

### DIFF
--- a/google/cloud/bigtable/internal/completion_queue_impl.h
+++ b/google/cloud/bigtable/internal/completion_queue_impl.h
@@ -200,6 +200,7 @@ class AsyncUnaryStreamRpcFunctor : public AsyncOperation {
   void Set(Client& client, MemberFunction Client::*call,
            std::unique_ptr<grpc::ClientContext> context, Request const& request,
            grpc::CompletionQueue* cq, void* tag) {
+    std::unique_lock<std::mutex> lk(mu_);
     tag_ = tag;
     context_ = std::move(context);
     response_reader_ = (client.*call)(context_.get(), request, cq, tag);


### PR DESCRIPTION
Before this fix, a callback (`Notify`) can be executed in parallel with
the `Set` member function. Due to that, `response_reader_` might not be
properly set, leading to a nullptr dereference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1419)
<!-- Reviewable:end -->
