### PR TITLE
Improve documentation for all operations.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -131,7 +131,11 @@ class Client {
    *     Valid types for this operation include `MaxResults`, `Prefix`,
    *     `UserProject`, and `Projection`.
    *
-   * @throw std::runtime_error if the operation fails.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Being a read-only operation this is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc list buckets for project
@@ -158,7 +162,12 @@ class Client {
    *
    * @throw std::logic_error if the function is called without a default
    *     project id set.
-   * @throw std::runtime_error if the operation fails.
+   *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Being a read-only operation this is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc list buckets
@@ -184,7 +193,11 @@ class Client {
    *     Valid types for this operation include `PredefinedAcl`,
    *     `PredefinedDefaultObjectAcl`, `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if the operation fails.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * This operation is always idempotent, it fails if the bucket already exists.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc create bucket
@@ -214,7 +227,11 @@ class Client {
    *     Valid types for this operation include `PredefinedAcl`,
    *     `PredefinedDefaultObjectAcl`, `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if the operation fails.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * This operation is always idempotent, it fails if the bucket already exists.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc create bucket for project
@@ -239,8 +256,11 @@ class Client {
    *     Valid types for this operation include `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, `UserProject`, and `Projection`.
    *
-   * @throw std::runtime_error if the metadata cannot be fetched using the
-   * current policies.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Being a read-only operation this is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc get bucket metadata
@@ -261,8 +281,13 @@ class Client {
    *     Valid types for this operation include `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, and `UserProject`.
    *
-   * @throw std::runtime_error if the metadata cannot be fetched using the
-   * current policies.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions, in this case,
+   * `IfMetagenerationMatch`.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc delete bucket
@@ -285,7 +310,16 @@ class Client {
    *     `IfMetagenerationNotMatch`, `PredefinedAcl`,
    *     `PredefinedDefaultObjectAcl`, `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if the operation fails.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions, in this case,
+   * `IfMetagenerationMatch`.
+   *
+   * @par Idempotency
+   * Being a read-only operation this is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc update bucket
@@ -315,8 +349,13 @@ class Client {
    *     Valid types for this operation include `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if the metadata cannot be fetched using the
-   * current policies.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions, in this case,
+   * `IfMetagenerationMatch`.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc patch bucket storage class
@@ -343,8 +382,13 @@ class Client {
    *     Valid types for this operation include `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if the metadata cannot be fetched using the
-   * current policies.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions, in this case,
+   * `IfMetagenerationMatch`.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc patch bucket storage class with builder
@@ -381,7 +425,11 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if the operation fails.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Being a read-only operation this is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_iam_samples.cc get bucket iam policy
@@ -427,12 +475,18 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if the operation fails.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
    *
-   * @par Examples
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions, in this case,
+   * `IfMetagenerationMatch`.
    *
+   * @par Example: adding a new member
    * @snippet storage_bucket_iam_samples.cc add bucket iam member
    *
+   * @par Example: removing a IAM member
    * @snippet storage_bucket_iam_samples.cc remove bucket iam member
    */
   template <typename... Options>
@@ -465,7 +519,11 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if the operation fails.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Being a read-only operation this is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_iam_samples.cc test bucket iam permissions
@@ -510,16 +568,23 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if the operation fails.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
    *
-   * @par Examples
+   * @par Idempotency
+   * This operation is always idempotent because the `metageneration` parameter
+   * is always required, and it acts as a pre-condition on the operation.
    *
+   * @par Example: lock the retention policy
    * @snippet storage_bucket_samples.cc lock retention policy
    *
+   * @par Example: get the current retention policy
    * @snippet storage_bucket_samples.cc get retention policy
    *
+   * @par Example: set the current retention policy
    * @snippet storage_bucket_samples.cc set retention policy
    *
+   * @par Example: remove the retention policy
    * @snippet storage_bucket_samples.cc remove retention policy
    */
   template <typename... Options>
@@ -561,8 +626,13 @@ class Client {
    *     `IfMetagenerationNotMatch`, `KmsKeyName`, `MD5HashValue`,
    *     `PredefinedAcl`, `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if the operation cannot be completed using the
-   *   current policies.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions, in this case,
+   * `IfGenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_samples.cc insert object
@@ -607,13 +677,18 @@ class Client {
    *     `Projection`, `SourceGeneration`, `UserProject`, and
    *     `WithObjectMetadata`.
    *
-   * @throw std::runtime_error if the operation cannot be completed using the
-   *   current policies.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
    *
-   * @par Examples
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions, in this case,
+   * `IfGenerationMatch`.
    *
+   * @par Example
    * @snippet storage_object_samples.cc copy object
    *
+   * @par Example: copy an encrypted object
    * @snippet storage_object_samples.cc copy encrypted object
    */
   template <typename... Options>
@@ -640,8 +715,11 @@ class Client {
    *     `IfMetagenerationNotMatch`, `Projection`, and `UserProject`.
    *
    *
-   * @throw std::runtime_error if the metadata cannot be fetched using the
-   * current policies.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Being a read-only operation this is always idempotent.
    *
    * @par Example
    * @snippet storage_object_samples.cc get object metadata
@@ -664,8 +742,11 @@ class Client {
    *     `IfMetagenerationMatch`, `IfMetagenerationNotMatch`, `UserProject`,
    *     `Projection`, `Prefix`, and `Versions`.
    *
-   * @throw std::runtime_error if the operation cannot be completed using the
-   *   current policies.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Being a read-only operation this is always idempotent.
    *
    * @par Example
    * @snippet storage_object_samples.cc list objects
@@ -688,10 +769,16 @@ class Client {
    *     `IfGenerationMatch`, `IfGenerationNotMatch`, `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, and `UserProject`.
    *
-   * @par Examples
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
    *
+   * @par Idempotency
+   * Being a read-only operation this is always idempotent.
+   *
+   * @par Example
    * @snippet storage_object_samples.cc read object
    *
+   * @par Example: read a object encrypted with a CSEK.
    * @snippet storage_object_samples.cc read encrypted object
    */
   template <typename... Options>
@@ -715,10 +802,18 @@ class Client {
    *   `IfMetagenerationMatch`, `IfMetagenerationNotMatch`, `KmsKeyName`,
    *   `MD5HashValue`, `PredefinedAcl`, `Projection`, and `UserProject`.
    *
-   * @par Examples
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
    *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions, in this case,
+   * `IfGenerationMatch`.
+   *
+   * @par Example
    * @snippet storage_object_samples.cc write object
    *
+   * @par Example: write an object with a CMEK.
    * @snippet storage_object_samples.cc write object with kms key
    */
   template <typename... Options>
@@ -749,6 +844,14 @@ class Client {
    *   `IfMetagenerationMatch`, `IfMetagenerationNotMatch`, `KmsKeyName`,
    *   `MD5HashValue`, `PredefinedAcl`, `Projection`, `UserProject`, and
    *   `WithObjectMetadata`.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions, in this case,
+   * `IfGenerationMatch`.
+   *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
    *
    * @par Example
    * @snippet storage_object_samples.cc upload file
@@ -781,6 +884,12 @@ class Client {
    *   `IfGenerationNotMatch`, `IfMetagenerationMatch`,
    *   `IfMetagenerationNotMatch`, `Generation`, and `UserProject`.
    *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Being a read-only operation this is always idempotent.
+   *
    * @par Example
    * @snippet storage_object_samples.cc download file
    */
@@ -790,7 +899,7 @@ class Client {
                       std::string const& file_name, Options&&... options) {
     internal::ReadObjectRangeRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    DownloadFileImpl(std::move(request), file_name);
+    DownloadFileImpl(request, file_name);
   }
 
   /**
@@ -802,6 +911,9 @@ class Client {
    *     Valid types for this operation include `Generation`,
    *     `IfGenerationMatch`, `IfGenerationNotMatch`, `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, and `UserProject`.
+   *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
    *
    * @par Example
    * @snippet storage_object_samples.cc delete object
@@ -829,7 +941,13 @@ class Client {
    *     `IfMetagenerationNotMatch`, `PredefinedAcl`,
    *     `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if the operation fails.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions, in this case,
+   * `IfMetagenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_samples.cc update object metadata
@@ -838,7 +956,7 @@ class Client {
   ObjectMetadata UpdateObject(std::string bucket_name, std::string object_name,
                               ObjectMetadata metadata, Options&&... options) {
     internal::UpdateObjectRequest request(
-        std::move(bucket_name), std::string(object_name), std::move(metadata));
+        std::move(bucket_name), std::move(object_name), std::move(metadata));
     request.set_multiple_options(std::forward<Options>(options)...);
     return raw_client_->UpdateObject(request).second;
   }
@@ -862,8 +980,13 @@ class Client {
    *     `IfMetagenerationNotMatch`, `PredefinedAcl`,
    *     `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if the metadata cannot be fetched using the
-   * current policies.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions, in this case,
+   * `IfMetagenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_samples.cc patch object delete metadata
@@ -896,8 +1019,13 @@ class Client {
    *     `IfMetagenerationNotMatch`, `PredefinedAcl`,
    *     `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if the metadata cannot be fetched using the
-   * current policies.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions, in this case,
+   * `IfMetagenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_samples.cc patch object content type
@@ -925,12 +1053,18 @@ class Client {
    *      `IfGenerationMatch`, `IfMetagenerationMatch`, `KmsKeyName`,
    *      `UserProject`, and `WithObjectMetadata`.
    *
-   * @throw std::runtime_error if the operation fails.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions, in this case,
+   * `IfGenerationMatch`.
    *
    * @par Example
-   *
    * @snippet storage_object_samples.cc compose object
    *
+   * @par Example: using encrypted objects with CSEK
    * @snippet storage_object_samples.cc compose object from encrypted objects
    */
   template <typename... Options>
@@ -966,10 +1100,16 @@ class Client {
    *      `IfGenerationNotMatch`, `IfMetagenerationMatch`,
    *      `IfSourceGenerationMatch`, `IfSourceGenerationNotMatch`,
    *      `IfSourceMetagenerationMatch`, `IfSourceMetagenerationNotMatch`,
-   *      `MaxBytesRewrittenPerCall`, `Projection`, `SourceEncryptionKey,
+   *      `MaxBytesRewrittenPerCall`, `Projection`, `SourceEncryptionKey`,
    *      `SourceGeneration`, `UserProject`, and `WithObjectMetadata`.
    *
-   * @throw std::runtime_error if the operation fails.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions, in this case,
+   * `IfGenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_samples.cc rewrite object non blocking
@@ -1012,10 +1152,16 @@ class Client {
    *      `IfGenerationNotMatch`, `IfMetagenerationMatch`,
    *      `IfSourceGenerationMatch`, `IfSourceGenerationNotMatch`,
    *      `IfSourceMetagenerationMatch`, `IfSourceMetagenerationNotMatch`,
-   *      `MaxBytesRewrittenPerCall`, `Projection`, `SourceEncryptionKey,
+   *      `MaxBytesRewrittenPerCall`, `Projection`, `SourceEncryptionKey`,
    *      `SourceGeneration`, `UserProject`, and `WithObjectMetadata`.
    *
-   * @throw std::runtime_error if the operation fails.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions, in this case,
+   * `IfGenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_samples.cc rewrite object resume
@@ -1060,17 +1206,24 @@ class Client {
    *      `IfGenerationNotMatch`, `IfMetagenerationMatch`,
    *      `IfSourceGenerationMatch`, `IfSourceGenerationNotMatch`,
    *      `IfSourceMetagenerationMatch`, `IfSourceMetagenerationNotMatch`,
-   *      `MaxBytesRewrittenPerCall`, `Projection`, `SourceEncryptionKey,
+   *      `MaxBytesRewrittenPerCall`, `Projection`, `SourceEncryptionKey`,
    *      `SourceGeneration`, `UserProject`, and `WithObjectMetadata`.
    *
-   * @throw std::runtime_error if the operation fails.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
    *
-   * @par Examples
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions, in this case,
+   * `IfGenerationMatch`.
    *
+   * @par Example
    * @snippet storage_object_samples.cc rewrite object
    *
+   * @par Example: using rewrite object to rotate the encryption key
    * @snippet storage_object_samples.cc rotate encryption key
    *
+   * @par Example: using rewrite object to rename an object
    * @snippet storage_object_samples.cc rename object
    *
    */
@@ -1123,6 +1276,12 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Being a read-only operation this is always idempotent.
+   *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc list bucket acl
    */
@@ -1142,6 +1301,14 @@ class Client {
    * @param role the role of the entity.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
+   *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions. There are no pre-conditions for
+   * this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc create bucket acl
@@ -1164,6 +1331,14 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions. There are no pre-conditions for
+   * this operation that can make it idempotent.
+   *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc delete bucket acl
    */
@@ -1182,6 +1357,12 @@ class Client {
    * @param entity the name of the entity to query.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
+   *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Being a read-only operation this is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc get bucket acl
@@ -1203,6 +1384,14 @@ class Client {
    *   will be modified by the server.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
+   *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions. There are no pre-conditions for
+   * this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc update bucket acl
@@ -1243,6 +1432,14 @@ class Client {
    *     Valid types for this operation include `UserProject`, and the standard
    *     options available to all operations.
    *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions. There are no pre-conditions for
+   * this operation that can make it idempotent.
+   *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc patch bucket acl
    *
@@ -1282,6 +1479,14 @@ class Client {
    * @param options a list of optional query parameters and/or request
    *     headers. Valid types for this operation include `Generation`,
    *     `UserProject`, `IfMatchEtag`, and `IfNoneMatchEtag`.
+   *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions. There are no pre-conditions for
+   * this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc patch bucket acl no-read
@@ -1327,6 +1532,12 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `Generation`, and `UserProject`.
    *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Being a read-only operation this is always idempotent.
+   *
    * @par Example
    * @snippet storage_object_acl_samples.cc list object acl
    */
@@ -1348,6 +1559,14 @@ class Client {
    * @param role the role of the entity.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `Generation`, and `UserProject`.
+   *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions. There are no pre-conditions for
+   * this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_object_acl_samples.cc create object acl
@@ -1374,6 +1593,14 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `Generation`, and `UserProject`.
    *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions. There are no pre-conditions for
+   * this operation that can make it idempotent.
+   *
    * @par Example
    * @snippet storage_object_acl_samples.cc delete object acl
    */
@@ -1394,6 +1621,12 @@ class Client {
    * @param entity the name of the entity added to the ACL.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `Generation`, and `UserProject`.
+   *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Being a read-only operation this is always idempotent.
    *
    * @par Example
    * @snippet storage_object_acl_samples.cc get object acl
@@ -1417,6 +1650,14 @@ class Client {
    *   will be modified by the server.
    * @param options a list of optional query parameters and/or request
    *     Valid types for this operation include `Generation`, and `UserProject`.
+   *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions. There are no pre-conditions for
+   * this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_object_acl_samples.cc update object acl
@@ -1459,6 +1700,14 @@ class Client {
    *     headers. Valid types for this operation include `Generation`,
    *     `UserProject`, `IfMatchEtag`, and `IfNoneMatchEtag`.
    *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions. There are no pre-conditions for
+   * this operation that can make it idempotent.
+   *
    * @par Example
    * @snippet storage_object_acl_samples.cc patch object acl
    *
@@ -1500,6 +1749,14 @@ class Client {
    *     headers. Valid types for this operation include `Generation`,
    *     `UserProject`, `IfMatchEtag`, and `IfNoneMatchEtag`.
    *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions. There are no pre-conditions for
+   * this operation that can make it idempotent.
+   *
    * @par Example
    * @snippet storage_object_acl_samples.cc patch object acl no-read
    *
@@ -1540,6 +1797,12 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Being a read-only operation this is always idempotent.
+   *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc list default object acl
    *
@@ -1565,6 +1828,14 @@ class Client {
    * @param role the role of the entity.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
+   *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions. There are no pre-conditions for
+   * this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc create default object acl
@@ -1593,6 +1864,14 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions. There are no pre-conditions for
+   * this operation that can make it idempotent.
+   *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc delete default object acl
    *
@@ -1617,6 +1896,12 @@ class Client {
    * @param entity the name of the entity.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
+   *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Being a read-only operation this is always idempotent.
    *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc get default object acl
@@ -1644,6 +1929,14 @@ class Client {
    *   will be modified by the server.
    * @param options a list of optional query parameters and/or request
    *     Valid types for this operation include `UserProject`.
+   *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions. There are no pre-conditions for
+   * this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc update default object acl
@@ -1685,6 +1978,14 @@ class Client {
    *     as the standard parameters, such as `IfMatchEtag`, and
    *     `IfNoneMatchEtag`.
    *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions. There are no pre-conditions for
+   * this operation that can make it idempotent.
+   *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc patch default object acl
    *
@@ -1723,6 +2024,14 @@ class Client {
    *     headers. Valid types for this operation include `UserProject`, as well
    *     as the standard parameters, such as `IfMatchEtag`, and
    *     `IfNoneMatchEtag`.
+   *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions. There are no pre-conditions for
+   * this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc patch default object acl
@@ -1766,7 +2075,11 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if the operation fails.
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Being a read-only operation this is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc get service account for project
@@ -1801,7 +2114,12 @@ class Client {
    *
    * @throw std::logic_error if the function is called without a default
    *     project id set.
-   * @throw std::runtime_error if the operation fails.
+   *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Being a read-only operation this is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc get service account
@@ -1843,6 +2161,12 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Being a read-only operation this is always idempotent.
+   *
    * @par Example
    * @snippet storage_notification_samples.cc list notifications
    */
@@ -1873,6 +2197,14 @@ class Client {
    *     as the list of event types, or any custom attributes.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
+   *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Like other operations that mutate the state of GCS, this operation is only
+   * idempotent if restricted by pre-conditions. There are no pre-conditions for
+   * this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_notification_samples.cc create notification
@@ -1908,6 +2240,12 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * Being a read-only operation this is always idempotent.
+   *
    * @par Example
    * @snippet storage_notification_samples.cc get notification
    *
@@ -1938,6 +2276,14 @@ class Client {
    * @param notification_id the id of the notification config.
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
+   *
+   * @throw std::runtime_error if there is a permanent failure, or if there more
+   *     transient failures than allowed by the current retry policy.
+   *
+   * @par Idempotency
+   * This operation is always idempotent because it only acts on a specific
+   * `notification_id`, the state after calling this function multiple times is
+   * to delete that notification.  New notifications get different ids.
    *
    * @par Example
    * @snippet storage_notification_samples.cc delete notification

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -131,8 +131,8 @@ class Client {
    *     Valid types for this operation include `MaxResults`, `Prefix`,
    *     `UserProject`, and `Projection`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Being a read-only operation this is always idempotent.
@@ -163,8 +163,8 @@ class Client {
    * @throw std::logic_error if the function is called without a default
    *     project id set.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Being a read-only operation this is always idempotent.
@@ -193,11 +193,11 @@ class Client {
    *     Valid types for this operation include `PredefinedAcl`,
    *     `PredefinedDefaultObjectAcl`, `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * This operation is always idempotent, it fails if the bucket already exists.
+   * This operation is always idempotent. It fails if the bucket already exists.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc create bucket
@@ -227,11 +227,11 @@ class Client {
    *     Valid types for this operation include `PredefinedAcl`,
    *     `PredefinedDefaultObjectAcl`, `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * This operation is always idempotent, it fails if the bucket already exists.
+   * This operation is always idempotent. It fails if the bucket already exists.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc create bucket for project
@@ -256,8 +256,8 @@ class Client {
    *     Valid types for this operation include `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, `UserProject`, and `Projection`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Being a read-only operation this is always idempotent.
@@ -281,8 +281,8 @@ class Client {
    *     Valid types for this operation include `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -310,8 +310,8 @@ class Client {
    *     `IfMetagenerationNotMatch`, `PredefinedAcl`,
    *     `PredefinedDefaultObjectAcl`, `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -349,8 +349,8 @@ class Client {
    *     Valid types for this operation include `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -382,8 +382,8 @@ class Client {
    *     Valid types for this operation include `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -425,8 +425,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Being a read-only operation this is always idempotent.
@@ -475,8 +475,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -519,8 +519,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Being a read-only operation this is always idempotent.
@@ -568,8 +568,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * This operation is always idempotent because the `metageneration` parameter
@@ -626,8 +626,8 @@ class Client {
    *     `IfMetagenerationNotMatch`, `KmsKeyName`, `MD5HashValue`,
    *     `PredefinedAcl`, `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -677,8 +677,8 @@ class Client {
    *     `Projection`, `SourceGeneration`, `UserProject`, and
    *     `WithObjectMetadata`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -715,8 +715,8 @@ class Client {
    *     `IfMetagenerationNotMatch`, `Projection`, and `UserProject`.
    *
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Being a read-only operation this is always idempotent.
@@ -742,8 +742,8 @@ class Client {
    *     `IfMetagenerationMatch`, `IfMetagenerationNotMatch`, `UserProject`,
    *     `Projection`, `Prefix`, and `Versions`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Being a read-only operation this is always idempotent.
@@ -769,8 +769,8 @@ class Client {
    *     `IfGenerationMatch`, `IfGenerationNotMatch`, `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Being a read-only operation this is always idempotent.
@@ -802,8 +802,8 @@ class Client {
    *   `IfMetagenerationMatch`, `IfMetagenerationNotMatch`, `KmsKeyName`,
    *   `MD5HashValue`, `PredefinedAcl`, `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -850,8 +850,8 @@ class Client {
    * idempotent if restricted by pre-conditions, in this case,
    * `IfGenerationMatch`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Example
    * @snippet storage_object_samples.cc upload file
@@ -884,8 +884,8 @@ class Client {
    *   `IfGenerationNotMatch`, `IfMetagenerationMatch`,
    *   `IfMetagenerationNotMatch`, `Generation`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Being a read-only operation this is always idempotent.
@@ -912,8 +912,8 @@ class Client {
    *     `IfGenerationMatch`, `IfGenerationNotMatch`, `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Example
    * @snippet storage_object_samples.cc delete object
@@ -941,8 +941,8 @@ class Client {
    *     `IfMetagenerationNotMatch`, `PredefinedAcl`,
    *     `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -980,8 +980,8 @@ class Client {
    *     `IfMetagenerationNotMatch`, `PredefinedAcl`,
    *     `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -1019,8 +1019,8 @@ class Client {
    *     `IfMetagenerationNotMatch`, `PredefinedAcl`,
    *     `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -1053,8 +1053,8 @@ class Client {
    *      `IfGenerationMatch`, `IfMetagenerationMatch`, `KmsKeyName`,
    *      `UserProject`, and `WithObjectMetadata`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -1103,8 +1103,8 @@ class Client {
    *      `MaxBytesRewrittenPerCall`, `Projection`, `SourceEncryptionKey`,
    *      `SourceGeneration`, `UserProject`, and `WithObjectMetadata`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -1155,8 +1155,8 @@ class Client {
    *      `MaxBytesRewrittenPerCall`, `Projection`, `SourceEncryptionKey`,
    *      `SourceGeneration`, `UserProject`, and `WithObjectMetadata`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -1209,8 +1209,8 @@ class Client {
    *      `MaxBytesRewrittenPerCall`, `Projection`, `SourceEncryptionKey`,
    *      `SourceGeneration`, `UserProject`, and `WithObjectMetadata`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -1276,8 +1276,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Being a read-only operation this is always idempotent.
@@ -1302,8 +1302,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -1331,8 +1331,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -1358,8 +1358,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Being a read-only operation this is always idempotent.
@@ -1385,8 +1385,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -1432,8 +1432,8 @@ class Client {
    *     Valid types for this operation include `UserProject`, and the standard
    *     options available to all operations.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -1480,8 +1480,8 @@ class Client {
    *     headers. Valid types for this operation include `Generation`,
    *     `UserProject`, `IfMatchEtag`, and `IfNoneMatchEtag`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -1532,8 +1532,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `Generation`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Being a read-only operation this is always idempotent.
@@ -1560,8 +1560,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `Generation`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -1593,8 +1593,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `Generation`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -1622,8 +1622,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `Generation`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Being a read-only operation this is always idempotent.
@@ -1651,8 +1651,8 @@ class Client {
    * @param options a list of optional query parameters and/or request
    *     Valid types for this operation include `Generation`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -1700,8 +1700,8 @@ class Client {
    *     headers. Valid types for this operation include `Generation`,
    *     `UserProject`, `IfMatchEtag`, and `IfNoneMatchEtag`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -1749,8 +1749,8 @@ class Client {
    *     headers. Valid types for this operation include `Generation`,
    *     `UserProject`, `IfMatchEtag`, and `IfNoneMatchEtag`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -1797,8 +1797,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Being a read-only operation this is always idempotent.
@@ -1829,8 +1829,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -1864,8 +1864,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -1897,8 +1897,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Being a read-only operation this is always idempotent.
@@ -1930,8 +1930,8 @@ class Client {
    * @param options a list of optional query parameters and/or request
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -1978,8 +1978,8 @@ class Client {
    *     as the standard parameters, such as `IfMatchEtag`, and
    *     `IfNoneMatchEtag`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -2025,8 +2025,8 @@ class Client {
    *     as the standard parameters, such as `IfMatchEtag`, and
    *     `IfNoneMatchEtag`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -2075,8 +2075,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Being a read-only operation this is always idempotent.
@@ -2115,8 +2115,8 @@ class Client {
    * @throw std::logic_error if the function is called without a default
    *     project id set.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Being a read-only operation this is always idempotent.
@@ -2161,8 +2161,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Being a read-only operation this is always idempotent.
@@ -2198,8 +2198,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Like other operations that mutate the state of GCS, this operation is only
@@ -2240,8 +2240,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * Being a read-only operation this is always idempotent.
@@ -2277,8 +2277,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there more
-   *     transient failures than allowed by the current retry policy.
+   * @throw std::runtime_error if there is a permanent failure, or if there were
+   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * This operation is always idempotent because it only acts on a specific

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -135,7 +135,7 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Being a read-only operation this is always idempotent.
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc list buckets for project
@@ -167,7 +167,7 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Being a read-only operation this is always idempotent.
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc list buckets
@@ -260,7 +260,7 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Being a read-only operation this is always idempotent.
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc get bucket metadata
@@ -285,9 +285,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions, in this case,
-   * `IfMetagenerationMatch`.
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfMetagenerationMatch`.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc delete bucket
@@ -314,12 +313,11 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions, in this case,
-   * `IfMetagenerationMatch`.
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case,`IfMetagenerationMatch`.
    *
    * @par Idempotency
-   * Being a read-only operation this is always idempotent.
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc update bucket
@@ -353,9 +351,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions, in this case,
-   * `IfMetagenerationMatch`.
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfMetagenerationMatch`.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc patch bucket storage class
@@ -386,9 +383,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions, in this case,
-   * `IfMetagenerationMatch`.
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfMetagenerationMatch`.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc patch bucket storage class with builder
@@ -429,7 +425,7 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Being a read-only operation this is always idempotent.
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_iam_samples.cc get bucket iam policy
@@ -479,9 +475,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions, in this case,
-   * `IfMetagenerationMatch`.
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfMetagenerationMatch`.
    *
    * @par Example: adding a new member
    * @snippet storage_bucket_iam_samples.cc add bucket iam member
@@ -523,7 +518,7 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Being a read-only operation this is always idempotent.
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_iam_samples.cc test bucket iam permissions
@@ -630,9 +625,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions, in this case,
-   * `IfGenerationMatch`.
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfGenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_samples.cc insert object
@@ -681,9 +675,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions, in this case,
-   * `IfGenerationMatch`.
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfGenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_samples.cc copy object
@@ -719,7 +712,7 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Being a read-only operation this is always idempotent.
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_object_samples.cc get object metadata
@@ -746,7 +739,7 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Being a read-only operation this is always idempotent.
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_object_samples.cc list objects
@@ -773,7 +766,7 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Being a read-only operation this is always idempotent.
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_object_samples.cc read object
@@ -806,9 +799,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions, in this case,
-   * `IfGenerationMatch`.
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfGenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_samples.cc write object
@@ -846,9 +838,8 @@ class Client {
    *   `WithObjectMetadata`.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions, in this case,
-   * `IfGenerationMatch`.
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfGenerationMatch`.
    *
    * @throw std::runtime_error if there is a permanent failure, or if there were
    *     more transient failures than allowed by the current retry policy.
@@ -888,7 +879,7 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Being a read-only operation this is always idempotent.
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_object_samples.cc download file
@@ -945,9 +936,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions, in this case,
-   * `IfMetagenerationMatch`.
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfMetagenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_samples.cc update object metadata
@@ -984,9 +974,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions, in this case,
-   * `IfMetagenerationMatch`.
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfMetagenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_samples.cc patch object delete metadata
@@ -1023,9 +1012,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions, in this case,
-   * `IfMetagenerationMatch`.
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfMetagenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_samples.cc patch object content type
@@ -1057,9 +1045,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions, in this case,
-   * `IfGenerationMatch`.
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfGenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_samples.cc compose object
@@ -1107,9 +1094,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions, in this case,
-   * `IfGenerationMatch`.
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfGenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_samples.cc rewrite object non blocking
@@ -1159,9 +1145,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions, in this case,
-   * `IfGenerationMatch`.
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfGenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_samples.cc rewrite object resume
@@ -1213,9 +1198,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions, in this case,
-   * `IfGenerationMatch`.
+   * This operation is only idempotent if restricted by pre-conditions, in this
+   * case, `IfGenerationMatch`.
    *
    * @par Example
    * @snippet storage_object_samples.cc rewrite object
@@ -1280,7 +1264,7 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Being a read-only operation this is always idempotent.
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc list bucket acl
@@ -1306,9 +1290,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions. There are no pre-conditions for
-   * this operation that can make it idempotent.
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc create bucket acl
@@ -1335,9 +1318,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions. There are no pre-conditions for
-   * this operation that can make it idempotent.
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc delete bucket acl
@@ -1362,7 +1344,7 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Being a read-only operation this is always idempotent.
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc get bucket acl
@@ -1389,9 +1371,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions. There are no pre-conditions for
-   * this operation that can make it idempotent.
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc update bucket acl
@@ -1436,9 +1417,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions. There are no pre-conditions for
-   * this operation that can make it idempotent.
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc patch bucket acl
@@ -1484,9 +1464,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions. There are no pre-conditions for
-   * this operation that can make it idempotent.
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_bucket_acl_samples.cc patch bucket acl no-read
@@ -1536,7 +1515,7 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Being a read-only operation this is always idempotent.
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_object_acl_samples.cc list object acl
@@ -1564,9 +1543,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions. There are no pre-conditions for
-   * this operation that can make it idempotent.
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_object_acl_samples.cc create object acl
@@ -1597,9 +1575,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions. There are no pre-conditions for
-   * this operation that can make it idempotent.
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_object_acl_samples.cc delete object acl
@@ -1626,7 +1603,7 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Being a read-only operation this is always idempotent.
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_object_acl_samples.cc get object acl
@@ -1655,9 +1632,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions. There are no pre-conditions for
-   * this operation that can make it idempotent.
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_object_acl_samples.cc update object acl
@@ -1704,9 +1680,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions. There are no pre-conditions for
-   * this operation that can make it idempotent.
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_object_acl_samples.cc patch object acl
@@ -1753,9 +1728,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions. There are no pre-conditions for
-   * this operation that can make it idempotent.
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_object_acl_samples.cc patch object acl no-read
@@ -1801,7 +1775,7 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Being a read-only operation this is always idempotent.
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc list default object acl
@@ -1833,9 +1807,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions. There are no pre-conditions for
-   * this operation that can make it idempotent.
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc create default object acl
@@ -1868,9 +1841,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions. There are no pre-conditions for
-   * this operation that can make it idempotent.
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc delete default object acl
@@ -1901,7 +1873,7 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Being a read-only operation this is always idempotent.
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc get default object acl
@@ -1934,9 +1906,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions. There are no pre-conditions for
-   * this operation that can make it idempotent.
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc update default object acl
@@ -1982,9 +1953,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions. There are no pre-conditions for
-   * this operation that can make it idempotent.
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc patch default object acl
@@ -2029,9 +1999,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions. There are no pre-conditions for
-   * this operation that can make it idempotent.
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_default_object_acl_samples.cc patch default object acl
@@ -2079,7 +2048,7 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Being a read-only operation this is always idempotent.
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc get service account for project
@@ -2119,7 +2088,7 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Being a read-only operation this is always idempotent.
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc get service account
@@ -2165,7 +2134,7 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Being a read-only operation this is always idempotent.
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_notification_samples.cc list notifications
@@ -2202,9 +2171,8 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Like other operations that mutate the state of GCS, this operation is only
-   * idempotent if restricted by pre-conditions. There are no pre-conditions for
-   * this operation that can make it idempotent.
+   * This operation is only idempotent if restricted by pre-conditions. There
+   * are no pre-conditions for this operation that can make it idempotent.
    *
    * @par Example
    * @snippet storage_notification_samples.cc create notification
@@ -2244,7 +2212,7 @@ class Client {
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
-   * Being a read-only operation this is always idempotent.
+   * This is a read-only operation and is always idempotent.
    *
    * @par Example
    * @snippet storage_notification_samples.cc get notification


### PR DESCRIPTION
Improve the description of when std::runtime_error is raised.
Described when the operations are idempotent.
In the cases where there are multiple examples use a paragraph for each
one so they are more readable in the generated pages.
Some stuff was not formatted right because of missing backticks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1586)
<!-- Reviewable:end -->
