### PR TITLE
Implement AsyncPollLongrunningOp.

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -155,6 +155,7 @@ add_library(bigtable_client
             internal/async_bulk_apply.h
             internal/async_check_consistency.h
             internal/async_future_from_callback.h
+            internal/async_longrunning_op.h
             internal/async_op_traits.h
             internal/async_poll_op.h
             internal/async_sample_row_keys.h
@@ -301,6 +302,7 @@ set(bigtable_client_unit_tests
     instance_update_config_test.cc
     internal/async_check_consistency_test.cc
     internal/async_future_from_callback_test.cc
+    internal/async_longrunning_op_test.cc
     internal/async_poll_op_test.cc
     internal/async_retry_op_test.cc
     internal/bulk_mutator_test.cc

--- a/google/cloud/bigtable/bigtable_client.bzl
+++ b/google/cloud/bigtable/bigtable_client.bzl
@@ -19,6 +19,7 @@ bigtable_client_HDRS = [
     "internal/async_bulk_apply.h",
     "internal/async_check_consistency.h",
     "internal/async_future_from_callback.h",
+    "internal/async_longrunning_op.h",
     "internal/async_op_traits.h",
     "internal/async_poll_op.h",
     "internal/async_sample_row_keys.h",

--- a/google/cloud/bigtable/bigtable_client_unit_tests.bzl
+++ b/google/cloud/bigtable/bigtable_client_unit_tests.bzl
@@ -19,6 +19,7 @@ bigtable_client_unit_tests = [
     "instance_update_config_test.cc",
     "internal/async_check_consistency_test.cc",
     "internal/async_future_from_callback_test.cc",
+    "internal/async_longrunning_op_test.cc",
     "internal/async_poll_op_test.cc",
     "internal/async_retry_op_test.cc",
     "internal/bulk_mutator_test.cc",

--- a/google/cloud/bigtable/internal/async_longrunning_op.h
+++ b/google/cloud/bigtable/internal/async_longrunning_op.h
@@ -196,4 +196,4 @@ class AsyncPollLongrunningOp
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_LONGRUNNING_OP_H__
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_LONGRUNNING_OP_H_

--- a/google/cloud/bigtable/internal/async_longrunning_op.h
+++ b/google/cloud/bigtable/internal/async_longrunning_op.h
@@ -1,0 +1,199 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_LONGRUNNING_OP_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_LONGRUNNING_OP_H_
+
+#include "google/cloud/bigtable/async_operation.h"
+#include "google/cloud/bigtable/completion_queue.h"
+#include "google/cloud/bigtable/internal/async_poll_op.h"
+#include "google/cloud/bigtable/internal/completion_queue_impl.h"
+#include "google/cloud/bigtable/polling_policy.h"
+#include <google/longrunning/operations.grpc.pb.h>
+#include <sstream>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
+
+/**
+ * A wrapper around longrunning.Operation and a client to check it on.
+ *
+ * This class, binds a client and a longrunning.Operation, so that one can check
+ * if the operation is completed via the `Start` member function. It also
+ * performs the unwrapping of the result, if one is obtained.
+ *
+ * It satisfies the requirements to be used as the `Operation` parameter in
+ * `AsyncPollOp`.
+ *
+ * @tparam Client the type of client to execute AsyncGetOperation on
+ * @tparam ResponseType the type of the response packed in the
+ *     longrunning.Operation
+ * @tparam valid_cliend a formal parameter, uses
+ *     `std::enable_if<>` to disable this template if the Client doesn't have a
+ *     proper AsyncGetOperation member function.
+ */
+template <typename Client, typename ResponseType,
+          typename std::enable_if<
+              CheckAsyncUnaryRpcSignature<
+                  typename internal::ExtractMemberFunctionType<decltype(
+                      &Client::AsyncGetOperation)>::MemberFunction>::value,
+              int>::type valid_client = 0>
+class AsyncLongrunningOp {
+ public:
+  using Request = google::longrunning::GetOperationRequest;
+  using Response = ResponseType;
+
+  AsyncLongrunningOp(std::shared_ptr<Client> client,
+                     google::longrunning::Operation operation)
+      : client_(client), operation_(std::move(operation)) {}
+
+  /**
+   * Start the bound asynchronous request.
+   *
+   * @tparam Functor the type of the function-like object that will receive the
+   *     results.
+   *
+   * @tparam valid_callback_type a format parameter, uses `std::enable_if<>` to
+   *     disable this template if the functor does not match the expected
+   *     signature.
+   *
+   * @param cq the completion queue to run the asynchronous operations.
+   *
+   * @param context the gRPC context used for this request
+   *
+   * @param callback the functor which will be fired in an unspecified thread
+   *     once the response stream completes
+   */
+  template <typename Functor,
+            typename std::enable_if<
+                google::cloud::internal::is_invocable<
+                    Functor, CompletionQueue&, bool, grpc::Status&>::value,
+                int>::type valid_callback_type = 0>
+  std::shared_ptr<AsyncOperation> Start(
+      CompletionQueue& cq, std::unique_ptr<grpc::ClientContext>&& context,
+      Functor&& callback) {
+    if (operation_.done()) {
+      // The operation supplied in the ctor can be already completed. In such a
+      // case, let's not send the RPC.
+      //
+      // We could fire the callback right here, but we'd be risking a deadlock
+      // if the user held a lock while submitting this request. Instead, let's
+      // schedule the callback to fire on the thread running the completion
+      // queue by submitting an expired timer.
+      return cq.MakeRelativeTimer(
+          std::chrono::seconds(0),
+          [callback, this](CompletionQueue& cq, AsyncTimerResult result) {
+            if (operation_.has_error()) {
+              grpc::Status status(
+                  static_cast<grpc::StatusCode>(operation_.error().code()),
+                  operation_.error().message(),
+                  "Error in operation " + operation_.name());
+              callback(cq, true, status);
+            } else {
+              grpc::Status status;
+              callback(cq, true, status);
+            }
+          });
+    }
+    google::longrunning::GetOperationRequest request;
+    request.set_name(operation_.name());
+    return cq.MakeUnaryRpc(
+        *client_, &Client::AsyncGetOperation, request, std::move(context),
+        [this, callback](CompletionQueue& cq,
+                         google::longrunning::Operation& operation,
+                         grpc::Status& status) {
+          if (not status.ok()) {
+            callback(cq, false, status);
+            return;
+          }
+          operation_.Swap(&operation);
+          if (not operation_.done()) {
+            callback(cq, false, status);
+            return;
+          }
+          if (operation_.has_error()) {
+            grpc::Status res_status(
+                static_cast<grpc::StatusCode>(operation_.error().code()),
+                operation_.error().message(),
+                "Error in operation " + operation_.name());
+            callback(cq, true, res_status);
+            return;
+          } else {
+            callback(cq, true, status);
+            return;
+          }
+        });
+  }
+
+  Response AccumulatedResult() {
+    if (operation_.has_response()) {
+      auto const& any = operation_.response();
+      Response res;
+      any.UnpackTo(&res);
+      return res;
+    } else {
+      return Response();
+    }
+  }
+
+ private:
+  std::shared_ptr<Client> client_;
+  google::longrunning::Operation operation_;
+};
+
+/**
+ * Poll `AsyncLongrunningOp` result.
+ *
+ * @tparam Functor the type of the function-like object that will receive the
+ *     results. It must satisfy (using C++17 types):
+ *     static_assert(std::is_invocable_v<
+ *         Functor, CompletionQueue&, Response, grpc::Status&>);
+ * @tparam Client the type of client to execute AsyncGetOperation on
+ * @tparam ResponseType the type of the response packed in the
+ *     longrunning.Operation
+ * @tparam valid_callback_type a format parameter, uses `std::enable_if<>` to
+ *     disable this template if the functor does not match the expected
+ *     signature.
+ */
+template <typename Functor, typename Client, typename Response,
+          typename std::enable_if<
+              google::cloud::internal::is_invocable<
+                  Functor, CompletionQueue&, Response&, grpc::Status&>::value,
+              int>::type valid_callback_type = 0>
+class AsyncPollLongrunningOp
+    : public AsyncPollOp<Functor, AsyncLongrunningOp<Client, Response>> {
+ public:
+  AsyncPollLongrunningOp(char const* error_message,
+                         std::unique_ptr<PollingPolicy> polling_policy,
+                         MetadataUpdatePolicy metadata_update_policy,
+                         std::shared_ptr<Client> client,
+                         google::longrunning::Operation operation,
+                         Functor&& callback)
+      : AsyncPollOp<Functor, AsyncLongrunningOp<Client, Response>>(
+            error_message, std::move(polling_policy),
+            std::move(metadata_update_policy), std::forward<Functor>(callback),
+            AsyncLongrunningOp<Client, Response>(std::move(client),
+                                                 std::move(operation))) {}
+};
+
+}  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_LONGRUNNING_OP_H__

--- a/google/cloud/bigtable/internal/async_longrunning_op_test.cc
+++ b/google/cloud/bigtable/internal/async_longrunning_op_test.cc
@@ -314,7 +314,7 @@ INSTANTIATE_TEST_CASE_P(
                       grpc::StatusCode::OK},
         // First RPC fails, but second succeeds.
         OpRetryConfig{// The error code returned by the first attempt.
-                      grpc::StatusCode::OK,
+                      grpc::StatusCode::UNAVAILABLE,
                       // The error code returned by the whole long running
                       // operation on the
                       // second attempt.

--- a/google/cloud/bigtable/internal/async_longrunning_op_test.cc
+++ b/google/cloud/bigtable/internal/async_longrunning_op_test.cc
@@ -1,0 +1,336 @@
+// Copyright 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/internal/async_longrunning_op.h"
+#include "google/cloud/bigtable/admin_client.h"
+#include "google/cloud/bigtable/internal/table_admin.h"
+#include "google/cloud/bigtable/testing/internal_table_test_fixture.h"
+#include "google/cloud/bigtable/testing/mock_admin_client.h"
+#include "google/cloud/bigtable/testing/mock_completion_queue.h"
+#include "google/cloud/bigtable/testing/mock_response_reader.h"
+#include "google/cloud/bigtable/testing/table_test_fixture.h"
+#include "google/cloud/testing_util/chrono_literals.h"
+#include <gmock/gmock.h>
+#include <thread>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace noex {
+namespace {
+
+namespace bt = ::google::cloud::bigtable;
+namespace btproto = google::bigtable::admin::v2;
+using namespace google::cloud::testing_util::chrono_literals;
+using namespace ::testing;
+using MockAsyncLongrunningOpReader =
+    google::cloud::bigtable::testing::MockAsyncResponseReader<
+        google::longrunning::Operation>;
+
+class NoexAsyncLongrunningOpTest : public ::testing::Test {};
+
+/// @test Verify that TableAdmin::LongrunningOp() works in a simplest case.
+TEST_F(NoexAsyncLongrunningOpTest, Simple) {
+  auto client = std::make_shared<testing::MockAdminClient>();
+  auto cq_impl = std::make_shared<testing::MockCompletionQueue>();
+  bigtable::CompletionQueue cq(cq_impl);
+
+  auto longrunning_reader =
+      google::cloud::internal::make_unique<MockAsyncLongrunningOpReader>();
+  EXPECT_CALL(*longrunning_reader, Finish(_, _, _))
+      .WillOnce(Invoke([](google::longrunning::Operation* response,
+                          grpc::Status* status, void*) {
+        // This might be confusing, but we're using a GetOperationRequest as
+        // response. This could have been any other message for the purpose of
+        // this test, but this is simple, so it's handy.
+        google::longrunning::GetOperationRequest response_content;
+        response_content.set_name("asdfgh");
+        auto any =
+            google::cloud::internal::make_unique<google::protobuf::Any>();
+        any->PackFrom(response_content);
+        response->set_allocated_response(any.release());
+        response->set_name("qwerty");
+        response->set_done(true);
+        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+      }));
+
+  EXPECT_CALL(*client, AsyncGetOperation(_, _, _))
+      .WillOnce(
+          Invoke([&longrunning_reader](
+                     grpc::ClientContext*,
+                     google::longrunning::GetOperationRequest const& request,
+                     grpc::CompletionQueue*) {
+            EXPECT_EQ("qwerty", request.name());
+            // This is safe, see comments in MockAsyncResponseReader.
+            return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
+                google::longrunning::Operation>>(longrunning_reader.get());
+          }));
+
+  bool user_op_called = false;
+  auto user_callback = [&user_op_called](
+                           CompletionQueue& cq,
+                           google::longrunning::GetOperationRequest& response,
+                           grpc::Status const& status) {
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ("asdfgh", response.name());
+    EXPECT_EQ("mocked-status", status.error_message());
+    user_op_called = true;
+  };
+  using OpType = internal::AsyncPollLongrunningOp<
+      decltype(user_callback), testing::MockAdminClient,
+      google::longrunning::GetOperationRequest>;
+  google::longrunning::Operation op_arg;
+  op_arg.set_name("qwerty");
+  auto polling_policy =
+      bigtable::DefaultPollingPolicy(internal::kBigtableLimits);
+  MetadataUpdatePolicy metadata_update_policy(
+      "instance_id", MetadataParamTypes::NAME, "table_id");
+  auto op = std::make_shared<OpType>(
+      __func__, polling_policy->clone(), metadata_update_policy, client,
+      std::move(op_arg), std::move(user_callback));
+  op->Start(cq);
+
+  EXPECT_FALSE(user_op_called);
+  EXPECT_EQ(1U, cq_impl->size());
+  cq_impl->SimulateCompletion(cq, true);
+
+  EXPECT_TRUE(user_op_called);
+  EXPECT_TRUE(cq_impl->empty());
+}
+
+class NoexAsyncLongrunningImmediatelyFinished
+    : public bigtable::testing::internal::TableTestFixture,
+      public WithParamInterface<bool> {};
+
+// Verify that handling already finished operations works.
+TEST_P(NoexAsyncLongrunningImmediatelyFinished, ImmeditalyFinished) {
+  bool const has_error = GetParam();
+  auto client = std::make_shared<testing::MockAdminClient>();
+  auto cq_impl = std::make_shared<testing::MockCompletionQueue>();
+  bigtable::CompletionQueue cq(cq_impl);
+
+  google::longrunning::Operation longrunning_op;
+  longrunning_op.set_name("qwerty");
+  longrunning_op.set_done(true);
+  if (not has_error) {
+    // This might be confusing, but we're using a GetOperationRequest as
+    // response. This could have been any other message for the purpose of
+    // this test, but this is simple, so it's handy.
+    google::longrunning::GetOperationRequest response_content;
+    response_content.set_name("asdfgh");
+    auto any = google::cloud::internal::make_unique<google::protobuf::Any>();
+    any->PackFrom(response_content);
+    longrunning_op.set_allocated_response(any.release());
+  } else {
+    auto error = google::cloud::internal::make_unique<google::rpc::Status>();
+    error->set_code(grpc::StatusCode::FAILED_PRECONDITION);
+    error->set_message("something is broken");
+    longrunning_op.set_allocated_error(error.release());
+  }
+
+  auto longrunning_reader =
+      google::cloud::internal::make_unique<MockAsyncLongrunningOpReader>();
+
+  // Make the asynchronous request.
+  bool user_op_called = false;
+  auto user_callback = [&user_op_called, has_error](
+                           CompletionQueue& cq,
+                           google::longrunning::GetOperationRequest& response,
+                           grpc::Status const& status) {
+    EXPECT_EQ(status.ok(), not has_error);
+    if (has_error) {
+      EXPECT_EQ(grpc::StatusCode::FAILED_PRECONDITION, status.error_code());
+    } else {
+      EXPECT_EQ("asdfgh", response.name());
+    }
+    user_op_called = true;
+  };
+  using OpType = internal::AsyncPollLongrunningOp<
+      decltype(user_callback), testing::MockAdminClient,
+      google::longrunning::GetOperationRequest>;
+  auto polling_policy =
+      bigtable::DefaultPollingPolicy(internal::kBigtableLimits);
+  MetadataUpdatePolicy metadata_update_policy(
+      "instance_id", MetadataParamTypes::NAME, "table_id");
+  auto op = std::make_shared<OpType>(
+      __func__, polling_policy->clone(), metadata_update_policy, client,
+      std::move(longrunning_op), std::move(user_callback));
+  op->Start(cq);
+
+  EXPECT_FALSE(user_op_called);
+  EXPECT_EQ(1U, cq_impl->size());  // timer
+  cq_impl->SimulateCompletion(cq, true);
+
+  EXPECT_TRUE(user_op_called);
+  EXPECT_TRUE(cq_impl->empty());
+}
+
+INSTANTIATE_TEST_CASE_P(
+    ImmediateFinished, NoexAsyncLongrunningImmediatelyFinished,
+    ::testing::Values(
+        // The long running operation was successful.
+        true,
+        // The long running operation finished with an error.
+        false));
+
+class OpRetryConfig {
+ public:
+  grpc::StatusCode first_rpc_error_code;
+  grpc::StatusCode whole_op_error_code;
+};
+
+class NoexAsyncLongrunningOpRetryTest
+    : public bigtable::testing::internal::TableTestFixture,
+      public WithParamInterface<OpRetryConfig> {};
+
+// Verify that one retry works. No reason for many tests - AsyncPollOp is
+// thoroughly tested.
+TEST_P(NoexAsyncLongrunningOpRetryTest, OneRetry) {
+  auto const config = GetParam();
+  auto client = std::make_shared<testing::MockAdminClient>();
+  auto cq_impl = std::make_shared<testing::MockCompletionQueue>();
+  bigtable::CompletionQueue cq(cq_impl);
+
+  auto longrunning_reader =
+      google::cloud::internal::make_unique<MockAsyncLongrunningOpReader>();
+  EXPECT_CALL(*longrunning_reader, Finish(_, _, _))
+      .WillOnce(Invoke([config](google::longrunning::Operation* response,
+                                grpc::Status* status, void*) {
+        response->set_name("qwerty");
+        response->set_done(false);
+        *status = grpc::Status(config.first_rpc_error_code, "mocked-status");
+      }))
+      .WillOnce(Invoke([&config](google::longrunning::Operation* response,
+                                 grpc::Status* status, void*) {
+        response->set_name("qwerty");
+        response->set_done(true);
+        if (config.whole_op_error_code == grpc::StatusCode::OK) {
+          // This might be confusing, but we're using a GetOperationRequest as
+          // response. This could have been any other message for the purpose of
+          // this test, but this is simple, so it's handy.
+          google::longrunning::GetOperationRequest response_content;
+          response_content.set_name("asdfgh");
+          auto any =
+              google::cloud::internal::make_unique<google::protobuf::Any>();
+          any->PackFrom(response_content);
+          response->set_allocated_response(any.release());
+        } else {
+          auto error =
+              google::cloud::internal::make_unique<google::rpc::Status>();
+          error->set_code(config.whole_op_error_code);
+          error->set_message("something is broken");
+          response->set_allocated_error(error.release());
+        }
+        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+      }));
+
+  EXPECT_CALL(*client, AsyncGetOperation(_, _, _))
+      .WillOnce(
+          Invoke([&longrunning_reader](
+                     grpc::ClientContext*,
+                     google::longrunning::GetOperationRequest const& request,
+                     grpc::CompletionQueue*) {
+            EXPECT_EQ("qwerty", request.name());
+            // This is safe, see comments in MockAsyncResponseReader.
+            return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
+                google::longrunning::Operation>>(longrunning_reader.get());
+          }))
+      .WillOnce(
+          Invoke([&longrunning_reader](
+                     grpc::ClientContext*,
+                     google::longrunning::GetOperationRequest const& request,
+                     grpc::CompletionQueue*) {
+            EXPECT_EQ("qwerty", request.name());
+            // This is safe, see comments in MockAsyncResponseReader.
+            return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
+                google::longrunning::Operation>>(longrunning_reader.get());
+          }));
+
+  // Make the asynchronous request.
+  bool user_op_called = false;
+  auto user_callback = [&user_op_called, &config](
+                           CompletionQueue& cq,
+                           google::longrunning::GetOperationRequest& response,
+                           grpc::Status const& status) {
+    EXPECT_EQ(config.whole_op_error_code, status.error_code());
+    if (status.ok()) {
+      EXPECT_EQ("asdfgh", response.name());
+      EXPECT_EQ("mocked-status", status.error_message());
+    }
+    user_op_called = true;
+  };
+  using OpType = internal::AsyncPollLongrunningOp<
+      decltype(user_callback), testing::MockAdminClient,
+      google::longrunning::GetOperationRequest>;
+  google::longrunning::Operation op_arg;
+  op_arg.set_name("qwerty");
+  auto polling_policy =
+      bigtable::DefaultPollingPolicy(internal::kBigtableLimits);
+  MetadataUpdatePolicy metadata_update_policy(
+      "instance_id", MetadataParamTypes::NAME, "table_id");
+  auto op = std::make_shared<OpType>(
+      __func__, polling_policy->clone(), metadata_update_policy, client,
+      std::move(op_arg), std::move(user_callback));
+  op->Start(cq);
+
+  EXPECT_FALSE(user_op_called);
+  EXPECT_EQ(1U, cq_impl->size());  // request
+  cq_impl->SimulateCompletion(cq, true);
+  EXPECT_FALSE(user_op_called);
+  EXPECT_EQ(1U, cq_impl->size());  // timer
+
+  cq_impl->SimulateCompletion(cq, true);
+  EXPECT_FALSE(user_op_called);
+  EXPECT_EQ(1U, cq_impl->size());  //  request
+
+  cq_impl->SimulateCompletion(cq, true);
+
+  EXPECT_TRUE(user_op_called);
+  EXPECT_TRUE(cq_impl->empty());
+}
+
+INSTANTIATE_TEST_CASE_P(
+    OneRetry, NoexAsyncLongrunningOpRetryTest,
+    ::testing::Values(
+        // First RPC returns an OK status but indicates
+        // the long running op has not finished yet.
+        OpRetryConfig{// The error code returned by the first attempt.
+                      grpc::StatusCode::OK,
+                      // The error code returned by the whole long running
+                      // operation on the
+                      // second attempt.
+                      grpc::StatusCode::OK},
+        // First RPC fails, but second succeeds.
+        OpRetryConfig{// The error code returned by the first attempt.
+                      grpc::StatusCode::OK,
+                      // The error code returned by the whole long running
+                      // operation on the
+                      // second attempt.
+                      grpc::StatusCode::OK},
+        // First RPC fails, second succeds, but indicates
+        // that the operation failed permanently.
+        OpRetryConfig{// The error code returned by the first attempt.
+                      grpc::StatusCode::OK,
+                      // The error code returned by the whole long running
+                      // operation on the
+                      // second attempt.
+                      grpc::StatusCode::FAILED_PRECONDITION}));
+
+}  // namespace
+}  // namespace noex
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
This is a part of #1397.

This is basically `PollLongRunningOperation`'s counterpart - it wraps
sending GetOperation and then wraps it in AsyncPollOp.

The next step will be implementing a cancellable "then" async operation
to be able to run an longrunning RPC and then asynchronously wait for
it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1466)
<!-- Reviewable:end -->
