### PR TITLE
Implement resumable upload sessions in CurlClient.

### DIFF
--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -168,8 +168,23 @@ std::pair<Status, ResumableUploadResponse> CurlClient::UploadChunk(
   if (not status.ok()) {
     return std::make_pair(status, ResumableUploadResponse{});
   }
-  return std::make_pair(Status(600, "not-implemented"),
-                        ResumableUploadResponse{});
+  builder.AddHeader(request.RangeHeader());
+  builder.AddHeader("Content-Type: application/octet-stream");
+  builder.AddHeader("Content-Length: " +
+                    std::to_string(request.payload().size()));
+  auto payload = builder.BuildRequest().MakeRequest(request.payload());
+  if (payload.status_code == 308 and
+      payload.headers.find("range") != payload.headers.end()) {
+    return std::make_pair(Status(), ResumableUploadResponse::FromHttpResponse(
+                                        std::move(payload)));
+  }
+  if (payload.status_code >= 300) {
+    return std::make_pair(
+        Status{payload.status_code, std::move(payload.payload)},
+        ResumableUploadResponse{});
+  }
+  return std::make_pair(
+      Status(), ResumableUploadResponse::FromHttpResponse(std::move(payload)));
 }
 
 std::pair<Status, ResumableUploadResponse> CurlClient::QueryResumableUpload(
@@ -179,8 +194,22 @@ std::pair<Status, ResumableUploadResponse> CurlClient::QueryResumableUpload(
   if (not status.ok()) {
     return std::make_pair(status, ResumableUploadResponse{});
   }
-  return std::make_pair(Status(600, "not-implemented"),
-                        ResumableUploadResponse{});
+  builder.AddHeader("Content-Range: bytes */*");
+  builder.AddHeader("Content-Type: application/octet-stream");
+  builder.AddHeader("Content-Length: 0");
+  auto payload = builder.BuildRequest().MakeRequest(std::string{});
+  if (payload.status_code == 308 and
+      payload.headers.find("range") != payload.headers.end()) {
+    return std::make_pair(Status(), ResumableUploadResponse::FromHttpResponse(
+                                        std::move(payload)));
+  }
+  if (payload.status_code >= 300) {
+    return std::make_pair(
+        Status{payload.status_code, std::move(payload.payload)},
+        ResumableUploadResponse{});
+  }
+  return std::make_pair(
+      Status(), ResumableUploadResponse::FromHttpResponse(std::move(payload)));
 }
 
 std::pair<Status, ListBucketsResponse> CurlClient::ListBuckets(
@@ -637,6 +666,41 @@ std::pair<Status, RewriteObjectResponse> CurlClient::RewriteObject(
   }
   return std::make_pair(Status(),
                         RewriteObjectResponse::FromHttpResponse(payload));
+}
+
+std::pair<Status, std::unique_ptr<ResumableUploadSession>>
+CurlClient::CreateResumableSession(ResumableUploadRequest const& request) {
+  CurlRequestBuilder builder(
+      upload_endpoint_ + "/b/" + request.bucket_name() + "/o", upload_factory_);
+  auto status = SetupBuilder(builder, request, "POST");
+  if (not status.ok()) {
+    return std::make_pair(status, std::unique_ptr<ResumableUploadSession>());
+  }
+  builder.AddQueryParameter("uploadType", "resumable");
+  builder.AddQueryParameter("name", request.object_name());
+  builder.AddHeader("Content-Type: application/json; charset=UTF-8");
+  std::string request_payload;
+  if (request.HasOption<WithObjectMetadata>()) {
+    request_payload =
+        request.GetOption<WithObjectMetadata>().value().JsonPayloadForUpdate();
+  }
+  builder.AddHeader("Content-Length: " +
+                    std::to_string(request_payload.size()));
+  auto payload = builder.BuildRequest().MakeRequest(request_payload);
+  if (payload.status_code >= 300) {
+    return std::make_pair(
+        Status{payload.status_code, std::move(payload.payload)},
+        std::unique_ptr<ResumableUploadSession>());
+  }
+  auto response = ResumableUploadResponse::FromHttpResponse(std::move(payload));
+  if (response.upload_session_url.empty()) {
+    return std::make_pair(Status(600, std::string("Invalid server response")),
+                          std::unique_ptr<ResumableUploadSession>());
+  }
+  auto session =
+      google::cloud::internal::make_unique<CurlResumableUploadSession>(
+          shared_from_this(), std::move(response.upload_session_url));
+  return std::make_pair(Status(), std::move(session));
 }
 
 std::pair<Status, ListBucketAclResponse> CurlClient::ListBucketAcl(

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -109,6 +109,8 @@ class CurlClient : public RawClient,
       PatchObjectRequest const& request) override;
   std::pair<Status, ObjectMetadata> ComposeObject(
       ComposeObjectRequest const& request) override;
+  std::pair<Status, std::unique_ptr<ResumableUploadSession>>
+  CreateResumableSession(ResumableUploadRequest const& request);
 
   std::pair<Status, ListBucketAclResponse> ListBucketAcl(
       ListBucketAclRequest const& request) override;

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(storage_client_integration_tests
     curl_upload_request_integration_test.cc
     curl_download_request_integration_test.cc
     curl_request_integration_test.cc
+    curl_resumable_upload_session_integration_test.cc
     curl_streambuf_integration_test.cc
     object_media_integration_test.cc
     object_insert_integration_test.cc

--- a/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
+++ b/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
@@ -1,0 +1,135 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/curl_client.h"
+#include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/testing_util/init_google_mock.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+using ::testing::HasSubstr;
+
+class ResumableUploadTestEnvironment : public ::testing::Environment {
+ public:
+  ResumableUploadTestEnvironment(std::string instance) {
+    bucket_name_ = std::move(instance);
+  }
+
+  static std::string const& bucket_name() { return bucket_name_; }
+
+ private:
+  static std::string bucket_name_;
+};
+
+std::string ResumableUploadTestEnvironment::bucket_name_;
+
+class CurlResumableUploadIntegrationTest
+    : public google::cloud::storage::testing::StorageIntegrationTest {};
+
+TEST_F(CurlResumableUploadIntegrationTest, Simple) {
+  auto client = CurlClient::Create(ClientOptions());
+  auto bucket_name = ResumableUploadTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+
+  ResumableUploadRequest request(bucket_name, object_name);
+  request.set_multiple_options(IfGenerationMatch(0));
+
+  Status status;
+  std::unique_ptr<ResumableUploadSession> session;
+  std::tie(status, session) = client->CreateResumableSession(request);
+
+  ASSERT_TRUE(status.ok());
+
+  std::string const contents = LoremIpsum();
+  ResumableUploadResponse response;
+  std::tie(status, response) = session->UploadChunk(contents, contents.size());
+
+  ASSERT_TRUE(status.ok());
+  EXPECT_FALSE(response.payload.empty());
+  auto metadata = ObjectMetadata::ParseFromString(response.payload);
+  EXPECT_EQ(object_name, metadata.name());
+  EXPECT_EQ(bucket_name, metadata.bucket());
+  EXPECT_EQ(contents.size(), metadata.size());
+
+  client->DeleteObject(DeleteObjectRequest(bucket_name, object_name));
+}
+
+TEST_F(CurlResumableUploadIntegrationTest, WithReset) {
+  auto client = CurlClient::Create(ClientOptions());
+  auto bucket_name = ResumableUploadTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+
+  ResumableUploadRequest request(bucket_name, object_name);
+  request.set_multiple_options(IfGenerationMatch(0));
+
+  Status status;
+  std::unique_ptr<ResumableUploadSession> session;
+  std::tie(status, session) = client->CreateResumableSession(request);
+
+  ASSERT_TRUE(status.ok());
+
+  std::string const contents(UploadChunkRequest::kChunkSizeQuantum, '0');
+  ResumableUploadResponse response;
+  std::tie(status, response) =
+      session->UploadChunk(contents, 2 * contents.size());
+  ASSERT_TRUE(status.status_code() == 200 or status.status_code() == 308)
+      << status;
+
+  std::tie(status, response) = session->ResetSession();
+  ASSERT_TRUE(status.ok()) << status;
+
+  std::tie(status, response) =
+      session->UploadChunk(contents, 2 * contents.size());
+  ASSERT_TRUE(status.ok()) << status;
+
+  EXPECT_FALSE(response.payload.empty());
+  auto metadata = ObjectMetadata::ParseFromString(response.payload);
+  EXPECT_EQ(object_name, metadata.name());
+  EXPECT_EQ(bucket_name, metadata.bucket());
+  EXPECT_EQ(2 * contents.size(), metadata.size());
+
+  client->DeleteObject(DeleteObjectRequest(bucket_name, object_name));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+int main(int argc, char* argv[]) {
+  google::cloud::testing_util::InitGoogleMock(argc, argv);
+
+  // Make sure the arguments are valid.
+  if (argc != 2) {
+    std::string const cmd = argv[0];
+    auto last_slash = std::string(argv[0]).find_last_of('/');
+    std::cerr << "Usage: " << cmd.substr(last_slash + 1) << " <bucket-name>"
+              << std::endl;
+    return 1;
+  }
+
+  std::string const bucket_name = argv[1];
+  (void)::testing::AddGlobalTestEnvironment(
+      new google::cloud::storage::internal::ResumableUploadTestEnvironment(
+          bucket_name));
+
+  return RUN_ALL_TESTS();
+}

--- a/google/cloud/storage/tests/run_integration_tests_production.sh
+++ b/google/cloud/storage/tests/run_integration_tests_production.sh
@@ -25,6 +25,10 @@ set -eu
 #   to the VMs running the integration tests.
 
 echo
+echo "Running storage::internal::CurlResumableUploadSession integration tests."
+./curl_resumable_upload_session_integration_test "${BUCKET_NAME}"
+
+echo
 echo "Running GCS Bucket APIs integration tests."
 ./bucket_integration_test "${PROJECT_ID}" "${BUCKET_NAME}" "${TOPIC_NAME}"
 

--- a/google/cloud/storage/tests/run_integration_tests_testbench.sh
+++ b/google/cloud/storage/tests/run_integration_tests_testbench.sh
@@ -46,6 +46,10 @@ echo "Running storage::internal::CurlRequestDownload integration test."
 ./curl_download_request_integration_test
 
 echo
+echo "Running storage::internal::CurlResumableUploadSession integration tests."
+./curl_resumable_upload_session_integration_test "${BUCKET_NAME}"
+
+echo
 echo "Running storage::internal::CurlStreambuf integration test."
 ./curl_streambuf_integration_test
 

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -4,6 +4,7 @@ storage_client_integration_tests = [
     "curl_upload_request_integration_test.cc",
     "curl_download_request_integration_test.cc",
     "curl_request_integration_test.cc",
+    "curl_resumable_upload_session_integration_test.cc",
     "curl_streambuf_integration_test.cc",
     "object_media_integration_test.cc",
     "object_insert_integration_test.cc",


### PR DESCRIPTION
This is the base implementation of resumable upload sessions, without
logging or retries. Part of the work for #559.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1542)
<!-- Reviewable:end -->
