### PR TITLE
Rename CurlStreambuf to CurlWriteStreambuf.

### DIFF
--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -1400,9 +1400,10 @@ CurlClient::WriteObjectXml(InsertObjectStreamingRequest const& request) {
   // QuotaUser cannot be set, checked by the caller.
   // UserIp cannot be set, checked by the caller.
 
-  std::unique_ptr<internal::CurlStreambuf> buf(new internal::CurlStreambuf(
-      builder.BuildUpload(), client_options().upload_buffer_size(),
-      CreateHashValidator(request)));
+  std::unique_ptr<internal::CurlWriteStreambuf> buf(
+      new internal::CurlWriteStreambuf(builder.BuildUpload(),
+                                       client_options().upload_buffer_size(),
+                                       CreateHashValidator(request)));
   return std::make_pair(
       Status(),
       std::unique_ptr<internal::ObjectWriteStreambuf>(std::move(buf)));
@@ -1429,9 +1430,10 @@ std::pair<Status, ObjectMetadata> CurlClient::InsertObjectMediaMultipart(
 
   // 3. Perform a streaming upload because computing the size upfront is more
   //    complicated than it is worth.
-  std::unique_ptr<internal::CurlStreambuf> buf(new internal::CurlStreambuf(
-      builder.BuildUpload(), client_options().upload_buffer_size(),
-      CreateHashValidator(request)));
+  std::unique_ptr<internal::CurlWriteStreambuf> buf(
+      new internal::CurlWriteStreambuf(builder.BuildUpload(),
+                                       client_options().upload_buffer_size(),
+                                       CreateHashValidator(request)));
   ObjectWriteStream writer(std::move(buf));
 
   nl::json metadata = nl::json::object();
@@ -1544,9 +1546,10 @@ CurlClient::WriteObjectSimple(InsertObjectStreamingRequest const& request) {
   }
   builder.AddQueryParameter("uploadType", "media");
   builder.AddQueryParameter("name", request.object_name());
-  std::unique_ptr<internal::CurlStreambuf> buf(new internal::CurlStreambuf(
-      builder.BuildUpload(), client_options().upload_buffer_size(),
-      CreateHashValidator(request)));
+  std::unique_ptr<internal::CurlWriteStreambuf> buf(
+      new internal::CurlWriteStreambuf(builder.BuildUpload(),
+                                       client_options().upload_buffer_size(),
+                                       CreateHashValidator(request)));
   return std::make_pair(
       Status(),
       std::unique_ptr<internal::ObjectWriteStreambuf>(std::move(buf)));

--- a/google/cloud/storage/internal/curl_streambuf.h
+++ b/google/cloud/storage/internal/curl_streambuf.h
@@ -60,13 +60,13 @@ class CurlReadStreambuf : public ObjectReadStreambuf {
 /**
  * Implement a wrapper for libcurl-based streaming uploads.
  */
-class CurlStreambuf : public ObjectWriteStreambuf {
+class CurlWriteStreambuf : public ObjectWriteStreambuf {
  public:
-  explicit CurlStreambuf(CurlUploadRequest&& upload,
-                         std::size_t max_buffer_size,
-                         std::unique_ptr<HashValidator> hash_validator);
+  explicit CurlWriteStreambuf(CurlUploadRequest&& upload,
+                              std::size_t max_buffer_size,
+                              std::unique_ptr<HashValidator> hash_validator);
 
-  ~CurlStreambuf() override = default;
+  ~CurlWriteStreambuf() override = default;
 
   bool IsOpen() const override;
   void ValidateHash(ObjectMetadata const& meta) override;

--- a/google/cloud/storage/tests/curl_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/curl_streambuf_integration_test.cc
@@ -37,9 +37,10 @@ TEST(CurlStreambufIntegrationTest, WriteManyBytes) {
                                        internal::GetDefaultCurlHandleFactory());
   builder.AddHeader("Content-Type: application/octet-stream");
   builder.SetMethod("POST");
-  std::unique_ptr<internal::CurlStreambuf> buf(new internal::CurlStreambuf(
-      builder.BuildUpload(), 128 * 1024,
-      google::cloud::internal::make_unique<internal::NullHashValidator>()));
+  std::unique_ptr<internal::CurlWriteStreambuf> buf(
+      new internal::CurlWriteStreambuf(
+          builder.BuildUpload(), 128 * 1024,
+          google::cloud::internal::make_unique<internal::NullHashValidator>()));
   ObjectWriteStream writer(std::move(buf));
 
   auto generator = google::cloud::internal::MakeDefaultPRNG();


### PR DESCRIPTION
This was really only for writing, the counterpart to
`ObjectReadStreambuf`, and derives from `ObjectWriteStreambuf`. In other
words, the naming was all wrong.

This is a class in `storage::internal` so it does not break the (public)
API, but technically it breaks the API and ABIs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1611)
<!-- Reviewable:end -->
