### PR TITLE
Refactor WriteObject() for simple uploads.

### DIFF
--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -494,27 +494,8 @@ CurlClient::WriteObject(InsertObjectStreamingRequest const& request) {
       request.GetOption<Fields>().value().empty()) {
     return WriteObjectXml(request);
   }
-  auto url = upload_endpoint_ + "/b/" + request.bucket_name() + "/o";
-  CurlRequestBuilder builder(url, upload_factory_);
-  auto status = SetupBuilder(builder, request, "POST");
-  if (not status.ok()) {
-    return std::make_pair(status,
-                          std::unique_ptr<ObjectWriteStreambuf>(nullptr));
-  }
 
-  // Set the content type of a sensible value, the application can override this
-  // in the options for the request.
-  if (not request.HasOption<ContentType>()) {
-    builder.AddHeader("content-type: application/octet-stream");
-  }
-  builder.AddQueryParameter("uploadType", "media");
-  builder.AddQueryParameter("name", request.object_name());
-  std::unique_ptr<internal::CurlStreambuf> buf(new internal::CurlStreambuf(
-      builder.BuildUpload(), client_options().upload_buffer_size(),
-      CreateHashValidator(request)));
-  return std::make_pair(
-      Status(),
-      std::unique_ptr<internal::ObjectWriteStreambuf>(std::move(buf)));
+  return WriteObjectSimple(request);
 }
 
 std::pair<Status, ListObjectsResponse> CurlClient::ListObjects(
@@ -1448,6 +1429,32 @@ std::pair<Status, ObjectMetadata> CurlClient::InsertObjectMediaSimple(
   }
   return std::make_pair(Status(),
                         ObjectMetadata::ParseFromString(payload.payload));
+}
+
+std::pair<Status, std::unique_ptr<ObjectWriteStreambuf>>
+CurlClient::WriteObjectSimple(
+    InsertObjectStreamingRequest const& request) {
+  auto url = upload_endpoint_ + "/b/" + request.bucket_name() + "/o";
+  CurlRequestBuilder builder(url, upload_factory_);
+  auto status = SetupBuilder(builder, request, "POST");
+  if (not status.ok()) {
+    return std::make_pair(status,
+                          std::unique_ptr<ObjectWriteStreambuf>(nullptr));
+  }
+
+  // Set the content type of a sensible value, the application can override this
+  // in the options for the request.
+  if (not request.HasOption<ContentType>()) {
+    builder.AddHeader("content-type: application/octet-stream");
+  }
+  builder.AddQueryParameter("uploadType", "media");
+  builder.AddQueryParameter("name", request.object_name());
+  std::unique_ptr<internal::CurlStreambuf> buf(new internal::CurlStreambuf(
+      builder.BuildUpload(), client_options().upload_buffer_size(),
+      CreateHashValidator(request)));
+  return std::make_pair(
+      Status(),
+      std::unique_ptr<internal::ObjectWriteStreambuf>(std::move(buf)));
 }
 
 std::pair<Status, std::string> CurlClient::AuthorizationHeader(

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -201,6 +201,10 @@ class CurlClient : public RawClient,
   std::pair<Status, ObjectMetadata> InsertObjectMediaSimple(
       InsertObjectMediaRequest const& request);
 
+  /// Upload an object using uploadType=simple.
+  std::pair<Status, std::unique_ptr<ObjectWriteStreambuf>> WriteObjectSimple(
+      InsertObjectStreamingRequest const& request);
+
   ClientOptions options_;
   std::string storage_endpoint_;
   std::string upload_endpoint_;


### PR DESCRIPTION
We will soon introduce a WriteObjectResumable() to go along with
WriteObjectXml() and WriteObjectSimpl().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1549)
<!-- Reviewable:end -->
