### PR TITLE
URL-escape the object names.

### DIFF
--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -102,6 +102,16 @@ std::string XmlMapPredefinedAcl(std::string const& acl) {
   return loc->second;
 }
 
+std::string UrlEscapeString(std::string const& value) {
+  CurlHandle handle;
+  return std::string(handle.MakeEscapedString(value).get());
+}
+
+template <typename Request>
+std::string EscapeObjectName(Request const& request) {
+  return UrlEscapeString(request.object_name());
+}
+
 }  // namespace
 
 Status CurlClient::SetupBuilderCommon(CurlRequestBuilder& builder,
@@ -490,8 +500,9 @@ std::pair<Status, ObjectMetadata> CurlClient::CopyObject(
     CopyObjectRequest const& request) {
   CurlRequestBuilder builder(
       storage_endpoint_ + "/b/" + request.source_bucket() + "/o/" +
-          request.source_object() + "/copyTo/b/" +
-          request.destination_bucket() + "/o/" + request.destination_object(),
+          UrlEscapeString(request.source_object()) + "/copyTo/b/" +
+          request.destination_bucket() + "/o/" +
+          UrlEscapeString(request.destination_object()),
       storage_factory_);
   auto status = SetupBuilder(builder, request, "POST");
   if (not status.ok()) {
@@ -516,7 +527,7 @@ std::pair<Status, ObjectMetadata> CurlClient::CopyObject(
 std::pair<Status, ObjectMetadata> CurlClient::GetObjectMetadata(
     GetObjectMetadataRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + request.object_name(),
+                                 "/o/" + EscapeObjectName(request),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
   if (not status.ok()) {
@@ -541,7 +552,7 @@ std::pair<Status, std::unique_ptr<ObjectReadStreambuf>> CurlClient::ReadObject(
   }
   // Assume the bucket name is validated by the caller.
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + request.object_name(),
+                                 "/o/" + EscapeObjectName(request),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
   if (not status.ok()) {
@@ -601,7 +612,7 @@ std::pair<Status, EmptyResponse> CurlClient::DeleteObject(
     DeleteObjectRequest const& request) {
   // Assume the bucket name is validated by the caller.
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + request.object_name(),
+                                 "/o/" + EscapeObjectName(request),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "DELETE");
   if (not status.ok()) {
@@ -619,7 +630,7 @@ std::pair<Status, EmptyResponse> CurlClient::DeleteObject(
 std::pair<Status, ObjectMetadata> CurlClient::UpdateObject(
     UpdateObjectRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + request.object_name(),
+                                 "/o/" + EscapeObjectName(request),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PUT");
   if (not status.ok()) {
@@ -639,7 +650,7 @@ std::pair<Status, ObjectMetadata> CurlClient::UpdateObject(
 std::pair<Status, ObjectMetadata> CurlClient::PatchObject(
     PatchObjectRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + request.object_name(),
+                                 "/o/" + EscapeObjectName(request),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PATCH");
   if (not status.ok()) {
@@ -659,7 +670,7 @@ std::pair<Status, ObjectMetadata> CurlClient::PatchObject(
 std::pair<Status, ObjectMetadata> CurlClient::ComposeObject(
     ComposeObjectRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + request.object_name() + "/compose",
+                                 "/o/" + EscapeObjectName(request) + "/compose",
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "POST");
   if (not status.ok()) {
@@ -680,8 +691,9 @@ std::pair<Status, RewriteObjectResponse> CurlClient::RewriteObject(
     RewriteObjectRequest const& request) {
   CurlRequestBuilder builder(
       storage_endpoint_ + "/b/" + request.source_bucket() + "/o/" +
-          request.source_object() + "/rewriteTo/b/" +
-          request.destination_bucket() + "/o/" + request.destination_object(),
+          UrlEscapeString(request.source_object()) + "/rewriteTo/b/" +
+          request.destination_bucket() + "/o/" +
+          UrlEscapeString(request.destination_object()),
       storage_factory_);
   auto status = SetupBuilder(builder, request, "POST");
   if (not status.ok()) {
@@ -748,7 +760,7 @@ std::pair<Status, ListBucketAclResponse> CurlClient::ListBucketAcl(
 std::pair<Status, BucketAccessControl> CurlClient::GetBucketAcl(
     GetBucketAclRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/acl/" + request.entity(),
+                                 "/acl/" + UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
   if (not status.ok()) {
@@ -790,7 +802,7 @@ std::pair<Status, BucketAccessControl> CurlClient::CreateBucketAcl(
 std::pair<Status, EmptyResponse> CurlClient::DeleteBucketAcl(
     DeleteBucketAclRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/acl/" + request.entity(),
+                                 "/acl/" + UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "DELETE");
   if (not status.ok()) {
@@ -808,7 +820,7 @@ std::pair<Status, EmptyResponse> CurlClient::DeleteBucketAcl(
 std::pair<Status, BucketAccessControl> CurlClient::UpdateBucketAcl(
     UpdateBucketAclRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/acl/" + request.entity(),
+                                 "/acl/" + UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PUT");
   if (not status.ok()) {
@@ -831,7 +843,7 @@ std::pair<Status, BucketAccessControl> CurlClient::UpdateBucketAcl(
 std::pair<Status, BucketAccessControl> CurlClient::PatchBucketAcl(
     PatchBucketAclRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/acl/" + request.entity(),
+                                 "/acl/" + UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PATCH");
   if (not status.ok()) {
@@ -852,7 +864,7 @@ std::pair<Status, ListObjectAclResponse> CurlClient::ListObjectAcl(
     ListObjectAclRequest const& request) {
   // Assume the bucket name is validated by the caller.
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + request.object_name() + "/acl",
+                                 "/o/" + EscapeObjectName(request) + "/acl",
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
   if (not status.ok()) {
@@ -872,7 +884,7 @@ std::pair<Status, ListObjectAclResponse> CurlClient::ListObjectAcl(
 std::pair<Status, ObjectAccessControl> CurlClient::CreateObjectAcl(
     CreateObjectAclRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + request.object_name() + "/acl",
+                                 "/o/" + EscapeObjectName(request) + "/acl",
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "POST");
   if (not status.ok()) {
@@ -895,8 +907,8 @@ std::pair<Status, ObjectAccessControl> CurlClient::CreateObjectAcl(
 std::pair<Status, EmptyResponse> CurlClient::DeleteObjectAcl(
     DeleteObjectAclRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + request.object_name() + "/acl/" +
-                                 request.entity(),
+                                 "/o/" + EscapeObjectName(request) + "/acl/" +
+                                 UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "DELETE");
   if (not status.ok()) {
@@ -914,8 +926,8 @@ std::pair<Status, EmptyResponse> CurlClient::DeleteObjectAcl(
 std::pair<Status, ObjectAccessControl> CurlClient::GetObjectAcl(
     GetObjectAclRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + request.object_name() + "/acl/" +
-                                 request.entity(),
+                                 "/o/" + EscapeObjectName(request) + "/acl/" +
+                                 UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
   if (not status.ok()) {
@@ -934,8 +946,8 @@ std::pair<Status, ObjectAccessControl> CurlClient::GetObjectAcl(
 std::pair<Status, ObjectAccessControl> CurlClient::UpdateObjectAcl(
     UpdateObjectAclRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + request.object_name() + "/acl/" +
-                                 request.entity(),
+                                 "/o/" + EscapeObjectName(request) + "/acl/" +
+                                 UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PUT");
   if (not status.ok()) {
@@ -958,8 +970,8 @@ std::pair<Status, ObjectAccessControl> CurlClient::UpdateObjectAcl(
 std::pair<Status, ObjectAccessControl> CurlClient::PatchObjectAcl(
     PatchObjectAclRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + request.object_name() + "/acl/" +
-                                 request.entity(),
+                                 "/o/" + EscapeObjectName(request) + "/acl/" +
+                                 UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PATCH");
   if (not status.ok()) {
@@ -1023,7 +1035,8 @@ std::pair<Status, ObjectAccessControl> CurlClient::CreateDefaultObjectAcl(
 std::pair<Status, EmptyResponse> CurlClient::DeleteDefaultObjectAcl(
     DeleteDefaultObjectAclRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/defaultObjectAcl/" + request.entity(),
+                                 "/defaultObjectAcl/" +
+                                 UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "DELETE");
   if (not status.ok()) {
@@ -1041,7 +1054,8 @@ std::pair<Status, EmptyResponse> CurlClient::DeleteDefaultObjectAcl(
 std::pair<Status, ObjectAccessControl> CurlClient::GetDefaultObjectAcl(
     GetDefaultObjectAclRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/defaultObjectAcl/" + request.entity(),
+                                 "/defaultObjectAcl/" +
+                                 UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
   if (not status.ok()) {
@@ -1060,7 +1074,8 @@ std::pair<Status, ObjectAccessControl> CurlClient::GetDefaultObjectAcl(
 std::pair<Status, ObjectAccessControl> CurlClient::UpdateDefaultObjectAcl(
     UpdateDefaultObjectAclRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/defaultObjectAcl/" + request.entity(),
+                                 "/defaultObjectAcl/" +
+                                 UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PUT");
   if (not status.ok()) {
@@ -1083,7 +1098,8 @@ std::pair<Status, ObjectAccessControl> CurlClient::UpdateDefaultObjectAcl(
 std::pair<Status, ObjectAccessControl> CurlClient::PatchDefaultObjectAcl(
     PatchDefaultObjectAclRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/defaultObjectAcl/" + request.entity(),
+                                 "/defaultObjectAcl/" +
+                                 UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PATCH");
   if (not status.ok()) {
@@ -1207,7 +1223,7 @@ std::pair<Status, ObjectMetadata> CurlClient::InsertObjectMediaXml(
     InsertObjectMediaRequest const& request) {
   CurlRequestBuilder builder(xml_upload_endpoint_ + "/" +
                                  request.bucket_name() + "/" +
-                                 request.object_name(),
+                                 EscapeObjectName(request),
                              xml_upload_factory_);
   auto status = SetupBuilderCommon(builder, "PUT");
   if (not status.ok()) {
@@ -1294,7 +1310,7 @@ std::pair<Status, std::unique_ptr<ObjectReadStreambuf>>
 CurlClient::ReadObjectXml(ReadObjectRangeRequest const& request) {
   CurlRequestBuilder builder(xml_download_endpoint_ + "/" +
                                  request.bucket_name() + "/" +
-                                 request.object_name(),
+                                 EscapeObjectName(request),
                              xml_download_factory_);
   auto status = SetupBuilderCommon(builder, "GET");
   if (not status.ok()) {
@@ -1344,7 +1360,7 @@ std::pair<Status, std::unique_ptr<ObjectWriteStreambuf>>
 CurlClient::WriteObjectXml(InsertObjectStreamingRequest const& request) {
   CurlRequestBuilder builder(xml_upload_endpoint_ + "/" +
                                  request.bucket_name() + "/" +
-                                 request.object_name(),
+                                 EscapeObjectName(request),
                              xml_upload_factory_);
   auto status = SetupBuilderCommon(builder, "PUT");
   if (not status.ok()) {

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -107,11 +107,6 @@ std::string UrlEscapeString(std::string const& value) {
   return std::string(handle.MakeEscapedString(value).get());
 }
 
-template <typename Request>
-std::string EscapeObjectName(Request const& request) {
-  return UrlEscapeString(request.object_name());
-}
-
 }  // namespace
 
 Status CurlClient::SetupBuilderCommon(CurlRequestBuilder& builder,
@@ -527,7 +522,7 @@ std::pair<Status, ObjectMetadata> CurlClient::CopyObject(
 std::pair<Status, ObjectMetadata> CurlClient::GetObjectMetadata(
     GetObjectMetadataRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + EscapeObjectName(request),
+                                 "/o/" + UrlEscapeString(request.object_name()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
   if (not status.ok()) {
@@ -552,7 +547,7 @@ std::pair<Status, std::unique_ptr<ObjectReadStreambuf>> CurlClient::ReadObject(
   }
   // Assume the bucket name is validated by the caller.
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + EscapeObjectName(request),
+                                 "/o/" + UrlEscapeString(request.object_name()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
   if (not status.ok()) {
@@ -612,7 +607,7 @@ std::pair<Status, EmptyResponse> CurlClient::DeleteObject(
     DeleteObjectRequest const& request) {
   // Assume the bucket name is validated by the caller.
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + EscapeObjectName(request),
+                                 "/o/" + UrlEscapeString(request.object_name()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "DELETE");
   if (not status.ok()) {
@@ -630,7 +625,7 @@ std::pair<Status, EmptyResponse> CurlClient::DeleteObject(
 std::pair<Status, ObjectMetadata> CurlClient::UpdateObject(
     UpdateObjectRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + EscapeObjectName(request),
+                                 "/o/" + UrlEscapeString(request.object_name()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PUT");
   if (not status.ok()) {
@@ -650,7 +645,7 @@ std::pair<Status, ObjectMetadata> CurlClient::UpdateObject(
 std::pair<Status, ObjectMetadata> CurlClient::PatchObject(
     PatchObjectRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + EscapeObjectName(request),
+                                 "/o/" + UrlEscapeString(request.object_name()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PATCH");
   if (not status.ok()) {
@@ -670,7 +665,7 @@ std::pair<Status, ObjectMetadata> CurlClient::PatchObject(
 std::pair<Status, ObjectMetadata> CurlClient::ComposeObject(
     ComposeObjectRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + EscapeObjectName(request) + "/compose",
+                                 "/o/" + UrlEscapeString(request.object_name()) + "/compose",
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "POST");
   if (not status.ok()) {
@@ -864,7 +859,7 @@ std::pair<Status, ListObjectAclResponse> CurlClient::ListObjectAcl(
     ListObjectAclRequest const& request) {
   // Assume the bucket name is validated by the caller.
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + EscapeObjectName(request) + "/acl",
+                                 "/o/" + UrlEscapeString(request.object_name()) + "/acl",
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
   if (not status.ok()) {
@@ -884,7 +879,7 @@ std::pair<Status, ListObjectAclResponse> CurlClient::ListObjectAcl(
 std::pair<Status, ObjectAccessControl> CurlClient::CreateObjectAcl(
     CreateObjectAclRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + EscapeObjectName(request) + "/acl",
+                                 "/o/" + UrlEscapeString(request.object_name()) + "/acl",
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "POST");
   if (not status.ok()) {
@@ -907,7 +902,7 @@ std::pair<Status, ObjectAccessControl> CurlClient::CreateObjectAcl(
 std::pair<Status, EmptyResponse> CurlClient::DeleteObjectAcl(
     DeleteObjectAclRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + EscapeObjectName(request) + "/acl/" +
+                                 "/o/" + UrlEscapeString(request.object_name()) + "/acl/" +
                                  UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "DELETE");
@@ -926,7 +921,7 @@ std::pair<Status, EmptyResponse> CurlClient::DeleteObjectAcl(
 std::pair<Status, ObjectAccessControl> CurlClient::GetObjectAcl(
     GetObjectAclRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + EscapeObjectName(request) + "/acl/" +
+                                 "/o/" + UrlEscapeString(request.object_name()) + "/acl/" +
                                  UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
@@ -946,7 +941,7 @@ std::pair<Status, ObjectAccessControl> CurlClient::GetObjectAcl(
 std::pair<Status, ObjectAccessControl> CurlClient::UpdateObjectAcl(
     UpdateObjectAclRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + EscapeObjectName(request) + "/acl/" +
+                                 "/o/" + UrlEscapeString(request.object_name()) + "/acl/" +
                                  UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PUT");
@@ -970,7 +965,7 @@ std::pair<Status, ObjectAccessControl> CurlClient::UpdateObjectAcl(
 std::pair<Status, ObjectAccessControl> CurlClient::PatchObjectAcl(
     PatchObjectAclRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
-                                 "/o/" + EscapeObjectName(request) + "/acl/" +
+                                 "/o/" + UrlEscapeString(request.object_name()) + "/acl/" +
                                  UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PATCH");
@@ -1223,7 +1218,7 @@ std::pair<Status, ObjectMetadata> CurlClient::InsertObjectMediaXml(
     InsertObjectMediaRequest const& request) {
   CurlRequestBuilder builder(xml_upload_endpoint_ + "/" +
                                  request.bucket_name() + "/" +
-                                 EscapeObjectName(request),
+                                 UrlEscapeString(request.object_name()),
                              xml_upload_factory_);
   auto status = SetupBuilderCommon(builder, "PUT");
   if (not status.ok()) {
@@ -1310,7 +1305,7 @@ std::pair<Status, std::unique_ptr<ObjectReadStreambuf>>
 CurlClient::ReadObjectXml(ReadObjectRangeRequest const& request) {
   CurlRequestBuilder builder(xml_download_endpoint_ + "/" +
                                  request.bucket_name() + "/" +
-                                 EscapeObjectName(request),
+                                 UrlEscapeString(request.object_name()),
                              xml_download_factory_);
   auto status = SetupBuilderCommon(builder, "GET");
   if (not status.ok()) {
@@ -1360,7 +1355,7 @@ std::pair<Status, std::unique_ptr<ObjectWriteStreambuf>>
 CurlClient::WriteObjectXml(InsertObjectStreamingRequest const& request) {
   CurlRequestBuilder builder(xml_upload_endpoint_ + "/" +
                                  request.bucket_name() + "/" +
-                                 EscapeObjectName(request),
+                                 UrlEscapeString(request.object_name()),
                              xml_upload_factory_);
   auto status = SetupBuilderCommon(builder, "PUT");
   if (not status.ok()) {

--- a/google/cloud/storage/internal/curl_resumable_streambuf.cc
+++ b/google/cloud/storage/internal/curl_resumable_streambuf.cc
@@ -37,8 +37,6 @@ bool CurlResumableStreambuf::IsOpen() const {
 
 void CurlResumableStreambuf::ValidateHash(ObjectMetadata const& meta) {
   hash_validator_->ProcessMetadata(meta);
-  std::cout << "meta=" << meta << std::endl;
-
   hash_validator_result_ =
       HashValidator::FinishAndCheck(__func__, std::move(*hash_validator_));
 }

--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -51,6 +51,70 @@ std::string ObjectTestEnvironment::bucket_name_;
 class ObjectInsertIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {};
 
+TEST_F(ObjectInsertIntegrationTest, SimpleInsertWithNonUrlSafeName) {
+  Client client;
+  auto bucket_name = ObjectTestEnvironment::bucket_name();
+  auto object_name = "name-+-&-=- -%-" + MakeRandomObjectName();
+
+  std::string expected = LoremIpsum();
+
+  // Create the object, but only if it does not exist already.
+  ObjectMetadata meta = client.InsertObject(
+      bucket_name, object_name, expected, IfGenerationMatch(0),
+      DisableCrc32cChecksum(true), DisableMD5Hash(true));
+  EXPECT_EQ(object_name, meta.name());
+  EXPECT_EQ(bucket_name, meta.bucket());
+
+  // Create a iostream to read the object back.
+  auto stream = client.ReadObject(bucket_name, object_name);
+  std::string actual(std::istreambuf_iterator<char>{stream}, {});
+  EXPECT_EQ(expected, actual);
+
+  client.DeleteObject(bucket_name, object_name);
+}
+
+TEST_F(ObjectInsertIntegrationTest, XmlInsertWithNonUrlSafeName) {
+  Client client;
+  auto bucket_name = ObjectTestEnvironment::bucket_name();
+  auto object_name = "name-+-&-=- -%-" + MakeRandomObjectName();
+
+  std::string expected = LoremIpsum();
+
+  // Create the object, but only if it does not exist already.
+  ObjectMetadata meta = client.InsertObject(
+      bucket_name, object_name, expected, IfGenerationMatch(0), Fields(""));
+  EXPECT_EQ(object_name, meta.name());
+  EXPECT_EQ(bucket_name, meta.bucket());
+
+  // Create a iostream to read the object back.
+  auto stream = client.ReadObject(bucket_name, object_name);
+  std::string actual(std::istreambuf_iterator<char>{stream}, {});
+  EXPECT_EQ(expected, actual);
+
+  client.DeleteObject(bucket_name, object_name);
+}
+
+TEST_F(ObjectInsertIntegrationTest, MultipartInsertWithNonUrlSafeName) {
+  Client client;
+  auto bucket_name = ObjectTestEnvironment::bucket_name();
+  auto object_name = "name-+-&-=- -%-" + MakeRandomObjectName();
+
+  std::string expected = LoremIpsum();
+
+  // Create the object, but only if it does not exist already.
+  ObjectMetadata meta = client.InsertObject(
+      bucket_name, object_name, expected, IfGenerationMatch(0));
+  EXPECT_EQ(object_name, meta.name());
+  EXPECT_EQ(bucket_name, meta.bucket());
+
+  // Create a iostream to read the object back.
+  auto stream = client.ReadObject(bucket_name, object_name);
+  std::string actual(std::istreambuf_iterator<char>{stream}, {});
+  EXPECT_EQ(expected, actual);
+
+  client.DeleteObject(bucket_name, object_name);
+}
+
 TEST_F(ObjectInsertIntegrationTest, InsertWithMD5) {
   Client client;
   auto bucket_name = ObjectTestEnvironment::bucket_name();


### PR DESCRIPTION
The object names are not necessarily URL safe, so we need to URL-escape
them.  Also noticed that the entity names may not be
(foo+bar@example.com is a valid email address). I did not URL-escape the
bucket names in this PR because I am not sure we should, they are
supposed to be URL safe, if the application provides an invalid bucket
name this falls under the "do-not-duplicate-server-side-validation" ADR.

This fixes #1590.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1605)
<!-- Reviewable:end -->
