### PR TITLE
AsyncLongrunninOp: use static_assert.

### DIFF
--- a/google/cloud/bigtable/internal/async_longrunning_op.h
+++ b/google/cloud/bigtable/internal/async_longrunning_op.h
@@ -42,17 +42,14 @@ namespace internal {
  * @tparam Client the type of client to execute `AsyncGetOperation` on
  * @tparam ResponseType the type of the response packed in the
  *     `google.longrunning.Operation`
- * @tparam valid_cliend a formal parameter, uses
- *     `std::enable_if<>` to disable this template if the `Client` doesn't have
- * a proper `AsyncGetOperation` member function.
  */
-template <typename Client, typename ResponseType,
-          typename std::enable_if<
-              CheckAsyncUnaryRpcSignature<
-                  typename internal::ExtractMemberFunctionType<decltype(
-                      &Client::AsyncGetOperation)>::MemberFunction>::value,
-              int>::type valid_client = 0>
+template <typename Client, typename ResponseType>
 class AsyncLongrunningOp {
+  static_assert(
+      CheckAsyncUnaryRpcSignature<typename internal::ExtractMemberFunctionType<
+          decltype(&Client::AsyncGetOperation)>::MemberFunction>::value,
+      "Client toesn't have a proper AsyncGetOperation member function.");
+
  public:
   using Request = google::longrunning::GetOperationRequest;
   using Response = ResponseType;


### PR DESCRIPTION
The use of `std::enable_if` is an overkill in this case - SFINAE is
unlikely. `static_assert` makes forward declarations of this class more concise.
They will be needed for declaring this class as a friend.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1470)
<!-- Reviewable:end -->
