### PR TITLE
future<T> and promise<T> even without exceptions.

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -108,6 +108,7 @@ add_library(google_cloud_cpp_common
             internal/future_base.h
             internal/future_fwd.h
             internal/future_impl.h
+            internal/future_impl.cc
             internal/future_then_impl.h
             internal/future_then_meta.h
             internal/future_generic.h
@@ -130,8 +131,7 @@ add_library(google_cloud_cpp_common
             optional.h
             terminate_handler.h
             terminate_handler.cc
-            version.h
-            internal/future_impl.cc)
+            version.h)
 target_link_libraries(google_cloud_cpp_common
                       PUBLIC Threads::Threads
                       PRIVATE google_cloud_cpp_common_options)

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -130,7 +130,8 @@ add_library(google_cloud_cpp_common
             optional.h
             terminate_handler.h
             terminate_handler.cc
-            version.h)
+            version.h
+            internal/future_impl.cc)
 target_link_libraries(google_cloud_cpp_common
                       PUBLIC Threads::Threads
                       PRIVATE google_cloud_cpp_common_options)
@@ -158,6 +159,7 @@ add_library(google_cloud_cpp_testing
             testing_util/chrono_literals.h
             testing_util/environment_variable_restore.h
             testing_util/environment_variable_restore.cc
+            testing_util/expect_future_error.h
             testing_util/custom_google_mock_main.cc
             testing_util/init_google_mock.h
             testing_util/init_google_mock.cc

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -40,4 +40,5 @@ google_cloud_cpp_common_SRCS = [
     "internal/throw_delegate.cc",
     "log.cc",
     "terminate_handler.cc",
+    "internal/future_impl.cc",
 ]

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -34,11 +34,11 @@ google_cloud_cpp_common_SRCS = [
     "iam_policy.cc",
     "internal/backoff_policy.cc",
     "internal/filesystem.cc",
+    "internal/future_impl.cc",
     "internal/getenv.cc",
     "internal/random.cc",
     "internal/setenv.cc",
     "internal/throw_delegate.cc",
     "log.cc",
     "terminate_handler.cc",
-    "internal/future_impl.cc",
 ]

--- a/google/cloud/google_cloud_cpp_testing.bzl
+++ b/google/cloud/google_cloud_cpp_testing.bzl
@@ -4,6 +4,7 @@ google_cloud_cpp_testing_HDRS = [
     "testing_util/check_predicate_becomes_false.h",
     "testing_util/chrono_literals.h",
     "testing_util/environment_variable_restore.h",
+    "testing_util/expect_future_error.h",
     "testing_util/init_google_mock.h",
     "testing_util/testing_types.h",
 ]

--- a/google/cloud/internal/future_base.h
+++ b/google/cloud/internal/future_base.h
@@ -20,10 +20,6 @@
  * Define the implementation details for `google::cloud::future<T>`.
  */
 
-#include "google/cloud/internal/port_platform.h"
-
-// C++ futures only make sense when exceptions are enabled.
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 #include "google/cloud/internal/future_impl.h"
 
 namespace google {
@@ -138,7 +134,7 @@ class future_base {
   /// Raises an exception if the shared state is not valid.
   void check_valid() const {
     if (not shared_state_) {
-      throw std::future_error(std::future_errc::no_state);
+      RaiseFutureError(std::future_errc::no_state, __func__);
     }
   }
 
@@ -174,7 +170,7 @@ class promise_base {
    */
   void set_exception(std::exception_ptr ex) {
     if (not shared_state_) {
-      throw std::future_error(std::future_errc::no_state);
+      RaiseFutureError(std::future_errc::no_state, __func__);
     }
     shared_state_->set_exception(std::move(ex));
   }
@@ -190,5 +186,4 @@ class promise_base {
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_BASE_H_

--- a/google/cloud/internal/future_generic.h
+++ b/google/cloud/internal/future_generic.h
@@ -20,10 +20,6 @@
  * Fully specialize `future<void>` and `promise<R>` for void.
  */
 
-#include "google/cloud/internal/port_platform.h"
-
-// C++ futures only make sense when exceptions are enabled.
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 #include "google/cloud/internal/future_base.h"
 #include "google/cloud/internal/future_fwd.h"
 #include "google/cloud/internal/future_impl.h"
@@ -182,7 +178,7 @@ class promise final : private internal::promise_base<T> {
    */
   void set_value(T&& value) {
     if (not this->shared_state_) {
-      throw std::future_error(std::future_errc::no_state);
+      internal::RaiseFutureError(std::future_errc::no_state, __func__);
     }
     this->shared_state_->set_value(std::forward<T>(value));
   }
@@ -204,5 +200,4 @@ class promise final : private internal::promise_base<T> {
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_GENERIC_H_

--- a/google/cloud/internal/future_impl.cc
+++ b/google/cloud/internal/future_impl.cc
@@ -12,35 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_FWD_H_
-#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_FWD_H_
-
-#include "google/cloud/version.h"
+#include "google/cloud/internal/future_impl.h"
+#include "google/cloud/terminate_handler.h"
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
 
 namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
-// Forward declare the promise type so we can write some helpers.
-template <typename R>
-class promise;
-
-// Forward declare the future type so we can write some helpers.
-template <typename R>
-class future;
-
-// Forward declare the specializations for references.
-template <typename R>
-class promise<R&>;
-template <typename R>
-class future<R&>;
-
-// Forward declare the specialization for `void`.
-template <>
-class promise<void>;
-template <>
-class future<void>;
+namespace internal {
+[[noreturn]] void RaiseFutureError(std::future_errc ec, char const* msg) {
+#ifdef GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  throw std::future_error(ec);
+#else
+  std::string full_msg = "future_error[";
+  full_msg += std::make_error_code(ec).message();
+  full_msg += "]: ";
+  full_msg += msg;
+  google::cloud::Terminate(full_msg.c_str());
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+}  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud
 }  // namespace google
-
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_FWD_H_

--- a/google/cloud/internal/future_then_impl.h
+++ b/google/cloud/internal/future_then_impl.h
@@ -26,10 +26,6 @@
  * functions inline.
  */
 
-#include "google/cloud/internal/port_platform.h"
-
-// C++ futures only make sense when exceptions are enabled.
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 #include "google/cloud/internal/future_generic.h"
 #include "google/cloud/internal/future_void.h"
 
@@ -213,5 +209,4 @@ typename internal::then_helper<F, void>::future_t future<void>::then_impl(
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_THEN_IMPL_H_

--- a/google/cloud/internal/future_void.h
+++ b/google/cloud/internal/future_void.h
@@ -20,10 +20,6 @@
  * Fully specialize `future<void>` and `promise<R>` for void.
  */
 
-#include "google/cloud/internal/port_platform.h"
-
-// C++ futures only make sense when exceptions are enabled.
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 #include "google/cloud/internal/future_base.h"
 #include "google/cloud/internal/future_fwd.h"
 #include "google/cloud/internal/future_impl.h"
@@ -178,7 +174,7 @@ class promise<void> final : private internal::promise_base<void> {
    */
   void set_value() {
     if (not shared_state_) {
-      throw std::future_error(std::future_errc::no_state);
+      internal::RaiseFutureError(std::future_errc::no_state, __func__);
     }
     shared_state_->set_value();
   }
@@ -190,5 +186,4 @@ class promise<void> final : private internal::promise_base<void> {
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_VOID_H_

--- a/google/cloud/testing_util/expect_future_error.h
+++ b/google/cloud/testing_util/expect_future_error.h
@@ -1,0 +1,56 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_EXPECT_FUTURE_ERROR_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_EXPECT_FUTURE_ERROR_H_
+
+#include "google/cloud/version.h"
+#include <gmock/gmock.h>
+#include <future>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace testing_util {
+/**
+ * Verify that a given functor raises `std::future_error` with the right error
+ * code.
+ *
+ * @param functor the functor to call, typically a lambda that will perform the
+ *     operation under test.
+ * @param code the expected error code.
+ * @tparam Functor the type of @p functor.
+ */
+template <typename Functor>
+void ExpectFutureError(Functor functor, std::future_errc code) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(try { functor(); } catch (std::future_error const& ex) {
+    EXPECT_EQ(code, ex.code());
+    throw;
+  },
+               std::future_error);
+#else
+  std::string expected = "future_error\\[";
+  expected += std::make_error_code(code).message();
+  expected += "\\]";
+  EXPECT_DEATH_IF_SUPPORTED(functor(), expected);
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+}  // namespace testing_util
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_EXPECT_FUTURE_ERROR_H_


### PR DESCRIPTION
Using `future<T>` and `promise<T>` without exceptions is probably unwise,
but we need to compile the code without exception, and want to avoid littering
the rest of the code with #ifdef/#endif blocks. Part of the work for #1345.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1426)
<!-- Reviewable:end -->
