### PR TITLE
FindGTest does not work with debug builds.

### DIFF
--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -126,7 +126,7 @@ function install_googletest {
   tar -xf release-1.8.1.tar.gz
   cd googletest-release-1.8.1
   env CXX="${cached_cxx}" CC="${cached_cc}"  cmake \
-      -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+      -DCMAKE_BUILD_TYPE="Release" \
       ${CMAKE_FLAGS} \
       -H. -B.build/googletest
   cmake --build .build/googletest --target install -- -j ${NCPU}


### PR DESCRIPTION
The installed gtest libraries must be built in "Release" mode. We were
not doing that for the `TEST_INSTALL` builds, though we do it when
using `externalproject_add()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1513)
<!-- Reviewable:end -->
