### PR TITLE
Fix flaky test.

### DIFF
--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -169,13 +169,16 @@ run_retention_policy_examples() {
 #   COLOR_*: colorize output messages, defined in colors.sh
 #   EXIT_STATUS: control the final exit status for the program.
 # Arguments:
-#   bucket_name: the name of the bucket to run the examples against.
+#   None
 # Returns:
 #   None
-################################################
+###############################################
 run_all_bucket_acl_examples() {
-  local bucket_name=$1
-  shift
+  # Use a fresh bucket to avoid flaky tests due to other tests also making
+  # changes on the bucket.
+  local bucket_name="cloud-cpp-test-bucket-$(date +%s)-${RANDOM}-${RANDOM}"
+  run_example ./storage_bucket_samples create-bucket-for-project \
+      "${bucket_name}" "${PROJECT_ID}"
 
   run_example ./storage_bucket_acl_samples list-bucket-acl \
       "${bucket_name}"
@@ -192,6 +195,9 @@ run_all_bucket_acl_examples() {
   run_example ./storage_bucket_acl_samples delete-bucket-acl \
       "${bucket_name}" allAuthenticatedUsers
 
+  run_example ./storage_bucket_samples delete-bucket \
+      "${bucket_name}"
+
   # Verify that calling without a command produces the right exit status and
   # some kind of Usage message.
   run_example_usage ./storage_bucket_acl_samples
@@ -203,13 +209,16 @@ run_all_bucket_acl_examples() {
 #   COLOR_*: colorize output messages, defined in colors.sh
 #   EXIT_STATUS: control the final exit status for the program.
 # Arguments:
-#   bucket_name: the name of the bucket to run the examples against.
+#   None
 # Returns:
 #   None
 ################################################
 run_all_default_object_acl_examples() {
-  local bucket_name=$1
-  shift
+  # Use a fresh bucket to avoid flaky tests due to other tests also making
+  # changes on the bucket.
+  local bucket_name="cloud-cpp-test-bucket-$(date +%s)-${RANDOM}-${RANDOM}"
+  run_example ./storage_bucket_samples create-bucket-for-project \
+      "${bucket_name}" "${PROJECT_ID}"
 
   run_example ./storage_default_object_acl_samples list-default-object-acl \
       "${bucket_name}"
@@ -225,6 +234,9 @@ run_all_default_object_acl_examples() {
       "${bucket_name}" allAuthenticatedUsers OWNER
   run_example ./storage_default_object_acl_samples delete-default-object-acl \
       "${bucket_name}" allAuthenticatedUsers
+
+  run_example ./storage_bucket_samples delete-bucket \
+      "${bucket_name}"
 
   # Verify that calling without a command produces the right exit status and
   # some kind of Usage message.
@@ -676,13 +688,16 @@ run_all_notification_examples() {
 #   COLOR_*: colorize output messages, defined in colors.sh
 #   EXIT_STATUS: control the final exit status for the program.
 # Arguments:
-#   bucket_name: the name of the bucket to run the examples against.
+#   None
 # Returns:
 #   None
 ################################################
 run_all_bucket_iam_examples() {
-  local bucket_name=$1
-  shift
+  # Use a fresh bucket to avoid flaky tests due to other tests also making
+  # changes on the bucket.
+  local bucket_name="cloud-cpp-test-bucket-$(date +%s)-${RANDOM}-${RANDOM}"
+  run_example ./storage_bucket_samples create-bucket-for-project \
+      "${bucket_name}" "${PROJECT_ID}"
 
   run_example ./storage_bucket_iam_samples get-bucket-iam-policy \
       "${bucket_name}"
@@ -692,6 +707,9 @@ run_all_bucket_iam_examples() {
       "${bucket_name}" "roles/storage.objectViewer" "allAuthenticatedUsers"
   run_example ./storage_bucket_iam_samples test-bucket-iam-permissions \
       "${bucket_name}" "storage.objects.list" "storage.objects.delete"
+
+  run_example ./storage_bucket_samples delete-bucket \
+      "${bucket_name}"
 
   # Verify that calling without a command produces the right exit status and
   # some kind of Usage message.
@@ -735,8 +753,8 @@ run_all_storage_examples() {
   run_all_bucket_examples
   run_default_event_based_hold_examples
   run_retention_policy_examples
-  run_all_bucket_acl_examples "${BUCKET_NAME}"
-  run_all_default_object_acl_examples "${BUCKET_NAME}"
+  run_all_bucket_acl_examples
+  run_all_default_object_acl_examples
   run_all_requester_pays_examples
   run_all_object_examples "${BUCKET_NAME}"
   run_upload_and_download_examples "${BUCKET_NAME}"
@@ -747,7 +765,7 @@ run_all_storage_examples() {
   run_all_object_acl_examples "${BUCKET_NAME}"
   run_all_notification_examples "${TOPIC_NAME}"
   run_all_cmek_examples "${STORAGE_CMEK_KEY}"
-  run_all_bucket_iam_examples "${BUCKET_NAME}"
+  run_all_bucket_iam_examples
   echo "${COLOR_GREEN}[ ======== ]${COLOR_RESET}" \
       " Google Cloud Storage Examples Finished"
   if [ "${EXIT_STATUS}" = "0" ]; then

--- a/google/cloud/storage/examples/storage_bucket_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_acl_samples.cc
@@ -159,9 +159,8 @@ void PatchBucketAcl(google::cloud::storage::Client client, int& argc,
         client.GetBucketAcl(bucket_name, entity);
     auto new_acl = original_acl;
     new_acl.set_role(role);
-    gcs::BucketAccessControl updated_acl =
-        client.PatchBucketAcl(bucket_name, entity, original_acl, new_acl,
-                              gcs::IfMatchEtag(original_acl.etag()));
+    gcs::BucketAccessControl updated_acl = client.PatchBucketAcl(
+        bucket_name, entity, original_acl, new_acl);
     std::cout << "ACL entry for " << entity << " in bucket " << bucket_name
               << " is now " << updated_acl << std::endl;
   }
@@ -198,7 +197,7 @@ int main(int argc, char* argv[]) try {
 
   // Build the list of commands and the usage string from that list.
   using CommandType =
-      std::function<void(google::cloud::storage::Client, int&, char* [])>;
+      std::function<void(google::cloud::storage::Client, int&, char*[])>;
   std::map<std::string, CommandType> commands = {
       {"list-bucket-acl", &ListBucketAcl},
       {"create-bucket-acl", &CreateBucketAcl},

--- a/google/cloud/storage/examples/storage_default_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_default_object_acl_samples.cc
@@ -163,9 +163,8 @@ void PatchDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
         client.GetDefaultObjectAcl(bucket_name, entity);
     auto new_acl = original_acl;
     new_acl.set_role(role);
-    gcs::ObjectAccessControl updated_acl =
-        client.PatchDefaultObjectAcl(bucket_name, entity, original_acl, new_acl,
-                                     gcs::IfMatchEtag(original_acl.etag()));
+    gcs::ObjectAccessControl updated_acl = client.PatchDefaultObjectAcl(
+        bucket_name, entity, original_acl, new_acl);
     std::cout << "Default Object ACL entry for " << entity << " in bucket "
               << bucket_name << " is now " << updated_acl << std::endl;
   }
@@ -203,7 +202,7 @@ int main(int argc, char* argv[]) try {
 
   // Build the list of commands and the usage string from that list.
   using CommandType =
-      std::function<void(google::cloud::storage::Client, int&, char* [])>;
+      std::function<void(google::cloud::storage::Client, int&, char*[])>;
   std::map<std::string, CommandType> commands = {
       {"list-default-object-acl", &ListDefaultObjectAcl},
       {"create-default-object-acl", &CreateDefaultObjectAcl},

--- a/google/cloud/storage/examples/storage_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_object_acl_samples.cc
@@ -169,9 +169,8 @@ void PatchObjectAcl(gcs::Client client, int& argc, char* argv[]) {
         client.GetObjectAcl(bucket_name, object_name, entity);
     auto new_acl = original_acl;
     new_acl.set_role(role);
-    gcs::ObjectAccessControl updated_acl =
-        client.PatchObjectAcl(bucket_name, object_name, entity, original_acl,
-                              new_acl, gcs::IfMatchEtag(original_acl.etag()));
+    gcs::ObjectAccessControl updated_acl = client.PatchObjectAcl(
+        bucket_name, object_name, entity, original_acl, new_acl);
     std::cout << "ACL entry for " << entity << " in object " << object_name
               << " in bucket " << bucket_name << " is now " << updated_acl
               << std::endl;
@@ -210,7 +209,7 @@ int main(int argc, char* argv[]) try {
   gcs::Client client;
 
   // Build the list of commands and the usage string from that list.
-  using CommandType = std::function<void(gcs::Client, int&, char* [])>;
+  using CommandType = std::function<void(gcs::Client, int&, char*[])>;
   std::map<std::string, CommandType> commands = {
       {"list-object-acl", &ListObjectAcl},
       {"create-object-acl", &CreateObjectAcl},

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -332,7 +332,7 @@ void UpdateObjectMetadata(google::cloud::storage::Client client, int& argc,
     gcs::ObjectMetadata desired = meta;
     desired.mutable_metadata().emplace(key, value);
     gcs::ObjectMetadata updated = client.UpdateObject(
-        bucket_name, object_name, desired, gcs::IfMatchEtag(meta.etag()));
+        bucket_name, object_name, desired, gcs::Generation(meta.generation()));
     std::cout << "Object updated. The full metadata after the update is: "
               << updated << std::endl;
   }

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -23,9 +23,9 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
+using google::cloud::storage::testing::TestPermanentFailure;
 using ::testing::ElementsAreArray;
 using ::testing::HasSubstr;
-using google::cloud::storage::testing::TestPermanentFailure;
 
 /// Store the project and instance captured from the command-line arguments.
 class BucketTestEnvironment : public ::testing::Environment {
@@ -373,8 +373,10 @@ TEST_F(BucketIntegrationTest, AccessControlCRUD) {
 
   new_acl = get_result;
   new_acl.set_role("OWNER");
-  get_result = client.PatchBucketAcl(bucket_name, entity_name, get_result,
-                                     new_acl, IfMatchEtag(get_result.etag()));
+  // Because this is a freshly created bucket, with a random name, we do not
+  // worry about implementing optimistic concurrency control.
+  get_result =
+      client.PatchBucketAcl(bucket_name, entity_name, get_result, new_acl);
   EXPECT_EQ(get_result.role(), new_acl.role());
 
   client.DeleteBucketAcl(bucket_name, entity_name);

--- a/google/cloud/storage/tests/run_integration_tests_production.sh
+++ b/google/cloud/storage/tests/run_integration_tests_production.sh
@@ -21,6 +21,7 @@ set -eu
 #   tests should have Storage.Admin access to this project.
 # - BUCKET_NAME: the name of a Google Cloud Storage Bucket, the integration
 #   tests should have read/write access to this bucket.
+# - TOPIC_NAME: a valid Cloud Pub/Sub topic.
 # - STORAGE_REGION_ID: the name of of Google Cloud Storage region, ideally close
 #   to the VMs running the integration tests.
 
@@ -45,7 +46,7 @@ echo "Running GCS Object media integration tests."
 ./object_media_integration_test "${PROJECT_ID}" "${BUCKET_NAME}"
 
 echo
-echo "Running GCS Projects.serviceAccount integration tests."
+echo "Running GCS multi-threaded integration test."
 ./thread_integration_test "${PROJECT_ID}" "${STORAGE_REGION_ID}"
 
 echo


### PR DESCRIPTION
Some of the integration tests for bucket operations were flaky, they
were all operating on the same bucket, so if another integration build
was running at the same time they would not work. This fixes those tests
by creating a bucket (with a random name) for each relevant test.

I also removed a number of pre-conditions in the examples (IfMatchEtag)
that have no effect.

This fixes #1370.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1563)
<!-- Reviewable:end -->
