### PR TITLE
Implement unwrapping constructor.

### DIFF
--- a/google/cloud/internal/future_generic.h
+++ b/google/cloud/internal/future_generic.h
@@ -54,7 +54,9 @@ class future final : private internal::future_base<T> {
    *
    * @note The technical specification requires this to be a `noexcept`
    *   constructor I (@coryan) believe this is a defect in the technical
-   *   specification, as this *creates* a new shared state, and that can raise.
+   *   specification, as this *creates* a new shared state: shared states are
+   *   dynamically allocated, and the allocator (which might be the default
+   *   `operator new`) may raise.
    */
   future(future<future<T>>&& rhs) noexcept(false);
 

--- a/google/cloud/internal/future_generic.h
+++ b/google/cloud/internal/future_generic.h
@@ -43,9 +43,20 @@ class future final : private internal::future_base<T> {
 
   future() noexcept = default;
 
-  // TODO(#1345) - implement the unwrapping constructor.
-  // future(future<future<T>>&& f) noexcept;
-  // future& operator=(future<future<T>>&& f) noexcept;
+  /**
+   * Creates a new future that unwraps @p rhs.
+   *
+   * This constructor creates a new shared state that becomes satisfied when
+   * both `rhs` and `rhs.get()` become satisfied. If `rhs` is satisfied, but
+   * `rhs.get()` returns an invalid future then the newly created future becomes
+   * satisfied with a `std::future_error` exception, and the exception error
+   * code is `std::future_errc::broken_promise`.
+   *
+   * @note The technical specification requires this to be a `noexcept`
+   *   constructor I (@coryan) believe this is a defect in the technical
+   *   specification, as this *creates* a new shared state, and that can raise.
+   */
+  future(future<future<T>>&& rhs) noexcept(false);
 
   /**
    * Waits until the shared state becomes ready, then retrieves the value stored
@@ -111,6 +122,7 @@ class future final : private internal::future_base<T> {
 
   template <typename U>
   friend class future;
+  friend class future<void>;
 };
 
 /**

--- a/google/cloud/internal/future_generic_then_test.cc
+++ b/google/cloud/internal/future_generic_then_test.cc
@@ -111,8 +111,103 @@ TEST(FutureTestInt, ThenUnwrap) {
 // The test names match the section and paragraph from the TS.
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
-TEST(FutureTestInt, conform_2_3_2) {
-  // TODO(#1345) - implement unwrapping constructor from future<future<int>>.
+TEST(FutureTestInt, conform_2_3_2_a) {
+  // future<T> should have an unwrapping constructor.
+  promise<future<int>> p;
+  future<future<int>> f = p.get_future();
+
+  future<int> unwrapped(std::move(f));
+  EXPECT_FALSE(noexcept(future<int>(p.get_future())));
+}
+
+/// @test Verify conformance with section 2.3 of the Concurrency TS.
+TEST(FutureTestInt, conform_2_3_3_a) {
+  // A future<T> created via the unwrapping constructor becomes satisfied
+  // when both become satisfied.
+  promise<future<int>> p;
+
+  future<int> unwrapped(p.get_future());
+  EXPECT_TRUE(unwrapped.valid());
+  EXPECT_FALSE(unwrapped.is_ready());
+
+  promise<int> p2;
+  p.set_value(p2.get_future());
+  EXPECT_FALSE(unwrapped.is_ready());
+
+  p2.set_value(42);
+  EXPECT_TRUE(unwrapped.is_ready());
+  EXPECT_EQ(42, unwrapped.get());
+}
+
+/// @test Verify conformance with section 2.3 of the Concurrency TS.
+TEST(FutureTestInt, conform_2_3_3_b) {
+  // A future<T> created via the unwrapping constructor becomes satisfied
+  // when the wrapped future is satisfied by an exception.
+  promise<future<int>> p;
+
+  future<int> unwrapped(p.get_future());
+  EXPECT_TRUE(unwrapped.valid());
+  EXPECT_FALSE(unwrapped.is_ready());
+
+  p.set_exception(std::make_exception_ptr(std::runtime_error("test message")));
+  EXPECT_TRUE(unwrapped.is_ready());
+  EXPECT_THROW( try { unwrapped.get(); } catch(std::runtime_error const& ex) {
+    EXPECT_THAT(ex.what(), HasSubstr("test message"));
+    throw;
+  }, std::runtime_error);
+}
+
+/// @test Verify conformance with section 2.3 of the Concurrency TS.
+TEST(FutureTestInt, conform_2_3_3_c) {
+  // A future<T> created via the unwrapping constructor becomes satisfied
+  // when the inner future is satisfied by an exception.
+  promise<future<int>> p;
+
+  future<int> unwrapped(p.get_future());
+  EXPECT_TRUE(unwrapped.valid());
+  EXPECT_FALSE(unwrapped.is_ready());
+
+  promise<int> p2;
+  p.set_value(p2.get_future());
+  EXPECT_FALSE(unwrapped.is_ready());
+
+  p2.set_exception(std::make_exception_ptr(std::runtime_error("test message")));
+  EXPECT_TRUE(unwrapped.is_ready());
+  EXPECT_THROW( try { unwrapped.get(); } catch(std::runtime_error const& ex) {
+    EXPECT_THAT(ex.what(), HasSubstr("test message"));
+    throw;
+  }, std::runtime_error);
+}
+
+/// @test Verify conformance with section 2.3 of the Concurrency TS.
+TEST(FutureTestInt, conform_2_3_3_d) {
+  // A future<T> created via the unwrapping constructor becomes satisfied
+  // when the inner future is invalid.
+  promise<future<int>> p;
+
+  future<int> unwrapped(p.get_future());
+  EXPECT_TRUE(unwrapped.valid());
+  EXPECT_FALSE(unwrapped.is_ready());
+
+  promise<int> p2;
+  p.set_value(future<int>{});
+  EXPECT_TRUE(unwrapped.is_ready());
+
+  EXPECT_THROW( try { unwrapped.get(); } catch(std::future_error const& ex) {
+    EXPECT_EQ(std::future_errc::broken_promise, ex.code());
+    throw;
+  }, std::future_error);
+}
+
+/// @test Verify conformance with section 2.3 of the Concurrency TS.
+TEST(FutureTestInt, conform_2_3_4) {
+  // future<T> should leaves the source invalid.
+  promise<future<int>> p;
+  future<future<int>> f = p.get_future();
+
+  future<int> unwrapped(std::move(f));
+  EXPECT_TRUE(unwrapped.valid());
+  EXPECT_FALSE(f.valid());
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.

--- a/google/cloud/internal/future_impl_test.cc
+++ b/google/cloud/internal/future_impl_test.cc
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/port_platform.h"
+
+// C++ futures only make sense when exceptions are enabled.
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 #include "google/cloud/internal/future_impl.h"
 #include "google/cloud/internal/make_unique.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/testing_types.h"
 #include <gmock/gmock.h>
 
-// C++ futures only make sense when exceptions are enabled.
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {

--- a/google/cloud/internal/future_then_impl.h
+++ b/google/cloud/internal/future_then_impl.h
@@ -26,18 +26,26 @@
  * functions inline.
  */
 
+#include "google/cloud/internal/port_platform.h"
+
+// C++ futures only make sense when exceptions are enabled.
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 #include "google/cloud/internal/future_generic.h"
 #include "google/cloud/internal/future_void.h"
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
-// This function cannot be defined inline, as most template functions are,
+// These functions cannot be defined inline, as most template functions are,
 // because the full definition of `future<T>`, `future<R&>` and `future<void>`,
 // must be visible at the point of definition. There is no order of definition
 // for the `future<T>` specializations that would permit us to define the
 // functions inline.
+
+template <typename T>
+inline future<T>::future(future<future<T>>&& rhs)
+    : future<T>(rhs.then([](future<future<T>> f) { return f.get(); })) {}
+
 template <typename T>
 template <typename F>
 typename internal::then_helper<F, T>::future_t future<T>::then_impl(
@@ -78,11 +86,6 @@ typename internal::then_helper<F, T>::future_t future<T>::then_impl(
   return future_t(std::move(output_shared_state));
 }
 
-// This function cannot be defined inline, as most template functions are,
-// because the full definition of `future<T>`, `future<R&>` and `future<void>`,
-// must be visible at the point of definition. There is no order of definition
-// for the `future<T>` specializations that would permit us to define the
-// functions inline.
 template <typename T>
 template <typename F>
 typename internal::then_helper<F, T>::future_t future<T>::then_impl(
@@ -124,11 +127,9 @@ typename internal::then_helper<F, T>::future_t future<T>::then_impl(
   return future_t(std::move(output_shared_state));
 }
 
-// This function cannot be defined inline, as most template functions are,
-// because the full definition of `future<T>`, `future<R&>` and `future<void>`,
-// must be visible at the point of definition. There is no order of definition
-// for the `future<T>` specializations that would permit us to define the
-// functions inline.
+inline future<void>::future(future<future<void>>&& rhs)
+    : future<void>(rhs.then([](future<future<void>> f) { return f.get(); })) {}
+
 template <typename F>
 typename internal::then_helper<F, void>::future_t future<void>::then_impl(
     F&& functor, std::false_type) {
@@ -168,11 +169,6 @@ typename internal::then_helper<F, void>::future_t future<void>::then_impl(
   return future_t(std::move(output_shared_state));
 }
 
-// This function cannot be defined inline, as most template functions are,
-// because the full definition of `future<T>`, `future<R&>` and `future<void>`,
-// must be visible at the point of definition. There is no order of definition
-// for the `future<T>` specializations that would permit us to define the
-// functions inline.
 template <typename F>
 typename internal::then_helper<F, void>::future_t future<void>::then_impl(
     F&& functor, std::true_type) {

--- a/google/cloud/internal/future_void.h
+++ b/google/cloud/internal/future_void.h
@@ -43,9 +43,20 @@ class future<void> final : private internal::future_base<void> {
 
   future() noexcept = default;
 
-  // TODO(#1345) - implement the unwrapping constructor.
-  // future(future<future<void>>&& f) noexcept;
-  // future& operator=(future<future<void>>&& f) noexcept;
+  /**
+   * Creates a new future that unwraps @p rhs.
+   *
+   * This constructor creates a new shared state that becomes satisfied when
+   * both `rhs` and `rhs.get()` become satisfied. If `rhs` is satisfied, but
+   * `rhs.get()` returns an invalid future then the newly created future becomes
+   * satisfied with a `std::future_error` exception, and the exception error
+   * code is `std::future_errc::broken_promise`.
+   *
+   * @note The technical specification requires this to be a `noexcept`
+   *   constructor I (@coryan) believe this is a defect in the technical
+   *   specification, as this *creates* a new shared state, and that can raise.
+   */
+  future(future<future<void>>&& rhs) noexcept(false);
 
   /**
    * Waits until the shared state becomes ready, then retrieves the value stored

--- a/google/cloud/internal/future_void.h
+++ b/google/cloud/internal/future_void.h
@@ -54,7 +54,9 @@ class future<void> final : private internal::future_base<void> {
    *
    * @note The technical specification requires this to be a `noexcept`
    *   constructor I (@coryan) believe this is a defect in the technical
-   *   specification, as this *creates* a new shared state, and that can raise.
+   *   specification, as this *creates* a new shared state: shared states are
+   *   dynamically allocated, and the allocator (which might be the default
+   *   `operator new`) may raise.
    */
   future(future<future<void>>&& rhs) noexcept(false);
 


### PR DESCRIPTION
This implements `future<T>::future(future<future<T>>&& rhs)`.
It creates a new future whose shared state is satisfied when both
`rhs` and `rhs.get()` are satisfied.

Part of the work for #1345.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1423)
<!-- Reviewable:end -->
