### PR TITLE
Cleanup MSVC warnings.

### DIFF
--- a/google/cloud/bigtable/internal/completion_queue_impl.h
+++ b/google/cloud/bigtable/internal/completion_queue_impl.h
@@ -158,14 +158,14 @@ class AsyncUnaryRpcFunctor : public AsyncOperation {
 
   void Cancel() override {
     // Make sure context_ is visible in this thread.
-    sync_.load(std::memory_order_acquire);
+    static_cast<void>(sync_.load(std::memory_order_acquire));
     context_->TryCancel();
   }
 
  private:
   bool Notify(CompletionQueue& cq, bool ok) override {
     // Make sure members are visible.
-    sync_.load(std::memory_order_acquire);
+    static_cast<void>(sync_.load(std::memory_order_acquire));
     if (not ok) {
       // This would mean a bug in grpc. Documentation states that Finish()
       // always returns true.

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/log.h"
 #include "google/cloud/storage/client.h"
@@ -53,7 +54,7 @@ class ObjectMediaIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {};
 
 bool UsingTestbench() {
-  return std::getenv("CLOUD_STORAGE_TESTBENCH_ENDPOINT") != nullptr;
+  return google::cloud::internal::GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT").has_value();
 }
 
 TEST_F(ObjectMediaIntegrationTest, XmlDownloadFile) {


### PR DESCRIPTION
See AppVeyor logs for details.  `std::atomic<bool>::load` has a
`[[nodiscard]]` qualifier.  And one `std::getenv()` in the last round of
fixes.

Eventually we want to turn on "warnings as errors" with MSVC, but not
quite ready for it yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1428)
<!-- Reviewable:end -->
