### PR TITLE
Support shared_from_this() in CurlClient.

### DIFF
--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -31,8 +31,7 @@ static_assert(std::is_copy_assignable<storage::Client>::value,
               "storage::Client must be assignable");
 
 Client::Client(ClientOptions options)
-    : Client(std::shared_ptr<internal::RawClient>(
-          new internal::CurlClient(std::move(options)))) {}
+    : Client(internal::CurlClient::Create(std::move(options))) {}
 
 ObjectMetadata Client::UploadFileImpl(
     std::string const& file_name,

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -33,12 +33,17 @@ class CurlRequestBuilder;
  *
  * TODO(#717) - document the CurlRequest interface as a concept.
  */
-class CurlClient : public RawClient {
+class CurlClient : public RawClient,
+                   public std::enable_shared_from_this<CurlClient> {
  public:
-  explicit CurlClient(std::shared_ptr<oauth2::Credentials> credentials)
-      : CurlClient(ClientOptions(std::move(credentials))) {}
-
-  explicit CurlClient(ClientOptions options);
+  static std::shared_ptr<CurlClient> Create(ClientOptions options) {
+    // Cannot use std::make_shared because the constructor is private.
+    return std::shared_ptr<CurlClient>(new CurlClient(std::move(options)));
+  }
+  static std::shared_ptr<CurlClient> Create(
+      std::shared_ptr<oauth2::Credentials> credentials) {
+    return Create(ClientOptions(std::move(credentials)));
+  }
 
   CurlClient(CurlClient const& rhs) = delete;
   CurlClient(CurlClient&& rhs) = delete;
@@ -151,6 +156,11 @@ class CurlClient : public RawClient {
 
   void LockShared();
   void UnlockShared();
+
+ protected:
+  // The constructor is private because the class must always be created
+  // as a shared_ptr<>.
+  explicit CurlClient(ClientOptions options);
 
  private:
   /// Setup the configuration parameters that do not depend on the request.

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -49,17 +49,17 @@ class FailingCredentials : public Credentials {
 class CurlClientTest : public ::testing::Test {
  protected:
   static void SetUpTestCase() {
-    client_ = google::cloud::internal::make_unique<CurlClient>(
-        std::make_shared<FailingCredentials>());
+    client_ = CurlClient::Create(std::make_shared<FailingCredentials>());
   }
 
   static void TearDownTestCase() {
     client_.reset();
   }
 
-  static std::unique_ptr<CurlClient> client_;
+  static std::shared_ptr<CurlClient> client_;
 };
-std::unique_ptr<CurlClient> CurlClientTest::client_ = nullptr;
+
+std::shared_ptr<CurlClient> CurlClientTest::client_;
 
 void TestCorrectFailureStatus(Status const& status) {
   EXPECT_EQ(status.status_code(), STATUS_ERROR_CODE);


### PR DESCRIPTION
To create a CurlResumableUploadSession we will need a "shared pointer to
this". We need to hide the constructors to avoid accidentally creating
an instance of the CurlClient class that is not held via shared
pointers. Part of the work for #559.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1516)
<!-- Reviewable:end -->
