### PR TITLE
Use WithObjectMetadata in CopyObject().

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -578,15 +578,14 @@ class Client {
    * @param destination_bucket_name the name of the bucket that will contain the
    *     new object.
    * @param destination_object_name the name of the new object.
-   * @param metadata additional metadata attributes that you want to set in the
-   *     new object.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `DestinationPredefinedAcl`,
    *     `EncryptionKey`, `IfGenerationMatch`, `IfGenerationNotMatch`,
    *     `IfMetagenerationMatch`, `IfMetagenerationNotMatch`,
    *     `IfSourceGenerationMatch`, `IfSourceGenerationNotMatch`,
    *     `IfSourceMetagenerationMatch`, `IfSourceMetagenerationNotMatch`,
-   *     `Projection`, `SourceGeneration`, and `UserProject`.
+   *     `Projection`, `SourceGeneration`, `UserProject`, and
+   *     `WithObjectMetadata`.
    *
    * @throw std::runtime_error if the operation cannot be completed using the
    *   current policies.
@@ -602,12 +601,10 @@ class Client {
                             std::string source_object_name,
                             std::string destination_bucket_name,
                             std::string destination_object_name,
-                            ObjectMetadata const& metadata,
                             Options&&... options) {
     internal::CopyObjectRequest request(
         std::move(source_bucket_name), std::move(source_object_name),
-        std::move(destination_bucket_name), std::move(destination_object_name),
-        metadata);
+        std::move(destination_bucket_name), std::move(destination_object_name));
     request.set_multiple_options(std::forward<Options>(options)...);
     return raw_client_->CopyObject(request).second;
   }

--- a/google/cloud/storage/client_object_copy_test.cc
+++ b/google/cloud/storage/client_object_copy_test.cc
@@ -71,7 +71,6 @@ TEST_F(ObjectCopyTest, CopyObject) {
         EXPECT_EQ("test-object-name", request.destination_object());
         EXPECT_EQ("source-bucket-name", request.source_bucket());
         EXPECT_EQ("source-object-name", request.source_object());
-        EXPECT_THAT(request.json_payload(), HasSubstr("text/plain"));
         return std::make_pair(storage::Status(), expected);
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock),
@@ -79,7 +78,7 @@ TEST_F(ObjectCopyTest, CopyObject) {
 
   ObjectMetadata actual = client.CopyObject(
       "source-bucket-name", "source-object-name", "test-bucket-name",
-      "test-object-name", ObjectMetadata().set_content_type("text/plain"));
+      "test-object-name");
   EXPECT_EQ(expected, actual);
 }
 
@@ -88,13 +87,12 @@ TEST_F(ObjectCopyTest, CopyObjectTooManyFailures) {
       mock, EXPECT_CALL(*mock, CopyObject(_)),
       [](Client& client) {
         client.CopyObject("source-bucket-name", "source-object-name",
-                          "test-bucket-name", "test-object-name",
-                          ObjectMetadata());
+                          "test-bucket-name", "test-object-name");
       },
       [](Client& client) {
         client.CopyObject("source-bucket-name", "source-object-name",
                           "test-bucket-name", "test-object-name",
-                          ObjectMetadata(), IfGenerationMatch(0));
+                          IfGenerationMatch(0));
       },
       "CopyObject");
 }
@@ -104,8 +102,7 @@ TEST_F(ObjectCopyTest, CopyObjectPermanentFailure) {
       *client, EXPECT_CALL(*mock, CopyObject(_)),
       [](Client& client) {
         client.CopyObject("source-bucket-name", "source-object-name",
-                          "test-bucket-name", "test-object-name",
-                          ObjectMetadata());
+                          "test-bucket-name", "test-object-name");
       },
       "CopyObject");
 }

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -105,7 +105,7 @@ void CopyObject(google::cloud::storage::Client client, int& argc,
      std::string destination_object_name) {
     gcs::ObjectMetadata new_copy_meta = client.CopyObject(
         source_bucket_name, source_object_name, destination_bucket_name,
-        destination_object_name, gcs::ObjectMetadata());
+        destination_object_name);
     std::cout << "Object copied. The full metadata after the copy is: "
               << new_copy_meta << std::endl;
   }
@@ -134,8 +134,7 @@ void CopyEncryptedObject(google::cloud::storage::Client client, int& argc,
      std::string destination_object_name, std::string key_base64) {
     gcs::ObjectMetadata new_copy_meta = client.CopyObject(
         source_bucket_name, source_object_name, destination_bucket_name,
-        destination_object_name, gcs::ObjectMetadata(),
-        gcs::EncryptionKey::FromBase64Key(key_base64));
+        destination_object_name, gcs::EncryptionKey::FromBase64Key(key_base64));
     std::cout << "Object copied. The full metadata after the copy is: "
               << new_copy_meta << std::endl;
   }

--- a/google/cloud/storage/idempotency_policy_test.cc
+++ b/google/cloud/storage/idempotency_policy_test.cc
@@ -150,7 +150,7 @@ TEST(StrictIdempotencyPolicyTest, CopyObject) {
   StrictIdempotencyPolicy policy;
   internal::CopyObjectRequest request("test-source-bucket",
                                       "test-source-object", "test-bucket-name",
-                                      "test-object-name", ObjectMetadata());
+                                      "test-object-name");
   EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
@@ -158,7 +158,7 @@ TEST(StrictIdempotencyPolicyTest, CopyObjectIfGenerationMatch) {
   StrictIdempotencyPolicy policy;
   internal::CopyObjectRequest request("test-source-bucket",
                                       "test-source-object", "test-bucket-name",
-                                      "test-object-name", ObjectMetadata());
+                                      "test-object-name");
   request.set_option(IfGenerationMatch(0));
   EXPECT_TRUE(policy.IsIdempotent(request));
 }
@@ -269,7 +269,7 @@ TEST(StrictIdempotencyPolicyTest, ComposeObjectIfGenerationMatch) {
   StrictIdempotencyPolicy policy;
   internal::CopyObjectRequest request("test-source-bucket",
                                       "test-source-object", "test-bucket-name",
-                                      "test-object-name", ObjectMetadata());
+                                      "test-object-name");
   request.set_option(IfGenerationMatch(0));
   EXPECT_TRUE(policy.IsIdempotent(request));
 }

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -392,7 +392,12 @@ std::pair<Status, ObjectMetadata> CurlClient::CopyObject(
     return std::make_pair(status, ObjectMetadata{});
   }
   builder.AddHeader("Content-Type: application/json");
-  auto payload = builder.BuildRequest().MakeRequest(request.json_payload());
+  std::string json_payload("{}");
+  if (request.HasOption<WithObjectMetadata>()) {
+    json_payload =
+        request.GetOption<WithObjectMetadata>().value().JsonPayloadForCopy();
+  }
+  auto payload = builder.BuildRequest().MakeRequest(json_payload);
   if (payload.status_code >= 300) {
     return std::make_pair(
         Status{payload.status_code, std::move(payload.payload)},

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -185,7 +185,7 @@ TEST_F(CurlClientTest, ListBucketAcl) {
 
 TEST_F(CurlClientTest, CopyObject) {
   auto status_and_foo = client_->CopyObject(
-      CopyObjectRequest("bkt", "obj1", "bkt", "obj2", ObjectMetadata()));
+      CopyObjectRequest("bkt", "obj1", "bkt", "obj2"));
   TestCorrectFailureStatus(status_and_foo.first);
 }
 

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -82,7 +82,7 @@ std::ostream& operator<<(std::ostream& os, CopyObjectRequest const& r) {
      << ", source_bucket=" << r.source_bucket()
      << ", source_object=" << r.source_object();
   r.DumpOptions(os, ", ");
-  return os << ", payload=" << r.json_payload() << "}";
+  return os << "}";
 }
 
 std::ostream& operator<<(std::ostream& os, ReadObjectRangeRequest const& r) {

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -143,31 +143,27 @@ class CopyObjectRequest
           IfMetagenerationNotMatch, IfSourceGenerationMatch,
           IfSourceGenerationNotMatch, IfSourceMetagenerationMatch,
           IfSourceMetagenerationNotMatch, Projection, SourceGeneration,
-          UserProject> {
+          UserProject, WithObjectMetadata> {
  public:
   CopyObjectRequest() = default;
   CopyObjectRequest(std::string source_bucket, std::string source_object,
                     std::string destination_bucket,
-                    std::string destination_object,
-                    ObjectMetadata const& metadata)
+                    std::string destination_object)
       : source_bucket_(std::move(source_bucket)),
         source_object_(std::move(source_object)),
         destination_bucket_(std::move(destination_bucket)),
-        destination_object_(std::move(destination_object)),
-        json_payload_(metadata.JsonPayloadForCopy()) {}
+        destination_object_(std::move(destination_object)) {}
 
   std::string const& source_bucket() const { return source_bucket_; }
   std::string const& source_object() const { return source_object_; }
   std::string const& destination_bucket() const { return destination_bucket_; }
   std::string const& destination_object() const { return destination_object_; }
-  std::string const& json_payload() const { return json_payload_; }
 
  private:
   std::string source_bucket_;
   std::string source_object_;
   std::string destination_bucket_;
   std::string destination_object_;
-  std::string json_payload_;
 };
 
 std::ostream& operator<<(std::ostream& os, CopyObjectRequest const& r);

--- a/google/cloud/storage/internal/object_requests_test.cc
+++ b/google/cloud/storage/internal/object_requests_test.cc
@@ -130,15 +130,15 @@ TEST(ObjectRequestsTest, InsertObjectMediaUpdateContents) {
 
 TEST(ObjectRequestsTest, Copy) {
   CopyObjectRequest request("source-bucket", "source-object", "my-bucket",
-                            "my-object",
-                            ObjectMetadata().set_content_type("text/plain"));
+                            "my-object");
   EXPECT_EQ("source-bucket", request.source_bucket());
   EXPECT_EQ("source-object", request.source_object());
   EXPECT_EQ("my-bucket", request.destination_bucket());
   EXPECT_EQ("my-object", request.destination_object());
-  request.set_multiple_options(IfMetagenerationNotMatch(7),
-                               DestinationPredefinedAcl("private"),
-                               UserProject("my-project"));
+  request.set_multiple_options(
+      IfMetagenerationNotMatch(7), DestinationPredefinedAcl("private"),
+      UserProject("my-project"),
+      WithObjectMetadata(ObjectMetadata().set_content_type("text/plain")));
 
   std::ostringstream os;
   os << request;
@@ -466,30 +466,25 @@ TEST(ObjectRequestsTest, ResumableUploadResponse) {
 
 TEST(ObjectRequestsTest, ResumableUploadResponseNoLocation) {
   auto actual = ResumableUploadResponse::FromHttpResponse(
-      HttpResponse{200,
-                   "test-payload",
-                   {{"range", "bytes=0-2000"}}});
+      HttpResponse{200, "test-payload", {{"range", "bytes=0-2000"}}});
   EXPECT_EQ("test-payload", actual.payload);
   EXPECT_EQ("", actual.upload_session_url);
   EXPECT_EQ(2000U, actual.last_committed_byte);
 }
 
 TEST(ObjectRequestsTest, ResumableUploadResponseNoRange) {
-  auto actual = ResumableUploadResponse::FromHttpResponse(HttpResponse{
-      200,
-      "test-payload",
-      {{"location", "location-value"}}});
+  auto actual = ResumableUploadResponse::FromHttpResponse(
+      HttpResponse{200, "test-payload", {{"location", "location-value"}}});
   EXPECT_EQ("test-payload", actual.payload);
   EXPECT_EQ("location-value", actual.upload_session_url);
   EXPECT_EQ(0U, actual.last_committed_byte);
 }
 
 TEST(ObjectRequestsTest, ResumableUploadResponseMissingBytesInRange) {
-  auto actual = ResumableUploadResponse::FromHttpResponse(
-      HttpResponse{200,
-                   "test-payload",
-                   {{"location", "location-value"},
-                    {"range", "units=0-2000"}}});
+  auto actual = ResumableUploadResponse::FromHttpResponse(HttpResponse{
+      200,
+      "test-payload",
+      {{"location", "location-value"}, {"range", "units=0-2000"}}});
   EXPECT_EQ("test-payload", actual.payload);
   EXPECT_EQ("location-value", actual.upload_session_url);
   EXPECT_EQ(0U, actual.last_committed_byte);
@@ -497,9 +492,7 @@ TEST(ObjectRequestsTest, ResumableUploadResponseMissingBytesInRange) {
 
 TEST(ObjectRequestsTest, ResumableUploadResponseMissingRangeEnd) {
   auto actual = ResumableUploadResponse::FromHttpResponse(
-      HttpResponse{200,
-                   "test-payload",
-                   {{"range", "bytes=0-"}}});
+      HttpResponse{200, "test-payload", {{"range", "bytes=0-"}}});
   EXPECT_EQ("test-payload", actual.payload);
   EXPECT_EQ("", actual.upload_session_url);
   EXPECT_EQ(0U, actual.last_committed_byte);
@@ -507,9 +500,7 @@ TEST(ObjectRequestsTest, ResumableUploadResponseMissingRangeEnd) {
 
 TEST(ObjectRequestsTest, ResumableUploadResponseInvalidRangeEnd) {
   auto actual = ResumableUploadResponse::FromHttpResponse(
-      HttpResponse{200,
-                   "test-payload",
-                   {{"range", "bytes=0-abcd"}}});
+      HttpResponse{200, "test-payload", {{"range", "bytes=0-abcd"}}});
   EXPECT_EQ("test-payload", actual.payload);
   EXPECT_EQ("", actual.upload_session_url);
   EXPECT_EQ(0U, actual.last_committed_byte);
@@ -517,9 +508,7 @@ TEST(ObjectRequestsTest, ResumableUploadResponseInvalidRangeEnd) {
 
 TEST(ObjectRequestsTest, ResumableUploadResponseInvalidRangeBegin) {
   auto actual = ResumableUploadResponse::FromHttpResponse(
-      HttpResponse{200,
-                   "test-payload",
-                   {{"range", "bytes=abcd-2000"}}});
+      HttpResponse{200, "test-payload", {{"range", "bytes=abcd-2000"}}});
   EXPECT_EQ("test-payload", actual.payload);
   EXPECT_EQ("", actual.upload_session_url);
   EXPECT_EQ(0U, actual.last_committed_byte);
@@ -527,9 +516,7 @@ TEST(ObjectRequestsTest, ResumableUploadResponseInvalidRangeBegin) {
 
 TEST(ObjectRequestsTest, ResumableUploadResponseUnexpectedRangeBegin) {
   auto actual = ResumableUploadResponse::FromHttpResponse(
-      HttpResponse{200,
-                   "test-payload",
-                   {{"range", "bytes=3000-2000"}}});
+      HttpResponse{200, "test-payload", {{"range", "bytes=3000-2000"}}});
   EXPECT_EQ("test-payload", actual.payload);
   EXPECT_EQ("", actual.upload_session_url);
   EXPECT_EQ(0U, actual.last_committed_byte);
@@ -537,9 +524,7 @@ TEST(ObjectRequestsTest, ResumableUploadResponseUnexpectedRangeBegin) {
 
 TEST(ObjectRequestsTest, ResumableUploadResponseNegativeEnd) {
   auto actual = ResumableUploadResponse::FromHttpResponse(
-      HttpResponse{200,
-                   "test-payload",
-                   {{"range", "bytes=0--7"}}});
+      HttpResponse{200, "test-payload", {{"range", "bytes=0--7"}}});
   EXPECT_EQ("test-payload", actual.payload);
   EXPECT_EQ("", actual.upload_session_url);
   EXPECT_EQ(0U, actual.last_committed_byte);

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -25,9 +25,9 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using ::testing::HasSubstr;
 using google::cloud::storage::testing::CountMatchingEntities;
 using google::cloud::storage::testing::TestPermanentFailure;
+using ::testing::HasSubstr;
 
 /// Store the project and instance captured from the command-line arguments.
 class ObjectTestEnvironment : public ::testing::Environment {
@@ -346,7 +346,7 @@ TEST_F(ObjectIntegrationTest, Copy) {
 
   ObjectMetadata meta = client.CopyObject(
       bucket_name, source_object_name, bucket_name, destination_object_name,
-      ObjectMetadata().set_content_type("text/plain"));
+      WithObjectMetadata(ObjectMetadata().set_content_type("text/plain")));
   EXPECT_EQ(destination_object_name, meta.name());
   EXPECT_EQ(bucket_name, meta.bucket());
   EXPECT_EQ("text/plain", meta.content_type());
@@ -548,7 +548,7 @@ TEST_F(ObjectIntegrationTest, CopyPredefinedAclAuthenticatedRead) {
   ObjectMetadata original = client.InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
   ObjectMetadata meta = client.CopyObject(
-      bucket_name, object_name, bucket_name, copy_name, ObjectMetadata(),
+      bucket_name, object_name, bucket_name, copy_name,
       IfGenerationMatch(0), DestinationPredefinedAcl::AuthenticatedRead(),
       Projection::Full());
   EXPECT_LT(0, CountMatchingEntities(meta.acl(),
@@ -575,7 +575,7 @@ TEST_F(ObjectIntegrationTest, CopyPredefinedAclBucketOwnerFullControl) {
   ObjectMetadata original = client.InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
   ObjectMetadata meta = client.CopyObject(
-      bucket_name, object_name, bucket_name, copy_name, ObjectMetadata(),
+      bucket_name, object_name, bucket_name, copy_name,
       IfGenerationMatch(0), DestinationPredefinedAcl::BucketOwnerFullControl(),
       Projection::Full());
   EXPECT_LT(0, CountMatchingEntities(
@@ -601,7 +601,7 @@ TEST_F(ObjectIntegrationTest, CopyPredefinedAclBucketOwnerRead) {
   ObjectMetadata original = client.InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
   ObjectMetadata meta = client.CopyObject(
-      bucket_name, object_name, bucket_name, copy_name, ObjectMetadata(),
+      bucket_name, object_name, bucket_name, copy_name,
       IfGenerationMatch(0), DestinationPredefinedAcl::BucketOwnerRead(),
       Projection::Full());
   EXPECT_LT(0, CountMatchingEntities(
@@ -622,7 +622,7 @@ TEST_F(ObjectIntegrationTest, CopyPredefinedAclPrivate) {
   ObjectMetadata original = client.InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
   ObjectMetadata meta = client.CopyObject(
-      bucket_name, object_name, bucket_name, copy_name, ObjectMetadata(),
+      bucket_name, object_name, bucket_name, copy_name,
       IfGenerationMatch(0), DestinationPredefinedAcl::Private(),
       Projection::Full());
   ASSERT_TRUE(meta.has_owner());
@@ -645,7 +645,7 @@ TEST_F(ObjectIntegrationTest, CopyPredefinedAclProjectPrivate) {
   ObjectMetadata original = client.InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
   ObjectMetadata meta = client.CopyObject(
-      bucket_name, object_name, bucket_name, copy_name, ObjectMetadata(),
+      bucket_name, object_name, bucket_name, copy_name,
       IfGenerationMatch(0), DestinationPredefinedAcl::ProjectPrivate(),
       Projection::Full());
   ASSERT_TRUE(meta.has_owner());
@@ -668,7 +668,7 @@ TEST_F(ObjectIntegrationTest, CopyPredefinedAclPublicRead) {
   ObjectMetadata original = client.InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
   ObjectMetadata meta = client.CopyObject(
-      bucket_name, object_name, bucket_name, copy_name, ObjectMetadata(),
+      bucket_name, object_name, bucket_name, copy_name,
       IfGenerationMatch(0), DestinationPredefinedAcl::PublicRead(),
       Projection::Full());
   EXPECT_LT(
@@ -1135,7 +1135,7 @@ TEST_F(ObjectIntegrationTest, CopyFailure) {
   // This operation should fail because the source object does not exist.
   TestPermanentFailure([&] {
     client.CopyObject(bucket_name, source_object_name, bucket_name,
-                      destination_object_name, ObjectMetadata());
+                      destination_object_name);
   });
 }
 


### PR DESCRIPTION
The Client::CopyObject() function was taking a ObjectMetadata parameter
that was often empty. It really needs to be an optional parameter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1517)
<!-- Reviewable:end -->
