### PR TITLE
Introduce AsyncGrpcOperation.

### DIFF
--- a/google/cloud/bigtable/async_operation.h
+++ b/google/cloud/bigtable/async_operation.h
@@ -43,12 +43,8 @@ struct AsyncTimerResult {
 /**
  * Represents a pending asynchronous operation.
  *
- * When applications create an asynchronous operations with a `CompletionQueue`
- * they provide a callback to be invoked when the operation completes
- * (successfully or not). The completion queue type-erases the callback and
- * hides it in a class derived from `AsyncOperation`.  A shared pointer to the
- * `AsyncOperation` is returned by the completion queue so library developers
- * can cancel the operation if needed.
+ * It can either be a simple RPC, or a more complex operation involving
+ * potentially many RPCs, sleeping and processing.
  */
 class AsyncOperation {
  public:
@@ -56,29 +52,8 @@ class AsyncOperation {
 
   /**
    * Requests that the operation be canceled.
-   *
-   * The result of canceling the operation is reported via `Notify()`, which
-   * invokes the callback registered when the operation was created.
    */
   virtual void Cancel() = 0;
-
- private:
-  friend class internal::CompletionQueueImpl;
-  /**
-   * Notifies the application that the operation completed.
-   *
-   * Derived classes wrap the callbacks provided by the application and invoke
-   * the callback when this virtual member function is called.
-   *
-   * @param cq the completion queue sending the notification, this is useful in
-   *   case the callback needs to retry the operation.
-   * @param ok opaque parameter returned by grpc::CompletionQueue.  The
-   *   semantics defined by gRPC depend on the type of operation, therefore the
-   *   operation needs to interpret this parameter based on those semantics.
-   * @return Whether the operation is completed (e.g. in case of streaming
-   *   response, it would return true only after the stream is finished).
-   */
-  virtual bool Notify(CompletionQueue& cq, bool ok) = 0;
 };
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/google/cloud/bigtable/internal/async_check_consistency.h
+++ b/google/cloud/bigtable/internal/async_check_consistency.h
@@ -167,13 +167,6 @@ class AsyncAwaitConsistency
         table_name_(table_name),
         cancelled_() {}
 
-  bool Notify(CompletionQueue& cq, bool ok) override {
-    // TODO(#1389) Notify should be moved from AsyncOperation to some more
-    // specific derived class.
-    google::cloud::internal::RaiseLogicError(
-        "This member function doesn't make sense here");
-  }
-
   void Cancel() override {
     std::lock_guard<std::mutex> lk(mu_);
     cancelled_ = true;

--- a/google/cloud/bigtable/internal/async_poll_op.h
+++ b/google/cloud/bigtable/internal/async_poll_op.h
@@ -121,14 +121,6 @@ class AsyncPollOp
     }
   }
 
-  bool Notify(CompletionQueue& cq, bool ok) override {
-    // TODO(#1389) Notify should be moved from AsyncOperation to some more
-    // specific derived class.
-    google::cloud::internal::RaiseLogicError(
-        "This member function doesn't make sense in "
-        "AsyncRetryOp");
-  }
-
   std::shared_ptr<AsyncOperation> Start(CompletionQueue& cq) {
     auto self = this->shared_from_this();
     std::unique_lock<std::mutex> lk(mu_);

--- a/google/cloud/bigtable/internal/async_poll_op_test.cc
+++ b/google/cloud/bigtable/internal/async_poll_op_test.cc
@@ -81,13 +81,6 @@ class DummyOperation {
 
 class AsyncOperationMock : public AsyncOperation {
  public:
-  bool Notify(CompletionQueue& cq, bool ok) override {
-    // TODO(#1389) Notify should be moved from AsyncOperation to some more
-    // specific derived class.
-    google::cloud::internal::RaiseLogicError(
-        "This member function doesn't make sense in "
-        "AsyncPollOp");
-  }
   MOCK_METHOD0(Cancel, void());
 };
 

--- a/google/cloud/bigtable/internal/async_retry_op.h
+++ b/google/cloud/bigtable/internal/async_retry_op.h
@@ -139,14 +139,6 @@ class AsyncRetryOp : public std::enable_shared_from_this<
     }
   }
 
-  bool Notify(CompletionQueue& cq, bool ok) override {
-    // TODO(#1389) Notify should be moved from AsyncOperation to some more
-    // specific derived class.
-    google::cloud::internal::RaiseLogicError(
-        "This member function doesn't make sense in "
-        "AsyncRetryOp");
-  }
-
   std::shared_ptr<AsyncOperation> Start(CompletionQueue& cq) {
     auto res =
         std::static_pointer_cast<AsyncOperation>(this->shared_from_this());

--- a/google/cloud/bigtable/internal/async_retry_op_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_op_test.cc
@@ -82,13 +82,6 @@ static_assert(internal::MeetsAsyncOperationRequirements<DummyOperation>::value,
 
 class AsyncOperationMock : public AsyncOperation {
  public:
-  bool Notify(CompletionQueue& cq, bool ok) override {
-    // TODO(#1389) Notify should be moved from AsyncOperation to some more
-    // specific derived class.
-    google::cloud::internal::RaiseLogicError(
-        "This member function doesn't make sense in "
-        "AsyncRetryOp");
-  }
   MOCK_METHOD0(Cancel, void());
 };
 

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll.h
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll.h
@@ -103,13 +103,6 @@ class AsyncRetryAndPollUnaryRpc
         cancelled_(),
         callback_(callback) {}
 
-  bool Notify(CompletionQueue& cq, bool ok) override {
-    // TODO(#1389) Notify should be moved from AsyncOperation to some more
-    // specific derived class.
-    google::cloud::internal::RaiseLogicError(
-        "This member function doesn't make sense here");
-  }
-
   void Cancel() override {
     std::lock_guard<std::mutex> lk(mu_);
     cancelled_ = true;

--- a/google/cloud/bigtable/internal/completion_queue_impl.cc
+++ b/google/cloud/bigtable/internal/completion_queue_impl.cc
@@ -59,7 +59,7 @@ std::unique_ptr<grpc::Alarm> CompletionQueueImpl::CreateAlarm() const {
 }
 
 void* CompletionQueueImpl::RegisterOperation(
-    std::shared_ptr<AsyncOperation> op) {
+    std::shared_ptr<AsyncGrpcOperation> op) {
   void* tag = op.get();
   std::unique_lock<std::mutex> lk(mu_);
   auto ins =
@@ -73,7 +73,8 @@ void* CompletionQueueImpl::RegisterOperation(
       "assertion failure: insertion should succeed");
 }
 
-std::shared_ptr<AsyncOperation> CompletionQueueImpl::FindOperation(void* tag) {
+std::shared_ptr<AsyncGrpcOperation> CompletionQueueImpl::FindOperation(
+    void* tag) {
   std::lock_guard<std::mutex> lk(mu_);
   auto loc = pending_ops_.find(reinterpret_cast<std::intptr_t>(tag));
   if (pending_ops_.end() == loc) {


### PR DESCRIPTION
This fixes #1389.

The `Notify()` member function in `AsyncOperation` doesn't make sense in
case of compund operations utilizing other higher level operations,
e.g. `AsyncRetryOp`. As a remedy, `AsyncGrpcOperation` is introduced.

`AsyncGrpcOperation` represents operations whose callbacks are triggered
by `grpc::CompletionQueue::AsyncNext()`. The notification is implemented
via overriding the `Notify()` member function. This class is inherent to
the implementation of `bigtable::internal::CompletionQueue`, so it is
defined there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1478)
<!-- Reviewable:end -->
