### PR TITLE
Fix definition of IsIdempotent for DeleteObject.

### DIFF
--- a/google/cloud/storage/idempotency_policy.cc
+++ b/google/cloud/storage/idempotency_policy.cc
@@ -314,19 +314,20 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::DeleteObjectRequest const& request) const {
-  return request.HasOption<IfGenerationMatch>();
+  return request.HasOption<Generation>() or
+         request.HasOption<IfGenerationMatch>();
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::UpdateObjectRequest const& request) const {
-  return (request.HasOption<IfMatchEtag>() or
-      request.HasOption<IfMetagenerationMatch>());
+  return request.HasOption<IfMatchEtag>() or
+         request.HasOption<IfMetagenerationMatch>();
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::PatchObjectRequest const& request) const {
-  return (request.HasOption<IfMatchEtag>() or
-      request.HasOption<IfMetagenerationMatch>());
+  return request.HasOption<IfMatchEtag>() or
+         request.HasOption<IfMetagenerationMatch>();
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(

--- a/google/cloud/storage/idempotency_policy_test.cc
+++ b/google/cloud/storage/idempotency_policy_test.cc
@@ -207,7 +207,14 @@ TEST(StrictIdempotencyPolicyTest, DeleteObject) {
 TEST(StrictIdempotencyPolicyTest, DeleteObjectIfGenerationMatch) {
   StrictIdempotencyPolicy policy;
   internal::DeleteObjectRequest request("test-bucket-name", "test-object-name");
-  request.set_option(IfGenerationMatch(0));
+  request.set_option(IfGenerationMatch(7));
+  EXPECT_TRUE(policy.IsIdempotent(request));
+}
+
+TEST(StrictIdempotencyPolicyTest, DeleteObjectGeneration) {
+  StrictIdempotencyPolicy policy;
+  internal::DeleteObjectRequest request("test-bucket-name", "test-object-name");
+  request.set_option(Generation(7));
   EXPECT_TRUE(policy.IsIdempotent(request));
 }
 


### PR DESCRIPTION
This was the only operation where setting the Generation() parameter
turned the operation into an idempotent op.  This fixes #1581.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1584)
<!-- Reviewable:end -->
