### PR TITLE
Introduce AsyncLoopOp.

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -156,6 +156,7 @@ add_library(bigtable_client
             internal/async_check_consistency.h
             internal/async_future_from_callback.h
             internal/async_longrunning_op.h
+            internal/async_loop_op.h
             internal/async_op_traits.h
             internal/async_poll_op.h
             internal/async_sample_row_keys.h

--- a/google/cloud/bigtable/bigtable_client.bzl
+++ b/google/cloud/bigtable/bigtable_client.bzl
@@ -20,6 +20,7 @@ bigtable_client_HDRS = [
     "internal/async_check_consistency.h",
     "internal/async_future_from_callback.h",
     "internal/async_longrunning_op.h",
+    "internal/async_loop_op.h",
     "internal/async_op_traits.h",
     "internal/async_poll_op.h",
     "internal/async_sample_row_keys.h",

--- a/google/cloud/bigtable/internal/async_loop_op.h
+++ b/google/cloud/bigtable/internal/async_loop_op.h
@@ -1,0 +1,240 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_LOOP_OP_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_LOOP_OP_H_
+
+#include "google/cloud/bigtable/completion_queue.h"
+#include "google/cloud/bigtable/internal/async_op_traits.h"
+#include "google/cloud/internal/make_unique.h"
+#include "google/cloud/internal/throw_delegate.h"
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
+
+/**
+ * A dummy function object only to ease specification of loopable operations.
+ *
+ * It is an example type which could be passed to `Start()` member function of
+ * the operation to be executed in a loop.
+ */
+struct PrototypeLoopOperationStartCallback {
+  void operator()(CompletionQueue&, bool finished) const {}
+};
+
+template <typename Operation>
+struct MeetsLoopOperationRequirements {
+  static_assert(
+      HasStart<Operation, PrototypeLoopOperationStartCallback>::value,
+      "Operation has to have a templated Start() member function "
+      "instantiatable with functors like PrototypeLoopOperationStartCallback");
+  static_assert(HasCancel<Operation>::value,
+                "Operation has to have an Cancel() member function.");
+  static_assert(HasWaitPeriod<Operation>::value,
+                "Operation has to have an WaitPeriod() member function.");
+  static_assert(
+      google::cloud::internal::is_invocable<
+          decltype(
+              &Operation::template Start<PrototypeLoopOperationStartCallback>),
+          Operation&, CompletionQueue&,
+          PrototypeLoopOperationStartCallback&&>::value,
+      "Operation::Start<PrototypeLoopOperationStartCallback> has to be "
+      "non-static and invocable with CompletionQueue&, "
+      "PrototypeLoopOperationStartCallback&&.");
+  static_assert(
+      google::cloud::internal::is_invocable<
+          decltype(&Operation::Cancel), Operation&, CompletionQueue&>::value,
+      "Operation::Cancel has to be non-static and invokable with "
+      "CompletionQueue&");
+  static_assert(google::cloud::internal::is_invocable<
+                    decltype(&Operation::WaitPeriod), Operation&>::value,
+                "Operation::WaitPeriod() has to be non-static and "
+                "invokable with no arguments.&");
+  static_assert(std::is_same<google::cloud::internal::invoke_result_t<
+                                 decltype(&Operation::template Start<
+                                          PrototypeLoopOperationStartCallback>),
+                                 Operation&, CompletionQueue&,
+                                 PrototypeLoopOperationStartCallback&&>,
+                             std::shared_ptr<AsyncOperation>>::value,
+                "Operation::Start<>(...) has to return a "
+                "std::shared_ptr<AsyncOperation>");
+  static_assert(std::is_same<google::cloud::internal::invoke_result_t<
+                                 decltype(&Operation::WaitPeriod), Operation&>,
+                             std::chrono::milliseconds>::value,
+                "Operation::WaitPeriod() has to return "
+                "std::chrono::milliseconds");
+};
+
+/**
+ * Loop an asynchronous operation while allowing for cancellation.
+ *
+ * Conceptually, this class implements an asynchronous counterpart of the
+ * following logic:
+ * ```
+ * for(;;) {
+ *   bool const finished = op.Start();
+ *   if (finished) {
+ *     break;
+ *   }
+ *   if (* someone cancelled the loop *) {
+ *     op.Cancel();
+ *     break;
+ *   }
+ *   sleep(op.GetDelay());
+ *   if (* someone cancelled the loop *) {
+ *     op.Cancel();
+ *     break;
+ *   }
+ * }
+ * ```
+ * It is used for implementing `AsyncRetryOp` (retrying an asynchronous
+ * operation), `AsyncPollOp` (asynchronously polling) and alike.
+ *
+ * The `Operation` is responsible for firing the user callback if it completes.
+ *
+ * The operation should implement 3 member functions (has to meet
+ * `MeetsLoopOperationRequirements`):
+ *  * Start() - starts a new attempt and indicates in the provided callback
+ *      whether the whole operation is finished (i.e. whether we should break
+ *      the loop).
+ *  * WaitPeriod() - indicates for how long we should pause the loop.
+ *  * Cancel() - this should immediately abort and call the user-provided
+ *      callback.
+ *
+ *  The `Operation` object is guaranteed to not be destroyed until it fires the
+ *  callback provided to it via `Start()` with finished==true or until
+ *  `Cancel()` function is called on it.
+ *
+ *  `Operation` doesn't need to be thread-safe, `AsyncLoopOp` guarantees serial
+ *  accesses. `AsyncLoopOp` also guarantees that neither
+ */
+template <typename Operation>
+class AsyncLoopOp : public std::enable_shared_from_this<AsyncLoopOp<Operation>>,
+                    public AsyncOperation {
+ public:
+  explicit AsyncLoopOp(Operation&& operation)
+      : cancelled_(), operation_(std::move(operation)) {}
+
+  void Cancel() override {
+    std::lock_guard<std::mutex> lk(mu_);
+    cancelled_ = true;
+    if (current_op_) {
+      current_op_->Cancel();
+      current_op_.reset();
+    }
+  }
+
+  std::shared_ptr<AsyncOperation> Start(CompletionQueue& cq) {
+    auto res =
+        std::static_pointer_cast<AsyncOperation>(this->shared_from_this());
+    std::unique_lock<std::mutex> lk(mu_);
+    if (cancelled_) {
+      lk.unlock();
+      // We could fire the callback right here, but we'd be risking a deadlock
+      // if the user held a lock while submitting this request. Instead, let's
+      // schedule the callback to fire on the thread running the completion
+      // queue by submitting an expired timer.
+      // There is no reason to store this timer in current_op_.
+      auto self = this->shared_from_this();
+      cq.RunAsync([self](CompletionQueue& cq) { self->OnTimer(cq, false); });
+      return res;
+    }
+    StartUnlocked(cq);
+    return res;
+  }
+
+ private:
+  /**
+   * Kick off the asynchronous request.
+   *
+   * @param cq the completion queue to run the asynchronous operations.
+   */
+  void StartUnlocked(CompletionQueue& cq) {
+    auto self = this->shared_from_this();
+    current_op_ =
+        operation_.Start(cq, [self](CompletionQueue& cq, bool finished) {
+          self->OnCompletion(cq, finished);
+        });
+  }
+
+  /// The callback to handle one asynchronous request completing.
+  void OnCompletion(CompletionQueue& cq, bool finished) {
+    std::unique_lock<std::mutex> lk(mu_);
+    // If we don't schedule a timer, we don't want this object to
+    // hold the operation.
+    current_op_.reset();
+    if (finished) {
+      // The operation signalled that it's finished - it must have already done
+      // fired the callback.
+      return;
+    }
+    if (cancelled_) {
+      // The operation didn't notice the cancellation, let's make it clear.
+      lk.unlock();
+      operation_.Cancel(cq);
+      return;
+    }
+    auto delay = operation_.WaitPeriod();
+    if (delay == std::chrono::milliseconds(0)) {
+      auto self = this->shared_from_this();
+      current_op_ = cq.RunAsync(
+          [self](CompletionQueue& cq) { self->OnTimer(cq, false); });
+      return;
+    }
+    auto self = this->shared_from_this();
+    current_op_ = cq.MakeRelativeTimer(
+        delay, [self](CompletionQueue& cq, AsyncTimerResult result) {
+          self->OnTimer(cq, result.cancelled);
+        });
+    return;
+  }
+
+  /// The callback to handle the timer completing.
+  void OnTimer(CompletionQueue& cq, bool cancelled) {
+    std::unique_lock<std::mutex> lk(mu_);
+    current_op_.reset();
+    if (cancelled or cancelled_) {
+      // Cancelled, no more action to take.
+      // The operation couldn't have noticed this cancellation, because it came
+      // while we were waiting.
+      lk.unlock();
+      operation_.Cancel(cq);
+      return;
+    }
+    StartUnlocked(cq);
+  }
+
+  MeetsLoopOperationRequirements<Operation> requirements_check_;
+  std::mutex mu_;
+  // Because of the racy nature of cancellation, a cancelled timer or operation
+  // might occasionally return a non-cancelled status (e.g. when cancellation
+  // occurs right before firing the callback). In order to not schedule a next
+  // retry in such a scenario, we indicate cancellation by using this flag.
+  bool cancelled_;
+  // A handle to a currently ongoing async operation - either a timer or one
+  // created through `Operation::Start`.
+  std::shared_ptr<AsyncOperation> current_op_;
+  Operation operation_;
+};
+
+}  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_LOOP_OP_H_

--- a/google/cloud/bigtable/internal/async_loop_op.h
+++ b/google/cloud/bigtable/internal/async_loop_op.h
@@ -38,6 +38,10 @@ struct PrototypeLoopOperationStartCallback {
 
 template <typename Operation>
 struct MeetsLoopOperationRequirements {
+  // Looks like MSVC 15.7.3 has a bug and evaluates the Has.* detectors to
+  // false. 15.9.2 seems to have worked, but I'm not adding specific version
+  // conditionals to avoid future surprises.
+#ifndef _MSC_VER
   static_assert(
       HasStart<Operation, PrototypeLoopOperationStartCallback>::value,
       "Operation has to have a templated Start() member function "
@@ -46,6 +50,7 @@ struct MeetsLoopOperationRequirements {
                 "Operation has to have an Cancel() member function.");
   static_assert(HasWaitPeriod<Operation>::value,
                 "Operation has to have an WaitPeriod() member function.");
+#endif
   static_assert(
       google::cloud::internal::is_invocable<
           decltype(

--- a/google/cloud/bigtable/internal/async_op_traits.h
+++ b/google/cloud/bigtable/internal/async_op_traits.h
@@ -62,6 +62,41 @@ struct HasStart<
     google::cloud::internal::void_t<decltype(&C::template Start<Functor>)>>
     : public std::true_type {};
 
+/**
+ * SFINAE detector whether class `C` has a `Cancel` member function.
+ *
+ * Catch-all, negative branch.
+ */
+template <typename C, typename M = void>
+struct HasCancel : public std::false_type {};
+
+/**
+ * SFINAE detector whether class `C` has a `Cancel` member function.
+ *
+ * Positive branch.
+ */
+template <typename C>
+struct HasCancel<C, google::cloud::internal::void_t<decltype(&C::Cancel)>>
+    : public std::true_type {};
+
+/**
+ * SFINAE detector whether class `C` has a `WaitPeriod` member function.
+ *
+ * Catch-all, negative branch.
+ */
+template <typename C, typename M = void>
+struct HasWaitPeriod : public std::false_type {};
+
+/**
+ * SFINAE detector whether class `C` has a `WaitPeriod` member function.
+ *
+ * Positive branch.
+ */
+template <typename C>
+struct HasWaitPeriod<C,
+                     google::cloud::internal::void_t<decltype(&C::WaitPeriod)>>
+    : public std::true_type {};
+
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/google/cloud/bigtable/internal/async_poll_op.h
+++ b/google/cloud/bigtable/internal/async_poll_op.h
@@ -16,8 +16,8 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_POLL_OP_H_
 
 #include "google/cloud/bigtable/completion_queue.h"
+#include "google/cloud/bigtable/internal/async_loop_op.h"
 #include "google/cloud/bigtable/internal/async_op_traits.h"
-#include "google/cloud/bigtable/internal/conjunction.h"
 #include "google/cloud/bigtable/metadata_update_policy.h"
 #include "google/cloud/bigtable/polling_policy.h"
 #include "google/cloud/internal/make_unique.h"
@@ -28,133 +28,160 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
 
+/**
+ * A dummy function object only to ease specification of pollable operations.
+ *
+ * It is an example type which could be passed to `Start()` member function of
+ * the operation to be polled.
+ */
 struct PrototypePollOpStartCallback {
   void operator()(CompletionQueue&, bool finished, grpc::Status&) const {}
 };
 
 /**
  * A check if the template parameter meets criteria for `AsyncPollOp`.
- *
- * This struct inherits from `std::true_type` or `std::false_type` depending on
- * whether it meets the criteria for an `Operation` parameter to `AsyncPollOp`.
- *
- * These criteria are:
- *  - has a `Start` member function,
- *  - has a `AccumulatedResult` member function,
- *  - the `Start` function is invokable with `CompletionQueue&`,
- *    `std::unique_ptr<grpc::ClientContext>&&` and `Functor&&`, where `Functor`
- *    is invokable with `CompletionQueue&`, bool and `grpc::Status&`,
- *  - the `AccumulatedResult` is invocable with no arguments,
- *  - the `Start` function returns a std::shared_ptr<AsyncOperation>
- *  - the `AccumulatedResult` function has the same return type as
- *    `Operation::Response`.
  */
 template <typename Operation>
-struct MeetsAsyncPollOperationRequirements
-    : public conjunction<
-          HasStart<Operation, PrototypePollOpStartCallback>,
-          HasAccumulatedResult<Operation>,
-          google::cloud::internal::is_invocable<
-              decltype(
-                  &Operation::template Start<PrototypePollOpStartCallback>),
-              Operation&, CompletionQueue&,
-              std::unique_ptr<grpc::ClientContext>&&,
-              PrototypePollOpStartCallback&&>,
-          google::cloud::internal::is_invocable<
-              decltype(&Operation::AccumulatedResult), Operation&>,
-          std::is_same<google::cloud::internal::invoke_result_t<
-                           decltype(&Operation::AccumulatedResult), Operation&>,
-                       typename Operation::Response>,
-          std::is_same<google::cloud::internal::invoke_result_t<
-                           decltype(&Operation::template Start<
-                                    PrototypePollOpStartCallback>),
-                           Operation&, CompletionQueue&,
-                           std::unique_ptr<grpc::ClientContext>&&,
-                           PrototypePollOpStartCallback&&>,
-                       std::shared_ptr<AsyncOperation>>> {};
+struct MeetsAsyncPollOperationRequirements {
+  static_assert(
+      HasStart<Operation, PrototypePollOpStartCallback>::value,
+      "Operation has to have a templated Start() member function "
+      "instantiatable with functors like PrototypePollOpStartCallback");
+  static_assert(
+      HasAccumulatedResult<Operation>::value,
+      "Operation has to have an AccumulatedResult() member function.");
+  static_assert(
+      google::cloud::internal::is_invocable<
+          decltype(&Operation::template Start<PrototypePollOpStartCallback>),
+          Operation&, CompletionQueue&, std::unique_ptr<grpc::ClientContext>&&,
+          PrototypePollOpStartCallback&&>::value,
+      "Operation::Start<PrototypePollOpStartCallback> has to be "
+      "non-static and invocable with "
+      "CompletionQueue&, std::unique_ptr<grpc::ClientContext>&&, "
+      "PrototypePollOpStartCallback&&.");
+  static_assert(google::cloud::internal::is_invocable<
+                    decltype(&Operation::AccumulatedResult), Operation&>::value,
+                "Operation::AccumulatedResult has to be non-static and "
+                "invokable with no arguments");
+  static_assert(std::is_same<google::cloud::internal::invoke_result_t<
+                                 decltype(&Operation::template Start<
+                                          PrototypePollOpStartCallback>),
+                                 Operation&, CompletionQueue&,
+                                 std::unique_ptr<grpc::ClientContext>&&,
+                                 PrototypePollOpStartCallback&&>,
+                             std::shared_ptr<AsyncOperation>>::value,
+                "Operation::Start<>(...) has to return a "
+                "std::shared_ptr<AsyncOperation>");
+
+  using Response = google::cloud::internal::invoke_result_t<
+      decltype(&Operation::AccumulatedResult), Operation&>;
+};
 
 /**
- * Perform asynchronous polling.
+ * A wrapper for operations adding polling logic if passed to `AsyncLoopOp`.
  *
- * @tparam Functor the type of the function-like object that will receive the
- *     results.
+ * If used in `AsyncLoopOp`, it will asynchronously poll `Operation`
+ *
+ * @tparam UserFunctor the type of the function-like object that will receive
+ *     the results.
  *
  * @tparam Operation a class responsible for submitting requests. Its `Start()`
  *     member function will be used for sending the retries and the original
- *     request. It follows the same scheme as AsyncRetryOp.
- *     `AsyncCheckConsistency` and `MeetsAsyncPollOperationRequirements`.
- *
- * @tparam valid_callback_type a format parameter, uses `std::enable_if<>` to
- *     disable this template if the functor does not match the expected
- *     signature.
+ *     request. It follows the same scheme as AsyncRetryOp. It should satisfy
+ *     `MeetsAsyncPollOperationRequirements`.
  */
-template <typename Functor, typename Operation,
-          typename std::enable_if<
-              google::cloud::internal::is_invocable<
-                  Functor, CompletionQueue&, typename Operation::Response&,
-                  grpc::Status&>::value,
-              int>::type valid_callback_type = 0,
-          typename std::enable_if<
-              MeetsAsyncPollOperationRequirements<Operation>::value, int>::type
-              operation_meets_requirements = 0>
-class AsyncPollOp
-    : public std::enable_shared_from_this<AsyncPollOp<Functor, Operation>>,
-      public AsyncOperation {
+template <typename UserFunctor, typename Operation>
+class PollableLoopAdapter {
+  using Response =
+      typename MeetsAsyncPollOperationRequirements<Operation>::Response;
+  static_assert(
+      google::cloud::internal::is_invocable<UserFunctor, CompletionQueue&,
+                                            Response&, grpc::Status&>::value,
+      "UserFunctor should be callable with Operation::AccumulatedResult()'s "
+      "return value.");
+
  public:
-  explicit AsyncPollOp(char const* error_message,
-                       std::unique_ptr<PollingPolicy> polling_policy,
-                       MetadataUpdatePolicy metadata_update_policy,
-                       Functor&& callback, Operation&& operation)
-      : cancelled_(),
-        error_message_(error_message),
+  explicit PollableLoopAdapter(char const* error_message,
+                               std::unique_ptr<PollingPolicy> polling_policy,
+                               MetadataUpdatePolicy metadata_update_policy,
+                               UserFunctor&& callback, Operation&& operation)
+      : error_message_(error_message),
         polling_policy_(std::move(polling_policy)),
         metadata_update_policy_(std::move(metadata_update_policy)),
-        callback_(std::forward<Functor>(callback)),
+        user_callback_(std::forward<UserFunctor>(callback)),
         operation_(std::move(operation)) {}
 
-  void Cancel() override {
-    std::lock_guard<std::mutex> lk(mu_);
-    cancelled_ = true;
-    if (current_op_) {
-      current_op_->Cancel();
-      current_op_.reset();
-    }
-  }
-
-  std::shared_ptr<AsyncOperation> Start(CompletionQueue& cq) {
-    auto self = this->shared_from_this();
-    std::unique_lock<std::mutex> lk(mu_);
-    if (cancelled_) {
-      lk.unlock();
-      // We could fire the callback right here, but we'd be risking a deadlock
-      // if the user held a lock while submitting this request. Instead, let's
-      // schedule the callback to fire on the thread running the completion
-      // queue.
-      // There is no reason to store this timer in current_op_.
-      cq.RunAsync([self](CompletionQueue& cq) { self->OnTimer(cq, false); });
-      return self;
-    }
-    StartUnlocked(cq);
-    return self;
-  }
-
- private:
-  /**
-   * Kick off the asynchronous request.
-   *
-   * @param cq the completion queue to run the asynchronous operations.
-   */
-  void StartUnlocked(CompletionQueue& cq) {
-    auto self = this->shared_from_this();
+  template <typename AttemptFunctor>
+  std::shared_ptr<AsyncOperation> Start(
+      CompletionQueue& cq, AttemptFunctor&& attempt_completed_callback) {
     auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
     // TODO(1431): add polling_policy_->Setup();
     metadata_update_policy_.Setup(*context);
 
-    current_op_ = operation_.Start(
+    return operation_.Start(
         cq, std::move(context),
-        [self](CompletionQueue& cq, bool finished, grpc::Status& status) {
-          self->OnCompletion(cq, finished, status);
+        [this, attempt_completed_callback](CompletionQueue& cq, bool finished,
+                                           grpc::Status& status) {
+          OnCompletion(cq, finished, status,
+                       std::move(attempt_completed_callback));
         });
+  }
+
+  std::chrono::milliseconds WaitPeriod() {
+    return polling_policy_->WaitPeriod();
+  }
+
+  void Cancel(CompletionQueue& cq) {
+    auto res = operation_.AccumulatedResult();
+    grpc::Status res_status(
+        grpc::StatusCode::CANCELLED,
+        FullErrorMessageUnlocked("pending operation cancelled"));
+    user_callback_(cq, res, res_status);
+  }
+
+ private:
+  /// The callback to handle one asynchronous request completing.
+  template <typename AttemptFunctor>
+  void OnCompletion(CompletionQueue& cq, bool finished, grpc::Status& status,
+                    AttemptFunctor&& attempt_completed_callback) {
+    if (status.error_code() == grpc::StatusCode::CANCELLED) {
+      // Cancelled, no retry necessary.
+      Cancel(cq);
+      attempt_completed_callback(cq, true);
+      return;
+    }
+    if (finished) {
+      // Finished, just report the result.
+      auto res = operation_.AccumulatedResult();
+      user_callback_(cq, res, status);
+      attempt_completed_callback(cq, true);
+      return;
+    }
+    // At this point we know the operation is not finished and not cancelled.
+    if (not status.ok() and not polling_policy_->OnFailure(status)) {
+      std::string full_message =
+          FullErrorMessageUnlocked(polling_policy_->IsPermanentError(status)
+                                       ? "permanent error"
+                                       : "too many transient errors",
+                                   status);
+      auto res = operation_.AccumulatedResult();
+      grpc::Status res_status(status.error_code(), full_message,
+                              status.error_details());
+      user_callback_(cq, res, res_status);
+      attempt_completed_callback(cq, true);
+      return;
+    }
+    if (polling_policy_->Exhausted()) {
+      auto res = operation_.AccumulatedResult();
+      grpc::Status res_status(
+          grpc::StatusCode::UNKNOWN,
+          FullErrorMessageUnlocked("polling policy exhausted"));
+      user_callback_(cq, res, res_status);
+      attempt_completed_callback(cq, true);
+      return;
+    }
+    status_ = status;
+    attempt_completed_callback(cq, false);
   }
 
   std::string FullErrorMessageUnlocked(char const* where) {
@@ -172,110 +199,38 @@ class AsyncPollOp
     return full_message;
   }
 
-  /// The callback to handle one asynchronous request completing.
-  void OnCompletion(CompletionQueue& cq, bool finished, grpc::Status& status) {
-    std::unique_lock<std::mutex> lk(mu_);
-    // If we don't schedule a timer, we don't want this object to
-    // hold the operation.
-    current_op_.reset();
-    // If the underlying operation didn't notice a cancel request and reported
-    // a different error or success, we should report the error or success
-    // unless we would continue trying. This is because it is our best knowledge
-    // about the status of the retried request.
-    if (status.error_code() == grpc::StatusCode::CANCELLED) {
-      // Cancelled, no retry necessary.
-      auto res = operation_.AccumulatedResult();
-      grpc::Status res_status(
-          grpc::StatusCode::CANCELLED,
-          FullErrorMessageUnlocked("pending operation cancelled", status),
-          status.error_details());
-      lk.unlock();
-      callback_(cq, res, res_status);
-      return;
-    }
-    if (finished) {
-      // Finished, just report the result.
-      auto res = operation_.AccumulatedResult();
-      lk.unlock();
-      callback_(cq, res, status);
-      return;
-    }
-    // At this point we know the operation is not finished and not cancelled.
-    if (not status.ok() and not polling_policy_->OnFailure(status)) {
-      std::string full_message =
-          FullErrorMessageUnlocked(polling_policy_->IsPermanentError(status)
-                                       ? "permanent error"
-                                       : "too many transient errors",
-                                   status);
-      auto res = operation_.AccumulatedResult();
-      grpc::Status res_status(status.error_code(), full_message,
-                              status.error_details());
-      lk.unlock();
-      callback_(cq, res, res_status);
-      return;
-    }
-    if (polling_policy_->Exhausted()) {
-      auto res = operation_.AccumulatedResult();
-      grpc::Status res_status(
-          grpc::StatusCode::UNKNOWN,
-          FullErrorMessageUnlocked("polling policy exhausted"));
-      lk.unlock();
-      callback_(cq, res, res_status);
-      return;
-    }
-    if (cancelled_) {
-      // At this point we know that the user intended to Cancel and we'd retry,
-      // so let's report the cancellation status to them.
-      auto res = operation_.AccumulatedResult();
-      grpc::Status res_status(
-          grpc::StatusCode::CANCELLED,
-          FullErrorMessageUnlocked("pending operation cancelled", status),
-          status.error_details());
-      lk.unlock();
-      callback_(cq, res, res_status);
-      return;
-    }
-
-    auto delay = polling_policy_->WaitPeriod();
-    auto self = this->shared_from_this();
-    current_op_ = cq.MakeRelativeTimer(
-        delay, [self](CompletionQueue& cq, AsyncTimerResult result) {
-          self->OnTimer(cq, result.cancelled);
-        });
-  }
-
-  void OnTimer(CompletionQueue& cq, bool cancelled) {
-    std::unique_lock<std::mutex> lk(mu_);
-    if (cancelled or cancelled_) {
-      // Cancelled, no more action to take.
-      current_op_.reset();
-      auto res = operation_.AccumulatedResult();
-      grpc::Status res_status(
-          grpc::StatusCode::CANCELLED,
-          FullErrorMessageUnlocked("pending timer cancelled"));
-      lk.unlock();
-      callback_(cq, res, res_status);
-      return;
-    }
-    StartUnlocked(cq);
-  }
-
-  std::mutex mu_;
-  // Because of the racy nature of cancellation, a cancelled timer or operation
-  // might occasionally return a non-cancelled status (e.g. when cancellation
-  // occurs right before firing the callback). In order to not schedule a next
-  // retry in such a scenario, we indicate cancellation by using this flag.
-  bool cancelled_;
   char const* error_message_;
   std::unique_ptr<PollingPolicy> polling_policy_;
   MetadataUpdatePolicy metadata_update_policy_;
-  Functor callback_;
-  // A handle to a currently ongoing async operation - either a timer or one
-  // created through `Operation::Start`.
-  std::shared_ptr<AsyncOperation> current_op_;
-
- protected:
+  UserFunctor user_callback_;
   Operation operation_;
+  grpc::Status status_;
+};
+
+/**
+ * Perform asynchronous polling.
+ *
+ * @tparam Functor the type of the function-like object that will receive the
+ *     results.
+ *
+ * @tparam Operation a class responsible for submitting requests. Its `Start()`
+ *     member function will be used for sending the retries and the original
+ *     request. It follows the same scheme as AsyncRetryOp. It should satisfy
+ *     `MeetsAsyncPollOperationRequirements`.
+ */
+template <typename Functor, typename Operation>
+class AsyncPollOp
+    : public AsyncLoopOp<PollableLoopAdapter<Functor, Operation>> {
+ public:
+  explicit AsyncPollOp(char const* error_message,
+                       std::unique_ptr<PollingPolicy> polling_policy,
+                       MetadataUpdatePolicy metadata_update_policy,
+                       Functor&& callback, Operation&& operation)
+      : AsyncLoopOp<PollableLoopAdapter<Functor, Operation>>(
+            PollableLoopAdapter<Functor, Operation>(
+                error_message, std::move(polling_policy),
+                metadata_update_policy, std::forward<Functor>(callback),
+                std::move(operation))) {}
 };
 
 }  // namespace internal
@@ -285,3 +240,4 @@ class AsyncPollOp
 }  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_POLL_OP_H_
+

--- a/google/cloud/bigtable/internal/async_poll_op.h
+++ b/google/cloud/bigtable/internal/async_poll_op.h
@@ -240,4 +240,3 @@ class AsyncPollOp
 }  // namespace google
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_POLL_OP_H_
-

--- a/google/cloud/bigtable/internal/async_retry_op.h
+++ b/google/cloud/bigtable/internal/async_retry_op.h
@@ -16,8 +16,8 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_RETRY_OP_H_
 
 #include "google/cloud/bigtable/completion_queue.h"
+#include "google/cloud/bigtable/internal/async_loop_op.h"
 #include "google/cloud/bigtable/internal/async_op_traits.h"
-#include "google/cloud/bigtable/internal/conjunction.h"
 #include "google/cloud/bigtable/metadata_update_policy.h"
 #include "google/cloud/bigtable/rpc_backoff_policy.h"
 #include "google/cloud/bigtable/rpc_retry_policy.h"
@@ -42,42 +42,186 @@ struct PrototypeStartCallback {
 
 /**
  * A check if the template parameter meets criteria for `AsyncRetryOp`.
- *
- * This struct inherits from `std::true_type` of `std::false_type` depending on
- * whether it meets the criteria for an `Operation` parameter to `AsyncRetryOp`.
- *
- * These criteria are:
- *  - has a `Start` member function,
- *  - has a `AccumulatedResult` member function,
- *  - the `Start` function is invokable with `CompletionQueue&`,
- *    `std::unique_ptr<grpc::ClientContext>&&` and `Functor&&`, where `Functor`
- *    is invokable with `CompletionQueue&` and `grpc::Status&`,
- *  - the `AccumulatedResult` is invocable with no arguments,
- *  - the `Start` function returns a std::shared_ptr<AsyncOperation>
- *  - the `AccumulatedResult` function has the same return type as
- *    `Operation::Response`.
  */
 template <typename Operation>
-struct MeetsAsyncOperationRequirements
-    : public conjunction<
-          HasStart<Operation, PrototypeStartCallback>,
-          HasAccumulatedResult<Operation>,
-          google::cloud::internal::is_invocable<
+struct MeetsAsyncOperationRequirements {
+  static_assert(HasStart<Operation, PrototypeStartCallback>::value,
+                "Operation has to have a templated Start() member function "
+                "instantiatable with functors like PrototypeStartCallback");
+  static_assert(
+      HasAccumulatedResult<Operation>::value,
+      "Operation has to have an AccumulatedResult() member function.");
+  static_assert(
+      google::cloud::internal::is_invocable<
+          decltype(&Operation::template Start<PrototypeStartCallback>),
+          Operation&, CompletionQueue&, std::unique_ptr<grpc::ClientContext>&&,
+          PrototypeStartCallback&&>::value,
+      "Operation::Start<PrototypeStartCallback> has to be "
+      "non-static and invocable with "
+      "CompletionQueue&, std::unique_ptr<grpc::ClientContext>&&, "
+      "PrototypeStartCallback&&.");
+  static_assert(google::cloud::internal::is_invocable<
+                    decltype(&Operation::AccumulatedResult), Operation&>::value,
+                "Operation::AccumulatedResult has to be non-static and "
+                "invokable with no arguments");
+  static_assert(
+      std::is_same<
+          google::cloud::internal::invoke_result_t<
               decltype(&Operation::template Start<PrototypeStartCallback>),
               Operation&, CompletionQueue&,
               std::unique_ptr<grpc::ClientContext>&&, PrototypeStartCallback&&>,
-          google::cloud::internal::is_invocable<
-              decltype(&Operation::AccumulatedResult), Operation&>,
-          std::is_same<google::cloud::internal::invoke_result_t<
-                           decltype(&Operation::AccumulatedResult), Operation&>,
-                       typename Operation::Response>,
-          std::is_same<
-              google::cloud::internal::invoke_result_t<
-                  decltype(&Operation::template Start<PrototypeStartCallback>),
-                  Operation&, CompletionQueue&,
-                  std::unique_ptr<grpc::ClientContext>&&,
-                  PrototypeStartCallback&&>,
-              std::shared_ptr<AsyncOperation>>> {};
+          std::shared_ptr<AsyncOperation>>::value,
+      "Operation::Start<>(...) has to return a "
+      "std::shared_ptr<AsyncOperation>");
+
+  using Response = google::cloud::internal::invoke_result_t<
+      decltype(&Operation::AccumulatedResult), Operation&>;
+};
+
+/**
+ * A wrapper for operations adding retry logic if passed to `AsyncLoopOp`.
+ *
+ * If used in `AsyncLoopOp`, it will asynchronously retry `Operation`
+ *
+ * @tparam IdempotencyPolicy the policy used to determine if an operation is
+ *     idempotent. In most cases this is just `ConstantIdempotentPolicy`
+ *     because the decision around idempotency can be made before the retry loop
+ *     starts. Some calls may dynamically determine if a retry (or a partial
+ *     retry for `BulkApply`) are idempotent.
+ *
+ * @tparam UserFunctor the type of the function-like object that will receive
+ *     the results.
+ *
+ * @tparam Operation a class responsible for submitting requests. Its `Start()`
+ *     member function will be used for sending the retries and the original
+ *     request. In case of simple operations, it will just keep sending the same
+ *     request, but in case of more sophisticated ones (e.g. `BulkApply`), the
+ *     content might change with every retry. For reference, consult
+ *     `AsyncUnaryRpc` and `MeetsAsyncOperationRequirements`.
+ */
+template <typename IdempotencyPolicy, typename UserFunctor, typename Operation>
+class RetriableLoopAdapter {
+  using Response =
+      typename MeetsAsyncOperationRequirements<Operation>::Response;
+  static_assert(
+      google::cloud::internal::is_invocable<UserFunctor, CompletionQueue&,
+                                            Response&, grpc::Status&>::value,
+      "UserFunctor should be callable with Operation::AccumulatedResult()'s "
+      "return value.");
+
+ public:
+  explicit RetriableLoopAdapter(
+      char const* error_message,
+      std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
+      std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
+      IdempotencyPolicy idempotent_policy,
+      MetadataUpdatePolicy metadata_update_policy, UserFunctor&& callback,
+      Operation&& operation)
+      : error_message_(error_message),
+        rpc_retry_policy_(std::move(rpc_retry_policy)),
+        rpc_backoff_policy_(std::move(rpc_backoff_policy)),
+        idempotent_policy_(std::move(idempotent_policy)),
+        metadata_update_policy_(std::move(metadata_update_policy)),
+        user_callback_(std::forward<UserFunctor>(callback)),
+        operation_(std::move(operation)) {}
+
+  template <typename AttemptFunctor>
+  std::shared_ptr<AsyncOperation> Start(
+      CompletionQueue& cq, AttemptFunctor&& attempt_completed_callback) {
+    auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
+    rpc_retry_policy_->Setup(*context);
+    rpc_backoff_policy_->Setup(*context);
+    metadata_update_policy_.Setup(*context);
+
+    return operation_.Start(
+        cq, std::move(context),
+        [this, attempt_completed_callback](CompletionQueue& cq,
+                                           grpc::Status& status) {
+          OnCompletion(cq, status, std::move(attempt_completed_callback));
+        });
+  }
+
+  std::chrono::milliseconds WaitPeriod() {
+    return rpc_backoff_policy_->OnCompletion(status_);
+  }
+
+  void Cancel(CompletionQueue& cq) {
+    auto res = operation_.AccumulatedResult();
+    grpc::Status res_status(
+        grpc::StatusCode::CANCELLED,
+        FullErrorMessageUnlocked("pending operation cancelled"));
+    user_callback_(cq, res, res_status);
+  }
+
+ private:
+  /// The callback to handle one asynchronous request completing.
+  template <typename AttemptFunctor>
+  void OnCompletion(CompletionQueue& cq, grpc::Status& status,
+                    AttemptFunctor&& attempt_completed_callback) {
+    if (status.error_code() == grpc::StatusCode::CANCELLED) {
+      // Cancelled, no retry necessary.
+      Cancel(cq);
+      attempt_completed_callback(cq, true);
+      return;
+    }
+    if (status.ok()) {
+      // Success, just report the result.
+      auto res = operation_.AccumulatedResult();
+      user_callback_(cq, res, status);
+      attempt_completed_callback(cq, true);
+      return;
+    }
+    if (not idempotent_policy_.is_idempotent()) {
+      grpc::Status res_status(
+          status.error_code(),
+          FullErrorMessageUnlocked("non-idempotent operation failed", status),
+          status.error_details());
+      auto res = operation_.AccumulatedResult();
+      user_callback_(cq, res, res_status);
+      attempt_completed_callback(cq, true);
+      return;
+    }
+    if (not rpc_retry_policy_->OnFailure(status)) {
+      std::string full_message =
+          FullErrorMessageUnlocked(RPCRetryPolicy::IsPermanentFailure(status)
+                                       ? "permanent error"
+                                       : "too many transient errors",
+                                   status);
+      grpc::Status res_status(status.error_code(), full_message,
+                              status.error_details());
+      auto res = operation_.AccumulatedResult();
+      user_callback_(cq, res, res_status);
+      attempt_completed_callback(cq, true);
+      return;
+    }
+    status_ = status;
+    attempt_completed_callback(cq, false);
+  }
+
+  std::string FullErrorMessageUnlocked(char const* where) {
+    std::string full_message = error_message_;
+    full_message += "(" + metadata_update_policy_.value() + ") ";
+    full_message += where;
+    return full_message;
+  }
+
+  std::string FullErrorMessageUnlocked(char const* where,
+                                       grpc::Status const& status) {
+    std::string full_message = FullErrorMessageUnlocked(where);
+    full_message += ", last error=";
+    full_message += status.error_message();
+    return full_message;
+  }
+
+  char const* error_message_;
+  std::unique_ptr<RPCRetryPolicy> rpc_retry_policy_;
+  std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy_;
+  IdempotencyPolicy idempotent_policy_;
+  MetadataUpdatePolicy metadata_update_policy_;
+  UserFunctor user_callback_;
+  Operation operation_;
+  grpc::Status status_;
+};
 
 /**
  * Perform an asynchronous operation, with retries.
@@ -97,208 +241,25 @@ struct MeetsAsyncOperationRequirements
  *     request, but in case of more sophisticated ones (e.g. `BulkApply`), the
  *     content might change with every retry. For reference, consult
  *     `AsyncUnaryRpc` and `MeetsAsyncOperationRequirements`.
- *
- * @tparam valid_callback_type a format parameter, uses `std::enable_if<>` to
- *     disable this template if the functor does not match the expected
- *     signature.
  */
-template <
-    typename IdempotencyPolicy, typename Functor, typename Operation,
-    typename std::enable_if<
-        google::cloud::internal::is_invocable<Functor, CompletionQueue&,
-                                              typename Operation::Response&,
-                                              grpc::Status&>::value,
-        int>::type valid_callback_type = 0,
-    typename std::enable_if<MeetsAsyncOperationRequirements<Operation>::value,
-                            int>::type operation_meets_requirements = 0>
-class AsyncRetryOp : public std::enable_shared_from_this<
-                         AsyncRetryOp<IdempotencyPolicy, Functor, Operation>>,
-                     public AsyncOperation {
+template <typename IdempotencyPolicy, typename Functor, typename Operation>
+class AsyncRetryOp
+    : public AsyncLoopOp<
+          RetriableLoopAdapter<IdempotencyPolicy, Functor, Operation>> {
  public:
-  explicit AsyncRetryOp(char const* error_message,
-                        std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
-                        std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
-                        IdempotencyPolicy idempotent_policy,
-                        MetadataUpdatePolicy metadata_update_policy,
-                        Functor&& callback, Operation&& operation)
-      : cancelled_(),
-        error_message_(error_message),
-        rpc_retry_policy_(std::move(rpc_retry_policy)),
-        rpc_backoff_policy_(std::move(rpc_backoff_policy)),
-        idempotent_policy_(std::move(idempotent_policy)),
-        metadata_update_policy_(std::move(metadata_update_policy)),
-        callback_(std::forward<Functor>(callback)),
-        operation_(std::move(operation)) {}
-
-  void Cancel() override {
-    std::lock_guard<std::mutex> lk(mu_);
-    cancelled_ = true;
-    if (current_op_) {
-      current_op_->Cancel();
-      current_op_.reset();
-    }
-  }
-
-  std::shared_ptr<AsyncOperation> Start(CompletionQueue& cq) {
-    auto res =
-        std::static_pointer_cast<AsyncOperation>(this->shared_from_this());
-    std::unique_lock<std::mutex> lk(mu_);
-    if (cancelled_) {
-      lk.unlock();
-      // We could fire the callback right here, but we'd be risking a deadlock
-      // if the user held a lock while submitting this request. Instead, let's
-      // schedule the callback to fire on the thread running the completion
-      // queue.
-      // There is no reason to store this timer in current_op_.
-      auto self = this->shared_from_this();
-      cq.RunAsync([self](CompletionQueue& cq) { self->OnTimer(cq, false); });
-      return res;
-    }
-    StartUnlocked(cq);
-    return res;
-  }
-
- private:
-  /**
-   * Kick off the asynchronous request.
-   *
-   * @param cq the completion queue to run the asynchronous operations.
-   */
-  void StartUnlocked(CompletionQueue& cq) {
-    auto self = this->shared_from_this();
-    auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
-    rpc_retry_policy_->Setup(*context);
-    rpc_backoff_policy_->Setup(*context);
-    metadata_update_policy_.Setup(*context);
-
-    current_op_ =
-        operation_.Start(cq, std::move(context),
-                         [self](CompletionQueue& cq, grpc::Status& status) {
-                           self->OnCompletion(cq, status);
-                         });
-  }
-
-  std::string FullErrorMessageUnlocked(char const* where) {
-    std::string full_message = error_message_;
-    full_message += "(" + metadata_update_policy_.value() + ") ";
-    full_message += where;
-    return full_message;
-  }
-
-  std::string FullErrorMessageUnlocked(char const* where,
-                                       grpc::Status const& status) {
-    std::string full_message = FullErrorMessageUnlocked(where);
-    full_message += ", last error=";
-    full_message += status.error_message();
-    return full_message;
-  }
-
-  /// The callback to handle one asynchronous request completing.
-  void OnCompletion(CompletionQueue& cq, grpc::Status& status) {
-    std::unique_lock<std::mutex> lk(mu_);
-    // If we don't schedule a timer, we don't want this object to
-    // hold the operation.
-    current_op_.reset();
-    // If the underlying operation didn't notice a cancel request and reported
-    // a different error or success, we should report the error or success
-    // unless we would continue trying. This is because it is our best knowledge
-    // about the status of the retried request.
-    if (status.error_code() == grpc::StatusCode::CANCELLED) {
-      // Cancelled, no retry necessary.
-      auto res = operation_.AccumulatedResult();
-      grpc::Status res_status(
-          grpc::StatusCode::CANCELLED,
-          FullErrorMessageUnlocked("pending operation cancelled", status),
-          status.error_details());
-      lk.unlock();
-      callback_(cq, res, res_status);
-      return;
-    }
-    if (status.ok()) {
-      // Success, just report the result.
-      auto res = operation_.AccumulatedResult();
-      lk.unlock();
-      callback_(cq, res, status);
-      return;
-    }
-    if (not idempotent_policy_.is_idempotent()) {
-      auto res = operation_.AccumulatedResult();
-      grpc::Status res_status(
-          status.error_code(),
-          FullErrorMessageUnlocked("non-idempotent operation failed", status),
-          status.error_details());
-      lk.unlock();
-      callback_(cq, res, res_status);
-      return;
-    }
-    if (not rpc_retry_policy_->OnFailure(status)) {
-      std::string full_message =
-          FullErrorMessageUnlocked(RPCRetryPolicy::IsPermanentFailure(status)
-                                       ? "permanent error"
-                                       : "too many transient errors",
-                                   status);
-      auto res = operation_.AccumulatedResult();
-      grpc::Status res_status(status.error_code(), full_message,
-                              status.error_details());
-      lk.unlock();
-      callback_(cq, res, res_status);
-      return;
-    }
-    if (cancelled_) {
-      // At this point we know that the user intended to Cancel and we'd retry,
-      // so let's report the cancellation status to them.
-      auto res = operation_.AccumulatedResult();
-      grpc::Status res_status(
-          grpc::StatusCode::CANCELLED,
-          FullErrorMessageUnlocked("pending operation cancelled", status),
-          status.error_details());
-      lk.unlock();
-      callback_(cq, res, res_status);
-      return;
-    }
-
-    auto delay = rpc_backoff_policy_->OnCompletion(status);
-    auto self = this->shared_from_this();
-    current_op_ = cq.MakeRelativeTimer(
-        delay, [self](CompletionQueue& cq, AsyncTimerResult result) {
-          self->OnTimer(cq, result.cancelled);
-        });
-  }
-
-  void OnTimer(CompletionQueue& cq, bool cancelled) {
-    std::unique_lock<std::mutex> lk(mu_);
-    if (cancelled or cancelled_) {
-      // Cancelled, no more action to take.
-      current_op_.reset();
-      auto res = operation_.AccumulatedResult();
-      grpc::Status res_status(
-          grpc::StatusCode::CANCELLED,
-          FullErrorMessageUnlocked("pending timer cancelled"));
-      lk.unlock();
-      callback_(cq, res, res_status);
-      return;
-    }
-    StartUnlocked(cq);
-  }
-
-  std::mutex mu_;
-  // Because of the racy nature of cancellation, a cancelled timer or operation
-  // might occasionally return a non-cancelled status (e.g. when cancellation
-  // occurs right before firing the callback). In order to not schedule a next
-  // retry in such a scenario, we indicate cancellation by using this flag.
-  bool cancelled_;
-  char const* error_message_;
-  std::unique_ptr<RPCRetryPolicy> rpc_retry_policy_;
-  std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy_;
-  IdempotencyPolicy idempotent_policy_;
-  MetadataUpdatePolicy metadata_update_policy_;
-  Functor callback_;
-  // A handle to a currently ongoing async operation - either a timer or one
-  // created through `Operation::Start`.
-  std::shared_ptr<AsyncOperation> current_op_;
-
- protected:
-  Operation operation_;
+  AsyncRetryOp(char const* error_message,
+               std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
+               std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
+               IdempotencyPolicy idempotent_policy,
+               MetadataUpdatePolicy metadata_update_policy, Functor&& callback,
+               Operation&& operation)
+      : AsyncLoopOp<
+            RetriableLoopAdapter<IdempotencyPolicy, Functor, Operation>>(
+            RetriableLoopAdapter<IdempotencyPolicy, Functor, Operation>(
+                error_message, std::move(rpc_retry_policy),
+                std::move(rpc_backoff_policy), std::move(idempotent_policy),
+                metadata_update_policy, std::forward<Functor>(callback),
+                std::move(operation))) {}
 };
 
 /**

--- a/google/cloud/bigtable/internal/async_retry_op_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_op_test.cc
@@ -77,9 +77,6 @@ class DummyOperation {
   std::shared_ptr<DummyOperationImpl> impl_;
 };
 
-static_assert(internal::MeetsAsyncOperationRequirements<DummyOperation>::value,
-              "DummyOperation is not a valid retriable operation.");
-
 class AsyncOperationMock : public AsyncOperation {
  public:
   MOCK_METHOD0(Cancel, void());

--- a/google/cloud/bigtable/internal/table_async_apply_test.cc
+++ b/google/cloud/bigtable/internal/table_async_apply_test.cc
@@ -482,7 +482,7 @@ TEST_F(NoexTableAsyncApplyTest, StopRetryOnTimerCancel) {
   EXPECT_THAT(capture_status.error_message(), HasSubstr("AsyncApply"));
   EXPECT_THAT(capture_status.error_message(), HasSubstr(tested.table_name()));
   EXPECT_THAT(capture_status.error_message(),
-              HasSubstr("pending timer cancelled"));
+              HasSubstr("pending operation cancelled"));
 }
 
 struct Counter : public grpc::ClientAsyncResponseReaderInterface<


### PR DESCRIPTION
`AsyncPollOp` and `AsyncRetryOp` share a non-tirivial amount of code
with each other. Moreover, a class for fetching responses in pages also
would (#1477 has shown that reusing `AsyncPollOp` is ugly).

`AsynLoopOp` is exactly what all of them have in common - running
requests in a loop, potentially sleeping between them and allowing for
cancellations.

There are no test because `AsyncRetryOp` and `AsyncPollOp` are already
tested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1539)
<!-- Reviewable:end -->
