### PR TITLE
WriteObject() uses resumable uploads if requested.

### DIFF
--- a/google/cloud/storage/client_write_object_test.cc
+++ b/google/cloud/storage/client_write_object_test.cc
@@ -63,6 +63,8 @@ class MockStreambuf : public internal::ObjectWriteStreambuf {
   MOCK_METHOD1(ValidateHash, void(ObjectMetadata const&));
   MOCK_CONST_METHOD0(received_hash, std::string const&());
   MOCK_CONST_METHOD0(computed_hash, std::string const&());
+  MOCK_CONST_METHOD0(resumable_session_id, std::string const&());
+  MOCK_CONST_METHOD0(next_expected_byte, std::uint64_t());
 };
 
 TEST_F(WriteObjectTest, WriteObject) {

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -342,7 +342,7 @@ void StartResumableUpload(google::cloud::storage::Client client, int& argc,
     // example we want to restore the session as-if the application had crashed,
     // where no destructors get called.
     stream << "This data will not get uploaded, it is too small" << std::endl;
-    stream.Suspend();
+    std::move(stream).Suspend();
   }
   //! [start resumable upload]
   (std::move(client), bucket_name, object_name);

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -362,6 +362,8 @@ void ResumeResumableUpload(google::cloud::storage::Client client, int &argc,
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string session_id) {
+    // Restore a resumable upload stream, the library automatically queries the
+    // state of the upload and discovers the next expected byte.
     gcs::ObjectWriteStream stream =
         client.WriteObject(bucket_name, object_name,
                            gcs::RestoreResumableUploadSession(session_id));

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -322,6 +322,72 @@ void WriteLargeObject(google::cloud::storage::Client client, int& argc,
   (std::move(client), bucket_name, object_name, object_size_in_MiB);
 }
 
+void StartResumableUpload(google::cloud::storage::Client client, int& argc,
+                          char* argv[]) {
+  if (argc != 3) {
+    throw Usage{"start-resumable-upload <bucket-name> <object-name>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  auto object_name = ConsumeArg(argc, argv);
+
+  //! [start resumable upload]
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string bucket_name, std::string object_name) {
+    gcs::ObjectWriteStream stream = client.WriteObject(
+        bucket_name, object_name, gcs::NewResumableUploadSession());
+    std::cout << "Created resumable upload: " << stream.resumable_session_id()
+              << std::endl;
+    // As it is customary in C++, the destructor automatically closes the
+    // stream, that would finish the upload and create the object. For this
+    // example we want to restore the session as-if the application had crashed,
+    // where no destructors get called.
+    stream << "This data will not get uploaded, it is too small" << std::endl;
+    stream.Suspend();
+  }
+  //! [start resumable upload]
+  (std::move(client), bucket_name, object_name);
+}
+
+void ResumeResumableUpload(google::cloud::storage::Client client, int &argc,
+                           char **argv) {
+  if (argc != 4) {
+    throw Usage{
+        "resume-resumable-upload <bucket-name> <object-name> <session-id>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  auto object_name = ConsumeArg(argc, argv);
+  auto session_id = ConsumeArg(argc, argv);
+
+  //! [resume resumable upload]
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string bucket_name, std::string object_name,
+     std::string session_id) {
+    gcs::ObjectWriteStream stream =
+        client.WriteObject(bucket_name, object_name,
+                           gcs::RestoreResumableUploadSession(session_id));
+    if (stream.next_expected_byte() == 0) {
+      // In this example we create a small object, smaller than the resumable
+      // upload quantum (256 KiB), so either all the data is there or not.
+      // Applications use `next_expected_byte()` to find the position in their
+      // input where they need to start uploading.
+      stream << R"""(
+Lorem ipsum dolor sit amet, consectetur adipiscing
+elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit
+esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+)""";
+    }
+
+    gcs::ObjectMetadata metadata = stream.Close();
+    std::cout << "Upload completed, the new object metadata is: " << metadata
+              << std::endl;
+  }
+  //! [resume resumable upload]
+  (std::move(client), bucket_name, object_name, session_id);
+}
+
 void UploadFile(google::cloud::storage::Client client, int& argc,
                 char* argv[]) {
   if (argc != 4) {
@@ -1034,6 +1100,8 @@ int main(int argc, char* argv[]) try {
       {"delete-object", &DeleteObject},
       {"write-object", &WriteObject},
       {"write-large-object", &WriteLargeObject},
+      {"start-resumable-upload", &StartResumableUpload},
+      {"resume-resumable-upload", &ResumeResumableUpload},
       {"upload-file", &UploadFile},
       {"upload-file-resumable", &UploadFileResumable},
       {"download-file", &DownloadFile},

--- a/google/cloud/storage/internal/curl_resumable_streambuf.cc
+++ b/google/cloud/storage/internal/curl_resumable_streambuf.cc
@@ -37,6 +37,8 @@ bool CurlResumableStreambuf::IsOpen() const {
 
 void CurlResumableStreambuf::ValidateHash(ObjectMetadata const& meta) {
   hash_validator_->ProcessMetadata(meta);
+  std::cout << "meta=" << meta << std::endl;
+
   hash_validator_result_ =
       HashValidator::FinishAndCheck(__func__, std::move(*hash_validator_));
 }
@@ -52,7 +54,7 @@ CurlResumableStreambuf::int_type CurlResumableStreambuf::overflow(int_type ch) {
 }
 
 int CurlResumableStreambuf::sync() {
-  Flush(true);
+  Flush(false);
   return 0;
 }
 

--- a/google/cloud/storage/internal/curl_resumable_streambuf.h
+++ b/google/cloud/storage/internal/curl_resumable_streambuf.h
@@ -46,6 +46,12 @@ class CurlResumableStreambuf : public ObjectWriteStreambuf {
   std::string const& computed_hash() const override {
     return hash_validator_result_.computed;
   }
+  std::string const& resumable_session_id() const override {
+    return upload_session_->session_id();
+  }
+  std::uint64_t next_expected_byte() const override {
+    return upload_session_->next_expected_byte();
+  }
 
  protected:
   int sync() override;

--- a/google/cloud/storage/internal/curl_streambuf.h
+++ b/google/cloud/storage/internal/curl_streambuf.h
@@ -76,6 +76,10 @@ class CurlStreambuf : public ObjectWriteStreambuf {
   std::string const& computed_hash() const override {
     return hash_validator_result_.computed;
   }
+  std::string const& resumable_session_id() const override {
+    return session_id_;
+  }
+  std::uint64_t next_expected_byte() const override { return 0; }
 
  protected:
   int sync() override;
@@ -96,6 +100,7 @@ class CurlStreambuf : public ObjectWriteStreambuf {
 
   std::unique_ptr<HashValidator> hash_validator_;
   HashValidator::Result hash_validator_result_;
+  std::string session_id_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -126,8 +126,8 @@ class InsertObjectStreamingRequest
           Crc32cChecksumValue, DisableCrc32cChecksum, DisableMD5Hash,
           EncryptionKey, IfGenerationMatch, IfGenerationNotMatch,
           IfMetagenerationMatch, IfMetagenerationNotMatch, KmsKeyName,
-          MD5HashValue, PredefinedAcl, Projection, UserProject,
-          WithObjectMetadata> {
+          MD5HashValue, PredefinedAcl, Projection, UseResumableUploadSession,
+          UserProject, WithObjectMetadata> {
  public:
   using GenericObjectRequest::GenericObjectRequest;
 };

--- a/google/cloud/storage/internal/object_streambuf.h
+++ b/google/cloud/storage/internal/object_streambuf.h
@@ -70,6 +70,12 @@ class ObjectWriteStreambuf : public std::basic_streambuf<char> {
   virtual std::string const& received_hash() const = 0;
   virtual std::string const& computed_hash() const = 0;
 
+  /// The session id, if applicable, it is empty for non-resumable uploads.
+  virtual std::string const& resumable_session_id() const = 0;
+
+  /// The next expected byte, if applicable, always 0 for non-resumable uploads.
+  virtual std::uint64_t next_expected_byte() const = 0;
+
  protected:
   virtual HttpResponse DoClose() = 0;
 };

--- a/google/cloud/storage/object_stream.cc
+++ b/google/cloud/storage/object_stream.cc
@@ -95,6 +95,10 @@ ObjectMetadata ObjectWriteStream::Close() {
   return metadata;
 }
 
+void ObjectWriteStream::Suspend() {
+  buf_.reset();
+}
+
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/object_stream.cc
+++ b/google/cloud/storage/object_stream.cc
@@ -95,7 +95,7 @@ ObjectMetadata ObjectWriteStream::Close() {
   return metadata;
 }
 
-void ObjectWriteStream::Suspend() {
+void ObjectWriteStream::Suspend() && {
   buf_.reset();
 }
 

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -150,15 +150,12 @@ class ObjectWriteStream : public std::basic_ostream<char> {
   /**
    * Suspends an upload.
    *
-   * For resumable uploads this function suspends the current upload, future
-   *
-   *
    * This is a destructive operation. Using this object after calling this
    * function results in undefined behavior. Applications should copy any
    * necessary state (such as the value `resumable_session_id()`) before calling
    * this function.
    */
-  void Suspend();
+  void Suspend() &&;
 
  private:
   std::unique_ptr<internal::ObjectWriteStreambuf> buf_;

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -123,6 +123,43 @@ class ObjectWriteStream : public std::basic_ostream<char> {
   std::string const& received_hash() const { return buf_->received_hash(); }
   std::string const& computed_hash() const { return buf_->computed_hash(); }
 
+  /**
+   * Returns the resumable upload session id for this upload.
+   *
+   * Note that this is an empty string for uploads that do not use resumable
+   * upload session ids. `Client::WriteObject()` enables resumable uploads based
+   * on the options set by the application.
+   *
+   * Furthermore, this value might change during an upload.
+   */
+  std::string const& resumable_session_id() const {
+    return buf_->resumable_session_id();
+  }
+
+  /**
+   * Returns the next expected byte.
+   *
+   * For non-resumable uploads this is always zero. Applications that use
+   * resumable uploads can use this value to resend any data not committed in
+   * the GCS.
+   */
+  std::uint64_t next_expected_byte() const {
+    return buf_->next_expected_byte();
+  }
+
+  /**
+   * Suspends an upload.
+   *
+   * For resumable uploads this function suspends the current upload, future
+   *
+   *
+   * This is a destructive operation. Using this object after calling this
+   * function results in undefined behavior. Applications should copy any
+   * necessary state (such as the value `resumable_session_id()`) before calling
+   * this function.
+   */
+  void Suspend();
+
  private:
   std::unique_ptr<internal::ObjectWriteStreambuf> buf_;
 };

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -132,7 +132,7 @@ TEST_F(ObjectResumableWriteIntegrationTest, WriteResume) {
         client.WriteObject(bucket_name, object_name, IfGenerationMatch(0),
                            NewResumableUploadSession());
     session_id = old_os.resumable_session_id();
-    old_os.Suspend();
+    std::move(old_os).Suspend();
   }
 
   auto os = client.WriteObject(bucket_name, object_name,

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -62,6 +62,7 @@ TEST_F(ObjectResumableWriteIntegrationTest, WriteWithContentType) {
       bucket_name, object_name, IfGenerationMatch(0),
       WithObjectMetadata(ObjectMetadata().set_content_type("text/plain")));
   os << LoremIpsum();
+  EXPECT_FALSE(os.resumable_session_id().empty());
   ObjectMetadata meta = os.Close();
   EXPECT_EQ(object_name, meta.name());
   EXPECT_EQ(bucket_name, meta.bucket());
@@ -90,6 +91,63 @@ TEST_F(ObjectResumableWriteIntegrationTest, WriteWithContentTypeFailure) {
     os << LoremIpsum();
     ObjectMetadata meta = os.Close();
   });
+}
+
+TEST_F(ObjectResumableWriteIntegrationTest, WriteWithUseResumable) {
+  Client client;
+  auto bucket_name = ObjectResumableWriteTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+
+  // We will construct the expected response while streaming the data up.
+  std::ostringstream expected;
+
+  // Create the object, but only if it does not exist already.
+  auto os = client.WriteObject(bucket_name, object_name, IfGenerationMatch(0),
+                               NewResumableUploadSession());
+  os << LoremIpsum();
+  EXPECT_FALSE(os.resumable_session_id().empty());
+  ObjectMetadata meta = os.Close();
+  EXPECT_EQ(object_name, meta.name());
+  EXPECT_EQ(bucket_name, meta.bucket());
+  if (UsingTestbench()) {
+    EXPECT_TRUE(meta.has_metadata("x_testbench_upload"));
+    EXPECT_EQ("resumable", meta.metadata("x_testbench_upload"));
+  }
+
+  client.DeleteObject(bucket_name, object_name);
+}
+
+TEST_F(ObjectResumableWriteIntegrationTest, WriteResume) {
+  Client client;
+  auto bucket_name = ObjectResumableWriteTestEnvironment::bucket_name();
+  auto object_name = MakeRandomObjectName();
+
+  // We will construct the expected response while streaming the data up.
+  std::ostringstream expected;
+
+  // Create the object, but only if it does not exist already.
+  std::string session_id;
+  {
+    auto old_os =
+        client.WriteObject(bucket_name, object_name, IfGenerationMatch(0),
+                           NewResumableUploadSession());
+    session_id = old_os.resumable_session_id();
+    old_os.Suspend();
+  }
+
+  auto os = client.WriteObject(bucket_name, object_name,
+                               RestoreResumableUploadSession(session_id));
+  EXPECT_EQ(session_id, os.resumable_session_id());
+  os << LoremIpsum();
+  ObjectMetadata meta = os.Close();
+  EXPECT_EQ(object_name, meta.name());
+  EXPECT_EQ(bucket_name, meta.bucket());
+  if (UsingTestbench()) {
+    EXPECT_TRUE(meta.has_metadata("x_testbench_upload"));
+    EXPECT_EQ("resumable", meta.metadata("x_testbench_upload"));
+  }
+
+  client.DeleteObject(bucket_name, object_name);
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
With this change the application can select resumable uploads for
streams created via WriteObject().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1597)
<!-- Reviewable:end -->
