### PR TITLE
Introduce CompletionQueue::RunAsync.

### DIFF
--- a/google/cloud/bigtable/completion_queue.h
+++ b/google/cloud/bigtable/completion_queue.h
@@ -206,10 +206,7 @@ class CompletionQueue {
   }
 
   /**
-   * Create a no-op operation.
-   *
-   * Such an operation might be useful for executing the passed callback on one
-   * of the threads executing the completion queue.
+   * Asynchronously run a functor on a thread `Run()`ning the `CompletionQueue`.
    *
    * @tparam Functor the functor to call on the CompletionQueue thread.
    *   It must satisfy the `void(CompletionQueue&)` signature.
@@ -219,9 +216,9 @@ class CompletionQueue {
    *   straight away
    */
   template <typename Functor,
-            typename std::enable_if<internal::CheckNoopCallback<Functor>::value,
-                                    int>::type = 0>
-  std::shared_ptr<AsyncOperation> MakeNoop(Functor&& functor) {
+            typename std::enable_if<
+                internal::CheckRunAsyncCallback<Functor>::value, int>::type = 0>
+  std::shared_ptr<AsyncOperation> RunAsync(Functor&& functor) {
     return MakeRelativeTimer(
         std::chrono::seconds(0),
         [functor](CompletionQueue& cq, AsyncTimerResult result) {

--- a/google/cloud/bigtable/completion_queue.h
+++ b/google/cloud/bigtable/completion_queue.h
@@ -205,6 +205,30 @@ class CompletionQueue {
     return op;
   }
 
+  /**
+   * Create a no-op operation.
+   *
+   * Such an operation might be useful for executing the passed callback on one
+   * of the threads executing the completion queue.
+   *
+   * @tparam Functor the functor to call on the CompletionQueue thread.
+   *   It must satisfy the `void(CompletionQueue&)` signature.
+   * @param functor the value of the functor.
+   * @return an asynchronous operation wrapping the functor; it can be used for
+   *   cancelling but it makes little sense given that it will be completed
+   *   straight away
+   */
+  template <typename Functor,
+            typename std::enable_if<internal::CheckNoopCallback<Functor>::value,
+                                    int>::type = 0>
+  std::shared_ptr<AsyncOperation> MakeNoop(Functor&& functor) {
+    return MakeRelativeTimer(
+        std::chrono::seconds(0),
+        [functor](CompletionQueue& cq, AsyncTimerResult result) {
+          functor(cq);
+        });
+  }
+
  private:
   std::shared_ptr<internal::CompletionQueueImpl> impl_;
 };

--- a/google/cloud/bigtable/completion_queue_test.cc
+++ b/google/cloud/bigtable/completion_queue_test.cc
@@ -294,7 +294,7 @@ TEST(CompletionQueueTest, Noop) {
 
   std::promise<void> promise;
   auto alarm =
-      cq.MakeNoop([&promise](CompletionQueue& cq) { promise.set_value(); });
+      cq.RunAsync([&promise](CompletionQueue& cq) { promise.set_value(); });
 
   promise.get_future().get();
 

--- a/google/cloud/bigtable/completion_queue_test.cc
+++ b/google/cloud/bigtable/completion_queue_test.cc
@@ -287,6 +287,21 @@ TEST(CompletionQueueTest, AsyncRpcStreamNotCreated) {
   EXPECT_TRUE(completion_called);
 }
 
+TEST(CompletionQueueTest, Noop) {
+  bigtable::CompletionQueue cq;
+
+  std::thread t([&cq]() { cq.Run(); });
+
+  std::promise<void> promise;
+  auto alarm =
+      cq.MakeNoop([&promise](CompletionQueue& cq) { promise.set_value(); });
+
+  promise.get_future().get();
+
+  cq.Shutdown();
+  t.join();
+}
+
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/internal/async_longrunning_op.h
+++ b/google/cloud/bigtable/internal/async_longrunning_op.h
@@ -91,22 +91,19 @@ class AsyncLongrunningOp {
       // We could fire the callback right here, but we'd be risking a deadlock
       // if the user held a lock while submitting this request. Instead, let's
       // schedule the callback to fire on the thread running the completion
-      // queue by submitting an expired timer.
-      // TODO(#1467): stop using a timer for this purpose
-      return cq.MakeRelativeTimer(
-          std::chrono::seconds(0),
-          [callback, this](CompletionQueue& cq, AsyncTimerResult result) {
-            if (operation_.has_error()) {
-              grpc::Status status(
-                  static_cast<grpc::StatusCode>(operation_.error().code()),
-                  operation_.error().message(),
-                  "Error in operation " + operation_.name());
-              callback(cq, true, status);
-            } else {
-              grpc::Status status;
-              callback(cq, true, status);
-            }
-          });
+      // queue.
+      return cq.MakeNoop([callback, this](CompletionQueue& cq) {
+        if (operation_.has_error()) {
+          grpc::Status status(
+              static_cast<grpc::StatusCode>(operation_.error().code()),
+              operation_.error().message(),
+              "Error in operation " + operation_.name());
+          callback(cq, true, status);
+        } else {
+          grpc::Status status;
+          callback(cq, true, status);
+        }
+      });
     }
     google::longrunning::GetOperationRequest request;
     request.set_name(operation_.name());

--- a/google/cloud/bigtable/internal/async_longrunning_op.h
+++ b/google/cloud/bigtable/internal/async_longrunning_op.h
@@ -92,7 +92,7 @@ class AsyncLongrunningOp {
       // if the user held a lock while submitting this request. Instead, let's
       // schedule the callback to fire on the thread running the completion
       // queue.
-      return cq.MakeNoop([callback, this](CompletionQueue& cq) {
+      return cq.RunAsync([callback, this](CompletionQueue& cq) {
         if (operation_.has_error()) {
           grpc::Status status(
               static_cast<grpc::StatusCode>(operation_.error().code()),

--- a/google/cloud/bigtable/internal/async_poll_op.h
+++ b/google/cloud/bigtable/internal/async_poll_op.h
@@ -139,7 +139,7 @@ class AsyncPollOp
       // schedule the callback to fire on the thread running the completion
       // queue.
       // There is no reason to store this timer in current_op_.
-      cq.MakeNoop([self](CompletionQueue& cq) { self->OnTimer(cq, false); });
+      cq.RunAsync([self](CompletionQueue& cq) { self->OnTimer(cq, false); });
       return self;
     }
     StartUnlocked(cq);

--- a/google/cloud/bigtable/internal/async_retry_op.h
+++ b/google/cloud/bigtable/internal/async_retry_op.h
@@ -159,7 +159,7 @@ class AsyncRetryOp : public std::enable_shared_from_this<
       // queue.
       // There is no reason to store this timer in current_op_.
       auto self = this->shared_from_this();
-      cq.MakeNoop([self](CompletionQueue& cq) { self->OnTimer(cq, false); });
+      cq.RunAsync([self](CompletionQueue& cq) { self->OnTimer(cq, false); });
       return res;
     }
     StartUnlocked(cq);

--- a/google/cloud/bigtable/internal/async_retry_op.h
+++ b/google/cloud/bigtable/internal/async_retry_op.h
@@ -156,14 +156,10 @@ class AsyncRetryOp : public std::enable_shared_from_this<
       // We could fire the callback right here, but we'd be risking a deadlock
       // if the user held a lock while submitting this request. Instead, let's
       // schedule the callback to fire on the thread running the completion
-      // queue by submitting an expired timer.
+      // queue.
       // There is no reason to store this timer in current_op_.
       auto self = this->shared_from_this();
-      cq.MakeRelativeTimer(
-          std::chrono::seconds(0),
-          [self](CompletionQueue& cq, AsyncTimerResult result) {
-            self->OnTimer(cq, result);
-          });
+      cq.MakeNoop([self](CompletionQueue& cq) { self->OnTimer(cq, false); });
       return res;
     }
     StartUnlocked(cq);
@@ -273,13 +269,13 @@ class AsyncRetryOp : public std::enable_shared_from_this<
     auto self = this->shared_from_this();
     current_op_ = cq.MakeRelativeTimer(
         delay, [self](CompletionQueue& cq, AsyncTimerResult result) {
-          self->OnTimer(cq, result);
+          self->OnTimer(cq, result.cancelled);
         });
   }
 
-  void OnTimer(CompletionQueue& cq, AsyncTimerResult& timer) {
+  void OnTimer(CompletionQueue& cq, bool cancelled) {
     std::unique_lock<std::mutex> lk(mu_);
-    if (timer.cancelled or cancelled_) {
+    if (cancelled or cancelled_) {
       // Cancelled, no more action to take.
       current_op_.reset();
       auto res = operation_.AccumulatedResult();

--- a/google/cloud/bigtable/internal/completion_queue_impl.h
+++ b/google/cloud/bigtable/internal/completion_queue_impl.h
@@ -359,6 +359,15 @@ struct CheckAsyncUnaryStreamRpcSignature<
 };
 
 /**
+ * Tests if @p Functor meets the requirements for a no-op callback.
+ *
+ * @tparam Functor a type the application wants to use as a callback.
+ */
+template <typename Functor>
+using CheckNoopCallback =
+    google::cloud::internal::is_invocable<Functor, CompletionQueue&>;
+
+/**
  * The implementation details for `CompletionQueue`.
  *
  * `CompletionQueue` is implemented using the PImpl idiom:

--- a/google/cloud/bigtable/internal/completion_queue_impl.h
+++ b/google/cloud/bigtable/internal/completion_queue_impl.h
@@ -359,12 +359,12 @@ struct CheckAsyncUnaryStreamRpcSignature<
 };
 
 /**
- * Tests if @p Functor meets the requirements for a no-op callback.
+ * Tests if @p Functor meets the requirements for a RunAsync callback.
  *
  * @tparam Functor a type the application wants to use as a callback.
  */
 template <typename Functor>
-using CheckNoopCallback =
+using CheckRunAsyncCallback =
     google::cloud::internal::is_invocable<Functor, CompletionQueue&>;
 
 /**


### PR DESCRIPTION
This fixes #1467.

In order to execute a callback on a thread executing `CompletionQueue`,
an expired timer was used. This commit introduces an explicit call for
it, which still uses an expired timer under the hood.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1480)
<!-- Reviewable:end -->
