### PR TITLE
Isolates credential expiration/validity logic.

### DIFF
--- a/google/cloud/storage/oauth2/authorized_user_credentials.h
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.h
@@ -90,23 +90,12 @@ class AuthorizedUserCredentials : public Credentials {
   }
 
   std::string AuthorizationHeader() override {
-    // Avoid locking if we don't need to refresh.
-    if (IsValid()) {
-      return authorization_header_;
-    }
-
-    std::unique_lock<std::mutex> credlock(mu_);
-    // Note that if multiple threads tried to request an authorization header
-    // at the same time and it had expired, they would all attempt to grab the
-    // lock and perform a token refresh. To avoid this and ensure only the first
-    // call results in a refresh, we grab the lock, then first check if the
-    // credential is valid (i.e. if another thread already refreshed it) before
-    // refreshing.
+    std::unique_lock<std::mutex> lock(mu_);
     if (IsValid()) {
       return authorization_header_;
     }
     // TODO(#516) - Return Refresh() result so caller can do retries instead.
-    cv_.wait(credlock, [this]() { return Refresh().ok(); });
+    cv_.wait(lock, [this]() { return Refresh().ok(); });
     return authorization_header_;
   }
 

--- a/google/cloud/storage/oauth2/authorized_user_credentials.h
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.h
@@ -90,19 +90,39 @@ class AuthorizedUserCredentials : public Credentials {
   }
 
   std::string AuthorizationHeader() override {
-    std::unique_lock<std::mutex> lk(mu_);
-    cv_.wait(lk, [this]() { return Refresh().ok(); });
+    // Avoid locking if we don't need to refresh.
+    if (IsValid()) {
+      return authorization_header_;
+    }
+
+    std::unique_lock<std::mutex> credlock(mu_);
+    // Note that if multiple threads tried to request an authorization header
+    // at the same time and it had expired, they would all attempt to grab the
+    // lock and perform a token refresh. To avoid this and ensure only the first
+    // call results in a refresh, we grab the lock, then first check if the
+    // credential is valid (i.e. if another thread already refreshed it) before
+    // refreshing.
+    if (IsValid()) {
+      return authorization_header_;
+    }
+    // TODO(#516) - Return Refresh() result so caller can do retries instead.
+    cv_.wait(credlock, [this]() { return Refresh().ok(); });
     return authorization_header_;
   }
 
  private:
-  storage::Status Refresh() {
-    namespace nl = storage::internal::nl;
-    if (std::chrono::system_clock::now() < expiration_time_) {
-      return storage::Status();
-    }
+  bool IsExpired() {
+    auto now = std::chrono::system_clock::now();
+    return now > (expiration_time_ - GoogleOAuthAccessTokenExpirationSlack());
+  }
 
-    // TODO(#516) - use retry policies to refresh the credentials.
+  bool IsValid() {
+    return not authorization_header_.empty() and not IsExpired();
+  }
+
+  google::cloud::storage::Status Refresh() {
+    namespace nl = storage::internal::nl;
+
     auto response = request_.MakeRequest(payload_);
     if (response.status_code >= 300) {
       return storage::Status(response.status_code, std::move(response.payload));
@@ -125,8 +145,7 @@ class AuthorizedUserCredentials : public Credentials {
     std::string new_id = access_token.value("id_token", "");
     auto expires_in =
         std::chrono::seconds(access_token.value("expires_in", int(0)));
-    auto new_expiration = std::chrono::system_clock::now() + expires_in -
-                          GoogleOAuthAccessTokenExpirationSlack();
+    auto new_expiration = std::chrono::system_clock::now() + expires_in;
     // Do not update any state until all potential exceptions are raised.
     authorization_header_ = std::move(header);
     expiration_time_ = new_expiration;

--- a/google/cloud/storage/oauth2/compute_engine_credentials.h
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.h
@@ -59,8 +59,23 @@ class ComputeEngineCredentials : public Credentials {
       : expiration_time_(), service_account_email_(service_account_email) {}
 
   std::string AuthorizationHeader() override {
-    std::unique_lock<std::mutex> lk(mu_);
-    cv_.wait(lk, [this]() { return Refresh().ok(); });
+    // Avoid locking if we don't need to refresh.
+    if (IsValid()) {
+      return authorization_header_;
+    }
+
+    std::unique_lock<std::mutex> credlock(mu_);
+    // Note that if multiple threads tried to request an authorization header
+    // at the same time and it had expired, they would all attempt to grab the
+    // lock and perform a token refresh. To avoid this and ensure only the first
+    // call results in a refresh, we grab the lock, then first check if the
+    // credential is valid (i.e. if another thread already refreshed it) before
+    // refreshing.
+    if (IsValid()) {
+      return authorization_header_;
+    }
+    // TODO(#516) - Return Refresh() result so caller can do retries instead.
+    cv_.wait(credlock, [this]() { return Refresh().ok(); });
     return authorization_header_;
   }
 
@@ -85,6 +100,15 @@ class ComputeEngineCredentials : public Credentials {
   std::set<std::string> scopes() { return scopes_; }
 
  private:
+  bool IsExpired() {
+    auto now = std::chrono::system_clock::now();
+    return now > (expiration_time_ - GoogleOAuthAccessTokenExpirationSlack());
+  }
+
+  bool IsValid() {
+    return not authorization_header_.empty() and not IsExpired();
+  }
+
   storage::internal::HttpResponse DoMetadataServerGetRequest(std::string path,
                                                              bool recursive) {
     std::string metadata_server_hostname =
@@ -133,13 +157,9 @@ class ComputeEngineCredentials : public Credentials {
 
   storage::Status Refresh() {
     namespace nl = storage::internal::nl;
-    if (std::chrono::system_clock::now() < expiration_time_) {
-      return storage::Status();
-    }
 
     auto status = RetrieveServiceAccountInfo();
     if (!status.ok()) {
-      // TODO(#516) - use retry policies.
       return status;
     }
 
@@ -147,7 +167,6 @@ class ComputeEngineCredentials : public Credentials {
         "/computeMetadata/v1/instance/service-accounts/" +
             service_account_email_ + "/token",
         false);
-    // TODO(#516) - use retry policies to refresh the credentials.
     if (response.status_code >= 300) {
       return storage::Status(response.status_code, std::move(response.payload));
     }
@@ -170,8 +189,7 @@ class ComputeEngineCredentials : public Credentials {
     header += access_token.value("access_token", "");
     auto expires_in =
         std::chrono::seconds(access_token.value("expires_in", int(0)));
-    auto new_expiration = std::chrono::system_clock::now() + expires_in -
-                          GoogleOAuthAccessTokenExpirationSlack();
+    auto new_expiration = std::chrono::system_clock::now() + expires_in;
 
     // Do not update any state until all potential exceptions are raised.
     authorization_header_ = std::move(header);

--- a/google/cloud/storage/oauth2/compute_engine_credentials.h
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.h
@@ -59,23 +59,12 @@ class ComputeEngineCredentials : public Credentials {
       : expiration_time_(), service_account_email_(service_account_email) {}
 
   std::string AuthorizationHeader() override {
-    // Avoid locking if we don't need to refresh.
-    if (IsValid()) {
-      return authorization_header_;
-    }
-
-    std::unique_lock<std::mutex> credlock(mu_);
-    // Note that if multiple threads tried to request an authorization header
-    // at the same time and it had expired, they would all attempt to grab the
-    // lock and perform a token refresh. To avoid this and ensure only the first
-    // call results in a refresh, we grab the lock, then first check if the
-    // credential is valid (i.e. if another thread already refreshed it) before
-    // refreshing.
+    std::unique_lock<std::mutex> lock(mu_);
     if (IsValid()) {
       return authorization_header_;
     }
     // TODO(#516) - Return Refresh() result so caller can do retries instead.
-    cv_.wait(credlock, [this]() { return Refresh().ok(); });
+    cv_.wait(lock, [this]() { return Refresh().ok(); });
     return authorization_header_;
   }
 


### PR DESCRIPTION
This better encapsulates the credential expiration logic, aligning it
with the semantics used by google-auth-library-python. The logic can be
seen in the Credentials class in this module:
https://github.com/googleapis/google-auth-library-python/blob/master/google/auth/credentials.py

This also alters the AuthorizationHeader method to avoid unnecessary
locking if the credential is not expired/invalid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1442)
<!-- Reviewable:end -->
