### PR TITLE
Add functions to support signed URLs.

### DIFF
--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -44,6 +44,13 @@ class FailingCredentials : public Credentials {
   std::pair<Status, std::string> AuthorizationHeader() override {
     return std::make_pair(Status(STATUS_ERROR_CODE, STATUS_ERROR_MSG), "");
   }
+  std::pair<google::cloud::storage::Status, std::string> SignBlob(
+      std::string const& blob) const override {
+    return std::make_pair(Status(), std::string());
+  }
+
+  /// Return the client id of these credentials.
+  std::string client_id() const override { return std::string(); }
 };
 
 class CurlClientTest : public ::testing::Test {
@@ -185,8 +192,8 @@ TEST_F(CurlClientTest, PatchObject) {
 }
 
 TEST_F(CurlClientTest, ComposeObject) {
-  auto status_and_foo = client_->ComposeObject(
-      ComposeObjectRequest("bkt", {}, "obj"));
+  auto status_and_foo =
+      client_->ComposeObject(ComposeObjectRequest("bkt", {}, "obj"));
   TestCorrectFailureStatus(status_and_foo.first);
 }
 
@@ -196,8 +203,8 @@ TEST_F(CurlClientTest, ListBucketAcl) {
 }
 
 TEST_F(CurlClientTest, CopyObject) {
-  auto status_and_foo = client_->CopyObject(
-      CopyObjectRequest("bkt", "obj1", "bkt", "obj2"));
+  auto status_and_foo =
+      client_->CopyObject(CopyObjectRequest("bkt", "obj1", "bkt", "obj2"));
   TestCorrectFailureStatus(status_and_foo.first);
 }
 
@@ -268,8 +275,8 @@ TEST_F(CurlClientTest, PatchObjectAcl) {
 }
 
 TEST_F(CurlClientTest, RewriteObject) {
-  auto status_and_foo = client_->RewriteObject(RewriteObjectRequest(
-      "bkt", "obj", "bkt2", "obj2", "token"));
+  auto status_and_foo = client_->RewriteObject(
+      RewriteObjectRequest("bkt", "obj", "bkt2", "obj2", "token"));
   TestCorrectFailureStatus(status_and_foo.first);
 }
 

--- a/google/cloud/storage/oauth2/anonymous_credentials.cc
+++ b/google/cloud/storage/oauth2/anonymous_credentials.cc
@@ -25,6 +25,15 @@ AnonymousCredentials::AuthorizationHeader() {
   return std::make_pair(google::cloud::storage::Status(), "");
 }
 
+std::pair<google::cloud::storage::Status, std::string>
+AnonymousCredentials::SignBlob(std::string const& blob) const {
+  return std::make_pair(google::cloud::storage::Status(
+                            600, "AnonymousCredentials cannot sign blobs"),
+                        "");
+}
+
+std::string AnonymousCredentials::client_id() const { return std::string(); }
+
 }  // namespace oauth2
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/oauth2/anonymous_credentials.h
+++ b/google/cloud/storage/oauth2/anonymous_credentials.h
@@ -37,6 +37,11 @@ class AnonymousCredentials : public Credentials {
 
   std::pair<google::cloud::storage::Status, std::string> AuthorizationHeader()
       override;
+
+  std::pair<google::cloud::storage::Status, std::string> SignBlob(
+      std::string const& blob) const override;
+
+  std::string client_id() const override;
 };
 
 }  // namespace oauth2

--- a/google/cloud/storage/oauth2/authorized_user_credentials.h
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.h
@@ -101,6 +101,16 @@ class AuthorizedUserCredentials : public Credentials {
         status, status.ok() ? authorization_header_ : std::string(""));
   }
 
+  std::pair<google::cloud::storage::Status, std::string> SignBlob(
+      std::string const& blob) const override {
+    return std::make_pair(
+        google::cloud::storage::Status(
+            600, "AuthorizedUserCredentials cannot sign blobs"),
+        "");
+  }
+
+  std::string client_id() const override { return std::string(); }
+
  private:
   bool IsExpired() {
     auto now = std::chrono::system_clock::now();

--- a/google/cloud/storage/oauth2/compute_engine_credentials.h
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.h
@@ -70,6 +70,19 @@ class ComputeEngineCredentials : public Credentials {
         status, status.ok() ? authorization_header_ : std::string(""));
   }
 
+  std::pair<google::cloud::storage::Status, std::string> SignBlob(
+      std::string const& blob) const override {
+    return std::make_pair(
+        google::cloud::storage::Status(
+            600, "ComputeEngineCredentials cannot sign blobs"),
+        "");
+  }
+
+  std::string client_id() const override {
+    std::unique_lock<std::mutex> lock(mu_);
+    return service_account_email_;
+  }
+
   /**
    * Returns the email or alias of this credential's service account.
    *
@@ -188,7 +201,7 @@ class ComputeEngineCredentials : public Credentials {
     return storage::Status();
   }
 
-  std::mutex mu_;
+  mutable std::mutex mu_;
   std::condition_variable cv_;
   // Credential attributes
   std::string authorization_header_;

--- a/google/cloud/storage/oauth2/credentials.h
+++ b/google/cloud/storage/oauth2/credentials.h
@@ -41,6 +41,22 @@ class Credentials {
    */
   virtual std::pair<google::cloud::storage::Status, std::string>
   AuthorizationHeader() = 0;
+
+  /**
+   * Sign a blob using the credentials.
+   *
+   * Create a RSA SHA256 signature of the blob using the Credential object. If
+   * the credentials do not support signing blobs it returns an error status.
+   *
+   * @param blob the bytes to sign.
+   * @return a Base64-encoded RSA SHA256 digest of @p blob using the current
+   *   credentials.
+   */
+  virtual std::pair<google::cloud::storage::Status, std::string> SignBlob(
+      std::string const& blob) const = 0;
+
+  /// Return the client id of these credentials.
+  virtual std::string client_id() const = 0;
 };
 
 }  // namespace oauth2


### PR DESCRIPTION
With this change the ServiceAccountCredentials class is able to sign a
blob. The other credential types return an error. In a future PR we will
create signed URLs by providing the right blobs to this function.