### PR TITLE
Enable misc-* clang-tidy warnings.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,10 +4,10 @@
 # Disabled:
 #  -google-readability-namespace-comments the BIGTABLE_CLIENT_NS is a macro, and
 #   clang-tidy fails to match it against the initial value.
-Checks: google-readability-*,modernize-*,readability-*,performance-*,-google-readability-namespace-comments
+Checks: google-readability-*,misc-*,modernize-*,readability-*,performance-*,-google-readability-namespace-comments
 
 # Enable most warnings as errors.
-WarningsAsErrors: clang-*,google-*,modernize-*,readability-*,performance-*
+WarningsAsErrors: clang-*,google-*,misc-*,modernize-*,readability-*,performance-*
 
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,7 +4,7 @@
 # Disabled:
 #  -google-readability-namespace-comments the BIGTABLE_CLIENT_NS is a macro, and
 #   clang-tidy fails to match it against the initial value.
-Checks: google-readability-*,misc-*,modernize-*,readability-*,performance-*,-google-readability-namespace-comments
+Checks: google-readability-*,misc-*,modernize-*,readability-*,performance-*,-google-readability-namespace-comments,-readability-named-parameter
 
 # Enable most warnings as errors.
 WarningsAsErrors: clang-*,google-*,misc-*,modernize-*,readability-*,performance-*

--- a/google/cloud/bigtable/idempotent_mutation_policy.cc
+++ b/google/cloud/bigtable/idempotent_mutation_policy.cc
@@ -44,7 +44,7 @@ std::unique_ptr<IdempotentMutationPolicy> AlwaysRetryMutationPolicy::clone()
 }
 
 bool AlwaysRetryMutationPolicy::is_idempotent(
-    google::bigtable::v2::Mutation const& m) {
+    google::bigtable::v2::Mutation const& /*m*/) {
   return true;
 }
 }  // namespace BIGTABLE_CLIENT_NS

--- a/google/cloud/bigtable/idempotent_mutation_policy.cc
+++ b/google/cloud/bigtable/idempotent_mutation_policy.cc
@@ -44,7 +44,7 @@ std::unique_ptr<IdempotentMutationPolicy> AlwaysRetryMutationPolicy::clone()
 }
 
 bool AlwaysRetryMutationPolicy::is_idempotent(
-    google::bigtable::v2::Mutation const& /*m*/) {
+    google::bigtable::v2::Mutation const&) {
   return true;
 }
 }  // namespace BIGTABLE_CLIENT_NS

--- a/google/cloud/bigtable/rpc_backoff_policy.cc
+++ b/google/cloud/bigtable/rpc_backoff_policy.cc
@@ -36,7 +36,7 @@ std::unique_ptr<RPCBackoffPolicy> ExponentialBackoffPolicy::clone() const {
 void ExponentialBackoffPolicy::Setup(grpc::ClientContext& /*unused*/) const {}
 
 std::chrono::milliseconds ExponentialBackoffPolicy::OnCompletion(
-    grpc::Status const& status) {
+    grpc::Status const& /*status*/) {
   return impl_.OnCompletion();
 }
 

--- a/google/cloud/bigtable/rpc_backoff_policy.cc
+++ b/google/cloud/bigtable/rpc_backoff_policy.cc
@@ -33,10 +33,10 @@ std::unique_ptr<RPCBackoffPolicy> ExponentialBackoffPolicy::clone() const {
   return std::unique_ptr<RPCBackoffPolicy>(new ExponentialBackoffPolicy(*this));
 }
 
-void ExponentialBackoffPolicy::Setup(grpc::ClientContext& /*unused*/) const {}
+void ExponentialBackoffPolicy::Setup(grpc::ClientContext&) const {}
 
 std::chrono::milliseconds ExponentialBackoffPolicy::OnCompletion(
-    grpc::Status const& /*status*/) {
+    grpc::Status const&) {
   return impl_.OnCompletion();
 }
 

--- a/google/cloud/bigtable/rpc_retry_policy.cc
+++ b/google/cloud/bigtable/rpc_retry_policy.cc
@@ -31,7 +31,7 @@ std::unique_ptr<RPCRetryPolicy> LimitedErrorCountRetryPolicy::clone() const {
 }
 
 void LimitedErrorCountRetryPolicy::Setup(
-    grpc::ClientContext& /*unused*/) const {}
+    grpc::ClientContext&) const {}
 
 bool LimitedErrorCountRetryPolicy::OnFailure(grpc::Status const& status) {
   return impl_.OnFailure(status);

--- a/google/cloud/internal/future_impl.cc
+++ b/google/cloud/internal/future_impl.cc
@@ -24,6 +24,7 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 [[noreturn]] void RaiseFutureError(std::future_errc ec, char const* msg) {
 #ifdef GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  (void)msg;  // disable unused argument warning.
   throw std::future_error(ec);
 #else
   std::string full_msg = "future_error[";

--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -49,14 +49,14 @@ std::size_t DefaultConnectionPoolSize() {
 // application. They are larger than the typical socket buffer size (64KiB), to
 // be able to read the full buffer into userspace if it happens to be full.
 #ifndef GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE
-#define GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE 128 * 1024
+#define GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE (128 * 1024)
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE
 
 // The documentation recommends uploads below "5MiB" to use simple uploads:
 //   https://cloud.google.com/storage/docs/json_api/v1/how-tos/upload
 #ifndef GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_MAXIMUM_SIMPLE_UPLOAD_SIZE
 #define GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_MAXIMUM_SIMPLE_UPLOAD_SIZE \
-  5 * 1024 * 1024L
+  (5 * 1024 * 1024L)
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_MAXIMUM_SIMPLE_UPLOAD_SIZE
 
 }  // namespace

--- a/google/cloud/storage/idempotency_policy.cc
+++ b/google/cloud/storage/idempotency_policy.cc
@@ -26,193 +26,193 @@ std::unique_ptr<IdempotencyPolicy> AlwaysRetryIdempotencyPolicy::clone() const {
 }
 
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::ListBucketsRequest const& request) const {
+    internal::ListBucketsRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::CreateBucketRequest const& request) const {
+    internal::CreateBucketRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::GetBucketMetadataRequest const& request) const {
+    internal::GetBucketMetadataRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::DeleteBucketRequest const& request) const {
+    internal::DeleteBucketRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::UpdateBucketRequest const& request) const {
+    internal::UpdateBucketRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::PatchBucketRequest const& request) const {
+    internal::PatchBucketRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::GetBucketIamPolicyRequest const& request) const {
+    internal::GetBucketIamPolicyRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::SetBucketIamPolicyRequest const& request) const {
+    internal::SetBucketIamPolicyRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::TestBucketIamPermissionsRequest const& request) const {
+    internal::TestBucketIamPermissionsRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::LockBucketRetentionPolicyRequest const& request) const {
-  return true;
-}
-
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::InsertObjectMediaRequest const& request) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::CopyObjectRequest const& request) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::GetObjectMetadataRequest const& request) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::ReadObjectRangeRequest const& request) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::InsertObjectStreamingRequest const& request) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::ListObjectsRequest const& request) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::DeleteObjectRequest const& request) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::UpdateObjectRequest const& request) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::PatchObjectRequest const& request) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::ComposeObjectRequest const& request) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::RewriteObjectRequest const& request) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::ResumableUploadRequest const& request) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::UploadChunkRequest const& request) const {
+    internal::LockBucketRetentionPolicyRequest const& /*request*/) const {
   return true;
 }
 
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::ListBucketAclRequest const& request) const {
+    internal::InsertObjectMediaRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::CreateBucketAclRequest const& request) const {
+    internal::CopyObjectRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::DeleteBucketAclRequest const& request) const {
+    internal::GetObjectMetadataRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::GetBucketAclRequest const& request) const {
+    internal::ReadObjectRangeRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::UpdateBucketAclRequest const& request) const {
+    internal::InsertObjectStreamingRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::PatchBucketAclRequest const& request) const {
-  return true;
-}
-
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::ListObjectAclRequest const& request) const {
+    internal::ListObjectsRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::CreateObjectAclRequest const& request) const {
+    internal::DeleteObjectRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::DeleteObjectAclRequest const& request) const {
+    internal::UpdateObjectRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::GetObjectAclRequest const& request) const {
+    internal::PatchObjectRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::UpdateObjectAclRequest const& request) const {
+    internal::ComposeObjectRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::PatchObjectAclRequest const& request) const {
-  return true;
-}
-
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::ListDefaultObjectAclRequest const& request) const {
+    internal::RewriteObjectRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::CreateDefaultObjectAclRequest const& request) const {
+    internal::ResumableUploadRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::DeleteDefaultObjectAclRequest const& request) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::GetDefaultObjectAclRequest const& request) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::UpdateDefaultObjectAclRequest const& request) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::PatchDefaultObjectAclRequest const& request) const {
+    internal::UploadChunkRequest const& /*request*/) const {
   return true;
 }
 
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::GetProjectServiceAccountRequest const& request) const {
+    internal::ListBucketAclRequest const& /*request*/) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::CreateBucketAclRequest const& /*request*/) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::DeleteBucketAclRequest const& /*request*/) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::GetBucketAclRequest const& /*request*/) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::UpdateBucketAclRequest const& /*request*/) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::PatchBucketAclRequest const& /*request*/) const {
   return true;
 }
 
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::ListNotificationsRequest const& request) const {
+    internal::ListObjectAclRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::CreateNotificationRequest const& request) const {
+    internal::CreateObjectAclRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::GetNotificationRequest const& request) const {
+    internal::DeleteObjectAclRequest const& /*request*/) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::DeleteNotificationRequest const& request) const {
+    internal::GetObjectAclRequest const& /*request*/) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::UpdateObjectAclRequest const& /*request*/) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::PatchObjectAclRequest const& /*request*/) const {
+  return true;
+}
+
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::ListDefaultObjectAclRequest const& /*request*/) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::CreateDefaultObjectAclRequest const& /*request*/) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::DeleteDefaultObjectAclRequest const& /*request*/) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::GetDefaultObjectAclRequest const& /*request*/) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::UpdateDefaultObjectAclRequest const& /*request*/) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::PatchDefaultObjectAclRequest const& /*request*/) const {
+  return true;
+}
+
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::GetProjectServiceAccountRequest const& /*request*/) const {
+  return true;
+}
+
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::ListNotificationsRequest const& /*request*/) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::CreateNotificationRequest const& /*request*/) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::GetNotificationRequest const& /*request*/) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::DeleteNotificationRequest const& /*request*/) const {
   return true;
 }
 
@@ -221,20 +221,20 @@ std::unique_ptr<IdempotencyPolicy> StrictIdempotencyPolicy::clone() const {
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::ListBucketsRequest const& request) const {
+    internal::ListBucketsRequest const& /*request*/) const {
   // Read operations are always idempotent.
   return true;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::CreateBucketRequest const& request) const {
+    internal::CreateBucketRequest const& /*request*/) const {
   // Creating a bucket is idempotent because you cannot create a new version
   // of a bucket, it succeeds only once.
   return true;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::GetBucketMetadataRequest const& request) const {
+    internal::GetBucketMetadataRequest const& /*request*/) const {
   // Read operations are always idempotent.
   return true;
 }
@@ -258,7 +258,7 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::GetBucketIamPolicyRequest const& request) const {
+    internal::GetBucketIamPolicyRequest const& /*request*/) const {
   return true;
 }
 
@@ -268,12 +268,12 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::TestBucketIamPermissionsRequest const& request) const {
+    internal::TestBucketIamPermissionsRequest const& /*request*/) const {
   return true;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::LockBucketRetentionPolicyRequest const& request) const {
+    internal::LockBucketRetentionPolicyRequest const& /*request*/) const {
   // This request type always requires a metageneration pre-condition.
   return true;
 }
@@ -293,12 +293,12 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::GetObjectMetadataRequest const& request) const {
+    internal::GetObjectMetadataRequest const& /*request*/) const {
   return true;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::ReadObjectRangeRequest const& request) const {
+    internal::ReadObjectRangeRequest const& /*request*/) const {
   return true;
 }
 
@@ -308,7 +308,7 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::ListObjectsRequest const& request) const {
+    internal::ListObjectsRequest const& /*request*/) const {
   return true;
 }
 
@@ -358,12 +358,12 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::UploadChunkRequest const& request) const {
+    internal::UploadChunkRequest const& /*request*/) const {
   return true;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::ListBucketAclRequest const& request) const {
+    internal::ListBucketAclRequest const& /*request*/) const {
   return true;
 }
 
@@ -378,7 +378,7 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::GetBucketAclRequest const& request) const {
+    internal::GetBucketAclRequest const& /*request*/) const {
   return true;
 }
 
@@ -393,7 +393,7 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::ListObjectAclRequest const& request) const {
+    internal::ListObjectAclRequest const& /*request*/) const {
   return true;
 }
 
@@ -408,7 +408,7 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::GetObjectAclRequest const& request) const {
+    internal::GetObjectAclRequest const& /*request*/) const {
   return true;
 }
 
@@ -423,7 +423,7 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::ListDefaultObjectAclRequest const& request) const {
+    internal::ListDefaultObjectAclRequest const& /*request*/) const {
   return true;
 }
 
@@ -438,7 +438,7 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::GetDefaultObjectAclRequest const& request) const {
+    internal::GetDefaultObjectAclRequest const& /*request*/) const {
   return true;
 }
 
@@ -453,27 +453,27 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::GetProjectServiceAccountRequest const& request) const {
+    internal::GetProjectServiceAccountRequest const& /*request*/) const {
   return true;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::ListNotificationsRequest const& request) const {
+    internal::ListNotificationsRequest const& /*request*/) const {
   return true;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::CreateNotificationRequest const& request) const {
+    internal::CreateNotificationRequest const& /*request*/) const {
   return true;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::GetNotificationRequest const& request) const {
+    internal::GetNotificationRequest const& /*request*/) const {
   return true;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::DeleteNotificationRequest const& request) const {
+    internal::DeleteNotificationRequest const& /*request*/) const {
   return true;
 }
 

--- a/google/cloud/storage/idempotency_policy.cc
+++ b/google/cloud/storage/idempotency_policy.cc
@@ -26,193 +26,193 @@ std::unique_ptr<IdempotencyPolicy> AlwaysRetryIdempotencyPolicy::clone() const {
 }
 
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::ListBucketsRequest const& /*request*/) const {
+    internal::ListBucketsRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::CreateBucketRequest const& /*request*/) const {
+    internal::CreateBucketRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::GetBucketMetadataRequest const& /*request*/) const {
+    internal::GetBucketMetadataRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::DeleteBucketRequest const& /*request*/) const {
+    internal::DeleteBucketRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::UpdateBucketRequest const& /*request*/) const {
+    internal::UpdateBucketRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::PatchBucketRequest const& /*request*/) const {
+    internal::PatchBucketRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::GetBucketIamPolicyRequest const& /*request*/) const {
+    internal::GetBucketIamPolicyRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::SetBucketIamPolicyRequest const& /*request*/) const {
+    internal::SetBucketIamPolicyRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::TestBucketIamPermissionsRequest const& /*request*/) const {
+    internal::TestBucketIamPermissionsRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::LockBucketRetentionPolicyRequest const& /*request*/) const {
-  return true;
-}
-
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::InsertObjectMediaRequest const& /*request*/) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::CopyObjectRequest const& /*request*/) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::GetObjectMetadataRequest const& /*request*/) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::ReadObjectRangeRequest const& /*request*/) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::InsertObjectStreamingRequest const& /*request*/) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::ListObjectsRequest const& /*request*/) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::DeleteObjectRequest const& /*request*/) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::UpdateObjectRequest const& /*request*/) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::PatchObjectRequest const& /*request*/) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::ComposeObjectRequest const& /*request*/) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::RewriteObjectRequest const& /*request*/) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::ResumableUploadRequest const& /*request*/) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::UploadChunkRequest const& /*request*/) const {
+    internal::LockBucketRetentionPolicyRequest const&) const {
   return true;
 }
 
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::ListBucketAclRequest const& /*request*/) const {
+    internal::InsertObjectMediaRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::CreateBucketAclRequest const& /*request*/) const {
+    internal::CopyObjectRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::DeleteBucketAclRequest const& /*request*/) const {
+    internal::GetObjectMetadataRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::GetBucketAclRequest const& /*request*/) const {
+    internal::ReadObjectRangeRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::UpdateBucketAclRequest const& /*request*/) const {
+    internal::InsertObjectStreamingRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::PatchBucketAclRequest const& /*request*/) const {
-  return true;
-}
-
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::ListObjectAclRequest const& /*request*/) const {
+    internal::ListObjectsRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::CreateObjectAclRequest const& /*request*/) const {
+    internal::DeleteObjectRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::DeleteObjectAclRequest const& /*request*/) const {
+    internal::UpdateObjectRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::GetObjectAclRequest const& /*request*/) const {
+    internal::PatchObjectRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::UpdateObjectAclRequest const& /*request*/) const {
+    internal::ComposeObjectRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::PatchObjectAclRequest const& /*request*/) const {
-  return true;
-}
-
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::ListDefaultObjectAclRequest const& /*request*/) const {
+    internal::RewriteObjectRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::CreateDefaultObjectAclRequest const& /*request*/) const {
+    internal::ResumableUploadRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::DeleteDefaultObjectAclRequest const& /*request*/) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::GetDefaultObjectAclRequest const& /*request*/) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::UpdateDefaultObjectAclRequest const& /*request*/) const {
-  return true;
-}
-bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::PatchDefaultObjectAclRequest const& /*request*/) const {
+    internal::UploadChunkRequest const&) const {
   return true;
 }
 
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::GetProjectServiceAccountRequest const& /*request*/) const {
+    internal::ListBucketAclRequest const&) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::CreateBucketAclRequest const&) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::DeleteBucketAclRequest const&) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::GetBucketAclRequest const&) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::UpdateBucketAclRequest const&) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::PatchBucketAclRequest const&) const {
   return true;
 }
 
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::ListNotificationsRequest const& /*request*/) const {
+    internal::ListObjectAclRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::CreateNotificationRequest const& /*request*/) const {
+    internal::CreateObjectAclRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::GetNotificationRequest const& /*request*/) const {
+    internal::DeleteObjectAclRequest const&) const {
   return true;
 }
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
-    internal::DeleteNotificationRequest const& /*request*/) const {
+    internal::GetObjectAclRequest const&) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::UpdateObjectAclRequest const&) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::PatchObjectAclRequest const&) const {
+  return true;
+}
+
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::ListDefaultObjectAclRequest const&) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::CreateDefaultObjectAclRequest const&) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::DeleteDefaultObjectAclRequest const&) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::GetDefaultObjectAclRequest const&) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::UpdateDefaultObjectAclRequest const&) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::PatchDefaultObjectAclRequest const&) const {
+  return true;
+}
+
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::GetProjectServiceAccountRequest const&) const {
+  return true;
+}
+
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::ListNotificationsRequest const&) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::CreateNotificationRequest const&) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::GetNotificationRequest const&) const {
+  return true;
+}
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::DeleteNotificationRequest const&) const {
   return true;
 }
 
@@ -221,20 +221,20 @@ std::unique_ptr<IdempotencyPolicy> StrictIdempotencyPolicy::clone() const {
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::ListBucketsRequest const& /*request*/) const {
+    internal::ListBucketsRequest const&) const {
   // Read operations are always idempotent.
   return true;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::CreateBucketRequest const& /*request*/) const {
+    internal::CreateBucketRequest const&) const {
   // Creating a bucket is idempotent because you cannot create a new version
   // of a bucket, it succeeds only once.
   return true;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::GetBucketMetadataRequest const& /*request*/) const {
+    internal::GetBucketMetadataRequest const&) const {
   // Read operations are always idempotent.
   return true;
 }
@@ -258,7 +258,7 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::GetBucketIamPolicyRequest const& /*request*/) const {
+    internal::GetBucketIamPolicyRequest const&) const {
   return true;
 }
 
@@ -268,12 +268,12 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::TestBucketIamPermissionsRequest const& /*request*/) const {
+    internal::TestBucketIamPermissionsRequest const&) const {
   return true;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::LockBucketRetentionPolicyRequest const& /*request*/) const {
+    internal::LockBucketRetentionPolicyRequest const&) const {
   // This request type always requires a metageneration pre-condition.
   return true;
 }
@@ -293,12 +293,12 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::GetObjectMetadataRequest const& /*request*/) const {
+    internal::GetObjectMetadataRequest const&) const {
   return true;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::ReadObjectRangeRequest const& /*request*/) const {
+    internal::ReadObjectRangeRequest const&) const {
   return true;
 }
 
@@ -308,7 +308,7 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::ListObjectsRequest const& /*request*/) const {
+    internal::ListObjectsRequest const&) const {
   return true;
 }
 
@@ -358,12 +358,12 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::UploadChunkRequest const& /*request*/) const {
+    internal::UploadChunkRequest const&) const {
   return true;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::ListBucketAclRequest const& /*request*/) const {
+    internal::ListBucketAclRequest const&) const {
   return true;
 }
 
@@ -378,7 +378,7 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::GetBucketAclRequest const& /*request*/) const {
+    internal::GetBucketAclRequest const&) const {
   return true;
 }
 
@@ -393,7 +393,7 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::ListObjectAclRequest const& /*request*/) const {
+    internal::ListObjectAclRequest const&) const {
   return true;
 }
 
@@ -408,7 +408,7 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::GetObjectAclRequest const& /*request*/) const {
+    internal::GetObjectAclRequest const&) const {
   return true;
 }
 
@@ -423,7 +423,7 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::ListDefaultObjectAclRequest const& /*request*/) const {
+    internal::ListDefaultObjectAclRequest const&) const {
   return true;
 }
 
@@ -438,7 +438,7 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::GetDefaultObjectAclRequest const& /*request*/) const {
+    internal::GetDefaultObjectAclRequest const&) const {
   return true;
 }
 
@@ -453,27 +453,27 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::GetProjectServiceAccountRequest const& /*request*/) const {
+    internal::GetProjectServiceAccountRequest const&) const {
   return true;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::ListNotificationsRequest const& /*request*/) const {
+    internal::ListNotificationsRequest const&) const {
   return true;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::CreateNotificationRequest const& /*request*/) const {
+    internal::CreateNotificationRequest const&) const {
   return true;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::GetNotificationRequest const& /*request*/) const {
+    internal::GetNotificationRequest const&) const {
   return true;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
-    internal::DeleteNotificationRequest const& /*request*/) const {
+    internal::DeleteNotificationRequest const&) const {
   return true;
 }
 

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -29,13 +29,15 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 
-extern "C" void CurlShareLockCallback(CURL* handle, curl_lock_data data,
-                                      curl_lock_access access, void* userptr) {
+extern "C" void CurlShareLockCallback(CURL* /*handle*/, curl_lock_data /*data*/,
+                                      curl_lock_access /*access*/,
+                                      void* userptr) {
   auto* client = reinterpret_cast<CurlClient*>(userptr);
   client->LockShared();
 }
 
-extern "C" void CurlShareUnlockCallback(CURL* handle, curl_lock_data data,
+extern "C" void CurlShareUnlockCallback(CURL* /*handle*/,
+                                        curl_lock_data /*data*/,
                                         void* userptr) {
   auto* client = reinterpret_cast<CurlClient*>(userptr);
   client->UnlockShared();
@@ -82,7 +84,7 @@ std::unique_ptr<HashValidator> CreateHashValidator(
 
 /// Create a HashValidator for an insert request.
 std::unique_ptr<HashValidator> CreateHashValidator(
-    InsertObjectMediaRequest const& request) {
+    InsertObjectMediaRequest const& /*request*/) {
   return google::cloud::internal::make_unique<NullHashValidator>();
 }
 

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -29,15 +29,15 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 
-extern "C" void CurlShareLockCallback(CURL* /*handle*/, curl_lock_data /*data*/,
-                                      curl_lock_access /*access*/,
+extern "C" void CurlShareLockCallback(CURL*, curl_lock_data,
+                                      curl_lock_access,
                                       void* userptr) {
   auto* client = reinterpret_cast<CurlClient*>(userptr);
   client->LockShared();
 }
 
-extern "C" void CurlShareUnlockCallback(CURL* /*handle*/,
-                                        curl_lock_data /*data*/,
+extern "C" void CurlShareUnlockCallback(CURL*,
+                                        curl_lock_data,
                                         void* userptr) {
   auto* client = reinterpret_cast<CurlClient*>(userptr);
   client->UnlockShared();
@@ -84,7 +84,7 @@ std::unique_ptr<HashValidator> CreateHashValidator(
 
 /// Create a HashValidator for an insert request.
 std::unique_ptr<HashValidator> CreateHashValidator(
-    InsertObjectMediaRequest const& /*request*/) {
+    InsertObjectMediaRequest const&) {
   return google::cloud::internal::make_unique<NullHashValidator>();
 }
 

--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -26,7 +26,7 @@ using google::cloud::storage::internal::BinaryDataAsDebugString;
 
 std::size_t const MAX_DATA_DEBUG_SIZE = 48;
 
-extern "C" int CurlHandleDebugCallback(CURL* /*handle*/, curl_infotype type,
+extern "C" int CurlHandleDebugCallback(CURL*, curl_infotype type,
                                        char* data, std::size_t size,
                                        void* userptr) {
   auto debug_buffer = reinterpret_cast<std::string*>(userptr);

--- a/google/cloud/storage/internal/curl_wrappers.cc
+++ b/google/cloud/storage/internal/curl_wrappers.cc
@@ -155,7 +155,7 @@ void InitializeSslLocking(bool enable_ssl_callbacks) {
   // default version.
 }
 #else
-void InitializeSslLocking(bool enable_ssl_callbacks) {}
+void InitializeSslLocking(bool /*enable_ssl_callbacks*/) {}
 #endif  // GOOGLE_CLOUD_CPP_SSL_REQUIRES_LOCKS
 
 /// Automatically initialize (and cleanup) the libcurl library.

--- a/google/cloud/storage/internal/curl_wrappers.cc
+++ b/google/cloud/storage/internal/curl_wrappers.cc
@@ -155,7 +155,7 @@ void InitializeSslLocking(bool enable_ssl_callbacks) {
   // default version.
 }
 #else
-void InitializeSslLocking(bool /*enable_ssl_callbacks*/) {}
+void InitializeSslLocking(bool) {}
 #endif  // GOOGLE_CLOUD_CPP_SSL_REQUIRES_LOCKS
 
 /// Automatically initialize (and cleanup) the libcurl library.

--- a/google/cloud/storage/internal/empty_response.cc
+++ b/google/cloud/storage/internal/empty_response.cc
@@ -20,7 +20,7 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
-std::ostream& operator<<(std::ostream& os, EmptyResponse const& r) {
+std::ostream& operator<<(std::ostream& os, EmptyResponse const& /*r*/) {
   return os << "EmptyResponse={}";
 }
 

--- a/google/cloud/storage/internal/empty_response.cc
+++ b/google/cloud/storage/internal/empty_response.cc
@@ -20,7 +20,7 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
-std::ostream& operator<<(std::ostream& os, EmptyResponse const& /*r*/) {
+std::ostream& operator<<(std::ostream& os, EmptyResponse const&) {
   return os << "EmptyResponse={}";
 }
 

--- a/google/cloud/storage/internal/hash_validator.cc
+++ b/google/cloud/storage/internal/hash_validator.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/internal/hash_validator.h"
 #include "google/cloud/internal/big_endian.h"
+#include "google/cloud/log.h"
 #include "google/cloud/storage/internal/openssl_util.h"
 #include "google/cloud/storage/object_metadata.h"
 #include "google/cloud/storage/status.h"
@@ -37,6 +38,10 @@ void HashValidator::CheckResult(std::string const& msg,
   // all the components. In that case we just do not raise an exception even if
   // there is a mismatch.
   throw HashMismatchError(msg, result.received, result.computed);
+#else
+  GCP_LOG(ERROR) << "Mismatched hashes: "
+                 << HashMismatchError(
+                     msg, result.received, result.computed).what();
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -103,7 +103,7 @@ MakeCall(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
 }  // namespace
 
 RetryClient::RetryClient(std::shared_ptr<RawClient> client,
-                         DefaultPolicies unused)
+                         DefaultPolicies /*unused*/)
     : client_(std::move(client)) {
   retry_policy_ =
       LimitedTimeRetryPolicy(STORAGE_CLIENT_DEFAULT_MAXIMUM_RETRY_PERIOD)

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -103,7 +103,7 @@ MakeCall(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
 }  // namespace
 
 RetryClient::RetryClient(std::shared_ptr<RawClient> client,
-                         DefaultPolicies /*unused*/)
+                         DefaultPolicies)
     : client_(std::move(client)) {
   retry_policy_ =
       LimitedTimeRetryPolicy(STORAGE_CLIENT_DEFAULT_MAXIMUM_RETRY_PERIOD)


### PR DESCRIPTION
Fixed the code that was in violation, and turned on the warnings. Recall
that we use warnings-as-errors for the clang-tidy warnings, so the
builds will break if we trigger these warnings in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1613)
<!-- Reviewable:end -->
