### PR TITLE
Implement query parameters for signed urls.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -323,6 +323,7 @@ set(storage_client_unit_tests
     notification_metadata_test.cc
     retry_policy_test.cc
     service_account_test.cc
+    signed_url_options_test.cc
     storage_class_test.cc
     storage_client_options_test.cc
     storage_version_test.cc

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -209,8 +209,11 @@ https://cloud.google.com/storage/docs/authentication
   std::string signature = curl.MakeEscapedString(result.second).get();
 
   std::ostringstream os;
-  os << "https://storage.googleapis.com/" << request.bucket_name() << '/'
-     << request.object_name() << "?GoogleAccessId=" << credentials->client_id()
+  os << "https://storage.googleapis.com/" << request.bucket_name();
+  if (not request.object_name().empty()) {
+    os << '/' << curl.MakeEscapedString(request.object_name()).get();
+  }
+  os << "?GoogleAccessId=" << credentials->client_id()
      << "&Expires=" << request.expiration_time_as_seconds().count()
      << "&Signature=" << signature;
 

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2158,15 +2158,18 @@ class Client {
    *
    * @note The application must ensure that any URL created with this function
    *     is a valid request via the XML API. For example, the options for
-   *     bucket requests may include a sub-resource (e.g. `WithAcl()`) but this
-   *     is not valid when querying objects.  Likewise, only a single
+   *     bucket requests may include a sub-resource (e.g. `WithBilling()`) but
+   *     not all sub-resources are valid for objects.  Likewise, only a single
    *     sub-resource may be retrieved in each request.
+   *
+   * @see https://cloud.google.com/storage/docs/access-control/signed-urls for
+   *     a general description of signed URLs and how they can be used.
    *
    * @see https://cloud.google.com/storage/docs/xml-api/overview for a detailed
    *     description of the XML API.
    *
    * @param verb the operation allowed through this signed URL, `GET`, `POST`,
-   *     `PUT`, etc. are valid values.
+   *     `PUT`, 'HEAD', etc. are valid values.
    * @param bucket_name the name of the bucket.
    * @param object_name the name of the object, note that the object may not
    *     exist for signed URLs that upload new objects. Use an empty string for

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2156,11 +2156,21 @@ class Client {
    *
    * @note By default URLs created with this function expire after 7 days.
    *
+   * @note The application must ensure that any URL created with this function
+   *     is a valid request via the XML API. For example, the options for
+   *     bucket requests may include a sub-resource (e.g. `WithAcl()`) but this
+   *     is not valid when querying objects.  Likewise, only a single
+   *     sub-resource may be retrieved in each request.
+   *
+   * @see https://cloud.google.com/storage/docs/xml-api/overview for a detailed
+   *     description of the XML API.
+   *
    * @param verb the operation allowed through this signed URL, `GET`, `POST`,
    *     `PUT`, etc. are valid values.
    * @param bucket_name the name of the bucket.
    * @param object_name the name of the object, note that the object may not
-   *     exist for signed URLs that upload new objects.
+   *     exist for signed URLs that upload new objects. Use an empty string for
+   *     requests that only affect a bucket.
    * @param options a list of optional parameters for the signed URL, this
    *     include: `ExpirationTime`, `MD5HashValue`, `ContentType`,
    *     `AddExtensionHeaderOption`, and `AddQueryParameterOption`. The
@@ -2168,10 +2178,9 @@ class Client {
    *     extension headers. Note that you can provides multiple values of this
    *     option. Likewise, the following helper functions can create properly
    *     formatted query parameters: `WithAcl()`, `WithBilling()`,
-   *     `WithCompose()`, `WithCors()`, `WithDelimiter()`,
-   *     `WithEncryption()`, `WithEncryptionConfig()`,`WithGeneration()`,
-   *     `WithGenerationMarker()`, `WithLifecycle()`, `WithLocation()`,
-   *     `WithLogging()`, `WithMarker()`, `WithMaxKeys()`, `WithPrefix()`,
+   *     `WithCompose()`, `WithCors()`, `WithEncryption()`,
+   *     `WithEncryptionConfig()`,`WithGeneration()`, `WithGenerationMarker()`,
+   *     `WithLifecycle()`, `WithLocation()`, `WithLogging()`, `WithMarker()`,
    *     `WithResponseContentDisposition()`, `WithResponseContentType()`,
    *     `WithStorageClass()`, `WithTagging()`, `WithUserProject()`.
    *

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2162,10 +2162,18 @@ class Client {
    * @param object_name the name of the object, note that the object may not
    *     exist for signed URLs that upload new objects.
    * @param options a list of optional parameters for the signed URL, this
-   *     include: `ExpirationTime`, `MD5HashValue`, `ContentType`, and
-   *     `AddExtensionHeaderOption`. The `AddExtensionHeader()` function
-   *     provides a simpler way to create extension headers. Note that you can
-   *     provides multiple values of this option.
+   *     include: `ExpirationTime`, `MD5HashValue`, `ContentType`,
+   *     `AddExtensionHeaderOption`, and `AddQueryParameterOption`. The
+   *     `AddExtensionHeader()` function provides a simpler way to create
+   *     extension headers. Note that you can provides multiple values of this
+   *     option. Likewise, the following helper functions can create properly
+   *     formatted query parameters: `WithAcl()`, `WithBilling()`,
+   *     `WithCompose()`, `WithCors()`, `WithDelimiter()`,
+   *     `WithEncryption()`, `WithEncryptionConfig()`,`WithGeneration()`,
+   *     `WithGenerationMarker()`, `WithLifecycle()`, `WithLocation()`,
+   *     `WithLogging()`, `WithMarker()`, `WithMaxKeys()`, `WithPrefix()`,
+   *     `WithResponseContentDisposition()`, `WithResponseContentType()`,
+   *     `WithStorageClass()`, `WithTagging()`, `WithUserProject()`.
    *
    * @par Example
    * @snippet storage_object_samples.cc sign url

--- a/google/cloud/storage/client_sign_url_test.cc
+++ b/google/cloud/storage/client_sign_url_test.cc
@@ -50,6 +50,25 @@ TEST(SignedUrlIntegrationTest, Sign) {
   EXPECT_THAT(actual, HasSubstr("test-object"));
 }
 
+TEST(SignedUrlIntegrationTest, BucketOnly) {
+  Client client(oauth2::CreateServiceAccountCredentialsFromJsonContents(
+      kJsonKeyfileContents));
+
+  auto actual = client.CreateV2SignedUrl("GET", "test-bucket", "", WithAcl());
+
+  EXPECT_THAT(actual, HasSubstr("test-bucket?GoogleAccessId="));
+}
+
+TEST(SignedUrlIntegrationTest, SignEscape) {
+  Client client(oauth2::CreateServiceAccountCredentialsFromJsonContents(
+      kJsonKeyfileContents));
+
+  auto actual = client.CreateV2SignedUrl("GET", "test-bucket", "test+object");
+
+  EXPECT_THAT(actual, HasSubstr("test-bucket"));
+  EXPECT_THAT(actual, HasSubstr("test%2Bobject"));
+}
+
 TEST(SignedUrlIntegrationTest, SignFailure) {
   Client client(google::cloud::storage::oauth2::CreateAnonymousCredentials());
 

--- a/google/cloud/storage/internal/signed_url_requests.cc
+++ b/google/cloud/storage/internal/signed_url_requests.cc
@@ -42,10 +42,12 @@ std::string SignUrlRequest::StringToSign() const {
   for (auto const& kv : extension_headers_) {
     os << kv.first << ":" << kv.second << "\n";
   }
-  CurlHandle curl;
-  os << "/" << bucket_name() << "/"
-     << curl.MakeEscapedString(object_name()).get();
 
+  CurlHandle curl;
+  os << '/' << bucket_name();
+  if (not object_name().empty()) {
+    os << '/'  << curl.MakeEscapedString(object_name()).get();
+  }
   char const* sep = "?";
   for (auto const& key_value : query_parameters_) {
     os << sep << key_value;

--- a/google/cloud/storage/internal/signed_url_requests.cc
+++ b/google/cloud/storage/internal/signed_url_requests.cc
@@ -46,6 +46,12 @@ std::string SignUrlRequest::StringToSign() const {
   os << "/" << bucket_name() << "/"
      << curl.MakeEscapedString(object_name()).get();
 
+  char const* sep = "?";
+  for (auto const& key_value : query_parameters_) {
+    os << sep << key_value;
+    sep = "&";
+  }
+
   return std::move(os).str();
 }
 

--- a/google/cloud/storage/internal/signed_url_requests.h
+++ b/google/cloud/storage/internal/signed_url_requests.h
@@ -89,6 +89,13 @@ class SignUrlRequest {
     }
   }
 
+  void set_option(AddQueryParameterOption const& o) {
+    if (not o.has_value()) {
+      return;
+    }
+    query_parameters_.push_back(o.value());
+  }
+
   std::string verb_;
   std::string bucket_name_;
   std::string object_name_;
@@ -96,6 +103,7 @@ class SignUrlRequest {
   std::string content_type_;
   std::chrono::system_clock::time_point expiration_time_;
   std::map<std::string, std::string> extension_headers_;
+  std::vector<std::string> query_parameters_;
 };
 
 std::ostream& operator<<(std::ostream& os, SignUrlRequest const& r);

--- a/google/cloud/storage/internal/signed_url_requests_test.cc
+++ b/google/cloud/storage/internal/signed_url_requests_test.cc
@@ -36,7 +36,8 @@ TEST(SignedUrlRequests, Sign) {
       AddExtensionHeader("x-goog-meta-foo", "bar"),
       AddExtensionHeader("x-goog-meta-foo", "baz"),
       AddExtensionHeader("x-goog-encryption-algorithm", "AES256"),
-      AddExtensionHeader("x-goog-acl", "project-private"));
+      AddExtensionHeader("x-goog-acl", "project-private"),
+      WithUserProject("test-project"));
 
   // Used this command to get the date in seconds:
   //   date +%s -u --date=2018-12-03T12:00:00Z
@@ -47,7 +48,7 @@ text/plain
 x-goog-acl:project-private
 x-goog-encryption-algorithm:AES256
 x-goog-meta-foo:bar,baz
-/test-bucket/test-object)""";
+/test-bucket/test-object?userProject=test-project)""";
 
   EXPECT_EQ(expected_blob, request.StringToSign());
 
@@ -63,7 +64,8 @@ TEST(SignedUrlRequests, SignEscaped) {
   EXPECT_EQ("test- -?-+-/-:-&-object", request.object_name());
 
   request.set_multiple_options(
-      ExpirationTime(ParseRfc3339("2018-12-03T12:00:00Z")));
+      ExpirationTime(ParseRfc3339("2018-12-03T12:00:00Z")),
+      WithDelimiter("+"));
 
   // Used this command to get the date in seconds:
   //   date +%s -u --date=2018-12-03T12:00:00Z
@@ -71,7 +73,7 @@ TEST(SignedUrlRequests, SignEscaped) {
 
 
 1543838400
-/test-bucket/test-%20-%3F-%2B-%2F-%3A-%26-object)""";
+/test-bucket/test-%20-%3F-%2B-%2F-%3A-%26-object?delimiter=%2B)""";
 
   EXPECT_EQ(expected_blob, request.StringToSign());
 

--- a/google/cloud/storage/internal/signed_url_requests_test.cc
+++ b/google/cloud/storage/internal/signed_url_requests_test.cc
@@ -65,7 +65,7 @@ TEST(SignedUrlRequests, SignEscaped) {
 
   request.set_multiple_options(
       ExpirationTime(ParseRfc3339("2018-12-03T12:00:00Z")),
-      WithDelimiter("+"));
+      WithMarker("foo+bar"));
 
   // Used this command to get the date in seconds:
   //   date +%s -u --date=2018-12-03T12:00:00Z
@@ -73,7 +73,7 @@ TEST(SignedUrlRequests, SignEscaped) {
 
 
 1543838400
-/test-bucket/test-%20-%3F-%2B-%2F-%3A-%26-object?delimiter=%2B)""";
+/test-bucket/test-%20-%3F-%2B-%2F-%3A-%26-object?marker=foo%2Bbar)""";
 
   EXPECT_EQ(expected_blob, request.StringToSign());
 

--- a/google/cloud/storage/signed_url_options.cc
+++ b/google/cloud/storage/signed_url_options.cc
@@ -1,15 +1,28 @@
-//   Copyright 2018 Carlos O'Ryan
+// Copyright 2018 Google LLC
 //
-//   Licensed under the Apache License, Version 2.0 (the "License");
-//   you may not use this file except in compliance with the License.
-//   You may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, software
-//   distributed under the License is distributed on an "AS IS" BASIS,
-//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//   See the License for the specific language governing permissions and
-//   limitations under the License.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-#include "signed_url_options.h"
+#include "google/cloud/storage/signed_url_options.h"
+#include "google/cloud/storage/internal/curl_handle.h"
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+std::string AddQueryParameterOption::UrlEscape(std::string const& value) {
+  return std::string(internal::CurlHandle().MakeEscapedString(value).get());
+}
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/signed_url_options.h
+++ b/google/cloud/storage/signed_url_options.h
@@ -90,11 +90,6 @@ inline AddQueryParameterOption WithCors() {
   return AddQueryParameterOption("cors");
 }
 
-inline AddQueryParameterOption WithDelimiter(std::string const& delimiter) {
-  return AddQueryParameterOption("delimiter=" +
-                                 AddQueryParameterOption::UrlEscape(delimiter));
-}
-
 inline AddQueryParameterOption WithEncryption() {
   return AddQueryParameterOption("encryption");
 }
@@ -130,17 +125,6 @@ inline AddQueryParameterOption WithLogging() {
 inline AddQueryParameterOption WithMarker(std::string const& marker) {
   return AddQueryParameterOption("marker=" +
                                  AddQueryParameterOption::UrlEscape(marker));
-}
-
-inline AddQueryParameterOption WithMaxKeys(std::int32_t max_keys) {
-  return AddQueryParameterOption(
-      "max-keys=" +
-      AddQueryParameterOption::UrlEscape(std::to_string(max_keys)));
-}
-
-inline AddQueryParameterOption WithPrefix(std::string const& prefix) {
-  return AddQueryParameterOption("prefix=" +
-                                 AddQueryParameterOption::UrlEscape(prefix));
 }
 
 inline AddQueryParameterOption WithResponseContentDisposition(

--- a/google/cloud/storage/signed_url_options.h
+++ b/google/cloud/storage/signed_url_options.h
@@ -56,6 +56,120 @@ inline AddExtensionHeaderOption AddExtensionHeader(std::string header,
       std::make_pair(std::move(header), std::move(value)));
 }
 
+/**
+ * Add a extension header to a signed URL.
+ */
+struct AddQueryParameterOption
+    : public internal::ComplexOption<AddQueryParameterOption, std::string> {
+  using ComplexOption<AddQueryParameterOption, std::string>::ComplexOption;
+  static char const* name() { return "query-parameter"; }
+
+  /**
+   * Escapes a string using URL encoding.
+   *
+   * This function acts as a compilation barrier because including
+   * internal/curl_wrappers.h in this header would expose that header (and the
+   * headers it depends on) in the public interface, and we want to avoid that.
+   */
+  static std::string UrlEscape(std::string const& value);
+};
+
+inline AddQueryParameterOption WithAcl() {
+  return AddQueryParameterOption("acl");
+}
+
+inline AddQueryParameterOption WithBilling() {
+  return AddQueryParameterOption("billing");
+}
+
+inline AddQueryParameterOption WithCompose() {
+  return AddQueryParameterOption("compose");
+}
+
+inline AddQueryParameterOption WithCors() {
+  return AddQueryParameterOption("cors");
+}
+
+inline AddQueryParameterOption WithDelimiter(std::string const& delimiter) {
+  return AddQueryParameterOption("delimiter=" +
+                                 AddQueryParameterOption::UrlEscape(delimiter));
+}
+
+inline AddQueryParameterOption WithEncryption() {
+  return AddQueryParameterOption("encryption");
+}
+
+inline AddQueryParameterOption WithEncryptionConfig() {
+  return AddQueryParameterOption("encryptionConfig");
+}
+
+inline AddQueryParameterOption WithGeneration(std::uint64_t generation) {
+  return AddQueryParameterOption(
+      "generation=" +
+      AddQueryParameterOption::UrlEscape(std::to_string(generation)));
+}
+
+inline AddQueryParameterOption WithGenerationMarker(std::uint64_t generation) {
+  return AddQueryParameterOption(
+      "generation-marker=" +
+      AddQueryParameterOption::UrlEscape(std::to_string(generation)));
+}
+
+inline AddQueryParameterOption WithLifecycle() {
+  return AddQueryParameterOption("lifecycle");
+}
+
+inline AddQueryParameterOption WithLocation() {
+  return AddQueryParameterOption("location");
+}
+
+inline AddQueryParameterOption WithLogging() {
+  return AddQueryParameterOption("logging");
+}
+
+inline AddQueryParameterOption WithMarker(std::string const& marker) {
+  return AddQueryParameterOption("marker=" +
+                                 AddQueryParameterOption::UrlEscape(marker));
+}
+
+inline AddQueryParameterOption WithMaxKeys(std::int32_t max_keys) {
+  return AddQueryParameterOption(
+      "max-keys=" +
+      AddQueryParameterOption::UrlEscape(std::to_string(max_keys)));
+}
+
+inline AddQueryParameterOption WithPrefix(std::string const& prefix) {
+  return AddQueryParameterOption("prefix=" +
+                                 AddQueryParameterOption::UrlEscape(prefix));
+}
+
+inline AddQueryParameterOption WithResponseContentDisposition(
+    std::string const& disposition) {
+  return AddQueryParameterOption(
+      "response-content-disposition=" +
+      AddQueryParameterOption::UrlEscape(disposition));
+}
+
+inline AddQueryParameterOption WithResponseContentType(
+    std::string const& type) {
+  return AddQueryParameterOption("response-content-type=" +
+                                 AddQueryParameterOption::UrlEscape(type));
+}
+
+inline AddQueryParameterOption WithStorageClass() {
+  return AddQueryParameterOption("storageClass");
+}
+
+inline AddQueryParameterOption WithTagging() {
+  return AddQueryParameterOption("tagging");
+}
+
+inline AddQueryParameterOption WithUserProject(
+    std::string const& user_project) {
+  return AddQueryParameterOption(
+      "userProject=" + AddQueryParameterOption::UrlEscape(user_project));
+}
+
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/signed_url_options_test.cc
+++ b/google/cloud/storage/signed_url_options_test.cc
@@ -25,7 +25,6 @@ TEST(SignedUrlOptions, QueryParamters) {
   EXPECT_EQ("billing", WithBilling().value());
   EXPECT_EQ("compose", WithCompose().value());
   EXPECT_EQ("cors", WithCors().value());
-  EXPECT_EQ("delimiter=%3A", WithDelimiter(":").value());
   EXPECT_EQ("encryption", WithEncryption().value());
   EXPECT_EQ("encryptionConfig", WithEncryptionConfig().value());
   EXPECT_EQ("generation=12345", WithGeneration(12345U).value());
@@ -34,8 +33,6 @@ TEST(SignedUrlOptions, QueryParamters) {
   EXPECT_EQ("location", WithLocation().value());
   EXPECT_EQ("logging", WithLogging().value());
   EXPECT_EQ("marker=abcd", WithMarker("abcd").value());
-  EXPECT_EQ("max-keys=1024", WithMaxKeys(1024).value());
-  EXPECT_EQ("prefix=foo%2Fbar%2F", WithPrefix("foo/bar/").value());
   EXPECT_EQ("response-content-disposition=inline",
             WithResponseContentDisposition("inline").value());
   EXPECT_EQ("response-content-type=text%2Fplain",

--- a/google/cloud/storage/signed_url_options_test.cc
+++ b/google/cloud/storage/signed_url_options_test.cc
@@ -1,0 +1,52 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/signed_url_options.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+TEST(SignedUrlOptions, QueryParamters) {
+  EXPECT_EQ("acl", WithAcl().value());
+  EXPECT_EQ("billing", WithBilling().value());
+  EXPECT_EQ("compose", WithCompose().value());
+  EXPECT_EQ("cors", WithCors().value());
+  EXPECT_EQ("delimiter=%3A", WithDelimiter(":").value());
+  EXPECT_EQ("encryption", WithEncryption().value());
+  EXPECT_EQ("encryptionConfig", WithEncryptionConfig().value());
+  EXPECT_EQ("generation=12345", WithGeneration(12345U).value());
+  EXPECT_EQ("generation-marker=23456", WithGenerationMarker(23456U).value());
+  EXPECT_EQ("lifecycle", WithLifecycle().value());
+  EXPECT_EQ("location", WithLocation().value());
+  EXPECT_EQ("logging", WithLogging().value());
+  EXPECT_EQ("marker=abcd", WithMarker("abcd").value());
+  EXPECT_EQ("max-keys=1024", WithMaxKeys(1024).value());
+  EXPECT_EQ("prefix=foo%2Fbar%2F", WithPrefix("foo/bar/").value());
+  EXPECT_EQ("response-content-disposition=inline",
+            WithResponseContentDisposition("inline").value());
+  EXPECT_EQ("response-content-type=text%2Fplain",
+            WithResponseContentType("text/plain").value());
+  EXPECT_EQ("storageClass", WithStorageClass().value());
+  EXPECT_EQ("tagging", WithTagging().value());
+  EXPECT_EQ("userProject=test-project",
+            WithUserProject("test-project").value());
+}
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -56,6 +56,7 @@ storage_client_unit_tests = [
     "notification_metadata_test.cc",
     "retry_policy_test.cc",
     "service_account_test.cc",
+    "signed_url_options_test.cc",
     "storage_class_test.cc",
     "storage_client_options_test.cc",
     "storage_version_test.cc",


### PR DESCRIPTION
Signed URLs can have any of the query parameters supported by the XML
API. This PR introduces a new option and helper functions to set these
query parameters (properly URL-escaped if needed).

This fixes #1588.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1608)
<!-- Reviewable:end -->
