### PR TITLE
Extend object unit tests for non-idempotent case.

### DIFF
--- a/google/cloud/storage/client_object_copy_test.cc
+++ b/google/cloud/storage/client_object_copy_test.cc
@@ -91,6 +91,11 @@ TEST_F(ObjectCopyTest, CopyObjectTooManyFailures) {
                           "test-bucket-name", "test-object-name",
                           ObjectMetadata());
       },
+      [](Client& client) {
+        client.CopyObject("source-bucket-name", "source-object-name",
+                          "test-bucket-name", "test-object-name",
+                          ObjectMetadata(), IfGenerationMatch(0));
+      },
       "CopyObject");
 }
 
@@ -159,6 +164,11 @@ TEST_F(ObjectCopyTest, ComposeObjectTooManyFailures) {
       [](Client& client) {
         client.ComposeObject("test-bucket-name", {{"object1"}, {"object2"}},
                              "test-object-name", ObjectMetadata());
+      },
+      [](Client& client) {
+        client.ComposeObject("test-bucket-name", {{"object1"}, {"object2"}},
+                             "test-object-name", ObjectMetadata(),
+                             IfGenerationMatch(7));
       },
       "ComposeObject");
 }
@@ -276,6 +286,12 @@ TEST_F(ObjectCopyTest, RewriteObjectTooManyFailures) {
             "test-source-bucket-name", "test-source-object",
             "test-dest-bucket-name", "test-dest-object", ObjectMetadata());
         rewrite.Result();
+      },
+      [](Client& client) {
+        client.RewriteObjectBlocking(
+            "test-source-bucket-name", "test-source-object",
+            "test-dest-bucket-name", "test-dest-object", ObjectMetadata(),
+            IfGenerationMatch(7));
       },
       "RewriteObject");
 }

--- a/google/cloud/storage/object_test.cc
+++ b/google/cloud/storage/object_test.cc
@@ -86,6 +86,10 @@ TEST_F(ObjectTest, InsertObjectMediaTooManyFailures) {
         client.InsertObject("test-bucket-name", "test-object-name",
                             "test object contents");
       },
+      [](Client& client) {
+        client.InsertObject("test-bucket-name", "test-object-name",
+                            "test object contents", IfGenerationMatch(0));
+      },
       "InsertObjectMedia");
 }
 
@@ -181,6 +185,10 @@ TEST_F(ObjectTest, DeleteObjectTooManyFailures) {
       [](Client& client) {
         client.DeleteObject("test-bucket-name", "test-object-name");
       },
+      [](Client& client) {
+        client.DeleteObject("test-bucket-name", "test-object-name",
+            IfGenerationMatch(7));
+      },
       "DeleteObject");
 }
 
@@ -269,6 +277,12 @@ TEST_F(ObjectTest, UpdateObjectTooManyFailures) {
             "test-bucket-name", "test-object-name",
             ObjectMetadata().set_content_language("new-language"));
       },
+      [](Client& client) {
+        client.UpdateObject(
+            "test-bucket-name", "test-object-name",
+            ObjectMetadata().set_content_language("new-language"),
+            IfMetagenerationMatch(42));
+      },
       "UpdateObject");
 }
 
@@ -335,6 +349,12 @@ TEST_F(ObjectTest, PatchObjectTooManyFailures) {
             "test-bucket-name", "test-object-name",
             ObjectMetadataPatchBuilder().SetContentLanguage("x-pig-latin"));
       },
+      [](Client& client) {
+        client.PatchObject(
+            "test-bucket-name", "test-object-name",
+            ObjectMetadataPatchBuilder().SetContentLanguage("x-pig-latin"),
+            IfMetagenerationMatch(42));
+      },
       "PatchObject");
 }
 
@@ -348,7 +368,6 @@ TEST_F(ObjectTest, PatchObjectPermanentFailure) {
       },
       "PatchObject");
 }
-
 }  // namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/testing/retry_tests.h
+++ b/google/cloud/storage/testing/retry_tests.h
@@ -50,10 +50,11 @@ namespace testing {
  * @return a function that implements the test.
  */
 template <typename ReturnType, typename F>
-void TooManyFailuresTest(std::shared_ptr<testing::MockClient> mock,
-                         ::testing::internal::TypedExpectation<F>& oncall,
-                         std::function<void(Client& client)> tested_operation,
-                         char const* api_name) {
+void TooManyFailuresTest(
+    std::shared_ptr<testing::MockClient> const& mock,
+    ::testing::internal::TypedExpectation<F>& oncall,
+    std::function<void(Client& client)> const& tested_operation,
+    char const* api_name) {
   using canonical_errors::TransientError;
   using ::testing::HasSubstr;
   using ::testing::Return;
@@ -85,6 +86,185 @@ void TooManyFailuresTest(std::shared_ptr<testing::MockClient> mock,
   EXPECT_DEATH_IF_SUPPORTED(tested_operation(client),
                             "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+/**
+ * Tests that non-idempotent operations are *not* retried case for a `Client::*`
+ * member function.
+ *
+ * We need to verify that non-idempotent operations are not retied when the
+ * policy says so. The tests are quite repetitive, and all have the same
+ * structure:
+ *
+ * - Create a `storage::Client` with the right idempotency policies.
+ * - Setup the mock to return the right number of transient failures.
+ * - Call the API.
+ * - Verify an exception was raised, with the right messages.
+ * - Also implement the last 3 steps for the no-exceptions case.
+ *
+ * This function implements these tests, saving us a lot of repetitive code.
+ *
+ * @tparam ReturnType The API return type.
+ * @tparam F a formal parameter, the googlemock representation of the mocked
+ *     call.
+ *
+ * @param oncall The internal type returned by EXPECT_CALL(...).
+ * @param tested_operation a function wrapping the operation to be tested.
+ * @param api_name the name of the api
+ * @param has_will_repeatedly `.WillRepeatedly()` can be called only once
+ *     in @p oncall. If this flag is set, the test will not setup that
+ *     expectation again.
+ * @return a function that implements the test.
+ */
+template <typename ReturnType, typename F>
+void NonIdempotentFailuresTest(
+    std::shared_ptr<testing::MockClient> const& mock,
+    ::testing::internal::TypedExpectation<F>& oncall,
+    std::function<void(Client& client)> const& tested_operation,
+    char const* api_name, bool has_will_repeatedly = false) {
+  using canonical_errors::TransientError;
+  using ::testing::HasSubstr;
+  using ::testing::Return;
+  // A storage::Client with the strict idempotency policy, but with a generous
+  // retry policy.
+  Client client{std::shared_ptr<internal::RawClient>(mock),
+                StrictIdempotencyPolicy(), LimitedErrorCountRetryPolicy(10)};
+
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  // The first transient error should stop the retries for non-idempotent
+  // operations.
+  oncall.WillOnce(Return(std::make_pair(TransientError(), ReturnType{})));
+
+  // Verify the right exception type, with the right content, is raised when
+  // calling the operation.
+  EXPECT_THROW(
+      try { tested_operation(client); } catch (std::runtime_error const& ex) {
+        EXPECT_THAT(ex.what(), HasSubstr("Error in non-idempotent"));
+        EXPECT_THAT(ex.what(), HasSubstr(api_name));
+        throw;
+      },
+      std::runtime_error);
+#else
+  // With EXPECT_DEATH*() the mocking framework cannot detect how many times
+  // the operation is called, so we cannot set an exact number of calls to
+  // expect.
+  if (not has_will_repeatedly) {
+    oncall.WillRepeatedly(
+        Return(std::make_pair(TransientError(), ReturnType{})));
+  }
+  EXPECT_DEATH_IF_SUPPORTED(tested_operation(client),
+                            "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+/**
+ * Tests that non-idempotent operations are *not* retried case for a `Client::*`
+ * member function.
+ *
+ * We need to verify that non-idempotent operations are not retied when the
+ * policy says so. The tests are quite repetitive, and all have the same
+ * structure:
+ *
+ * - Create a `storage::Client` with the right idempotency policies.
+ * - Setup the mock to return the right number of transient failures.
+ * - Call the API.
+ * - Verify an exception was raised, with the right messages.
+ * - Also implement the last 3 steps for the no-exceptions case.
+ *
+ * This function implements these tests, saving us a lot of repetitive code.
+ *
+ * @tparam ReturnType The API return type.
+ * @tparam F a formal parameter, the googlemock representation of the mocked
+ *     call.
+ *
+ * @param oncall The internal type returned by EXPECT_CALL(...).
+ * @param tested_operation a function wrapping the operation to be tested.
+ * @param api_name the name of the api
+ * @param has_will_repeatedly `.WillRepeatedly()` can be called only once
+ *     in @p oncall. If this flag is set, the test will not setup that
+ *     expectation again.
+ * @return a function that implements the test.
+ */
+template <typename ReturnType, typename F>
+void IdempotentFailuresTest(
+    std::shared_ptr<testing::MockClient> const& mock,
+    ::testing::internal::TypedExpectation<F>& oncall,
+    std::function<void(Client& client)> const& tested_operation,
+    char const* api_name, bool has_will_repeatedly = true) {
+  using canonical_errors::TransientError;
+  using ::testing::HasSubstr;
+  using ::testing::Return;
+  // A storage::Client with the strict idempotency policy, but with a generous
+  // retry policy.
+  Client client{std::shared_ptr<internal::RawClient>(mock),
+                StrictIdempotencyPolicy(), LimitedErrorCountRetryPolicy(2)};
+
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  // Expect exactly 3 calls before the retry policy is exhausted and an
+  // exception is raised.
+  oncall.WillOnce(Return(std::make_pair(TransientError(), ReturnType{})))
+      .WillOnce(Return(std::make_pair(TransientError(), ReturnType{})))
+      .WillOnce(Return(std::make_pair(TransientError(), ReturnType{})));
+
+  // Verify the right exception type, with the right content, is raised when
+  // calling the operation.
+  EXPECT_THROW(
+      try { tested_operation(client); } catch (std::runtime_error const& ex) {
+        EXPECT_THAT(ex.what(), HasSubstr("Retry policy exhausted"));
+        EXPECT_THAT(ex.what(), HasSubstr(api_name));
+        throw;
+      },
+      std::runtime_error);
+#else
+  // With EXPECT_DEATH*() the mocking framework cannot detect how many times
+  // the operation is called, so we cannot set an exact number of calls to
+  // expect.
+  if (not has_will_repeatedly) {
+    oncall.WillRepeatedly(
+        Return(std::make_pair(TransientError(), ReturnType{})));
+  }
+  EXPECT_DEATH_IF_SUPPORTED(tested_operation(client),
+                            "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+/**
+ * Test operations that are idempotent or not depending of their parameters.
+ *
+ * Some operations are idempotent when some parameters are set (preconditions),
+ * when the operation is idempotent, we want to verify that they are retried
+ * multiple times, when they are not, we want to retry them only once if the
+ * right policy is set.
+ *
+ * - Create a `storage::Client` with an easy-to-test retry policy.
+ * - Setup the mock to return the right number of transient failures.
+ * - Call the API.
+ * - Verify an exception was raised, with the right messages.
+ * - Also implement the last 3 steps for the no-exceptions case.
+ *
+ * This function implements these tests, saving us a lot of repetitive code.
+ *
+ * @tparam ReturnType The API return type.
+ * @tparam F a formal parameter, the googlemock representation of the mocked
+ *     call.
+ *
+ * @param oncall The internal type returned by EXPECT_CALL(...).
+ * @param tested_operation a function wrapping the operation to be tested.
+ * @param api_name the name of the api
+ * @return a function that implements the test.
+ */
+template <typename ReturnType, typename F>
+void TooManyFailuresTest(
+    std::shared_ptr<testing::MockClient> const& mock,
+    ::testing::internal::TypedExpectation<F>& oncall,
+    std::function<void(Client& client)> const& tested_operation,
+    std::function<void(Client& client)> const& idempotent_operation,
+    char const* api_name) {
+  TooManyFailuresTest<ReturnType>(mock, oncall, tested_operation, api_name);
+  IdempotentFailuresTest<ReturnType>(mock, oncall, idempotent_operation,
+                                     api_name, true);
+  NonIdempotentFailuresTest<ReturnType>(mock, oncall, tested_operation,
+                                        api_name, true);
 }
 
 /**


### PR DESCRIPTION
This is part of the work for #714. It implements unit test for the
`Object: *` operations that are sometimes idempotent, and verify that
both (a) non-idempotent failures stop the retry loop in the first
failure, and (b) idempotent failures are retried multiple times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1427)
<!-- Reviewable:end -->
