### PR TITLE
Implement the UserIp option.

### DIFF
--- a/google/cloud/storage/internal/curl_request_builder.h
+++ b/google/cloud/storage/internal/curl_request_builder.h
@@ -168,6 +168,11 @@ class CurlRequestBuilder {
     return handle_.MakeEscapedString(s);
   }
 
+  /// Get the last local IP address from the factory.
+  std::string LastClientIpAddress() const {
+    return factory_->LastClientIpAddress();
+  }
+
  private:
   void ValidateBuilderState(char const* where) const;
 

--- a/google/cloud/storage/internal/generic_request.h
+++ b/google/cloud/storage/internal/generic_request.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GENERIC_REQUEST_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GENERIC_REQUEST_H_
 
+#include "google/cloud/storage/internal/complex_option.h"
 #include "google/cloud/storage/well_known_headers.h"
 #include "google/cloud/storage/well_known_parameters.h"
 #include <iostream>
@@ -24,6 +25,25 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
+/**
+ * Sets the user IP on an operation for quota enforcement purposes.
+ *
+ * This parameter lets you enforce per-user quotas when calling the API from a
+ * server-side application. This parameter is overriden by `UserQuota` if both
+ * are set.
+ *
+ * If you set this parameter to an empty string, the client library will
+ * automatically select one of the user IP addresses of your server to include
+ * in the request.
+ *
+ * @see https://cloud.google.com/apis/docs/capping-api-usage for an introduction
+ *     to quotas in Google Cloud Platform.
+ */
+struct UserIp : public internal::ComplexOption<UserIp, std::string> {
+  using ComplexOption<UserIp, std::string>::ComplexOption;
+  static char const* name() { return "userIp"; }
+};
+
 namespace internal {
 // Forward declare the template so we can specialize it first. Defining the
 // specialization first, which is the base class, should be more readable.
@@ -177,10 +197,12 @@ class GenericRequestBase : public GenericRequestBase<Derived, Options...> {
 template <typename Derived, typename... Options>
 class GenericRequest
     : public GenericRequestBase<Derived, CustomHeader, Fields, IfMatchEtag,
-                                IfNoneMatchEtag, QuotaUser, Options...> {
+                                IfNoneMatchEtag, QuotaUser, UserIp,
+                                Options...> {
  public:
-  using Super = GenericRequestBase<Derived, CustomHeader, Fields, IfMatchEtag,
-                                   IfNoneMatchEtag, QuotaUser, Options...>;
+  using Super =
+      GenericRequestBase<Derived, CustomHeader, Fields, IfMatchEtag,
+                         IfNoneMatchEtag, QuotaUser, UserIp, Options...>;
 
   template <typename H, typename... T>
   Derived& set_multiple_options(H&& h, T&&... tail) {


### PR DESCRIPTION
This fixes #1026. It implement an option to set the userIp query
parameter. If the application sets this option to an empty string the
library attempts to use the last-known IP address as the parameter
value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1530)
<!-- Reviewable:end -->
