### PR TITLE
Add option to force resumable uploads.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -355,7 +355,6 @@ set(storage_client_unit_tests
     storage_class_test.cc
     storage_client_options_test.cc
     storage_version_test.cc
-    upload_options.h
     well_known_headers_test.cc)
 
 foreach (fname ${storage_client_unit_tests})

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -224,6 +224,7 @@ add_library(storage_client
             service_account.cc
             status.h
             storage_class.h
+            upload_options.h
             version.h
             version.cc
             well_known_headers.h
@@ -354,6 +355,7 @@ set(storage_client_unit_tests
     storage_class_test.cc
     storage_client_options_test.cc
     storage_version_test.cc
+    upload_options.h
     well_known_headers_test.cc)
 
 foreach (fname ${storage_client_unit_tests})

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/internal/generic_object_request.h"
 #include "google/cloud/storage/internal/http_response.h"
 #include "google/cloud/storage/object_metadata.h"
+#include "google/cloud/storage/upload_options.h"
 #include "google/cloud/storage/well_known_parameters.h"
 
 namespace google {
@@ -368,8 +369,8 @@ class ResumableUploadRequest
           Crc32cChecksumValue, DisableCrc32cChecksum, DisableMD5Hash,
           EncryptionKey, IfGenerationMatch, IfGenerationNotMatch,
           IfMetagenerationMatch, IfMetagenerationNotMatch, KmsKeyName,
-          MD5HashValue, PredefinedAcl, Projection, UserProject,
-          WithObjectMetadata> {
+          MD5HashValue, PredefinedAcl, Projection, UseResumableUploadSession,
+          UserProject, WithObjectMetadata> {
  public:
   ResumableUploadRequest() = default;
 

--- a/google/cloud/storage/storage_client.bzl
+++ b/google/cloud/storage/storage_client.bzl
@@ -71,6 +71,7 @@ storage_client_HDRS = [
     "service_account.h",
     "status.h",
     "storage_class.h",
+    "upload_options.h",
     "version.h",
     "well_known_headers.h",
     "well_known_parameters.h",

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -57,5 +57,6 @@ storage_client_unit_tests = [
     "storage_class_test.cc",
     "storage_client_options_test.cc",
     "storage_version_test.cc",
+    "upload_options.h",
     "well_known_headers_test.cc",
 ]

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -57,6 +57,5 @@ storage_client_unit_tests = [
     "storage_class_test.cc",
     "storage_client_options_test.cc",
     "storage_version_test.cc",
-    "upload_options.h",
     "well_known_headers_test.cc",
 ]

--- a/google/cloud/storage/upload_options.h
+++ b/google/cloud/storage/upload_options.h
@@ -1,0 +1,46 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_UPLOAD_OPTIONS_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_UPLOAD_OPTIONS_H_
+
+#include "google/cloud/storage/internal/complex_option.h"
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+/**
+ * Request a resumable upload, restoring a previous session if necessary.
+ *
+ * When this option is used the client library prefers using resumable uploads.
+ *
+ * If the value passed to this option is the empty string, then the library will
+ * create a new resumable session. Otherwise the value should be the id of a
+ * previous upload sesion, the client library will restore that session in
+ * this case.
+ */
+struct UseResumableUploadSession
+    : public internal::ComplexOption<UseResumableUploadSession, std::string> {
+  using ComplexOption<UseResumableUploadSession, std::string>::ComplexOption;
+  static char const* name() { return "resumable-upload"; }
+};
+
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_UPLOAD_OPTIONS_H_

--- a/google/cloud/storage/upload_options.h
+++ b/google/cloud/storage/upload_options.h
@@ -39,13 +39,13 @@ struct UseResumableUploadSession
 };
 
 /// Create a UseResumableUploadSession option that restores previous sessions.
-UseResumableUploadSession RestoreResumableUploadSession(
+inline UseResumableUploadSession RestoreResumableUploadSession(
     std::string session_id) {
   return UseResumableUploadSession(std::move(session_id));
 }
 
 /// Create a UseResumableUploadSession option that requests new sessions.
-UseResumableUploadSession NewResumableUploadSession() {
+inline UseResumableUploadSession NewResumableUploadSession() {
   return UseResumableUploadSession("");
 }
 

--- a/google/cloud/storage/upload_options.h
+++ b/google/cloud/storage/upload_options.h
@@ -38,6 +38,17 @@ struct UseResumableUploadSession
   static char const* name() { return "resumable-upload"; }
 };
 
+/// Create a UseResumableUploadSession option that restores previous sessions.
+UseResumableUploadSession RestoreResumableUploadSession(
+    std::string session_id) {
+  return UseResumableUploadSession(std::move(session_id));
+}
+
+/// Create a UseResumableUploadSession option that requests new sessions.
+UseResumableUploadSession NewResumableUploadSession() {
+  return UseResumableUploadSession("");
+}
+
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud


### PR DESCRIPTION
The library automatically selects resumable uploads when it can
determine that this is the best upload strategy. But sometimes the
application simply knows that a resumable upload is necessary, in this
case the application developer should be able to force a resumable
upload. In addition, setting this option to a non-empty string will be
used to restore a previously created resumable upload.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1566)
<!-- Reviewable:end -->
