### PR TITLE
An abstraction for resumable upload sessions.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -175,6 +175,7 @@ add_library(storage_client
             internal/patch_builder.h
             internal/raw_client.h
             internal/raw_client_wrapper_utils.h
+            internal/resumable_upload_session.h
             internal/retry_client.h
             internal/retry_client.cc
             internal/service_account_requests.h

--- a/google/cloud/storage/internal/resumable_upload_session.h
+++ b/google/cloud/storage/internal/resumable_upload_session.h
@@ -1,0 +1,57 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_RESUMABLE_UPLOAD_SESSION_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_RESUMABLE_UPLOAD_SESSION_H_
+
+#include "google/cloud/storage/internal/object_requests.h"
+#include "google/cloud/storage/status.h"
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+/**
+ * Defines the interface for a resumable upload session.
+ */
+class ResumableUploadSession {
+ public:
+  virtual ~ResumableUploadSession() = default;
+
+  /**
+   * Uploads a chunk and returns the resulting response.
+   *
+   * @param buffer the chunk to upload
+   * @param upload_size the total size of the upload, use `0` if the size is not
+   *   known.
+   * @return The result of uploading the chunk.
+   */
+  virtual std::pair<Status, ResumableUploadResponse> UploadChunk(
+      std::string const& buffer, std::uint64_t upload_size) = 0;
+
+  /// Reset the session by querying its current state.
+  virtual std::pair<Status, ResumableUploadResponse> ResetSession() = 0;
+
+  ///
+  virtual std::uint64_t next_expected_byte() const = 0;
+};
+
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_RESUMABLE_UPLOAD_SESSION_H_

--- a/google/cloud/storage/internal/resumable_upload_session.h
+++ b/google/cloud/storage/internal/resumable_upload_session.h
@@ -41,10 +41,16 @@ class ResumableUploadSession {
   virtual std::pair<Status, ResumableUploadResponse> UploadChunk(
       std::string const& buffer, std::uint64_t upload_size) = 0;
 
-  /// Reset the session by querying its current state.
+  /// Resets the session by querying its current state.
   virtual std::pair<Status, ResumableUploadResponse> ResetSession() = 0;
 
-  ///
+  /**
+   * Returns the next expected byte in the server.
+   *
+   * Users of this class should check this value in case a previous
+   * UploadChunk() has partially failed and the application (or the component
+   * using this class) needs to re-send a chunk.
+   */
   virtual std::uint64_t next_expected_byte() const = 0;
 };
 

--- a/google/cloud/storage/storage_client.bzl
+++ b/google/cloud/storage/storage_client.bzl
@@ -42,6 +42,7 @@ storage_client_HDRS = [
     "internal/patch_builder.h",
     "internal/raw_client.h",
     "internal/raw_client_wrapper_utils.h",
+    "internal/resumable_upload_session.h",
     "internal/retry_client.h",
     "internal/service_account_requests.h",
     "lifecycle_rule.h",


### PR DESCRIPTION
Later we will implement a parallel hierarchy matching `RetryClient`
(`RetryResumableUploadSession`),  LoggingClient`
(`LoggingResumableUploadSession`), and so forth. This is part of the fixes
for #559.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1484)
<!-- Reviewable:end -->
