### PR TITLE
Improve documentation for credentials classes.

### DIFF
--- a/google/cloud/storage/oauth2/anonymous_credentials.h
+++ b/google/cloud/storage/oauth2/anonymous_credentials.h
@@ -25,16 +25,23 @@ inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 
 /**
- * Defines credentials to access Google Cloud Storage anonymously.
+ * A Credentials subclass representing "anonymous" Google OAuth2.0 credentials.
  *
  * This is only useful in two cases: (a) in testing, where you want to access
  * a test bench without having to worry about authentication or SSL setup, and
- * (b) when accessing publicly readable buckets or objects without credentials.
+ * (b) when accessing publicly readable resources (e.g. a Google Cloud Storage
+ * object that is readable by the "allUsers" entity), which requires no
+ * authentication or authorization.
  */
 class AnonymousCredentials : public Credentials {
  public:
   AnonymousCredentials() = default;
 
+  /**
+   * While other Credentials subclasses return a string containing an
+   * Authorization HTTP header from this method, this class always returns an
+   * empty string.
+   */
   std::pair<google::cloud::storage::Status, std::string> AuthorizationHeader()
       override;
 };

--- a/google/cloud/storage/oauth2/authorized_user_credentials.h
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.h
@@ -43,23 +43,24 @@ AuthorizedUserCredentialsInfo ParseAuthorizedUserCredentials(
     std::string const& content, std::string const& source);
 
 /**
- * A C++ wrapper for Google's Authorized User Credentials.
+ * Wrapper class for Google OAuth 2.0 user account credentials.
  *
- * Takes a JSON object with the authorized user client id, secret, and access
- * token and uses Google's OAuth2 service to obtain an access token.
+ * Takes a JSON object with a client id, client secret, and the user's refresh
+ * token, and obtains access tokens from the Google Authorization Service as
+ * needed. Instances of this class should usually be created via the convenience
+ * methods declared in google_credentials.h.
  *
- * @warning
- * The current implementation is a placeholder to unblock development of the
- * Google Cloud Storage client libraries. There is substantial work needed
- * before this class is complete, in fact, we do not even have a complete set of
- * requirements for it.
+ * An HTTP Authorization header, with an access token as its value,
+ * can be obtained by calling the AuthorizationHeader() method; if the current
+ * access token is invalid or nearing expiration, this will class will first
+ * obtain a new access token before returning the Authorization header string.
  *
- * @see
- *   https://developers.google.com/identity/protocols/OAuth2ServiceAccount
- *   https://tools.ietf.org/html/rfc7523
+ * @see https://developers.google.com/identity/protocols/OAuth for an overview
+ * of using user credentials with Google's OAuth 2.0 system.
  *
  * @tparam HttpRequestBuilderType a dependency injection point. It makes it
- *     possible to mock the libcurl wrappers.
+ *     possible to mock internal libcurl wrappers. This should generally not be
+ *     overridden except for testing.
  */
 template <typename HttpRequestBuilderType =
               storage::internal::CurlRequestBuilder>

--- a/google/cloud/storage/oauth2/credentials.h
+++ b/google/cloud/storage/oauth2/credentials.h
@@ -24,7 +24,13 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 /**
- * Represents a credential to access Google Cloud Storage.
+ * Interface for OAuth 2.0 credentials used to access Google Cloud services.
+ *
+ * Instantiating a specific kind of Credentials should usually be done via the
+ * convenience methods declared in google_credentials.h.
+ *
+ * @see https://cloud.google.com/docs/authentication/ for an overview of
+ * authenticating to Google Cloud Platform APIs.
  */
 class Credentials {
  public:

--- a/google/cloud/storage/oauth2/google_credentials.h
+++ b/google/cloud/storage/oauth2/google_credentials.h
@@ -25,13 +25,16 @@ inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 
 /**
- * Produces a credential type based on a the runtime environment.
+ * Produces a credential type based on the runtime environment.
  *
  * If the GOOGLE_APPLICATION_CREDENTIALS environment variable is set, the JSON
  * file it points to will be loaded and used to create a credential of the
- * specified type. Otherwise, if running on a Google-hosted environment (Compute
- * Engine, etc.), credentials for the the environment's default service account
- * will be used.
+ * specified type. Otherwise, if running on a Google-hosted environment (e.g.
+ * Compute Engine), credentials for the the environment's default service
+ * account will be used.
+ *
+ * @see https://cloud.google.com/docs/authentication/production for details
+ * about Application Default Credentials.
  */
 std::shared_ptr<Credentials> GoogleDefaultCredentials();
 
@@ -44,7 +47,7 @@ std::shared_ptr<Credentials> GoogleDefaultCredentials();
 std::shared_ptr<Credentials> CreateAnonymousCredentials();
 
 /**
- * Creates an "authorized user" credential from a JSON file at the given path.
+ * Creates an AuthorizedUserCredentials from a JSON file at the given path.
  *
  * @note It is strongly preferred to instead use service account credentials
  * with Cloud Storage client libraries.
@@ -53,7 +56,7 @@ std::shared_ptr<Credentials> CreateAuthorizedUserCredentialsFromJsonFilePath(
     std::string const&);
 
 /**
- * Creates an "authorized user" credential from a JSON string.
+ * Creates an AuthorizedUserCredentials from a JSON string.
  *
  * @note It is strongly preferred to instead use service account credentials
  * with Cloud Storage client libraries.
@@ -61,22 +64,19 @@ std::shared_ptr<Credentials> CreateAuthorizedUserCredentialsFromJsonFilePath(
 std::shared_ptr<Credentials> CreateAuthorizedUserCredentialsFromJsonContents(
     std::string const&);
 
-/// Creates a "service account" credential from a JSON file at the given path.
+/// Creates a ServiceAccountCredentials rom a JSON file at the given path.
 std::shared_ptr<Credentials> CreateServiceAccountCredentialsFromJsonFilePath(
     std::string const&);
 
-/// Creates a "service account" credential from a JSON string.
+/// Creates a ServiceAccountCredentials from a JSON string.
 std::shared_ptr<Credentials> CreateServiceAccountCredentialsFromJsonContents(
     std::string const&);
 
-/// Creates a Google Compute Engine credential for the default service account.
+/// Creates a ComputeEngineCredentials for the VM's default service account.
 std::shared_ptr<Credentials> CreateComputeEngineCredentials();
 
-/// Creates a Google Compute Engine credential for the given service account.
+/// Creates a ComputeEngineCredentials for the VM's specified service account.
 std::shared_ptr<Credentials> CreateComputeEngineCredentials(std::string const&);
-
-// TODO(#1193): Should we support loading service account credentials from a P12
-// file too? Other libraries do, but the JSON format is strongly preferred.
 
 //@}
 


### PR DESCRIPTION
This refactors some of the functionality in the ServiceAccountCredentials
class so that the @see doxygen tags can be more closely applied to the
places they're relevant.

Written to address #1241.  We may also need (brief) code snippets to cover
the convenience functions defined in google_credentials.h. Thoughts?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1599)
<!-- Reviewable:end -->
