### PR TITLE
Restore macOS build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,18 @@ language: cpp
 # TODO(#62) - enable a SANITIZE_MEMORY=yes build when we eliminate the false positives
 matrix:
   include:
+    - # This is the only macOS entry in the matrix.  It is disabled on pull
+      # requests because Travis often has long backlogs for macOS.
+      os: osx
+      compiler: clang
+      env:
+        OPENSSL_ROOT_DIR=/usr/local/opt/libressl
+      install:
+      - git submodule update --init
+      - ci/install-retry.sh ci/travis/install-macosx.sh
+      script: ci/travis/build-macosx.sh
+      cache: ccache
+      if: type != pull_request
     - # Compile on Travis' native environment with Bazel
       os: linux
       compiler: gcc

--- a/cmake/external/curl.cmake
+++ b/cmake/external/curl.cmake
@@ -73,4 +73,17 @@ if (NOT TARGET curl_project)
                           OpenSSL::SSL
                           OpenSSL::Crypto
                           ZLIB::ZLIB)
+    if (WIN32)
+        set_property(TARGET CURL::CURL
+                     APPEND
+                     PROPERTY INTERFACE_LINK_LIBRARIES
+                              crypt32
+                              wsock32
+                              ws2_32)
+    endif ()
+    if (APPLE)
+        set_property(TARGET CURL::CURL
+                     APPEND
+                     PROPERTY INTERFACE_LINK_LIBRARIES ldap)
+    endif ()
 endif ()

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -212,9 +212,6 @@ target_link_libraries(storage_client
                              OpenSSL::Crypto
                              ZLIB::ZLIB
                       PRIVATE storage_common_options)
-if (WIN32)
-    target_link_libraries(storage_client PUBLIC crypt32 wsock32 ws2_32)
-endif ()
 target_include_directories(storage_client
                            PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
                                   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>

--- a/google/cloud/storage/internal/curl_wrappers.cc
+++ b/google/cloud/storage/internal/curl_wrappers.cc
@@ -38,9 +38,18 @@ namespace {
 //
 std::once_flag ssl_locking_initialized;
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L  // Older than version 1.1.0
-// OpenSSL before 1.1.0, and LibreSSL require the application to set locks
-// explicitly.  Both report OPENSSL_VERSION_NUMBER.
+#if LIBRESSL_VERSION_NUMBER
+// LibreSSL calls itself OpenSSL > 2.0, but it really is based on SSL 1.0.2
+// and requires locks.
+#define GOOGLE_CLOUD_CPP_SSL_REQUIRES_LOCKS 1
+#elif OPENSSL_VERSION_NUMBER < 0x10100000L  // Older than version 1.1.0
+// Before 1.1.0 OpenSSL requires locks to be used by multiple threads.
+#define GOOGLE_CLOUD_CPP_SSL_REQUIRES_LOCKS 1
+#else
+#define GOOGLE_CLOUD_CPP_SSL_REQUIRES_LOCKS 0
+#endif
+
+#if GOOGLE_CLOUD_CPP_SSL_REQUIRES_LOCKS
 std::vector<std::mutex> ssl_locks;
 
 // A callback to lock and unlock the mutexes needed by the SSL library.
@@ -147,7 +156,7 @@ void InitializeSslLocking(bool enable_ssl_callbacks) {
 }
 #else
 void InitializeSslLocking(bool enable_ssl_callbacks) {}
-#endif  // OPENSSL_VERSION_NUMBER < 0x10100000L
+#endif  // GOOGLE_CLOUD_CPP_SSL_REQUIRES_LOCKS
 
 /// Automatically initialize (and cleanup) the libcurl library.
 class CurlInitializer {
@@ -156,7 +165,6 @@ class CurlInitializer {
   ~CurlInitializer() { curl_global_cleanup(); }
 };
 }  // namespace
-
 
 std::string CurlSslLibraryId() {
   auto vinfo = curl_version_info(CURLVERSION_NOW);
@@ -169,15 +177,15 @@ bool SslLibraryNeedsLocking(std::string const& curl_ssl_id) {
   // Only these library prefixes require special configuration for using safely
   // with multiple threads.
   return (curl_ssl_id.rfind("OpenSSL/1.0", 0) == 0 or
-      curl_ssl_id.rfind("LibreSSL/2", 0) == 0);
+          curl_ssl_id.rfind("LibreSSL/2", 0) == 0);
 }
 
 bool SslLockingCallbacksInstalled() {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L  // Older than version 1.1.0
+#if GOOGLE_CLOUD_CPP_SSL_REQUIRES_LOCKS
   return not ssl_locks.empty();
 #else
   return false;
-#endif  // OPENSSL_VERSION_NUMBER < 0x10100000L
+#endif  // GOOGLE_CLOUD_CPP_SSL_REQUIRES_LOCKS
 }
 
 std::size_t CurlAppendHeaderData(CurlReceivedHeaders& received_headers,


### PR DESCRIPTION
Accidentally removed this in 5be86a48e5b16c4b7956a37a369026bedb9543fd when we disabled the static analysis builds, oops.

Some of the changes may seem strange, but are basically catch up work to
restore the macOS build to working order:

* When using a static CURL::CURL library we need to add its
  dependencies too. These vary depending on the platform, so they
  require a few if() statements. Better to move those to the
  `cmake/IncludeCurl.cmake` file that leave them in a random CMake
  file.

* Compiling libcurl as a external on macOS seems hard: there are
  dependencies on the LDAP libraries, default to find_package()
  for now. Created #1600 to track that.

* LibreSSL, which is common for macOS / BSD, reports itself as OpenSSL
  2.0, but behaves like OpenSSL 1.0.2, so we need some different checks
  than just the OpenSSL version to figure out if locking callbacks are needed.
  Sigh...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1601)
<!-- Reviewable:end -->
