### PR TITLE
Simplify CMake configuration.

### DIFF
--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -20,7 +20,7 @@ powershell -exec bypass ci\kokoro\windows\install-dependencies.ps1
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 set CONFIG=Debug
-set PROVIDER=vcpkg
+set PROVIDER=package
 call "c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
 
 echo %date% %time%

--- a/cmake/IncludeCrc32c.cmake
+++ b/cmake/IncludeCrc32c.cmake
@@ -25,13 +25,12 @@ set_property(CACHE GOOGLE_CLOUD_CPP_CRC32C_PROVIDER
              PROPERTY STRINGS
                       "external"
                       "package"
-                      "vcpkg"
                       "pkg-config")
 
 if (TARGET Crc32c::crc32c)
     # Crc32c::crc32c is already defined, do not define it again.
 elseif("${GOOGLE_CLOUD_CPP_CRC32C_PROVIDER}" STREQUAL "external")
     include(external/crc32c)
-elseif("${GOOGLE_CLOUD_CPP_CRC32C_PROVIDER}" MATCHES "^(package|vcpkg)$")
+elseif("${GOOGLE_CLOUD_CPP_CRC32C_PROVIDER}" STREQUAL "package")
     find_package(Crc32c CONFIG REQUIRED)
 endif ()

--- a/cmake/IncludeCurl.cmake
+++ b/cmake/IncludeCurl.cmake
@@ -25,12 +25,11 @@ set_property(CACHE GOOGLE_CLOUD_CPP_CURL_PROVIDER
              PROPERTY STRINGS
                       "external"
                       "package"
-                      "vcpkg"
                       "pkg-config")
 
 if ("${GOOGLE_CLOUD_CPP_CURL_PROVIDER}" STREQUAL "external")
     include(external/curl)
-elseif("${GOOGLE_CLOUD_CPP_CURL_PROVIDER}" MATCHES "^(package|vcpkg)$")
+elseif("${GOOGLE_CLOUD_CPP_CURL_PROVIDER}" STREQUAL "package")
     # Search for libcurl, in CMake 3.5 this does not define a target, but it
     # will in 3.12 (see https://cmake.org/cmake/help/git-
     # stage/module/FindCURL.html for details).  Until then, define the target

--- a/cmake/IncludeGrpc.cmake
+++ b/cmake/IncludeGrpc.cmake
@@ -25,7 +25,6 @@ set_property(CACHE GOOGLE_CLOUD_CPP_GRPC_PROVIDER
              PROPERTY STRINGS
                       "external"
                       "package"
-                      "vcpkg"
                       "pkg-config")
 
 # Additional compile-time definitions for WIN32.  We need to manually set these
@@ -52,7 +51,7 @@ set(GOOGLE_CLOUD_CPP_MSVC_COMPILE_OPTIONS
 
 if ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "external")
     include(external/grpc)
-elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" MATCHES "^(package|vcpkg)$")
+elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "package")
     find_package(protobuf REQUIRED protobuf>=3.5.2)
     find_package(gRPC REQUIRED gRPC>=1.9)
 


### PR DESCRIPTION
This is part of the work to simplify our CMake files. It removes the special cases for `vcpkg`.

See #1248 for motivations and such. This fixes #1300.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1606)
<!-- Reviewable:end -->
