### PR TITLE
Wrappers to capture callback results in promises.

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -154,6 +154,7 @@ add_library(bigtable_client
             instance_update_config.cc
             internal/async_bulk_apply.h
             internal/async_check_consistency.h
+            internal/async_future_from_callback.h
             internal/async_op_traits.h
             internal/async_poll_op.h
             internal/async_sample_row_keys.h
@@ -299,6 +300,7 @@ set(bigtable_client_unit_tests
     instance_config_test.cc
     instance_update_config_test.cc
     internal/async_check_consistency_test.cc
+    internal/async_future_from_callback_test.cc
     internal/async_poll_op_test.cc
     internal/async_retry_op_test.cc
     internal/bulk_mutator_test.cc

--- a/google/cloud/bigtable/bigtable_client.bzl
+++ b/google/cloud/bigtable/bigtable_client.bzl
@@ -18,6 +18,7 @@ bigtable_client_HDRS = [
     "instance_update_config.h",
     "internal/async_bulk_apply.h",
     "internal/async_check_consistency.h",
+    "internal/async_future_from_callback.h",
     "internal/async_op_traits.h",
     "internal/async_poll_op.h",
     "internal/async_sample_row_keys.h",

--- a/google/cloud/bigtable/bigtable_client_unit_tests.bzl
+++ b/google/cloud/bigtable/bigtable_client_unit_tests.bzl
@@ -18,6 +18,7 @@ bigtable_client_unit_tests = [
     "instance_config_test.cc",
     "instance_update_config_test.cc",
     "internal/async_check_consistency_test.cc",
+    "internal/async_future_from_callback_test.cc",
     "internal/async_poll_op_test.cc",
     "internal/async_retry_op_test.cc",
     "internal/bulk_mutator_test.cc",

--- a/google/cloud/bigtable/internal/async_future_from_callback.h
+++ b/google/cloud/bigtable/internal/async_future_from_callback.h
@@ -1,0 +1,108 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_FUTURE_FROM_CALLBACK_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_FUTURE_FROM_CALLBACK_H_
+
+#include "google/cloud/bigtable/completion_queue.h"
+#include "google/cloud/bigtable/grpc_error.h"
+#include "google/cloud/future.h"
+#include <google/protobuf/empty.pb.h>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
+/**
+ * A callback for Async* operations that stores the result in a `future`.
+ *
+ * The `noex` layer of the Bigtable client uses callbacks to communicate the
+ * result of an operation to the application. For the layer with exceptions we
+ * use `google::cloud::future<>` which offers a more powerful API, as the
+ * application can chose to use callbacks or block until the future completes.
+ *
+ * @note With C++14 this class would be unnecessary, as a extended lambda
+ * capture can do the work, but we need to support C++11, so an ad-hoc class is
+ * needed.
+ *
+ * @tparam R the result type for the callback.
+ */
+template <typename R>
+class AsyncFutureFromCallback {
+ public:
+  explicit AsyncFutureFromCallback(promise<R>&& p, char const* w)
+      : promise_(std::move(p)), where_(w) {}
+
+  void operator()(CompletionQueue& cq, R& result, grpc::Status& status) {
+    if (not status.ok()) {
+      promise_.set_exception(
+          std::make_exception_ptr(GRpcError(where_, status)));
+      return;
+    }
+    promise_.set_value(std::move(result));
+  }
+
+ private:
+  promise<R> promise_;
+  char const* where_;
+};
+
+/**
+ * Specialize `AsyncFutureFromCallback` for `void` results.
+ *
+ * When the asynchronous operation returns `void` (or the equivalent
+ * `google::protobuf::Empty`), we should use `future<void>` to represent the
+ * result, but the API for these futures is slightly different. This
+ * specialization deals with those differences.
+ */
+template <>
+class AsyncFutureFromCallback<void> {
+ public:
+  explicit AsyncFutureFromCallback(promise<void>&& p, char const* w)
+      : promise_(std::move(p)), where_(w) {}
+
+  void operator()(CompletionQueue& cq, google::protobuf::Empty& result,
+                  grpc::Status& status) {
+    if (not status.ok()) {
+      promise_.set_exception(
+          std::make_exception_ptr(GRpcError(where_, status)));
+      return;
+    }
+    promise_.set_value();
+  }
+
+  promise<void> promise_;
+  char const* where_;
+};
+
+/**
+ * Creates a `AsyncFutureFromCallback` of the correct type.
+ *
+ * Given a `promise<T>` deduce the desired type of `AsyncFutureFromCallback<T>`
+ * and returns a new instance.
+ */
+template <typename T>
+AsyncFutureFromCallback<T> MakeAsyncFutureFromCallback(promise<T>&& p,
+                                                       const char* w) {
+  return AsyncFutureFromCallback<T>(std::move(p), w);
+}
+
+}  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_FUTURE_FROM_CALLBACK_H_

--- a/google/cloud/bigtable/internal/async_future_from_callback_test.cc
+++ b/google/cloud/bigtable/internal/async_future_from_callback_test.cc
@@ -1,0 +1,110 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/internal/async_future_from_callback.h"
+#include "google/cloud/bigtable/grpc_error.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
+namespace {
+
+using ::testing::HasSubstr;
+
+TEST(AsyncFutureFromCallbackGeneric, Simple) {
+  CompletionQueue cq;
+  promise<int> p;
+  auto fut = p.get_future();
+  auto callback = MakeAsyncFutureFromCallback(std::move(p), __func__);
+  EXPECT_FALSE(fut.is_ready());
+  int value = 42;
+  grpc::Status status = grpc::Status::OK;
+  callback(cq, value, status);
+
+  ASSERT_TRUE(fut.is_ready());
+  EXPECT_EQ(42, fut.get());
+}
+
+TEST(AsyncFutureFromCallbackGeneric, Failure) {
+  CompletionQueue cq;
+  promise<int> p;
+  auto fut = p.get_future();
+  auto callback = MakeAsyncFutureFromCallback(std::move(p), __func__);
+  EXPECT_FALSE(fut.is_ready());
+  int value = 42;
+  grpc::Status status(grpc::StatusCode::UNAVAILABLE, "try again");
+  callback(cq, value, status);
+
+  ASSERT_TRUE(fut.is_ready());
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(
+      try { fut.get(); } catch (GRpcError const& ex) {
+        EXPECT_EQ(grpc::StatusCode::UNAVAILABLE, ex.error_code());
+        EXPECT_THAT(ex.what(), HasSubstr("try again"));
+        throw;
+      },
+      GRpcError);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(fut.get(), "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+TEST(AsyncFutureFromCallbackVoid, Simple) {
+  CompletionQueue cq;
+  promise<void> p;
+  auto fut = p.get_future();
+  auto callback = MakeAsyncFutureFromCallback(std::move(p), __func__);
+  EXPECT_FALSE(fut.is_ready());
+  google::protobuf::Empty value;
+  grpc::Status status = grpc::Status::OK;
+  callback(cq, value, status);
+
+  ASSERT_TRUE(fut.is_ready());
+  fut.get();
+  SUCCEED();
+}
+
+TEST(AsyncFutureFromCallbackVoid, Failure) {
+  CompletionQueue cq;
+  promise<void> p;
+  auto fut = p.get_future();
+  auto callback = MakeAsyncFutureFromCallback(std::move(p), __func__);
+  EXPECT_FALSE(fut.is_ready());
+  google::protobuf::Empty value;
+  grpc::Status status(grpc::StatusCode::UNAVAILABLE, "try again");
+  callback(cq, value, status);
+
+  ASSERT_TRUE(fut.is_ready());
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(
+      try { fut.get(); } catch (GRpcError const& ex) {
+        EXPECT_EQ(grpc::StatusCode::UNAVAILABLE, ex.error_code());
+        EXPECT_THAT(ex.what(), HasSubstr("try again"));
+        throw;
+      },
+      GRpcError);
+#else
+  EXPECT_DEATH_IF_SUPPORTED(fut.get(), "exceptions are disabled");
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
In the `noex` layer we use callbacks to report the result of
asynchronous operations.  In the layer with exceptions we will use
`future<T>`, and the application can block, or attach a continuation.

To convert between the two layers we need something that basically
stores the parameters of the callback into a `promise<T>`, with C++11 we
need a helper class to do this mapping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1453)
<!-- Reviewable:end -->
