### PR TITLE
Client option to select resumable vs. simple uploads.

### DIFF
--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -52,6 +52,13 @@ std::size_t DefaultConnectionPoolSize() {
 #define GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE 128 * 1024
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE
 
+// The documentation recommends uploads below "5MiB" to use simple uploads:
+//   https://cloud.google.com/storage/docs/json_api/v1/how-tos/upload
+#ifndef GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_MAXIMUM_SIMPLE_UPLOAD_SIZE
+#define GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_MAXIMUM_SIMPLE_UPLOAD_SIZE \
+  5 * 1024 * 1024L
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_MAXIMUM_SIMPLE_UPLOAD_SIZE
+
 }  // namespace
 
 ClientOptions::ClientOptions() : ClientOptions(StorageDefaultCredentials()) {}
@@ -64,7 +71,9 @@ ClientOptions::ClientOptions(std::shared_ptr<oauth2::Credentials> credentials)
       enable_raw_client_tracing_(false),
       connection_pool_size_(DefaultConnectionPoolSize()),
       download_buffer_size_(GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE),
-      upload_buffer_size_(GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE) {
+      upload_buffer_size_(GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE),
+      maximum_simple_upload_size_(
+          GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_MAXIMUM_SIMPLE_UPLOAD_SIZE) {
   auto emulator =
       google::cloud::internal::GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT");
   if (emulator.has_value()) {

--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -105,6 +105,14 @@ class ClientOptions {
     return *this;
   }
 
+  std::size_t maximum_simple_upload_size() const {
+    return maximum_simple_upload_size_;
+  }
+  ClientOptions& set_maximum_simple_upload_size(std::size_t v) {
+    maximum_simple_upload_size_ = v;
+    return *this;
+  }
+
  private:
   void SetupFromEnvironment();
 
@@ -119,6 +127,7 @@ class ClientOptions {
   std::size_t download_buffer_size_;
   std::size_t upload_buffer_size_;
   std::string user_agent_prefix_;
+  std::size_t maximum_simple_upload_size_;
 };
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/storage_client_options_test.cc
+++ b/google/cloud/storage/storage_client_options_test.cc
@@ -141,6 +141,16 @@ TEST_F(ClientOptionsTest, UserAgentPrefix) {
   EXPECT_EQ("bar-2.2/foo-1.0", options.user_agent_prefix());
 }
 
+TEST_F(ClientOptionsTest, SetMaximumSimpleUploadSize) {
+  ClientOptions client_options;
+  auto default_size = client_options.maximum_simple_upload_size();
+  EXPECT_NE(0U, default_size);
+  client_options.set_maximum_simple_upload_size(1024);
+  EXPECT_EQ(1024U, client_options.maximum_simple_upload_size());
+  client_options.set_maximum_simple_upload_size(0);
+  EXPECT_EQ(0U, client_options.maximum_simple_upload_size());
+}
+
 }  // namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage


### PR DESCRIPTION
This is part of the changes for #559. When uploading a file we will
select the type of upload (resumable vs. simple) based on the size of
the file. Small regular files can be loaded to memory and use a simple
retry strategy. Large files, or non-regular files, need to use resumable
uploads and a more sophisticated retry strategy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1465)
<!-- Reviewable:end -->
