### PR TITLE
Add Crypt32.lib to static builds on Windows.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -240,7 +240,7 @@ target_link_libraries(storage_client
                              ZLIB::ZLIB
                       PRIVATE storage_common_options)
 if (WIN32)
-    target_link_libraries(storage_client PUBLIC wsock32 ws2_32)
+    target_link_libraries(storage_client PUBLIC crypt32 wsock32 ws2_32)
 endif ()
 target_include_directories(storage_client
                            PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>


### PR DESCRIPTION
The latest vcpkg updates added `Crypt32.lib` as a dependency to libcurl.
It should be harmless to add this for older versions, so we simply add
it always. This fixes the broken builds on Windows.

The problem is already reported to vcpkg (Microsoft/vcpkg#4312).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1574)
<!-- Reviewable:end -->
