### PR TITLE
Support WithObjectMetadata option in InsertObjectMedia.

### DIFF
--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -88,7 +88,8 @@ class InsertObjectMediaRequest
           Crc32cChecksumValue, DisableCrc32cChecksum, DisableMD5Hash,
           EncryptionKey, IfGenerationMatch, IfGenerationNotMatch,
           IfMetagenerationMatch, IfMetagenerationNotMatch, KmsKeyName,
-          MD5HashValue, PredefinedAcl, Projection, UserProject> {
+          MD5HashValue, PredefinedAcl, Projection, UserProject,
+          WithObjectMetadata> {
  public:
   InsertObjectMediaRequest() : GenericObjectRequest(), contents_() {}
 

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/optional.h"
 #include "google/cloud/storage/internal/common_metadata.h"
+#include "google/cloud/storage/internal/complex_option.h"
 #include "google/cloud/storage/object_access_control.h"
 #include <map>
 
@@ -247,9 +248,9 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
   bool operator==(ObjectMetadata const& rhs) const;
   bool operator!=(ObjectMetadata const& rhs) const { return not(*this == rhs); }
 
- private:
   internal::nl::json JsonForUpdate() const;
 
+ private:
   friend std::ostream& operator<<(std::ostream& os, ObjectMetadata const& rhs);
   // Keep the fields in alphabetical order.
   std::vector<ObjectAccessControl> acl_;
@@ -329,6 +330,15 @@ class ObjectMetadataPatchBuilder {
   internal::PatchBuilder impl_;
   bool metadata_subpatch_dirty_;
   internal::PatchBuilder metadata_subpatch_;
+};
+
+/**
+ * A request option to define the object metadata attributes.
+ */
+struct WithObjectMetadata
+    : public internal::ComplexOption<WithObjectMetadata, ObjectMetadata> {
+  using ComplexOption<WithObjectMetadata, ObjectMetadata>::ComplexOption;
+  static char const* name() { return "object-metadata"; }
 };
 
 }  // namespace STORAGE_CLIENT_NS


### PR DESCRIPTION
When inserting objects it is now possible to set the metadata at the
same time as we upload the media. This is useful when the application
wants to set labels or other object metadata attributes and save the
additional request. The library automatically switches to a multipart
upload when this option is used, but prefers a simple upload otherwise.
Part of the changes for #1311.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1445)
<!-- Reviewable:end -->
