### PR TITLE
Update to gRPC 1.16.1

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -49,12 +49,12 @@ def google_cloud_cpp_deps():
     if "com_github_grpc_grpc" not in native.existing_rules():
         native.http_archive(
             name = "com_github_grpc_grpc",
-            strip_prefix = "grpc-1.14.1",
+            strip_prefix = "grpc-1.16.1",
             urls = [
-                "https://github.com/grpc/grpc/archive/v1.14.1.tar.gz",
-                "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.14.1.tar.gz",
+                "https://github.com/grpc/grpc/archive/v1.16.1.tar.gz",
+                "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.16.1.tar.gz",
             ],
-            sha256 = "16f22430210abf92e06626a5a116e114591075e5854ac78f1be8564171658b70",
+            sha256 = "a5342629fe1b689eceb3be4d4f167b04c70a84b9d61cf8b555e968bc500bdb5a",
         )
 
     # Load OpenCensus and its dependencies.

--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -55,7 +55,7 @@ function install_crc32c {
 }
 
 function install_protobuf {
-  # Install protobuf using CMake.  Some distributions include protobuf, gRPC
+  # Install protobuf using CMake. Some distributions include protobuf, but gRPC
   # requires 3.4.x or newer, and many of those distribution use older versions.
   # We need to install both the debug and Release version because:
   # - When using pkg-config, only the release version works, the pkg-config
@@ -63,9 +63,9 @@ function install_protobuf {
   # - When using CMake, only the version compiled with the same CMAKE_BUILD_TYPE
   #   as the dependent (gRPC or google-cloud-cpp) works.
   echo "${COLOR_YELLOW}Installing protobuf $(date)${COLOR_RESET}"
-  wget -q https://github.com/google/protobuf/archive/v3.5.2.tar.gz
-  tar -xf v3.5.2.tar.gz
-  cd protobuf-3.5.2/cmake
+  wget -q https://github.com/google/protobuf/archive/v3.6.1.tar.gz
+  tar -xf v3.6.1.tar.gz
+  cd protobuf-3.6.1/cmake
   for build_type in "Debug" "Release"; do
     env CXX="${cached_cxx}" CC="${cached_cc}" cmake \
         -DCMAKE_BUILD_TYPE="${build_type}" \
@@ -102,9 +102,9 @@ function install_grpc {
   # Install gRPC. Note that we use the system's zlib and ssl libraries.
   # For similar reasons to c-ares (see above), we need two install steps.
   echo "${COLOR_YELLOW}Installing gRPC $(date)${COLOR_RESET}"
-  wget -q https://github.com/grpc/grpc/archive/v1.14.0.tar.gz
-  tar -xf v1.14.0.tar.gz
-  cd grpc-1.14.0
+  wget -q https://github.com/grpc/grpc/archive/v1.16.1.tar.gz
+  tar -xf v1.16.1.tar.gz
+  cd grpc-1.16.1
   env CXX="${cached_cxx}" CC="${cached_cc}"  cmake \
       -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
       -DgRPC_BUILD_TESTS=OFF \

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -22,9 +22,9 @@ if (NOT TARGET gprc_project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_GRPC_URL
-        "https://github.com/grpc/grpc/archive/v1.14.1.tar.gz")
+        "https://github.com/grpc/grpc/archive/v1.16.1.tar.gz")
     set(GOOGLE_CLOUD_CPP_GRPC_SHA256
-        "16f22430210abf92e06626a5a116e114591075e5854ac78f1be8564171658b70")
+        "a5342629fe1b689eceb3be4d4f167b04c70a84b9d61cf8b555e968bc500bdb5a")
 
     if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
         OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -21,9 +21,9 @@ if (NOT TARGET protobuf_project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_PROTOBUF_URL
-        "https://github.com/google/protobuf/archive/v3.5.2.tar.gz")
+        "https://github.com/google/protobuf/archive/v3.6.1.tar.gz")
     set(GOOGLE_CLOUD_CPP_PROTOBUF_SHA256
-        "4ffd420f39f226e96aebc3554f9c66a912f6cad6261f39f194f16af8a1f6dab2")
+        "3d4e589d81b2006ca603c1ab712c9715a76227293032d05b26fca603f90b3f5b")
 
     if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
         OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")


### PR DESCRIPTION
Also updated to protobuf 3.6.1 because it is required by the newer gRPC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1511)
<!-- Reviewable:end -->
