### PR TITLE
Add RawClient function to resume uploads.

### DIFF
--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -110,7 +110,7 @@ class CurlClient : public RawClient,
   std::pair<Status, std::unique_ptr<ResumableUploadSession>>
   CreateResumableSession(ResumableUploadRequest const& request) override;
   std::pair<Status, std::unique_ptr<ResumableUploadSession>>
-  RestoreResumableSession(std::string const& session_id);
+  RestoreResumableSession(std::string const& session_id) override;
 
   std::pair<Status, ListBucketAclResponse> ListBucketAcl(
       ListBucketAclRequest const& request) override;

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -208,6 +208,12 @@ LoggingClient::CreateResumableSession(ResumableUploadRequest const& request) {
           std::move(result.second)));
 }
 
+std::pair<Status, std::unique_ptr<ResumableUploadSession>>
+LoggingClient::RestoreResumableSession(std::string const &request){
+  return MakeCallNoResponseLogging(
+      *client_, &RawClient::RestoreResumableSession, request, __func__);
+}
+
 std::pair<Status, ListBucketAclResponse> LoggingClient::ListBucketAcl(
     ListBucketAclRequest const& request) {
   return MakeCall(*client_, &RawClient::ListBucketAcl, request, __func__);

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -77,6 +77,8 @@ class LoggingClient : public RawClient {
       RewriteObjectRequest const&) override;
   std::pair<Status, std::unique_ptr<ResumableUploadSession>>
   CreateResumableSession(ResumableUploadRequest const& request) override;
+  std::pair<Status, std::unique_ptr<ResumableUploadSession>>
+  RestoreResumableSession(std::string const& request) override;
 
   std::pair<Status, ListBucketAclResponse> ListBucketAcl(
       ListBucketAclRequest const& request) override;

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -96,6 +96,8 @@ class RawClient {
       RewriteObjectRequest const&) = 0;
   virtual std::pair<Status, std::unique_ptr<ResumableUploadSession>>
   CreateResumableSession(ResumableUploadRequest const& request) = 0;
+  virtual std::pair<Status, std::unique_ptr<ResumableUploadSession>>
+  RestoreResumableSession(std::string const& session_id) = 0;
   //@}
 
   //@{

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -330,6 +330,15 @@ RetryClient::CreateResumableSession(ResumableUploadRequest const& request) {
           std::move(backoff_policy)));
 }
 
+std::pair<Status, std::unique_ptr<ResumableUploadSession>>
+RetryClient::RestoreResumableSession(std::string const& request) {
+  auto retry_policy = retry_policy_->clone();
+  auto backoff_policy = backoff_policy_->clone();
+  auto is_idempotent = true;
+  return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
+                  &RawClient::RestoreResumableSession, request, __func__);
+}
+
 std::pair<Status, ListBucketAclResponse> RetryClient::ListBucketAcl(
     ListBucketAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -90,6 +90,8 @@ class RetryClient : public RawClient {
       RewriteObjectRequest const&) override;
   std::pair<Status, std::unique_ptr<ResumableUploadSession>>
   CreateResumableSession(ResumableUploadRequest const& request) override;
+  std::pair<Status, std::unique_ptr<ResumableUploadSession>>
+  RestoreResumableSession(std::string const& request) override;
 
   std::pair<Status, ListBucketAclResponse> ListBucketAcl(
       ListBucketAclRequest const& request) override;

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -89,6 +89,10 @@ class MockClient : public google::cloud::storage::internal::RawClient {
       CreateResumableSession,
       ResponseWrapper<std::unique_ptr<internal::ResumableUploadSession>>(
           internal::ResumableUploadRequest const&));
+  MOCK_METHOD1(
+      RestoreResumableSession,
+      ResponseWrapper<std::unique_ptr<internal::ResumableUploadSession>>(
+          std::string const&));
 
   MOCK_METHOD1(ListBucketAcl, ResponseWrapper<internal::ListBucketAclResponse>(
                                   internal::ListBucketAclRequest const&));


### PR DESCRIPTION
With this change the RawClient, LoggingClient, and RetryClient classes
can restore a resumable upload session.