### PR TITLE
Create scripts for Kokoro Windows build.

### DIFF
--- a/ci/kokoro/windows/build-dependencies.ps1
+++ b/ci/kokoro/windows/build-dependencies.ps1
@@ -1,0 +1,120 @@
+# !/usr/bin/env powershell
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Stop on errors. This is similar to `set -e` on Unix shells.
+$ErrorActionPreference = "Stop"
+
+# First check the required environment variables.
+if (-not (Test-Path env:CONFIG)) {
+    throw "Aborting build because the CONFIG environment variable is not set."
+}
+$CONFIG = $env:CONFIG
+
+# Update or clone the 'vcpkg' package manager, this is a bit overly complicated,
+# but it works well on your workstation where you may want to run this script
+# multiple times while debugging vcpkg installs.  It also works on AppVeyor
+# where we cache the vcpkg installation, but it might be empty on the first
+# build.
+Write-Host "Obtaining vcpkg repository."
+Get-Date -Format o
+cd ..
+if (Test-Path vcpkg\.git) {
+    cd vcpkg
+    git pull
+} elseif (Test-Path vcpkg\installed) {
+    move vcpkg vcpkg-tmp
+    git clone https://github.com/Microsoft/vcpkg
+    move vcpkg-tmp\installed vcpkg
+    cd vcpkg
+} else {
+    git clone https://github.com/Microsoft/vcpkg
+    cd vcpkg
+}
+if ($LastExitCode) {
+    throw "vcpkg git setup failed with exit code $LastExitCode"
+}
+
+Write-Host "Downloading build cache."
+Get-Date -Format o
+gsutil cp gs://cloud-cpp-kokoro-results/build-artifacts/vcpkg-installed.zip .
+if ($LastExitCode) {
+    # Ignore errors, caching failures should not break the build.
+    Write-Host "extracting build cache failed with exit code $LastExitCode"
+}
+
+Write-Host "Extracting build cache."
+Get-Date -Format o
+cmd /c 7z x vcpkg-installed.zip -aoa
+if ($LastExitCode) {
+    # Ignore errors, caching failures should not break the build.
+    Write-Host "gsutil download failed with exit code $LastExitCode"
+}
+
+Write-Host "Bootstrap vcpkg."
+Get-Date -Format o
+powershell -exec bypass scripts\bootstrap.ps1
+if ($LastExitCode) {
+    throw "vcpkg bootstrap failed with exit code $LastExitCode"
+}
+
+# Only compile the release version of the packages we need, for Debug builds
+# this trick does not work, so we need to compile all versions (yuck).
+if ($CONFIG -eq "Release") {
+    Add-Content triplets\x64-windows-static.cmake "set(VCPKG_BUILD_TYPE release)"
+}
+
+# Integrate installed packages into the build environment.
+.\vcpkg.exe integrate install
+if ($LastExitCode) {
+    throw "vcpkg integrate failed with exit code $LastExitCode"
+}
+
+# Remove old versions of the packages.
+Write-Host "Cleanup old vcpkg package versions."
+Get-Date -Format o
+.\vcpkg.exe remove --outdated --recurse
+if ($LastExitCode) {
+    throw "vcpkg remove --outdated failed with exit code $LastExitCode"
+}
+
+Write-Host "Building vcpkg package versions."
+Get-Date -Format o
+$packages = @("zlib:x64-windows-static", "openssl:x64-windows-static",
+              "protobuf:x64-windows-static", "c-ares:x64-windows-static",
+              "grpc:x64-windows-static", "curl:x64-windows-static",
+              "gtest:x64-windows-static", "crc32c:x64-windows-static")
+foreach ($pkg in $packages) {
+    .\vcpkg.exe install $pkg
+    if ($LastExitCode) {
+        throw "vcpkg install $pkg failed with exit code $LastExitCode"
+    }
+}
+
+Write-Host "Create cache zip file."
+Get-Date -Format o
+cmd /c 7z a vcpkg-installed.zip installed\
+if ($LastExitCode) {
+    # Ignore errors, caching failures should not break the build.
+    Write-Host "zip build cache failed with exit code $LastExitCode"
+}
+
+Write-Host "Upload cache zip file."
+Get-Date -Format o
+gsutil cp vcpkg-installed.zip gs://cloud-cpp-kokoro-results/build-artifacts/vcpkg-installed.zip
+if ($LastExitCode) {
+    # Ignore errors, caching failures should not break the build.
+    Write-Host "gsutil upload failed with exit code $LastExitCode"
+}

--- a/ci/kokoro/windows/build-project.ps1
+++ b/ci/kokoro/windows/build-project.ps1
@@ -1,0 +1,84 @@
+# !/usr/bin/env powershell
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Stop on errors. This is similar to `set -e` on Unix shells.
+$ErrorActionPreference = "Stop"
+
+# First check the required environment variables.
+if (-not (Test-Path env:PROVIDER)) {
+    throw "Aborting build because the PROVIDER environment variable is not set."
+}
+if (-not (Test-Path env:CONFIG)) {
+    throw "Aborting build because the CONFIG environment variable is not set."
+}
+
+$CONFIG = $env:CONFIG
+$PROVIDER = $env:PROVIDER
+$GENERATOR = "Ninja"
+
+git submodule update --init
+if ($LastExitCode) {
+    throw "git submodule failed with exit code $LastExitCode"
+}
+
+# By default assume "module", use the configuration parameters and build in the `build-output` directory.
+$cmake_flags=@("-G$GENERATOR", "-DCMAKE_BUILD_TYPE=$CONFIG", "-H.", "-Bbuild-output")
+
+# This script expects vcpkg to be installed in ..\vcpkg, discover the full
+# path to that directory:
+$dir = Split-Path (Get-Item -Path ".\" -Verbose).FullName
+
+# Run the vcpkg integration.
+$integrate = "$dir\vcpkg\vcpkg.exe integrate install"
+Invoke-Expression $integrate
+if ($LastExitCode) {
+    throw "vcpkg integrate failed with exit code $LastExitCode"
+}
+
+# Setup the environment for vcpkg:
+$cmake_flags += "-DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=$PROVIDER"
+$cmake_flags += "-DCMAKE_TOOLCHAIN_FILE=`"$dir\vcpkg\scripts\buildsystems\vcpkg.cmake`""
+$cmake_flags += "-DVCPKG_TARGET_TRIPLET=x64-windows-static"
+$cmake_flags += "-DCMAKE_C_COMPILER=cl.exe"
+$cmake_flags += "-DCMAKE_CXX_COMPILER=cl.exe"
+
+# Configure CMake and create the build directory.
+Write-Host
+Get-Date -Format o
+Write-Host "Configuring CMake with $cmake_flags"
+cmake $cmake_flags
+if ($LastExitCode) {
+    throw "cmake config failed with exit code $LastExitCode"
+}
+
+Write-Host
+Get-Date -Format o
+Write-Host "Compiling with CMake $env:CONFIG"
+cmake --build build-output --config $CONFIG
+if ($LastExitCode) {
+    throw "cmake for 'all' target failed with exit code $LastExitCode"
+}
+
+Write-Host
+Get-Date -Format o
+cd build-output
+ctest --output-on-failure -C $CONFIG
+if ($LastExitCode) {
+    throw "ctest failed with exit code $LastExitCode"
+}
+
+Write-Host
+Get-Date -Format o

--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -1,0 +1,41 @@
+REM Copyright 2018 Google LLC
+REM
+REM Licensed under the Apache License, Version 2.0 (the "License");
+REM you may not use this file except in compliance with the License.
+REM You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+
+echo %date% %time%
+cd github\google-cloud-cpp
+
+echo %date% %time%
+powershell -exec bypass ci\kokoro\windows\install-dependencies.ps1
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+set CONFIG=Debug
+set PROVIDER=vcpkg
+call "c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+
+cmd /c gcloud auth activate-service-account --key-file %KOKORO_GFILE_DIR%/build-results-service-account.json
+
+echo %date% %time%
+powershell -exec bypass ci\kokoro\windows\build-dependencies.ps1
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+cmd /c gcloud auth revoke --all
+
+echo %date% %time%
+powershell -exec bypass ci\kokoro\windows\build-project.ps1
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+@echo %date% %time%
+@echo DONE DONE DONE "============================================="
+@echo DONE DONE DONE "============================================="
+@echo %date% %time%

--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -23,12 +23,14 @@ set CONFIG=Debug
 set PROVIDER=vcpkg
 call "c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
 
-cmd /c gcloud auth activate-service-account --key-file %KOKORO_GFILE_DIR%/build-results-service-account.json
+echo %date% %time%
+cmd /c gcloud auth activate-service-account --key-file "%KOKORO_GFILE_DIR%/build-results-service-account.json"
 
 echo %date% %time%
 powershell -exec bypass ci\kokoro\windows\build-dependencies.ps1
 if %errorlevel% neq 0 exit /b %errorlevel%
 
+echo %date% %time%
 cmd /c gcloud auth revoke --all
 
 echo %date% %time%

--- a/ci/kokoro/windows/continuous.cfg
+++ b/ci/kokoro/windows/continuous.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/windows/build.bat"
+timeout_mins: 120
+
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"

--- a/ci/kokoro/windows/install-dependencies.ps1
+++ b/ci/kokoro/windows/install-dependencies.ps1
@@ -1,0 +1,26 @@
+# !/usr/bin/env powershell
+
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+choco sources list
+
+# Ignore errors
+choco install --no-progress -y cmake
+
+# Ignore errors
+choco install --no-progress -y cmake.portable
+
+# Ignore errors
+choco install --no-progress -y ninja

--- a/ci/kokoro/windows/presubmit.cfg
+++ b/ci/kokoro/windows/presubmit.cfg
@@ -1,0 +1,22 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/windows/build.bat"
+timeout_mins: 120
+
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.sh"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.bat"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"


### PR DESCRIPTION
Building on Kokoro gives us more bandwidth. The servers have four
cores (or threads), while AppVeyor has only 2, and we get more
parallel builds: Kokoro runs all presubmit builds in parallel.

The disadvantage is that we have to manually do caching, Kokoro does
not make it easy to do that ourselves.

I am getting 35 minute builds with Kokoro, which is worse than the 25
minutes for AppVeyor. I believe this can be improved later,  and the 
advantage of parallel builds when multiple PRs are running is too
much to ignore.

This commit only introduces the build scripts, after it is committed a
separate CL will enable the build and another PR will disable appveyor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1432)
<!-- Reviewable:end -->
