### PR TITLE
Do not generate local files in tests.

### DIFF
--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -205,7 +205,7 @@ TEST_F(ObjectMediaIntegrationTest, DownloadFileCannotWriteToFile) {
 
 TEST_F(ObjectMediaIntegrationTest, UploadFile) {
   Client client;
-  auto file_name = MakeRandomObjectName();
+  auto file_name = ::testing::TempDir() + MakeRandomObjectName();
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
 
@@ -274,7 +274,7 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileMissingFileFailure) {
 
 TEST_F(ObjectMediaIntegrationTest, UploadFileUploadFailure) {
   Client client;
-  auto file_name = MakeRandomObjectName();
+  auto file_name = ::testing::TempDir() + MakeRandomObjectName();
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
 
@@ -314,7 +314,7 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileNonRegularWarning) {
   // the test there.
 #if GTEST_OS_LINUX
   Client client;
-  auto file_name = MakeRandomObjectName();
+  auto file_name = ::testing::TempDir() + MakeRandomObjectName();
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
 
@@ -351,7 +351,7 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileNonRegularWarning) {
 
 TEST_F(ObjectMediaIntegrationTest, XmlUploadFile) {
   Client client;
-  auto file_name = MakeRandomObjectName();
+  auto file_name = ::testing::TempDir() + MakeRandomObjectName();
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
 


### PR DESCRIPTION
The internal CI systems at Google do not allow us to create files in the
directory where the tests run. Instead we write to
`::testing::TempDir()`. This change will make it easier to import the
code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1459)
<!-- Reviewable:end -->
