### PR TITLE
Implement CurlClient function to resume uploads.

### DIFF
--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -687,6 +687,20 @@ CurlClient::CreateResumableSession(ResumableUploadRequest const& request) {
   return std::make_pair(Status(), std::move(session));
 }
 
+std::pair<Status, std::unique_ptr<ResumableUploadSession>>
+CurlClient::RestoreResumableSession(std::string const& session_id) {
+  auto session =
+      google::cloud::internal::make_unique<CurlResumableUploadSession>(
+          shared_from_this(), session_id);
+  auto response = session->ResetSession();
+  if (response.first.status_code() == 308 or
+      response.first.status_code() < 300) {
+    return std::make_pair(Status(), std::move(session));
+  }
+  return std::make_pair(std::move(response.first),
+                        std::unique_ptr<ResumableUploadSession>());
+}
+
 std::pair<Status, ListBucketAclResponse> CurlClient::ListBucketAcl(
     ListBucketAclRequest const& request) {
   CurlRequestBuilder builder(

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -109,6 +109,8 @@ class CurlClient : public RawClient,
       ComposeObjectRequest const& request) override;
   std::pair<Status, std::unique_ptr<ResumableUploadSession>>
   CreateResumableSession(ResumableUploadRequest const& request) override;
+  std::pair<Status, std::unique_ptr<ResumableUploadSession>>
+  RestoreResumableSession(std::string const& session_id);
 
   std::pair<Status, ListBucketAclResponse> ListBucketAcl(
       ListBucketAclRequest const& request) override;

--- a/google/cloud/storage/internal/curl_resumable_upload_session.h
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.h
@@ -39,7 +39,7 @@ class CurlResumableUploadSession : public ResumableUploadSession {
 
   std::uint64_t next_expected_byte() const override;
 
-  std::string const& session_id() const { return session_id_; }
+  std::string const& session_id() const override { return session_id_; }
 
  private:
   void Update(std::pair<Status, ResumableUploadResponse> const& result);

--- a/google/cloud/storage/internal/logging_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session.cc
@@ -48,6 +48,13 @@ std::uint64_t LoggingResumableUploadSession::next_expected_byte() const {
   return response;
 }
 
+std::string const& LoggingResumableUploadSession::session_id() const {
+  GCP_LOG(INFO) << __func__ << " << ()";
+  auto const& response = session_->session_id();
+  GCP_LOG(INFO) << __func__ << " >> " << response;
+  return response;
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/logging_resumable_upload_session.h
+++ b/google/cloud/storage/internal/logging_resumable_upload_session.h
@@ -35,6 +35,7 @@ class LoggingResumableUploadSession : public ResumableUploadSession {
       std::string const& buffer, std::uint64_t upload_size) override;
   std::pair<Status, ResumableUploadResponse> ResetSession() override;
   std::uint64_t next_expected_byte() const override;
+  std::string const& session_id() const override;
 
  private:
   std::unique_ptr<ResumableUploadSession> session_;

--- a/google/cloud/storage/internal/resumable_upload_session.h
+++ b/google/cloud/storage/internal/resumable_upload_session.h
@@ -52,6 +52,13 @@ class ResumableUploadSession {
    * using this class) needs to re-send a chunk.
    */
   virtual std::uint64_t next_expected_byte() const = 0;
+
+  /**
+   * Returns the current upload session id.
+   *
+   * Note that the session id might change during an upload.
+   */
+  virtual std::string const& session_id() const = 0;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/retry_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.cc
@@ -90,6 +90,10 @@ RetryResumableUploadSession::ResetSession() {
 std::uint64_t RetryResumableUploadSession::next_expected_byte() const {
   return session_->next_expected_byte();
 }
+
+std::string const& RetryResumableUploadSession::session_id() const {
+  return session_->session_id();
+}
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/retry_resumable_upload_session.h
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.h
@@ -43,6 +43,7 @@ class RetryResumableUploadSession : public ResumableUploadSession {
       std::string const& buffer, std::uint64_t upload_size) override;
   std::pair<Status, ResumableUploadResponse> ResetSession() override;
   std::uint64_t next_expected_byte() const override;
+  std::string const& session_id() const override;
 
  private:
   std::unique_ptr<ResumableUploadSession> session_;

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -165,6 +165,7 @@ class MockResumableUploadSession
                                          std::uint64_t upload_size));
   MOCK_METHOD0(ResetSession, ResponseType());
   MOCK_CONST_METHOD0(next_expected_byte, std::uint64_t());
+  MOCK_CONST_METHOD0(session_id, std::string const&());
 };
 }  // namespace testing
 }  // namespace storage


### PR DESCRIPTION
To fully support resumable uploads we need to be able to, well, resume
an upload. This PR adds functions to restore a resumable upload session
based on the session id. Once created the function queries GCS to
discover what is the latest received byte. In future PRs we will use
this to continue an upload after restoring the session.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1571)
<!-- Reviewable:end -->
