### PR TITLE
Make ccache bigger for coverage builds.

### DIFF
--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -151,7 +151,7 @@ if [ "${TEST_INSTALL:-}" = "yes" -o "${SCAN_BUILD:-}" = "yes" ]; then
   (cd /var/tmp/build-dependencies; install_c_ares)
   (cd /var/tmp/build-dependencies; install_grpc)
   (cd /var/tmp/build-dependencies; install_googletest)
-  ${ccache_command} --show-stats
+  "${ccache_command}" --show-stats
   echo
   echo "${COLOR_YELLOW}Finished dependency install at: $(date)${COLOR_RESET}"
   echo
@@ -208,12 +208,12 @@ echo "${COLOR_YELLOW}Finished build at: $(date)${COLOR_RESET}"
 if [ -n "${ccache_command}" ]; then
   echo
   echo "${COLOR_YELLOW}Print and clearing ccache stats: $(date)${COLOR_RESET}"
-  ${ccache_command} --show-stats
-  max_size="1GiB"
+  "${ccache_command}" --show-stats
+  max_size="1Gi"
   if [ "${BUILD_TYPE}" = "Coverage" ]; then
-    max_size="2.5GiB"
+    max_size="2.5Gi"
   fi
-  ${ccache_command} --zero-stats --cleanup --max-size="${max_size}"
+  "${ccache_command}" --zero-stats --cleanup --max-size="${max_size}"
 fi
 
 # Run the tests and output any failures.

--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -209,7 +209,11 @@ if [ -n "${ccache_command}" ]; then
   echo
   echo "${COLOR_YELLOW}Print and clearing ccache stats: $(date)${COLOR_RESET}"
   ${ccache_command} --show-stats
-  ${ccache_command} --zero-stats --cleanup --max-size=2.5Gi
+  max_size="1GiB"
+  if [ "${BUILD_TYPE}" = "Coverage" ]; then
+    max_size="2.5GiB"
+  fi
+  ${ccache_command} --zero-stats --cleanup --max-size="${max_size}"
 fi
 
 # Run the tests and output any failures.

--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -209,7 +209,7 @@ if [ -n "${ccache_command}" ]; then
   echo
   echo "${COLOR_YELLOW}Print and clearing ccache stats: $(date)${COLOR_RESET}"
   ${ccache_command} --show-stats
-  ${ccache_command} --zero-stats --cleanup --max-size=1Gi
+  ${ccache_command} --zero-stats --cleanup --max-size=2.5Gi
 fi
 
 # Run the tests and output any failures.


### PR DESCRIPTION
We need a bigger cache for the code coverage build. While most builds
take 500MiB, the code coverage build takes nearly 1.5GiB. This will slow
down all the builds by a few seconds, but speed up the coverage build
(the longest pole in the builds right now) from about 37 to about 30
minutes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1567)
<!-- Reviewable:end -->
