### PR TITLE
Implement AsyncAwaitConsistency.

### DIFF
--- a/google/cloud/bigtable/admin_client.h
+++ b/google/cloud/bigtable/admin_client.h
@@ -28,6 +28,7 @@ inline namespace BIGTABLE_CLIENT_NS {
 // Forward declare some classes so we can be friends.
 class TableAdmin;
 namespace internal {
+class AsyncAwaitConsistency;
 class AsyncCheckConsistency;
 }  // namespace internal
 namespace noex {
@@ -84,6 +85,7 @@ class AdminClient {
  protected:
   friend class TableAdmin;
   friend class noex::TableAdmin;
+  friend class internal::AsyncAwaitConsistency;
   friend class internal::AsyncCheckConsistency;
   template <typename ResultType, typename ClientType>
   friend ResultType internal::PollLongRunningOperation(

--- a/google/cloud/bigtable/internal/async_check_consistency.h
+++ b/google/cloud/bigtable/internal/async_check_consistency.h
@@ -248,7 +248,9 @@ class AsyncAwaitConsistency
                                 "unknown reason we didn't retry. Expected "
                                 "that either a consistent state is reached or "
                                 "a polling error is reported. That's a bug, "
-                                "please report it.");
+                                "please report it to "
+                                "https://github.com/GoogleCloudPlatform/"
+                                "google-cloud-cpp/issues/new");
         lk.unlock();
         callback_(cq, res_status);
         return;

--- a/google/cloud/bigtable/internal/async_check_consistency_test.cc
+++ b/google/cloud/bigtable/internal/async_check_consistency_test.cc
@@ -188,6 +188,358 @@ INSTANTIATE_TEST_CASE_P(OneRetry, NoexAsyncCheckConsistencyRetryTest,
                             // First RPC fails.
                             true));
 
+class EndToEndConfig {
+ public:
+  grpc::StatusCode generate_token_error_code;
+  bool expect_check_consistency_call;
+  grpc::StatusCode check_consistency_error_code;
+  bool check_consistency_finished;
+  grpc::StatusCode expected;
+};
+
+class NoexAsyncCheckConsistencyEndToEnd
+    : public bigtable::testing::internal::TableTestFixture,
+      public WithParamInterface<EndToEndConfig> {};
+
+TEST_P(NoexAsyncCheckConsistencyEndToEnd, EndToEnd) {
+  using namespace ::testing;
+
+  auto config = GetParam();
+
+  std::string const kProjectId = "the-project";
+  std::string const kInstanceId = "the-instance";
+  std::string const kClusterId = "the-cluster";
+  bigtable::TableId const kTableId("the-table");
+
+  internal::RPCPolicyParameters const noRetries = {
+      std::chrono::hours(0),
+      std::chrono::hours(0),
+      std::chrono::hours(0),
+  };
+  auto polling_policy = bigtable::DefaultPollingPolicy(noRetries);
+
+  auto client = std::make_shared<testing::MockAdminClient>();
+  EXPECT_CALL(*client, project()).WillRepeatedly(ReturnRef(kProjectId));
+  bigtable::noex::TableAdmin tested(client, kInstanceId, *polling_policy);
+  auto cq_impl = std::make_shared<testing::MockCompletionQueue>();
+  bigtable::CompletionQueue cq(cq_impl);
+
+  auto generate_token_reader =
+      google::cloud::internal::make_unique<MockAsyncGenerateConsistencyToken>();
+  EXPECT_CALL(*generate_token_reader, Finish(_, _, _))
+      .WillOnce(
+          Invoke([config](btproto::GenerateConsistencyTokenResponse* response,
+                          grpc::Status* status, void*) {
+            response->set_consistency_token("qwerty");
+            *status =
+                grpc::Status(config.generate_token_error_code, "mocked-status");
+          }));
+  auto check_consistency_reader =
+      google::cloud::internal::make_unique<MockAsyncCheckConsistencyReader>();
+  if (config.expect_check_consistency_call) {
+    EXPECT_CALL(*check_consistency_reader, Finish(_, _, _))
+        .WillOnce(Invoke([config](btproto::CheckConsistencyResponse* response,
+                                  grpc::Status* status, void*) {
+          response->set_consistent(config.check_consistency_finished);
+          *status = grpc::Status(config.check_consistency_error_code,
+                                 "mocked-status");
+        }));
+  }
+
+  EXPECT_CALL(*client, AsyncGenerateConsistencyToken(_, _, _))
+      .WillOnce(
+          Invoke([&generate_token_reader](
+                     grpc::ClientContext*,
+                     btproto::GenerateConsistencyTokenRequest const& request,
+                     grpc::CompletionQueue*) {
+            // This is safe, see comments in MockAsyncResponseReader.
+            return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
+                btproto::GenerateConsistencyTokenResponse>>(
+                generate_token_reader.get());
+          }));
+  if (config.expect_check_consistency_call) {
+    EXPECT_CALL(*client, AsyncCheckConsistency(_, _, _))
+        .WillOnce(Invoke([&check_consistency_reader](
+                             grpc::ClientContext*,
+                             btproto::CheckConsistencyRequest const& request,
+                             grpc::CompletionQueue*) {
+          EXPECT_EQ("qwerty", request.consistency_token());
+          // This is safe, see comments in MockAsyncResponseReader.
+          return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
+              btproto::CheckConsistencyResponse>>(
+              check_consistency_reader.get());
+        }));
+  }
+
+  // Make the asynchronous request.
+  bool user_op_called = false;
+  auto user_callback = [&user_op_called, &config](CompletionQueue& cq,
+                                                  grpc::Status const& status) {
+    user_op_called = true;
+    EXPECT_EQ(config.expected, status.error_code());
+  };
+  tested.AsyncAwaitConsistency(kTableId, cq, user_callback);
+
+  EXPECT_FALSE(user_op_called);
+  EXPECT_EQ(1U, cq_impl->size());  // AsyncGenerateConsistencyToken
+  cq_impl->SimulateCompletion(cq, true);
+
+  if (config.expect_check_consistency_call) {
+    EXPECT_FALSE(user_op_called);
+    EXPECT_EQ(1U, cq_impl->size());  // AsyncCheckConsistency
+    cq_impl->SimulateCompletion(cq, true);
+  }
+
+  EXPECT_TRUE(user_op_called);
+  EXPECT_TRUE(cq_impl->empty());
+}
+
+INSTANTIATE_TEST_CASE_P(
+    EndToEnd, NoexAsyncCheckConsistencyEndToEnd,
+    ::testing::Values(
+        // Everything succeeds immediately.
+        EndToEndConfig{
+            // Error code which GenerateToken returns.
+            grpc::StatusCode::OK,
+            // Expect that AsyncAwaitConsistency calls CheckConsistency.
+            true,
+            // Error code which CheckConsistency returns.
+            grpc::StatusCode::OK,
+            // CheckConsisteny reports that it's finished.
+            true,
+            // Expected result.
+            grpc::StatusCode::OK},
+        //
+        // Generating token fails, the error should be propagated.
+        EndToEndConfig{
+            // Error code which GenerateToken returns.
+            grpc::StatusCode::PERMISSION_DENIED,
+            // Expect that AsyncAwaitConsistency won't call CheckConsistency.
+            false,
+            // Error code which CheckConsistency returns.
+            grpc::StatusCode::UNKNOWN,
+            // CheckConsisteny reports that it's finished.
+            true,
+            // Expected result.
+            grpc::StatusCode::PERMISSION_DENIED},
+        // CheckConsistency times out w.r.t PollingPolicy, UNKNOWN is returned.
+        EndToEndConfig{
+            // Error code which GenerateToken returns.
+            grpc::StatusCode::OK,
+            // Expect that AsyncAwaitConsistency calls CheckConsistency.
+            true,
+            // Error code which CheckConsistency returns.
+            grpc::StatusCode::OK,
+            // CheckConsisteny reports that it's not yet finished.
+            false,
+            // Expected result.
+            grpc::StatusCode::UNKNOWN},
+        // CheckConsistency fails. UNKNOWN is returned.
+        EndToEndConfig{
+            // Error code which GenerateToken returns.
+            grpc::StatusCode::OK,
+            // Expect that AsyncAwaitConsistency calls CheckConsistency.
+            true,
+            // Error code which CheckConsistency returns.
+            grpc::StatusCode::UNAVAILABLE,
+            // CheckConsisteny reports that it's not yet finished.
+            false,
+            // Expected result.
+            grpc::StatusCode::UNAVAILABLE},
+        // CheckConsistency succeeds but reports an error - it is passed on.
+        EndToEndConfig{
+            // Error code which GenerateToken returns.
+            grpc::StatusCode::OK,
+            // Expect that AsyncAwaitConsistency calls CheckConsistency.
+            true,
+            // Error code which CheckConsistency returns.
+            grpc::StatusCode::UNAVAILABLE,
+            // CheckConsisteny reports that it's finished.
+            true,
+            // Expected result.
+            grpc::StatusCode::UNAVAILABLE}));
+
+class CancelConfig {
+ public:
+  // Error code returned from GenerateConsistencyToken
+  grpc::StatusCode generate_token_error_code;
+  // Whether to call cancel during GenerateConsistencyToken
+  bool cancel_generate_token;
+  // Whether to expect a call to CheckConsistency
+  bool expect_check_consistency_call;
+  // Error code returned from CheckConsistency
+  grpc::StatusCode check_consistency_error_code;
+  // Whether to call cancel during CheckConsistency
+  bool cancel_check_consistency;
+  grpc::StatusCode expected;
+};
+
+class NoexAsyncCheckConsistencyCancel
+    : public bigtable::testing::internal::TableTestFixture,
+      public WithParamInterface<CancelConfig> {};
+
+TEST_P(NoexAsyncCheckConsistencyCancel, Cancellations) {
+  using namespace ::testing;
+
+  auto config = GetParam();
+
+  std::string const kProjectId = "the-project";
+  std::string const kInstanceId = "the-instance";
+  std::string const kClusterId = "the-cluster";
+  bigtable::TableId const kTableId("the-table");
+
+  internal::RPCPolicyParameters const noRetries = {
+      std::chrono::hours(0),
+      std::chrono::hours(0),
+      std::chrono::hours(0),
+  };
+  auto polling_policy = bigtable::DefaultPollingPolicy(noRetries);
+
+  auto client = std::make_shared<testing::MockAdminClient>();
+  EXPECT_CALL(*client, project()).WillRepeatedly(ReturnRef(kProjectId));
+  bigtable::noex::TableAdmin tested(client, kInstanceId, *polling_policy);
+  auto cq_impl = std::make_shared<testing::MockCompletionQueue>();
+  bigtable::CompletionQueue cq(cq_impl);
+
+  auto generate_token_reader =
+      google::cloud::internal::make_unique<MockAsyncGenerateConsistencyToken>();
+  EXPECT_CALL(*generate_token_reader, Finish(_, _, _))
+      .WillOnce(
+          Invoke([config](btproto::GenerateConsistencyTokenResponse* response,
+                          grpc::Status* status, void*) {
+            response->set_consistency_token("qwerty");
+            *status =
+                grpc::Status(config.generate_token_error_code, "mocked-status");
+          }));
+  auto check_consistency_reader =
+      google::cloud::internal::make_unique<MockAsyncCheckConsistencyReader>();
+  if (config.expect_check_consistency_call) {
+    EXPECT_CALL(*check_consistency_reader, Finish(_, _, _))
+        .WillOnce(Invoke([config](btproto::CheckConsistencyResponse* response,
+                                  grpc::Status* status, void*) {
+          response->set_consistent(true);
+          *status = grpc::Status(config.check_consistency_error_code,
+                                 "mocked-status");
+        }));
+  }
+
+  EXPECT_CALL(*client, AsyncGenerateConsistencyToken(_, _, _))
+      .WillOnce(
+          Invoke([&generate_token_reader](
+                     grpc::ClientContext*,
+                     btproto::GenerateConsistencyTokenRequest const& request,
+                     grpc::CompletionQueue*) {
+            // This is safe, see comments in MockAsyncResponseReader.
+            return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
+                btproto::GenerateConsistencyTokenResponse>>(
+                generate_token_reader.get());
+          }));
+  if (config.expect_check_consistency_call) {
+    EXPECT_CALL(*client, AsyncCheckConsistency(_, _, _))
+        .WillOnce(Invoke([&check_consistency_reader](
+                             grpc::ClientContext*,
+                             btproto::CheckConsistencyRequest const& request,
+                             grpc::CompletionQueue*) {
+          EXPECT_EQ("qwerty", request.consistency_token());
+          // This is safe, see comments in MockAsyncResponseReader.
+          return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
+              btproto::CheckConsistencyResponse>>(
+              check_consistency_reader.get());
+        }));
+  }
+
+  // Make the asynchronous request.
+  bool user_op_called = false;
+  auto user_callback = [&user_op_called, &config](CompletionQueue& cq,
+                                                  grpc::Status const& status) {
+    user_op_called = true;
+    EXPECT_EQ(config.expected, status.error_code());
+  };
+  auto op = tested.AsyncAwaitConsistency(kTableId, cq, user_callback);
+
+  EXPECT_FALSE(user_op_called);
+  EXPECT_EQ(1U, cq_impl->size());  // AsyncGenerateConsistencyToken
+  if (config.cancel_generate_token) {
+    op->Cancel();
+  }
+
+  cq_impl->SimulateCompletion(cq, true);
+
+  if (config.expect_check_consistency_call) {
+    EXPECT_FALSE(user_op_called);
+    EXPECT_EQ(1U, cq_impl->size());  // AsyncCheckConsistency
+    if (config.cancel_check_consistency) {
+      op->Cancel();
+    }
+    cq_impl->SimulateCompletion(cq, true);
+  }
+
+  EXPECT_TRUE(user_op_called);
+  EXPECT_TRUE(cq_impl->empty());
+}
+
+INSTANTIATE_TEST_CASE_P(
+    CancelTest, NoexAsyncCheckConsistencyCancel,
+    ::testing::Values(
+        // Cancel during GenerateConsistencyTokenResponse
+        // yields the request returning CANCELLED.
+        CancelConfig{
+            // Error code which GenerateToken returns.
+            grpc::StatusCode::CANCELLED,
+            // Cancel while in GenerateToken.
+            true,
+            // Expect that AsyncAwaitConsistency won't call CheckConsistency.
+            false,
+            // Error code which CheckConsistency returns - irrelevant.
+            grpc::StatusCode::UNKNOWN,
+            // Don't cancel while in CheckConsistency
+            false,
+            // Expected result.
+            grpc::StatusCode::CANCELLED},
+        // Cancel during GenerateConsistencyTokenResponse
+        // yields the request returning OK.
+        CancelConfig{
+            // Error code which GenerateToken returns.
+            grpc::StatusCode::OK,
+            // Cancel while in GenerateToken.
+            true,
+            // Expect that AsyncAwaitConsistency won't call CheckConsistency.
+            false,
+            // Error code which CheckConsistency returns - irrelevant.
+            grpc::StatusCode::UNKNOWN,
+            // Don't cancel while in CheckConsistency
+            false,
+            // Expected result.
+            grpc::StatusCode::CANCELLED},
+        // Cancel during CheckConsistency
+        // yields the request returning CANCELLED.
+        CancelConfig{// Error code which GenerateToken returns.
+                     grpc::StatusCode::OK,
+                     // Don't cancel GenerateToken.
+                     false,
+                     // Expect that AsyncAwaitConsistency call CheckConsistency.
+                     true,
+                     // Error code which CheckConsistency returns
+                     grpc::StatusCode::CANCELLED,
+                     // Don't cancel while in CheckConsistency
+                     true,
+                     // Expected result.
+                     grpc::StatusCode::CANCELLED},
+        // Cancel during CheckConsistency
+        // yields the request returning OK.
+        CancelConfig{// Error code which GenerateToken returns.
+                     grpc::StatusCode::OK,
+                     // Don't cancel GenerateToken.
+                     false,
+                     // Expect that AsyncAwaitConsistency call CheckConsistency.
+                     true,
+                     // Error code which CheckConsistency returns
+                     grpc::StatusCode::OK,
+                     // Don't cancel while in CheckConsistency
+                     true,
+                     // Expected result.
+                     grpc::StatusCode::OK}));
+
 }  // namespace
 }  // namespace noex
 }  // namespace BIGTABLE_CLIENT_NS

--- a/google/cloud/bigtable/internal/table_admin.h
+++ b/google/cloud/bigtable/internal/table_admin.h
@@ -243,7 +243,23 @@ class TableAdmin {
                         grpc::Status& status);
 
   /**
-   * Make an asynchronous request to wait for replication to catch up.
+   * Asynchronously wait for replication to catch up.
+   *
+   * This function asks for a consistency token, and polls Cloud Bigtable until
+   * the replication has caught up to that consistency token, or until the
+   * polling policy has expired.
+   *
+   * When the replication catches up the callback receives a `grpc::Status::OK`.
+   *
+   * If the policy expires before the replication catches up with the
+   * consistency token then the callback receives `grpc::StatusCode::UNKNOWN`
+   * status code.
+   *
+   * After this function returns OK you can be sure that all mutations which
+   * have been applied before this call have made it to their replicas.
+   *
+   * @see https://cloud.google.com/bigtable/docs/replication-overview for an
+   * overview of Cloud Bigtable replication.
    *
    * @param table_id the table to wait on
    * @param cq the completion queue that will execute the asynchronous calls,

--- a/google/cloud/bigtable/internal/table_admin.h
+++ b/google/cloud/bigtable/internal/table_admin.h
@@ -270,7 +270,7 @@ class TableAdmin {
         MetadataUpdatePolicy(instance_name(), MetadataParamTypes::NAME,
                              table_id.get()),
         client_, TableName(table_id.get()));
-    return op->Start(cq, callback);
+    return op->Start(cq, std::forward<Functor>(callback));
   }
 
   void DeleteSnapshot(bigtable::ClusterId const& cluster_id,

--- a/google/cloud/bigtable/internal/table_admin.h
+++ b/google/cloud/bigtable/internal/table_admin.h
@@ -18,6 +18,7 @@
 #include "google/cloud/bigtable/admin_client.h"
 #include "google/cloud/bigtable/bigtable_strong_types.h"
 #include "google/cloud/bigtable/column_family.h"
+#include "google/cloud/bigtable/internal/async_check_consistency.h"
 #include "google/cloud/bigtable/internal/async_retry_unary_rpc.h"
 #include "google/cloud/bigtable/metadata_update_policy.h"
 #include "google/cloud/bigtable/polling_policy.h"
@@ -240,6 +241,37 @@ class TableAdmin {
   bool CheckConsistency(bigtable::TableId const& table_id,
                         bigtable::ConsistencyToken const& consistency_token,
                         grpc::Status& status);
+
+  /**
+   * Make an asynchronous request to wait for replication to catch up.
+   *
+   * @param table_id the table to wait on
+   * @param cq the completion queue that will execute the asynchronous calls,
+   *     the application must ensure that one or more threads are blocked on
+   *     `cq.Run()`.
+   * @param callback a functor to be called when the operation completes. It
+   *     must satisfy (using C++17 types):
+   *     static_assert(std::is_invocable_v<
+   *         Functor, grpc::Status const&>);
+   *
+   * @tparam Functor the type of the callback.
+   */
+  template <typename Functor,
+            typename std::enable_if<
+                google::cloud::internal::is_invocable<Functor, CompletionQueue&,
+                                                      grpc::Status&>::value,
+                int>::type valid_callback_type = 0>
+  std::shared_ptr<AsyncOperation> AsyncAwaitConsistency(
+      bigtable::TableId const& table_id, CompletionQueue& cq,
+      Functor&& callback) {
+    auto op = std::make_shared<internal::AsyncAwaitConsistency>(
+        __func__, polling_policy_->clone(), rpc_retry_policy_->clone(),
+        rpc_backoff_policy_->clone(),
+        MetadataUpdatePolicy(instance_name(), MetadataParamTypes::NAME,
+                             table_id.get()),
+        client_, TableName(table_id.get()));
+    return op->Start(cq, callback);
+  }
 
   void DeleteSnapshot(bigtable::ClusterId const& cluster_id,
                       bigtable::SnapshotId const& snapshot_id,

--- a/google/cloud/bigtable/internal/table_admin.h
+++ b/google/cloud/bigtable/internal/table_admin.h
@@ -249,10 +249,11 @@ class TableAdmin {
    * @param cq the completion queue that will execute the asynchronous calls,
    *     the application must ensure that one or more threads are blocked on
    *     `cq.Run()`.
-   * @param callback a functor to be called when the operation completes. It
-   *     must satisfy (using C++17 types):
+   * @param callback a functor to be called when the operation completes. The
+   *     replication will have caught up if status received by this callback is
+   *     OK. It must satisfy (using C++17 types):
    *     static_assert(std::is_invocable_v<
-   *         Functor, grpc::Status const&>);
+   *         Functor, CompletionQueue&, grpc::Status const&>);
    *
    * @tparam Functor the type of the callback.
    */


### PR DESCRIPTION
This fixes #1256.

The request kicks off a `AsyncGenerateConsistencyToken` and on success
passes it to `AsyncPollCheckConsistency` which in turn calls the user
callback.

Unfortunately, the implementation is not trivial because we have to
handle cancellations. In order for the whole request to be cancellable,
we need to create an `AsyncOperation`, which will cancel either of the
two underlying requests depending on the timing.

This implementation introduces a new request (`AsyncAwaitConsistency`),
which holds all the necessary data to launch the following
`AsyncPollCheckConsistency` after `AsyncGenerateConsistencyToken`
finishes and implements `AsyncOperation` so that it can return itself to
the user as a handle for cancellation.

By adding `CheckConsistencyFunctor` and
`ConsistencyTokenGeneratedFunctor` nested classes I achieved two things:
avoided copying the user-provided functor (as I would have to do with
lambdas) and managed to keep AsyncAwaitConsistency not a template, which
makes its use easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1448)
<!-- Reviewable:end -->
