### PR TITLE
Use external project for CURL and dependencies.

### DIFF
--- a/cmake/ExternalProjectHelper.cmake
+++ b/cmake/ExternalProjectHelper.cmake
@@ -74,6 +74,7 @@ function (set_library_properties_for_external_project _target _lib)
         "gpr"
         "address_sorting"
         "cares"
+        "curl"
         "z")
 
     if (${_lib} IN_LIST _libs_always_install_in_libdir)

--- a/cmake/IncludeCurl.cmake
+++ b/cmake/IncludeCurl.cmake
@@ -1,0 +1,66 @@
+# ~~~
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+# gRPC always requires thread support.
+find_package(Threads REQUIRED)
+
+# Configure the gRPC dependency, this can be found as a submodule, package, or
+# installed with pkg-config support.
+set(GOOGLE_CLOUD_CPP_CURL_PROVIDER ${GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER}
+    CACHE STRING "How to find the libcurl.")
+set_property(CACHE GOOGLE_CLOUD_CPP_CURL_PROVIDER
+             PROPERTY STRINGS
+                      "external"
+                      "package"
+                      "vcpkg"
+                      "pkg-config")
+
+if ("${GOOGLE_CLOUD_CPP_CURL_PROVIDER}" STREQUAL "external")
+    include(external/curl)
+elseif("${GOOGLE_CLOUD_CPP_CURL_PROVIDER}" MATCHES "^(package|vcpkg)$")
+    # Search for libcurl, in CMake 3.5 this does not define a target, but it
+    # will in 3.12 (see https://cmake.org/cmake/help/git-
+    # stage/module/FindCURL.html for details).  Until then, define the target
+    # ourselves if it is missing.
+    find_package(CURL REQUIRED)
+    if (NOT TARGET CURL::CURL)
+        add_library(CURL::CURL UNKNOWN IMPORTED)
+        set_property(TARGET CURL::CURL
+                     APPEND
+                     PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+                              "${CURL_INCLUDE_DIR}")
+        set_property(TARGET CURL::CURL
+                     APPEND
+                     PROPERTY IMPORTED_LOCATION "${CURL_LIBRARY}")
+    endif ()
+    # If the library is static, we need to explicitly link its dependencies.
+    # However, we should not do so for shared libraries, because the version of
+    # OpenSSL (for example) found by find_package() may be newer than the
+    # version linked against libcurl.
+    if ("${CURL_LIBRARY}" MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$")
+        find_package(OpenSSL REQUIRED)
+        find_package(ZLIB REQUIRED)
+        set_property(TARGET CURL::CURL
+                     APPEND
+                     PROPERTY INTERFACE_LINK_LIBRARIES
+                              OpenSSL::SSL
+                              OpenSSL::Crypto
+                              ZLIB::ZLIB)
+        message(STATUS "CURL linkage will be static")
+    else()
+        message(STATUS "CURL linkage will be non-static")
+    endif ()
+endif ()

--- a/cmake/external/curl.cmake
+++ b/cmake/external/curl.cmake
@@ -1,0 +1,76 @@
+# ~~~
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(external/c-ares)
+include(external/ssl)
+include(external/zlib)
+
+if (NOT TARGET curl_project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(GOOGLE_CLOUD_CPP_CURL_URL
+        "https://curl.haxx.se/download/curl-7.60.0.tar.gz")
+    set(GOOGLE_CLOUD_CPP_CURL_SHA256
+        "e9c37986337743f37fd14fe8737f246e97aec94b39d1b71e8a5973f72a9fc4f5")
+
+    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles")
+        include(ProcessorCount)
+        processorcount(NCPU)
+        set(PARALLEL "--" "-j" "${NCPU}")
+    else()
+        set(PARALLEL "")
+    endif ()
+
+    create_external_project_library_byproduct_list(curl_byproducts "curl")
+
+    include(ExternalProject)
+    externalproject_add(
+        curl_project
+        DEPENDS c_ares_project ssl_project zlib_project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/curl"
+        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
+        URL ${GOOGLE_CLOUD_CPP_CURL_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_CURL_SHA256}
+        CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+                   -DCMAKE_BUILD_TYPE=Release
+                   -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+                   -DENABLE_ARES=ON
+                   -DCURL_STATICLIB=$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>
+                   -DCMAKE_DEBUG_POSTFIX=
+                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        BUILD_COMMAND ${CMAKE_COMMAND}
+                      --build
+                      <BINARY_DIR>
+                      ${PARALLEL}
+        BUILD_BYPRODUCTS ${curl_byproducts}
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+
+    include(ExternalProjectHelper)
+    add_library(CURL::CURL INTERFACE IMPORTED)
+    add_dependencies(CURL::CURL curl_project)
+    set_library_properties_for_external_project(CURL::CURL curl)
+    set_property(TARGET CURL::CURL
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES
+                          c-ares::cares
+                          OpenSSL::SSL
+                          OpenSSL::Crypto
+                          ZLIB::ZLIB)
+endif ()

--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -24,8 +24,7 @@ if (NOT TARGET googletest_project)
     set(GOOGLE_CLOUD_CPP_GOOGLETEST_SHA256
         "9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c")
 
-    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
-        OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
+    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles")
         include(ProcessorCount)
         processorcount(NCPU)
         set(PARALLEL "--" "-j" "${NCPU}")
@@ -103,5 +102,4 @@ if (NOT TARGET googletest_project)
                  APPEND
                  PROPERTY INTERFACE_LINK_LIBRARIES
                           "GTest::gmock;GTest::gtest;Threads::Threads")
-
 endif ()

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -16,6 +16,7 @@
 
 include(ExternalProjectHelper)
 include(external/c-ares)
+include(external/ssl)
 include(external/protobuf)
 
 if (NOT TARGET gprc_project)
@@ -44,7 +45,7 @@ if (NOT TARGET gprc_project)
     include(ExternalProject)
     externalproject_add(
         grpc_project
-        DEPENDS c_ares_project protobuf_project
+        DEPENDS c_ares_project protobuf_project ssl_project
         EXCLUDE_FROM_ALL ON
         PREFIX "external/grpc"
         INSTALL_DIR "external"
@@ -54,7 +55,6 @@ if (NOT TARGET gprc_project)
                    -DCMAKE_BUILD_TYPE=Release
                    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-                   -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
                    -DgRPC_BUILD_TESTS=OFF
                    -DgRPC_ZLIB_PROVIDER=package
                    -DgRPC_SSL_PROVIDER=package
@@ -71,8 +71,6 @@ if (NOT TARGET gprc_project)
         LOG_CONFIGURE ON
         LOG_BUILD ON
         LOG_INSTALL ON)
-
-    find_package(OpenSSL REQUIRED)
 
     add_library(gRPC::address_sorting INTERFACE IMPORTED)
     set_library_properties_for_external_project(gRPC::address_sorting

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -16,6 +16,7 @@
 
 include(ExternalProjectHelper)
 find_package(Threads REQUIRED)
+include(external/zlib)
 
 if (NOT TARGET protobuf_project)
     # Give application developers a hook to configure the version and hash
@@ -40,6 +41,7 @@ if (NOT TARGET protobuf_project)
     include(ExternalProject)
     externalproject_add(
         protobuf_project
+        DEPENDS zlib_project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/protobuf"
         INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
@@ -70,7 +72,6 @@ if (NOT TARGET protobuf_project)
     add_library(protobuf::libprotobuf INTERFACE IMPORTED)
     add_dependencies(protobuf::libprotobuf protobuf_project)
     set_library_properties_for_external_project(protobuf::libprotobuf protobuf)
-    find_package(ZLIB REQUIRED)
     set_property(TARGET protobuf::libprotobuf
                  APPEND
                  PROPERTY INTERFACE_LINK_LIBRARIES

--- a/cmake/external/ssl.cmake
+++ b/cmake/external/ssl.cmake
@@ -1,0 +1,26 @@
+# ~~~
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+if (NOT TARGET ssl_project)
+    # For OpenSSL we don't really support external projects. OpenSSL build
+    # system is notoriously finicky. Use vcpkg on Windows, or install OpenSSL
+    # using your operating system packages instead.
+    #
+    # This file is here to simplify the definition of external projects, such as
+    # curl and gRPC, that depend on a SSL library.
+    add_custom_target(ssl_project)
+    find_package(OpenSSL REQUIRED)
+endif ()

--- a/cmake/external/zlib.cmake
+++ b/cmake/external/zlib.cmake
@@ -1,0 +1,61 @@
+# ~~~
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+if (NOT TARGET zlib_project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(GOOGLE_CLOUD_CPP_ZLIB_URL
+        "https://github.com/madler/zlib/archive/v1.2.11.tar.gz")
+    set(GOOGLE_CLOUD_CPP_ZLIB_SHA256
+        "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff")
+
+    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles")
+        include(ProcessorCount)
+        processorcount(NCPU)
+        set(PARALLEL "--" "-j" "${NCPU}")
+    else()
+        set(PARALLEL "")
+    endif ()
+
+    create_external_project_library_byproduct_list(zlib_byproducts "z")
+
+    include(ExternalProject)
+    externalproject_add(zlib_project
+                        EXCLUDE_FROM_ALL ON
+                        PREFIX "${CMAKE_BINARY_DIR}/external/zlib"
+                        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
+                        URL ${GOOGLE_CLOUD_CPP_ZLIB_URL}
+                        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_ZLIB_SHA256}
+                        CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+                                   -DCMAKE_BUILD_TYPE=Release
+                                   -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+                                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                        BUILD_COMMAND ${CMAKE_COMMAND}
+                                      --build
+                                      <BINARY_DIR>
+                                      ${PARALLEL}
+                        BUILD_BYPRODUCTS ${zlib_byproducts}
+                        LOG_DOWNLOAD ON
+                        LOG_CONFIGURE ON
+                        LOG_BUILD ON
+                        LOG_INSTALL ON)
+
+    include(ExternalProjectHelper)
+    add_library(ZLIB::ZLIB INTERFACE IMPORTED)
+    add_dependencies(ZLIB::ZLIB zlib_project)
+    set_library_properties_for_external_project(ZLIB::ZLIB z)
+
+endif ()

--- a/doc/managing-dependencies-in-cmake.md
+++ b/doc/managing-dependencies-in-cmake.md
@@ -22,7 +22,7 @@ Some of these libraries have dependencies themselves:
 
 * [protobuf](https://developers.google.com/protocol-buffers/) is a dependency
   for gRPC.
-* [zlib](https://github.com/madler/zlib) is a dependencies for protobuf.
+* [zlib](https://github.com/madler/zlib) is a dependency for protobuf.
 * [c-ares](https://c-ares.haxx.se/) is a dependency for gRPC.
 * One of the forks of [OpenSSL](https://www.openssl.org/source/), such as
   [BoringSSL](https://github.com/google/boringssl) or

--- a/doc/managing-dependencies-in-cmake.md
+++ b/doc/managing-dependencies-in-cmake.md
@@ -5,47 +5,51 @@ viewed as a blocker for adoption by our customers.  Only the following
 libraries are allowed as dependencies:
 
 * [googleapis](https://github.com/google/googleapis) because it contains the
-protocol definition (as protobufs) to contact Google Cloud services.
+  protocol definition (as protobufs) to contact Google Cloud services.
 * [gRPC](https://grpc.io) because this implements the protocol used to contact
-Google Cloud services.
+  Google Cloud services.
 * [googletest](https://github.com/google/googletest) because we needed a unit
-test framework and this was already a dependency for googleapis, gRPC, and
-Abseil.
+  test framework and this was already a dependency for googleapis, gRPC, and
+  Abseil.
+* [libcurl](https://github.com/curl/curl) is used by the storage library to send
+  http requests.
+* [nlohmann/json](https://github.com/nlohmann/json) is used by the storage
+  library to parse and generate JSON objects.
+* [OpenSSL](https://www.openssl.org/source/) is used by the storage library to
+  perform some Base64 encoding and JWT signing.
 
 Some of these libraries have dependencies themselves:
 
 * [protobuf](https://developers.google.com/protocol-buffers/) is a dependency
   for gRPC.
-  
-gRPC has many other dependencies at build time, but they are not transitive,
-for example, gRPC uses [c-ares](https://c-ares.haxx.se/) for asynchronous DNS
-requests.  But the library is linked into gRPC and not exposed externally.
-To comply with C++'s
-[One Definition Rule](http://en.cppreference.com/w/cpp/language/definition),
-applications that use c-ares or similar transitive dependencies of gRPC should
-ensure that all the code uses the same version, and that they are compiled
-with the same flags that affect the ABI. In any case, this problem is outside
-of scope for this document.
+* [zlib](https://github.com/madler/zlib) is a dependencies for protobuf.
+* [c-ares](https://c-ares.haxx.se/) is a dependency for gRPC.
+* One of the forks of [OpenSSL](https://www.openssl.org/source/), such as
+  [BoringSSL](https://github.com/google/boringssl) or
+  [LibreSSL](https://www.libressl.org/) is a dependency for both gRPC and
+  libcurl. 
 
 This document describes how the direct dependencies of `google-cloud-cpp`
 included in CMake files.
 
 ## Overview
 
-When compiling from source, we use dependencies as git submodules. Submodules
-are included using the `add_subdirectory()` macro.  We use the
-`EXCLUDE_FROM_ALL` parameter to avoid compiling additional targets, such as
-examples or tests, that are not required for the `google-cloud-cpp` targets.
+We will support two different modes to compile the library with CMake:
 
-Submodules included with `add_subdirectory()` introduce CMake
-[targets][cmake-doc-targets] that we can add as dependencies to the libraries
-and executables compiled in `google-cloud-cpp`. Any compiler flags, such as
-include directories, needed for these targets are automatically added when the
-target becomes a dependency.
+- Using [CMake external projects][cmake-doc-externalproject]
+- Using pre-installed dependencies.
 
+Bazel builds are basically external project builds.
 
-We want installed dependencies to have the same behavior. CMake supports this
-use case well as long as projects follow the following conventions:
+When compiline with external projects we will create
+[targets][cmake-doc-targets] that have the same names (and roles) as the
+installed for that dependency.
+For example, when protobuf is installed and discovered via `find_package()` the
+module for protobuf introduces a `protobuf::libprotobuf` target. We will
+construct our external projects to exhibit the same behavior.
+
+CMake supports this use case well as long as projects follow the following
+conventions:
 
 * One should use dependencies via their [exported][cmake-doc-export] names, for
   example, `absl::base` and not `absl_base`.
@@ -53,9 +57,6 @@ use case well as long as projects follow the following conventions:
   `target_compile_definitions()` to add compilation flags.
 * Dependencies should create a [package][cmake-doc-packages] config file as part
   of their installation.
-
-Unfortunately the dependencies for `google-cloud-cpp` do not follow these
-conventions, so we must support them as best we can without them.
 
 ## Detailed Management for all Dependencies
 
@@ -96,7 +97,7 @@ We will support four different configurations for gRPC:
     when compiled and installed with GNU Make, so we cannot assume these support
     files always exist.
     
-1. `module`: When `GOOGLE_CLOUD_CPP_GRPC_PROVIDER` is set to `module`
+1. `external`: When `GOOGLE_CLOUD_CPP_GRPC_PROVIDER` is set to `module`
    (the default) we will simply add the `third_party/grpc` subdirectory to
    the CMake build.
 
@@ -117,7 +118,7 @@ dependencies such as `libpthread`, `libc` and the C++ library (typically
 `libstdc++`). Of all these dependencies, only `protobuf`, `zlib`, and `pthread`
 need to be explicitly linked by the application.
 
-We already discussed how `protobuf` is discovered alonside `gRPC`.
+We already discussed how `protobuf` is discovered alongside `gRPC`.
 
 `zlib` is often installed as a system library and has a relatively stable
 interface.  Unless it is used as a module we will use the native library via
@@ -126,6 +127,11 @@ interface.  Unless it is used as a module we will use the native library via
 `libpthread` has native support in CMake and we will simply use that: the
 `FindThreads` module creates a `Threads::Threads` target that works on all
 platforms.
+
+### Googletest
+
+Googletest is not installed, nor should it be, and therefore it is only used
+as a submodule.
 
 ### Googleapis
 
@@ -141,18 +147,20 @@ needed by `google-cloud-cpp`.
 Every time a new service is wrapper in `google-cloud-cpp` is updated this
 library will need to be updated too.
 
-### Googletest
-
-Googletest is not installed, nor should it be, and therefore it is only used
-as a submodule.
-
 ## Implementation
 
-`google-cloud-cpp` defines a `*_PROVIDER` macro to control the support for each
-dependency. If the macro is defined as `module`, then that target is used as
-a submodule. If the macro is defined as `package`, then that target is used as
-a installed package with CMake support. If the macro is defined as `pkg-config`,
-the dependency is assumed to be installed with only `pkg-config` support.
+`google-cloud-cpp` defines a `GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER`
+configuration option to control where to find all the dependencies. The macro
+ can take the following values:
+ 
+ 
+* `external` implies that all the sources should be downloaded using the
+`ExternalProject` CMake module.
+* `package` implies that all the dependencies are already installed and can be
+found with `find_package()`.
+* `pkg-config` is used when the dependencies are already installed but cannot be
+found with `find_package()`, instead they can be found using the `pkg-config`
+tool.
 
 We will create a separate file in `cmake/Include<Dependency>.cmake` for each of
 the dependencies. The file will typically be of this form:
@@ -160,11 +168,10 @@ the dependencies. The file will typically be of this form:
 ```cmake
 set(GOOGLE_CLOUD_CPP_GRPC_PROVIDER "module" CACHE STRING "How to find the gRPC library")
 set_property(CACHE GOOGLE_CLOUD_CPP_GRPC_PROVIDER PROPERTY STRINGS "module" "package" "pkg-config")
-if ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "module")
-    # Some checking
-    add_subdirectory(third_party/grpc EXCLUDE_FROM_ALL)
+if ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "external")
+    include(external/grpc)
     # Define aliases if needed.
-    add_library(gRPC::grpc++ ALIAS grpc++)
+    add_library(gRPC::grpc++ INTERFACE IMPORTED)
     # ... some code ommitted ...
 elseif ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "package")
     find_package(GRPCPP REQUIRED >= 1.8)
@@ -184,29 +191,21 @@ endif ()
 The configurations must be tested as part of the CI builds. To ensure coverage
 we will:
 
-* Most builds will compile the dependencies from source, as submodules. This is
-  how the `google-cloud-cpp` developers use the system and we expect that many
-  of the users will too.
-
-* We will dedicate one CI build on Linux to compile against installed
-  dependencies using `pkg-config` files.
+* Most builds will compile the dependencies from source, as external projects.
+  This is how the `google-cloud-cpp` developers use the system and we expect
+  that many of the users will too.
+  
+* One or more of the builds install all the dependencies and then use `package`.
 
 * On Windows, we already use installed dependencies via `vcpkg`: compiling from
   source can be (a) so slow that we go over the time allocated in the CI build,
   and (b) the build may require patching the dependencies, as the `vcpkg` ports
   do.
 
-* We have no coverage for `*_PROVIDER == "package"` at the moment because (a)
-  we have not written `Findabsl.cmake` for the mock installations of Abseil, and
-  (b) previous versions of gRPC had a broken install target with CMake, though
-  this has not been tested recently.
+* We will dedicate one CI build on Linux to compile against installed
+  dependencies using `pkg-config` files.
 
 ## Alternatives Considered
-
-**Not Supporting a `make install` target**: we could take the stance that our
-users should always build from source. We have no data, but given the amount of
-effort the C++ community spends defining `install` targets we expect that this
-approach would be unpopular.
 
 **Create support files for each dependency and always use `find_package`**: the
 author ([@coryan](https://github.com/coryan)) could not design a solution that
@@ -222,6 +221,7 @@ There is a
 that implements all of this.
 
 [cmake-doc-export]:    https://cmake.org/cmake/help/v3.5/command/export.html
+[cmake-doc-externalproject]: https://cmake.org/cmake/help/v3.5/module/ExternalProject.html
 [cmake-doc-interface]: https://cmake.org/cmake/help/v3.5/command/add_library.html?highlight=interface
 [cmake-doc-packages]:  https://cmake.org/cmake/help/v3.5/manual/cmake-packages.7.html#manual:cmake-packages(7)
 [cmake-doc-targets]:   https://cmake.org/cmake/help/v3.5/manual/cmake-buildsystem.7.html#binary-targets

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -63,39 +63,7 @@ google_cloud_cpp_add_common_options(storage_common_options)
 # Enable unit tests
 enable_testing()
 
-# Search for libcurl, in CMake 3.5 this does not define a target, but it will in
-# 3.12 (see https://cmake.org/cmake/help/git-stage/module/FindCURL.html for
-# details).  Until then, define the target ourselves if it is missing.
-find_package(CURL REQUIRED)
-if (NOT TARGET CURL::CURL)
-    add_library(CURL::CURL UNKNOWN IMPORTED)
-    set_property(TARGET CURL::CURL
-                 APPEND
-                 PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${CURL_INCLUDE_DIR}")
-    set_property(TARGET CURL::CURL
-                 APPEND
-                 PROPERTY IMPORTED_LOCATION "${CURL_LIBRARY}")
-endif ()
-# If the library is static, we need to explicitly link its dependencies.
-# However, we should not do so for shared libraries, because the version of
-# OpenSSL (for example) found by find_package() may be newer than the version
-# linked against libcurl.
-if ("${CURL_LIBRARY}" MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$")
-    find_package(OpenSSL REQUIRED)
-    find_package(ZLIB REQUIRED)
-    set_property(TARGET CURL::CURL
-                 APPEND
-                 PROPERTY INTERFACE_LINK_LIBRARIES
-                          OpenSSL::SSL
-                          OpenSSL::Crypto
-                          ZLIB::ZLIB)
-    message(STATUS "CURL linkage will be static")
-else()
-    message(STATUS "CURL linkage will be non-static")
-endif ()
-
-find_package(OpenSSL REQUIRED)
-find_package(ZLIB REQUIRED)
+include(IncludeCurl)
 
 # the client library
 add_library(storage_client


### PR DESCRIPTION
This reduces the number of dependencies that need to be pre-installed to
just OpenSSL. It simplifies the builds, as described in #1248.

Incidentally, this seems to fix the internal Jenkins builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1592)
<!-- Reviewable:end -->
