### PR TITLE
Add AsyncGetOperation to admin clients.

### DIFF
--- a/google/cloud/bigtable/admin_client.cc
+++ b/google/cloud/bigtable/admin_client.cc
@@ -221,6 +221,17 @@ class DefaultAdminClient : public google::cloud::bigtable::AdminClient {
     return impl_.Stub()->AsyncDeleteSnapshot(context, request, cq);
   };
 
+  std::unique_ptr<
+      grpc::ClientAsyncResponseReaderInterface<google::longrunning::Operation>>
+  AsyncGetOperation(grpc::ClientContext* context,
+                    const google::longrunning::GetOperationRequest& request,
+                    grpc::CompletionQueue* cq) override {
+    auto stub = google::longrunning::Operations::NewStub(Channel());
+    return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
+        google::longrunning::Operation>>(
+        stub->AsyncGetOperation(context, request, cq).release());
+  }
+
  private:
   std::string project_;
   Impl impl_;

--- a/google/cloud/bigtable/admin_client.h
+++ b/google/cloud/bigtable/admin_client.h
@@ -213,6 +213,15 @@ class AdminClient {
       google::bigtable::admin::v2::DeleteSnapshotRequest const& request,
       grpc::CompletionQueue* cq) = 0;
   //@}
+
+  //@{
+  /// @name The `google.longrunning.Operations` async wrappers.
+  virtual std::unique_ptr<
+      grpc::ClientAsyncResponseReaderInterface<google::longrunning::Operation>>
+  AsyncGetOperation(grpc::ClientContext* context,
+                    const google::longrunning::GetOperationRequest& request,
+                    grpc::CompletionQueue* cq) = 0;
+  //@}
 };
 
 /// Create a new admin client configured via @p options.

--- a/google/cloud/bigtable/instance_admin_client.cc
+++ b/google/cloud/bigtable/instance_admin_client.cc
@@ -252,6 +252,17 @@ class DefaultInstanceAdminClient : public InstanceAdminClient {
     return impl_.Stub()->AsyncCreateAppProfile(context, request, cq);
   }
 
+  std::unique_ptr<
+      grpc::ClientAsyncResponseReaderInterface<google::longrunning::Operation>>
+  AsyncGetOperation(grpc::ClientContext* context,
+                    const google::longrunning::GetOperationRequest& request,
+                    grpc::CompletionQueue* cq) override {
+    auto stub = google::longrunning::Operations::NewStub(Channel());
+    return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
+        google::longrunning::Operation>>(
+        stub->AsyncGetOperation(context, request, cq).release());
+  }
+
   DefaultInstanceAdminClient(DefaultInstanceAdminClient const&) = delete;
   DefaultInstanceAdminClient& operator=(DefaultInstanceAdminClient const&) =
       delete;

--- a/google/cloud/bigtable/instance_admin_client.h
+++ b/google/cloud/bigtable/instance_admin_client.h
@@ -179,7 +179,18 @@ class InstanceAdminClient {
       grpc::ClientContext* context,
       google::iam::v1::TestIamPermissionsRequest const& request,
       google::iam::v1::TestIamPermissionsResponse* response) = 0;
+  //@}
 
+  //@{
+  /// @name The `google.longrunning.Operations` wrappers.
+  virtual grpc::Status GetOperation(
+      grpc::ClientContext* context,
+      google::longrunning::GetOperationRequest const& request,
+      google::longrunning::Operation* response) = 0;
+  //@}
+
+  //@{
+  /// @name The `google.bigtable.admin.v2.TableAdmin` Async operations.
   virtual std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
       google::bigtable::admin::v2::Instance>>
   AsyncGetInstance(
@@ -230,11 +241,12 @@ class InstanceAdminClient {
   //@}
 
   //@{
-  /// @name The `google.longrunning.Operations` wrappers.
-  virtual grpc::Status GetOperation(
-      grpc::ClientContext* context,
-      google::longrunning::GetOperationRequest const& request,
-      google::longrunning::Operation* response) = 0;
+  /// @name The `google.longrunning.Operations` async wrappers.
+  virtual std::unique_ptr<
+      grpc::ClientAsyncResponseReaderInterface<google::longrunning::Operation>>
+  AsyncGetOperation(grpc::ClientContext* context,
+                    const google::longrunning::GetOperationRequest& request,
+                    grpc::CompletionQueue* cq) = 0;
   //@}
 };
 

--- a/google/cloud/bigtable/testing/inprocess_admin_client.cc
+++ b/google/cloud/bigtable/testing/inprocess_admin_client.cc
@@ -177,6 +177,18 @@ InProcessAdminClient::AsyncDeleteSnapshot(
   return Stub()->AsyncDeleteSnapshot(context, request, cq);
 }
 
+std::unique_ptr<
+    grpc::ClientAsyncResponseReaderInterface<google::longrunning::Operation>>
+InProcessAdminClient::AsyncGetOperation(
+    grpc::ClientContext* context,
+    const google::longrunning::GetOperationRequest& request,
+    grpc::CompletionQueue* cq) {
+  auto stub = google::longrunning::Operations::NewStub(Channel());
+  return std::unique_ptr<
+      grpc::ClientAsyncResponseReaderInterface<google::longrunning::Operation>>(
+      stub->AsyncGetOperation(context, request, cq).release());
+}
+
 }  // namespace testing
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/testing/inprocess_admin_client.h
+++ b/google/cloud/bigtable/testing/inprocess_admin_client.h
@@ -157,6 +157,11 @@ class InProcessAdminClient : public bigtable::AdminClient {
       grpc::ClientContext* context,
       google::bigtable::admin::v2::DeleteSnapshotRequest const& request,
       grpc::CompletionQueue* cq) override;
+  std::unique_ptr<
+      grpc::ClientAsyncResponseReaderInterface<google::longrunning::Operation>>
+  AsyncGetOperation(grpc::ClientContext* context,
+                    const google::longrunning::GetOperationRequest& request,
+                    grpc::CompletionQueue* cq) override;
   //@}
 
  private:

--- a/google/cloud/bigtable/testing/mock_admin_client.h
+++ b/google/cloud/bigtable/testing/mock_admin_client.h
@@ -166,6 +166,12 @@ class MockAdminClient : public bigtable::AdminClient {
           grpc::ClientContext* context,
           google::bigtable::admin::v2::DeleteSnapshotRequest const& request,
           grpc::CompletionQueue* cq));
+  MOCK_METHOD3(AsyncGetOperation,
+               std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
+                   google::longrunning::Operation>>(
+                   grpc::ClientContext* context,
+                   const google::longrunning::GetOperationRequest& request,
+                   grpc::CompletionQueue* cq));
 };
 
 }  // namespace testing

--- a/google/cloud/bigtable/testing/mock_instance_admin_client.h
+++ b/google/cloud/bigtable/testing/mock_instance_admin_client.h
@@ -192,6 +192,12 @@ class MockInstanceAdminClient : public bigtable::InstanceAdminClient {
                grpc::Status(grpc::ClientContext*,
                             google::iam::v1::TestIamPermissionsRequest const&,
                             google::iam::v1::TestIamPermissionsResponse*));
+  MOCK_METHOD3(AsyncGetOperation,
+               std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
+                   google::longrunning::Operation>>(
+                   grpc::ClientContext* context,
+                   const google::longrunning::GetOperationRequest& request,
+                   grpc::CompletionQueue* cq));
 };
 
 }  // namespace testing


### PR DESCRIPTION
It is not added to DataClient because there are no RPCs utilizing
`longrunning.Operation` there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1462)
<!-- Reviewable:end -->
