### PR TITLE
Add idempotency unit test for all resources.

### DIFF
--- a/google/cloud/storage/bucket_test.cc
+++ b/google/cloud/storage/bucket_test.cc
@@ -181,6 +181,9 @@ TEST_F(BucketTest, DeleteBucketTooManyFailures) {
   testing::TooManyFailuresTest<internal::EmptyResponse>(
       mock, EXPECT_CALL(*mock, DeleteBucket(_)),
       [](Client& client) { client.DeleteBucket("test-bucket-name"); },
+      [](Client& client) {
+        client.DeleteBucket("test-bucket-name", IfMetagenerationMatch(42));
+      },
       "DeleteBucket");
 }
 
@@ -229,6 +232,10 @@ TEST_F(BucketTest, UpdateBucketTooManyFailures) {
       mock, EXPECT_CALL(*mock, UpdateBucket(_)),
       [](Client& client) {
         client.UpdateBucket("test-bucket-name", BucketMetadata());
+      },
+      [](Client& client) {
+        client.UpdateBucket("test-bucket-name", BucketMetadata(),
+                            IfMetagenerationMatch(42));
       },
       "UpdateBucket");
 }
@@ -279,6 +286,10 @@ TEST_F(BucketTest, PatchBucketTooManyFailures) {
       mock, EXPECT_CALL(*mock, PatchBucket(_)),
       [](Client& client) {
         client.PatchBucket("test-bucket-name", BucketMetadataPatchBuilder());
+      },
+      [](Client& client) {
+        client.PatchBucket("test-bucket-name", BucketMetadataPatchBuilder(),
+            IfMetagenerationMatch(42));
       },
       "PatchBucket");
 }
@@ -350,6 +361,9 @@ TEST_F(BucketTest, SetBucketIamPolicyTooManyFailures) {
       mock, EXPECT_CALL(*mock, SetBucketIamPolicy(_)),
       [](Client& client) {
         client.SetBucketIamPolicy("test-bucket-name", IamPolicy{});
+      },
+      [](Client& client) {
+        client.SetBucketIamPolicy("test-bucket-name", IamPolicy{}, IfMatchEtag("ABC="));
       },
       "SetBucketIamPolicy");
 }

--- a/google/cloud/storage/client_bucket_acl_test.cc
+++ b/google/cloud/storage/client_bucket_acl_test.cc
@@ -131,6 +131,10 @@ TEST_F(BucketAccessControlsTest, CreateBucketAclTooManyFailures) {
         client.CreateBucketAcl("test-bucket-name", "user-test-user-1",
                                "READER");
       },
+      [](Client& client) {
+        client.CreateBucketAcl("test-bucket-name", "user-test-user-1", "READER",
+                               IfMatchEtag("ABC="));
+      },
       "CreateBucketAcl");
 }
 
@@ -163,6 +167,10 @@ TEST_F(BucketAccessControlsTest, DeleteBucketAclTooManyFailures) {
       mock, EXPECT_CALL(*mock, DeleteBucketAcl(_)),
       [](Client& client) {
         client.DeleteBucketAcl("test-bucket-name", "user-test-user-1");
+      },
+      [](Client& client) {
+        client.DeleteBucketAcl("test-bucket-name", "user-test-user-1",
+                               IfMatchEtag("ABC="));
       },
       "DeleteBucketAcl");
 }
@@ -249,6 +257,13 @@ TEST_F(BucketAccessControlsTest, UpdateBucketAclTooManyFailures) {
                                    .set_entity("user-test-user-1")
                                    .set_role("OWNER"));
       },
+      [](Client& client) {
+        client.UpdateBucketAcl("test-bucket",
+                               BucketAccessControl()
+                                   .set_entity("user-test-user-1")
+                                   .set_role("OWNER"),
+                               IfMatchEtag("ABC="));
+      },
       "UpdateBucketAcl");
 }
 
@@ -296,6 +311,11 @@ TEST_F(BucketAccessControlsTest, PatchBucketAclTooManyFailures) {
       [](Client& client) {
         client.PatchBucketAcl("test-bucket", "user-test-user-1",
                               BucketAccessControlPatchBuilder());
+      },
+      [](Client& client) {
+        client.PatchBucketAcl("test-bucket", "user-test-user-1",
+                              BucketAccessControlPatchBuilder(),
+                              IfMatchEtag("ABC="));
       },
       "PatchBucketAcl");
 }

--- a/google/cloud/storage/client_default_object_acl_test.cc
+++ b/google/cloud/storage/client_default_object_acl_test.cc
@@ -134,6 +134,10 @@ TEST_F(DefaultObjectAccessControlsTest, CreateDefaultObjectAclTooManyFailures) {
         client.CreateDefaultObjectAcl("test-bucket-name", "user-test-user-1",
                                       "READER");
       },
+      [](Client& client) {
+        client.CreateDefaultObjectAcl("test-bucket-name", "user-test-user-1",
+                                      "READER", IfMatchEtag("ABC="));
+      },
       "CreateDefaultObjectAcl");
 }
 
@@ -169,6 +173,10 @@ TEST_F(DefaultObjectAccessControlsTest, DeleteDefaultObjectAclTooManyFailures) {
       mock, EXPECT_CALL(*mock, DeleteDefaultObjectAcl(_)),
       [](Client& client) {
         client.DeleteDefaultObjectAcl("test-bucket-name", "user-test-user-1");
+      },
+      [](Client& client) {
+        client.DeleteDefaultObjectAcl("test-bucket-name", "user-test-user-1",
+                                      IfMatchEtag("ABC="));
       },
       "DeleteDefaultObjectAcl");
 }
@@ -261,6 +269,10 @@ TEST_F(DefaultObjectAccessControlsTest, UpdateDefaultObjectAclTooManyFailures) {
         client.UpdateDefaultObjectAcl("test-bucket-name",
                                       ObjectAccessControl());
       },
+      [](Client& client) {
+        client.UpdateDefaultObjectAcl("test-bucket-name", ObjectAccessControl(),
+                                      IfMatchEtag("ABC="));
+      },
       "UpdateDefaultObjectAcl");
 }
 
@@ -307,6 +319,11 @@ TEST_F(DefaultObjectAccessControlsTest, PatchDefaultObjectAclTooManyFailures) {
       [](Client& client) {
         client.PatchDefaultObjectAcl("test-bucket-name", "user-test-user-1",
                                      ObjectAccessControlPatchBuilder());
+      },
+      [](Client& client) {
+        client.PatchDefaultObjectAcl("test-bucket-name", "user-test-user-1",
+                                     ObjectAccessControlPatchBuilder(),
+                                     IfMatchEtag("ABC="));
       },
       "PatchDefaultObjectAcl");
 }

--- a/google/cloud/storage/client_object_acl_test.cc
+++ b/google/cloud/storage/client_object_acl_test.cc
@@ -142,6 +142,11 @@ TEST_F(ObjectAccessControlsTest, CreateObjectAclTooManyFailures) {
         client.CreateObjectAcl("test-bucket-name", "test-object-name",
                                "user-test-user-1", "READER");
       },
+      [](Client& client) {
+        client.CreateObjectAcl("test-bucket-name", "test-object-name",
+                               "user-test-user-1", "READER",
+                               IfMatchEtag("ABC="));
+      },
       "CreateObjectAcl");
 }
 
@@ -178,6 +183,10 @@ TEST_F(ObjectAccessControlsTest, DeleteObjectAclTooManyFailures) {
       [](Client& client) {
         client.DeleteObjectAcl("test-bucket-name", "test-object-name",
                                "user-test-user-1");
+      },
+      [](Client& client) {
+        client.DeleteObjectAcl("test-bucket-name", "test-object-name",
+                               "user-test-user-1", IfMatchEtag("ABC="));
       },
       "DeleteObjectAcl");
 }
@@ -268,6 +277,10 @@ TEST_F(ObjectAccessControlsTest, UpdateObjectAclTooManyFailures) {
         client.UpdateObjectAcl("test-bucket-name", "test-object-name",
                                ObjectAccessControl());
       },
+      [](Client& client) {
+        client.UpdateObjectAcl("test-bucket-name", "test-object-name",
+                               ObjectAccessControl(), IfMatchEtag("ABC="));
+      },
       "UpdateObjectAcl");
 }
 
@@ -315,6 +328,11 @@ TEST_F(ObjectAccessControlsTest, PatchObjectAclTooManyFailures) {
         client.PatchObjectAcl("test-bucket-name", "test-object-name",
                               "user-test-user-1",
                               ObjectAccessControlPatchBuilder());
+      },
+      [](Client& client) {
+        client.PatchObjectAcl(
+            "test-bucket-name", "test-object-name", "user-test-user-1",
+            ObjectAccessControlPatchBuilder(), IfMatchEtag("ABC="));
       },
       "PatchObjectAcl");
 }


### PR DESCRIPTION
This fixes #714. All requests that may the non-idempotent have unit
tests to verify they work correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1429)
<!-- Reviewable:end -->
