### PR TITLE
Upgrade crc32c to 1.0.6

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -94,11 +94,11 @@ def google_cloud_cpp_deps():
     if "com_github_google_crc32c" not in native.existing_rules():
         native.new_http_archive(
             name = "com_github_google_crc32c",
-            strip_prefix = "crc32c-1.0.5",
+            strip_prefix = "crc32c-1.0.6",
             urls = [
-                "https://github.com/google/crc32c/archive/1.0.5.tar.gz",
+                "https://github.com/google/crc32c/archive/1.0.6.tar.gz",
             ],
-            sha256 = "c2c0dcc8d155a6a56cc8d56bc1413e076aa32c35784f4d457831e8ccebd9260b",
+            sha256 = "6b3b1d861bb8307658b2407bc7a4c59e566855ef5368a60b35c893551e4788e9",
             build_file = "@com_github_googlecloudplatform_google_cloud_cpp//bazel:crc32c.BUILD",
         )
 

--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -40,9 +40,9 @@ ccache_command="$(which ccache)"
 function install_crc32c {
   # Install googletest.
   echo "${COLOR_YELLOW}Installing Crc32c $(date)${COLOR_RESET}"
-  wget -q https://github.com/google/crc32c/archive/1.0.5.tar.gz
-  tar -xf 1.0.5.tar.gz
-  cd crc32c-1.0.5
+  wget -q https://github.com/google/crc32c/archive/1.0.6.tar.gz
+  tar -xf 1.0.6.tar.gz
+  cd crc32c-1.0.6
   env CXX="${cached_cxx}" CC="${cached_cc}"  cmake \
       -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
       -DCRC32C_BUILD_TESTS=OFF \

--- a/cmake/external/crc32c.cmake
+++ b/cmake/external/crc32c.cmake
@@ -18,9 +18,9 @@ if (NOT TARGET crc32c_project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_CRC32C_URL
-        "https://github.com/google/crc32c/archive/1.0.5.tar.gz")
+        "https://github.com/google/crc32c/archive/1.0.6.tar.gz")
     set(GOOGLE_CLOUD_CPP_CRC32C_SHA256
-        "c2c0dcc8d155a6a56cc8d56bc1413e076aa32c35784f4d457831e8ccebd9260b")
+        "6b3b1d861bb8307658b2407bc7a4c59e566855ef5368a60b35c893551e4788e9")
 
     if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
         OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")


### PR DESCRIPTION
This version supports shared libraries, so we can turn them on in our builds too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1493)
<!-- Reviewable:end -->
