### PR TITLE
Implement unwrapping .then().

### DIFF
--- a/google/cloud/internal/future_generic.h
+++ b/google/cloud/internal/future_generic.h
@@ -103,6 +103,14 @@ class future final : private internal::future_base<T> {
   template <typename F>
   typename internal::then_helper<F, T>::future_t then_impl(F&& functor,
                                                            std::false_type);
+
+  /// Implement `then()` if the result does not require unwrapping.
+  template <typename F>
+  typename internal::then_helper<F, T>::future_t then_impl(F&& functor,
+                                                           std::true_type);
+
+  template <typename U>
+  friend class future;
 };
 
 /**

--- a/google/cloud/internal/future_generic_then_test.cc
+++ b/google/cloud/internal/future_generic_then_test.cc
@@ -80,6 +80,32 @@ TEST(FutureTestInt, ThenException) {
   EXPECT_FALSE(next.valid());
 }
 
+TEST(FutureTestInt, ThenUnwrap) {
+  promise<int> p;
+  future<int> fut = p.get_future();
+  EXPECT_TRUE(fut.valid());
+
+  promise<std::string> pp;
+  bool called = false;
+  auto cont = [&pp, &called](future<int> r) {
+    called = true;
+    return pp.get_future();
+  };
+  future<std::string> next = fut.then(std::move(cont));
+  EXPECT_FALSE(fut.valid());
+  EXPECT_TRUE(next.valid());
+  EXPECT_FALSE(next.is_ready());
+
+  p.set_value(42);
+  EXPECT_TRUE(called);
+  EXPECT_FALSE(next.is_ready());
+
+  pp.set_value("value=42");
+  EXPECT_TRUE(next.is_ready());
+  EXPECT_EQ("value=42", next.get());
+  EXPECT_FALSE(next.valid());
+}
+
 // The following tests reference the technical specification:
 //   http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0159r0.html
 // The test names match the section and paragraph from the TS.
@@ -237,17 +263,124 @@ TEST(FutureTestInt, conform_2_3_9_b) {
   promise<int> p;
   future<int> f = p.get_future();
 
-  // TODO(#1345) - implement the unwrapping functions.
-  // The current implementation only declares that `.then()` should unwrap the
-  // types, but does not actually work if called. These tests simply validate
-  // that the declared types are correct.
-  auto returns_void = [](future<int>) -> future<int> {
+  auto returns_void = [](future<int>) -> future<void> {
+    return promise<void>().get_future();
+  };
+  EXPECT_TRUE(
+      (std::is_same<future<void>, decltype(f.then(returns_void))>::value));
+
+  auto returns_int = [](future<int>) -> future<int> {
     return promise<int>().get_future();
   };
   EXPECT_TRUE(
-      (std::is_same<future<int>, decltype(f.then(returns_void))>::value));
+      (std::is_same<future<int>, decltype(f.then(returns_int))>::value));
 
-  // TODO(#1345) - add tests for other types when future<T> is implemented.
+  // The spec says the returned type must be future<R2> *exactly*, references do
+  // not count.
+  promise<int> p_int;
+  future<int> f_int = p_int.get_future();
+  auto returns_int_ref = [&f_int](future<int>) -> future<int>& {
+    return f_int;
+  };
+  EXPECT_FALSE(
+      (std::is_same<future<int>, decltype(f.then(returns_int_ref))>::value));
+}
+
+/// @test Verify conformance with section 2.3 of the Concurrency TS.
+TEST(FutureTestInt, conform_2_3_9_c) {
+  // future<int>::then() implicitly unwrapping captures the returned value.
+  promise<int> p;
+  future<int> f = p.get_future();
+
+  promise<int> p2;
+  bool called = false;
+  future<int> r = f.then([&p2, &called](future<int> f) {
+    called = true;
+    EXPECT_EQ(7, f.get());
+    return p2.get_future();
+  });
+  EXPECT_TRUE(r.valid());
+  EXPECT_FALSE(r.is_ready());
+  EXPECT_FALSE(f.valid());
+
+  p.set_value(7);
+  EXPECT_TRUE(called);
+  EXPECT_FALSE(r.is_ready());
+
+  p2.set_value(42);
+  EXPECT_TRUE(r.is_ready());
+  EXPECT_EQ(42, r.get());
+}
+
+/// @test Verify conformance with section 2.3 of the Concurrency TS.
+TEST(FutureTestInt, conform_2_3_9_d) {
+  // future<int>::then() implicitly unwrapping captures exceptions.
+  promise<int> p;
+  future<int> f = p.get_future();
+
+  promise<int> p2;
+  bool called = false;
+  future<int> r = f.then([&p2, &called](future<int> f) {
+    called = true;
+    f.get();
+    return p2.get_future();
+  });
+  EXPECT_TRUE(r.valid());
+  EXPECT_FALSE(r.is_ready());
+  EXPECT_FALSE(f.valid());
+
+  p.set_exception(std::make_exception_ptr(std::runtime_error("test message")));
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(r.is_ready());
+
+  EXPECT_THROW(try { r.get(); } catch(std::runtime_error const& ex) {
+    EXPECT_THAT(ex.what(), HasSubstr("test message"));
+    throw;
+  }, std::runtime_error);
+}
+
+/// @test Verify conformance with section 2.3 of the Concurrency TS.
+TEST(FutureTestInt, conform_2_3_9_e) {
+  // future<int>::then() implicitly unwrapping raises on invalid future
+  // returned by continuation.
+  promise<int> p;
+  future<int> f = p.get_future();
+
+  bool called = false;
+  future<int> r = f.then([&called](future<int> f) {
+    called = true;
+    f.get();
+    return future<int>{};
+  });
+  EXPECT_TRUE(r.valid());
+  EXPECT_FALSE(r.is_ready());
+  EXPECT_FALSE(f.valid());
+
+  p.set_value(7);
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(r.is_ready());
+
+  EXPECT_THROW(try { r.get(); } catch(std::future_error const& ex) {
+    EXPECT_EQ(std::future_errc::broken_promise, ex.code());
+    throw;
+  }, std::future_error);
+}
+
+/// @test Verify conformance with section 2.3 of the Concurrency TS.
+TEST(FutureTestInt, conform_2_3_10) {
+  // future<int>::then() invalidates the source future.
+  promise<int> p;
+  future<int> f = p.get_future();
+  future<int> r = f.then([](future<int> f) {
+    return 2 * f.get();
+  });
+  EXPECT_TRUE(r.valid());
+  EXPECT_FALSE(r.is_ready());
+  EXPECT_FALSE(f.valid());
+
+  p.set_value(42);
+  EXPECT_TRUE(r.is_ready());
+  EXPECT_EQ(2 * 42, r.get());
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.

--- a/google/cloud/internal/future_then_impl.h
+++ b/google/cloud/internal/future_then_impl.h
@@ -83,6 +83,52 @@ typename internal::then_helper<F, T>::future_t future<T>::then_impl(
 // must be visible at the point of definition. There is no order of definition
 // for the `future<T>` specializations that would permit us to define the
 // functions inline.
+template <typename T>
+template <typename F>
+typename internal::then_helper<F, T>::future_t future<T>::then_impl(
+    F&& functor, std::true_type) {
+  // g++-4.9 gets confused about the use of a protected type alias here, so
+  // create a non-protected one:
+  using local_state_type = internal::future_shared_state<T>;
+  // Some type aliases to make the rest of the code more readable.
+  using result_t = typename internal::then_helper<F, T>::result_t;
+  using future_t = typename internal::then_helper<F, T>::future_t;
+
+  // `F` is basically a callable that meets the `future<R>(future<T>)`
+  // signature. The `shared_state_type` (aka `future_shared_state<T>`) is
+  // written without any reference to the `future<T>` class, otherwise there
+  // would be cyclic dependencies between the two classes. We must adapt the
+  // provided functor, to meet this signature:
+  //
+  // `std::shared_ptr<future_shared_state<R>>(std::shared_ptr<future_shared_state<void>>)`
+  //
+  // Because we need to support C++11, we use a local class instead of a lambda,
+  // as support for move+capture in lambdas is a C++14 feature.
+  struct adapter {
+    explicit adapter(F&& func) : functor(func) {}
+
+    auto operator()(std::shared_ptr<local_state_type> state)
+        -> std::shared_ptr<internal::future_shared_state<result_t>> {
+      return functor(future<T>(std::move(state))).shared_state_;
+    }
+
+    F functor;
+  };
+
+  auto output_shared_state = local_state_type::make_continuation(
+      this->shared_state_, adapter(std::forward<F>(functor)), std::true_type{});
+
+  // Nothing throws after this point, and we have not changed the state if
+  // anything did throw.
+  this->shared_state_.reset();
+  return future_t(std::move(output_shared_state));
+}
+
+// This function cannot be defined inline, as most template functions are,
+// because the full definition of `future<T>`, `future<R&>` and `future<void>`,
+// must be visible at the point of definition. There is no order of definition
+// for the `future<T>` specializations that would permit us to define the
+// functions inline.
 template <typename F>
 typename internal::then_helper<F, void>::future_t future<void>::then_impl(
     F&& functor, std::false_type) {
@@ -119,6 +165,51 @@ typename internal::then_helper<F, void>::future_t future<void>::then_impl(
   // Nothing throws after this point, and we have not changed the state if
   // anything did throw.
   shared_state_.reset();
+  return future_t(std::move(output_shared_state));
+}
+
+// This function cannot be defined inline, as most template functions are,
+// because the full definition of `future<T>`, `future<R&>` and `future<void>`,
+// must be visible at the point of definition. There is no order of definition
+// for the `future<T>` specializations that would permit us to define the
+// functions inline.
+template <typename F>
+typename internal::then_helper<F, void>::future_t future<void>::then_impl(
+    F&& functor, std::true_type) {
+  // g++-4.9 gets confused about the use of a protected type alias here, so
+  // create a non-protected one:
+  using local_state_type = internal::future_shared_state<void>;
+  // Some type aliases to make the rest of the code more readable.
+  using result_t = typename internal::then_helper<F, void>::result_t;
+  using future_t = typename internal::then_helper<F, void>::future_t;
+
+  // `F` is basically a callable that meets the `future<R>(future<void>)`
+  // signature. The `shared_state_type` (aka `future_shared_state<void>`) is
+  // written without any reference to the `future<U>` class, otherwise there
+  // would be cyclic dependencies between the two classes. We must adapt the
+  // provided functor, to meet this signature:
+  //
+  // `std::shared_ptr<future_shared_state<R>>(std::shared_ptr<future_shared_state<void>>)`
+  //
+  // Because we need to support C++11, we use a local class instead of a lambda,
+  // as support for move+capture in lambdas is a C++14 feature.
+  struct adapter {
+    explicit adapter(F&& func) : functor(func) {}
+
+    auto operator()(std::shared_ptr<local_state_type> state)
+        -> std::shared_ptr<internal::future_shared_state<result_t>> {
+      return functor(future<void>(std::move(state))).shared_state_;
+    }
+
+    F functor;
+  };
+
+  auto output_shared_state = local_state_type::make_continuation(
+      this->shared_state_, adapter(std::forward<F>(functor)), std::true_type{});
+
+  // Nothing throws after this point, and we have not changed the state if
+  // anything did throw.
+  this->shared_state_.reset();
   return future_t(std::move(output_shared_state));
 }
 

--- a/google/cloud/internal/future_void.h
+++ b/google/cloud/internal/future_void.h
@@ -100,6 +100,14 @@ class future<void> final : private internal::future_base<void> {
   template <typename F>
   typename internal::then_helper<F, void>::future_t then_impl(F&& functor,
                                                               std::false_type);
+
+  /// Implement `then()` if the result does require unwrapping.
+  template <typename F>
+  typename internal::then_helper<F, void>::future_t then_impl(F&& functor,
+                                                              std::true_type);
+
+  template <typename U>
+  friend class future;
 };
 
 /**


### PR DESCRIPTION
When passing a functor that returns `R` to `.then()` the return value is
`future<R>`. If implemented naively, `.then() would be incovenient when
the return value `R` is actually a `future<R2>`. The naive version would
return `future<future<R2>>` and the application developer would need to
wait for the first future, and then wait for the wrapped `future<R2>`.

The Technical Specification we are following requires `.then()` to
unwrap the future in this case, and return `future<R2>`. This unwrapping
future waits for the (implicit) `future<future<R2>>` to become
satisfied, and then waits for the `future<R2>` to become satisfied.

This is specially important for us, because we expect that most
`bigtable::*::Async*()` member functions will return a `future<R2>`, so
to use them in `.then()` (some lambda adapters) we need to support
unwrapping.

Part of the work for #1345.