### PR TITLE
Speed up Kokoro Windows Build.

### DIFF
--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -41,7 +41,7 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 @rem long time. The recommended workaround is to remove all the files that are
 @rem not interesting artifacts.
 echo %date% %time%
-cd %KOKORO_ARTIFACTS_DIR%
+cd "%KOKORO_ARTIFACTS_DIR%"
 powershell -Command "& {Get-ChildItem -Recurse -File -Exclude test.xml,sponge_log.xml,build.bat | Remove-Item}"
 if %errorlevel% neq 0 exit /b %errorlevel%
 

--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -37,6 +37,14 @@ echo %date% %time%
 powershell -exec bypass ci\kokoro\windows\build-project.ps1
 if %errorlevel% neq 0 exit /b %errorlevel%
 
+@rem Kokoro rsyncs all the files in the %KOKORO_ARTIFACTS_DIR%, which takes a
+@rem long time. The recommended workaround is to remove all the files that are
+@rem not interesting artifacts.
+echo %date% %time%
+cd %KOKORO_ARTIFACTS_DIR%
+powershell -Command "& {Get-ChildItem -Recurse -File -Exclude test.xml,sponge_log.xml,build.bat | Remove-Item}"
+if %errorlevel% neq 0 exit /b %errorlevel%
+
 @echo %date% %time%
 @echo DONE DONE DONE "============================================="
 @echo DONE DONE DONE "============================================="


### PR DESCRIPTION
This is following the recommendations from the Kokoro team.  The process to capture
any artifacts created by the build can take a long time because *all* the files in the
artifact directory, including source and objects, are copied out of the build machine.

This change removes all the uninteresting files before terminating the build.

Saves about 10 minutes.  I will send you the relevant internal links separately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1438)
<!-- Reviewable:end -->
