### PR TITLE
Refactor CurlClient::InsertObjectMedia.

### DIFF
--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -165,10 +165,14 @@ class CurlClient : public RawClient {
   std::pair<Status, std::unique_ptr<ObjectWriteStreambuf>> WriteObjectXml(
       InsertObjectStreamingRequest const& request);
 
-  /// Insert an object using the uploadType=multipart.
+  /// Insert an object using uploadType=multipart.
   std::pair<Status, ObjectMetadata> InsertObjectMediaMultipart(
       InsertObjectMediaRequest const& request);
   std::string PickBoundary(std::string const& text_to_avoid);
+
+  /// Insert an objet using uploadType=media.
+  std::pair<Status, ObjectMetadata> InsertObjectMediaSimple(
+      InsertObjectMediaRequest const& request);
 
   ClientOptions options_;
   std::string storage_endpoint_;


### PR DESCRIPTION
This will make it easier (I think) to support ObjectMetadata in all
upload operations. Part of the work for #1311.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1434)
<!-- Reviewable:end -->
