### PR TITLE
Implement support for bucket-only policies.

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -116,6 +116,7 @@ add_library(google_cloud_cpp_common
             internal/future_then_meta.h
             internal/getenv.h
             internal/getenv.cc
+            internal/ios_flags_saver.h
             internal/make_unique.h
             internal/port_platform.h
             internal/random.h

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -34,6 +34,7 @@ google_cloud_cpp_common_hdrs = [
     "internal/future_then_impl.h",
     "internal/future_then_meta.h",
     "internal/getenv.h",
+    "internal/ios_flags_saver.h",
     "internal/make_unique.h",
     "internal/port_platform.h",
     "internal/random.h",

--- a/google/cloud/internal/ios_flags_saver.h
+++ b/google/cloud/internal/ios_flags_saver.h
@@ -1,0 +1,58 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_IOS_FLAGS_SAVER_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_IOS_FLAGS_SAVER_H_
+
+#include "google/cloud/version.h"
+#include <iostream>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+/**
+ * Save the formatting flags in a std::ios_base and restores them.
+ *
+ * This class is a helper for functions that need to restore all formatting
+ * flags in a iostream. Typically it is used in the implementation of a ostream
+ * operator to restore any flags changed to format the output.
+ *
+ * @par Example
+ * @code
+ * std::ostream& operator<<(std::ostream& os, MyType const& rhs) {
+ *   IosFlagsSaver save_flags(io);
+ *   os << "enabled=" << std::boolalpha << rhs.enabled;
+ *   // more calls here ... potentially modifying more flags
+ *   return os << "blah";
+ * }
+ * @endcode
+ */
+class IosFlagsSaver final {
+ public:
+  IosFlagsSaver(std::ios_base& ios) : ios_(ios), flags_(ios_.flags()) {}
+  ~IosFlagsSaver() { ios_.setf(flags_); }
+
+ private:
+  std::ios_base& ios_;
+  std::ios_base::fmtflags flags_;
+};
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_IOS_FLAGS_SAVER_H_

--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/bucket_metadata.h"
+#include "google/cloud/internal/ios_flags_saver.h"
 #include "google/cloud/storage/internal/format_rfc3339.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include "google/cloud/storage/internal/nljson.h"
@@ -84,6 +85,7 @@ std::ostream& operator<<(std::ostream& os, CorsEntry const& rhs) {
 }
 
 std::ostream& operator<<(std::ostream& os, BucketOnlyPolicy const& rhs) {
+  google::cloud::internal::IosFlagsSaver save_format(os);
   return os << "BucketOnlyPolicy={enabled=" << std::boolalpha
             << rhs.enabled
             << ", locked_time=" << internal::FormatRfc3339(rhs.locked_time)
@@ -370,6 +372,7 @@ bool BucketMetadata::operator==(BucketMetadata const& rhs) const {
 }
 
 std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs) {
+  google::cloud::internal::IosFlagsSaver save_format(os);
   os << "BucketMetadata={name=" << rhs.name();
 
   os << ", acl=[";

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -127,6 +127,102 @@ inline bool operator>=(CorsEntry const& lhs, CorsEntry const& rhs) {
 std::ostream& operator<<(std::ostream& os, CorsEntry const& rhs);
 
 /**
+ * Configure if only the IAM policies are used for access control.
+ *
+ * @warning this is an Alpha feature of Google Cloud Storage, it is not subject
+ *     to the deprecation policy and subject to change without notice.
+ */
+struct BucketOnlyPolicy {
+  bool enabled;
+  std::chrono::system_clock::time_point locked_time;
+};
+
+//@{
+/// @name Comparison operators For BucketOnlyPolicy.
+inline bool operator==(BucketOnlyPolicy const& lhs,
+                       BucketOnlyPolicy const& rhs) {
+  return std::tie(lhs.enabled, lhs.locked_time) ==
+         std::tie(rhs.enabled, rhs.locked_time);
+}
+
+inline bool operator<(BucketOnlyPolicy const& lhs,
+                      BucketOnlyPolicy const& rhs) {
+  return std::tie(lhs.enabled, lhs.locked_time) <
+         std::tie(rhs.enabled, rhs.locked_time);
+}
+
+inline bool operator!=(BucketOnlyPolicy const& lhs,
+                       BucketOnlyPolicy const& rhs) {
+  return std::rel_ops::operator!=(lhs, rhs);
+}
+
+inline bool operator>(BucketOnlyPolicy const& lhs,
+                      BucketOnlyPolicy const& rhs) {
+  return std::rel_ops::operator>(lhs, rhs);
+}
+
+inline bool operator<=(BucketOnlyPolicy const& lhs,
+                       BucketOnlyPolicy const& rhs) {
+  return std::rel_ops::operator<=(lhs, rhs);
+}
+
+inline bool operator>=(BucketOnlyPolicy const& lhs,
+                       BucketOnlyPolicy const& rhs) {
+  return std::rel_ops::operator>=(lhs, rhs);
+}
+//@}
+
+std::ostream& operator<<(std::ostream& os, BucketOnlyPolicy const& rhs);
+
+/**
+ * The IAM configuration for a Bucket.
+ *
+ * Currently this only holds the BucketOnlyPolicy. In the future, we may define
+ * additional IAM which would be included in this object.
+ *
+ * @warning this is an Alpha feature of Google Cloud Storage, it is not subject
+ *     to the deprecation policy and subject to change without notice.
+ */
+struct BucketIamConfiguration {
+  google::cloud::optional<BucketOnlyPolicy> bucket_only_policy;
+};
+
+//@{
+/// @name Comparison operators for BucketIamConfiguration.
+inline bool operator==(BucketIamConfiguration const& lhs,
+                       BucketIamConfiguration const& rhs) {
+  return lhs.bucket_only_policy == rhs.bucket_only_policy;
+}
+
+inline bool operator<(BucketIamConfiguration const& lhs,
+                      BucketIamConfiguration const& rhs) {
+  return lhs.bucket_only_policy < rhs.bucket_only_policy;
+}
+
+inline bool operator!=(BucketIamConfiguration const& lhs,
+                       BucketIamConfiguration const& rhs) {
+  return std::rel_ops::operator!=(lhs, rhs);
+}
+
+inline bool operator>(BucketIamConfiguration const& lhs,
+                      BucketIamConfiguration const& rhs) {
+  return std::rel_ops::operator>(lhs, rhs);
+}
+
+inline bool operator<=(BucketIamConfiguration const& lhs,
+                       BucketIamConfiguration const& rhs) {
+  return std::rel_ops::operator<=(lhs, rhs);
+}
+
+inline bool operator>=(BucketIamConfiguration const& lhs,
+                       BucketIamConfiguration const& rhs) {
+  return std::rel_ops::operator>=(lhs, rhs);
+}
+//@}
+
+std::ostream& operator<<(std::ostream& os, BucketIamConfiguration const& rhs);
+
+/**
  * The Object Lifecycle configuration for a Bucket.
  *
  * @see https://cloud.google.com/storage/docs/managing-lifecycles for general
@@ -530,6 +626,29 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   //@}
 
   using CommonMetadata::etag;
+
+  //@{
+  /**
+   * @name Get and set the IAM configuration.
+   */
+  bool has_iam_configuration() const { return iam_configuration_.has_value(); }
+  BucketIamConfiguration const& iam_configuration() const {
+    return *iam_configuration_;
+  }
+  google::cloud::optional<BucketIamConfiguration> const&
+  iam_configuration_as_optional() const {
+    return iam_configuration_;
+  }
+  BucketMetadata& set_iam_configuration(BucketIamConfiguration v) {
+    iam_configuration_ = std::move(v);
+    return *this;
+  }
+  BucketMetadata& reset_iam_configuration() {
+    iam_configuration_.reset();
+    return *this;
+  }
+  //@}
+
   using CommonMetadata::id;
   using CommonMetadata::kind;
 
@@ -720,6 +839,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   bool default_event_based_hold_ = false;
   std::vector<ObjectAccessControl> default_acl_;
   google::cloud::optional<BucketEncryption> encryption_;
+  google::cloud::optional<BucketIamConfiguration> iam_configuration_;
   std::map<std::string, std::string> labels_;
   google::cloud::optional<BucketLifecycle> lifecycle_;
   std::string location_;
@@ -777,6 +897,10 @@ class BucketMetadataPatchBuilder {
    * @warning Currently the server ignores requests to reset the full ACL.
    */
   BucketMetadataPatchBuilder& ResetDefaultAcl();
+
+  BucketMetadataPatchBuilder& SetIamConfiguration(
+      BucketIamConfiguration const& v);
+  BucketMetadataPatchBuilder& ResetIamConfiguration();
 
   BucketMetadataPatchBuilder& SetEncryption(BucketEncryption const& v);
   BucketMetadataPatchBuilder& ResetEncryption();

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -114,6 +114,15 @@ PatchBucketRequest::PatchBucketRequest(std::string bucket,
     }
   }
 
+  if (original.iam_configuration_as_optional() !=
+      updated.iam_configuration_as_optional()) {
+    if (updated.has_iam_configuration()) {
+      builder.SetIamConfiguration(updated.iam_configuration());
+    } else {
+      builder.ResetIamConfiguration();
+    }
+  }
+
   if (original.labels() != updated.labels()) {
     if (updated.labels().empty()) {
       builder.ResetLabels();

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -326,6 +326,36 @@ TEST(PatchBucketRequestTest, DiffResetEncryption) {
   EXPECT_EQ(expected, patch);
 }
 
+TEST(PatchBucketRequestTest, DiffSetIamConfiguration) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  original.reset_encryption();
+  BucketMetadata updated = original;
+  BucketIamConfiguration configuration;
+  configuration.bucket_only_policy = BucketOnlyPolicy{true};
+  updated.set_iam_configuration(std::move(configuration));
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({
+      "iamConfiguration": {"bucketOnlyPolicy": {"enabled": true}}
+  })""");
+  EXPECT_EQ(expected, patch);
+}
+
+TEST(PatchBucketRequestTest, DiffResetIamConfiguration) {
+  BucketMetadata original = CreateBucketMetadataForTest();
+  BucketIamConfiguration configuration;
+  configuration.bucket_only_policy = BucketOnlyPolicy{true};
+  original.set_iam_configuration(std::move(configuration));
+  BucketMetadata updated = original;
+  updated.reset_iam_configuration();
+  PatchBucketRequest request("test-bucket", original, updated);
+
+  nl::json patch = nl::json::parse(request.payload());
+  nl::json expected = nl::json::parse(R"""({"iamConfiguration": null})""");
+  EXPECT_EQ(expected, patch);
+}
+
 TEST(PatchBucketRequestTest, DiffSetLabels) {
   BucketMetadata original = CreateBucketMetadataForTest();
   original.mutable_labels() = {

--- a/google/cloud/storage/testbench/gcs_bucket.py
+++ b/google/cloud/storage/testbench/gcs_bucket.py
@@ -127,6 +127,21 @@ class GcsBucket(object):
             'timeCreated': '2018-05-19T19:31:14Z',
             'updated': '2018-05-19T19:31:24Z',
         })
+        bop_was_enabled = False
+        if metadata.get('iamConfiguration'):
+            bop = metadata.get('iamConfiguration').get('bucketOnlyPolicy')
+            if bop:
+                bop_was_enabled = bop.get('enabled')
+        config = tmp.get('iamConfiguration')
+        if config is not None:
+            if config.get('bucketOnlyPolicy'):
+                bop_enabled = config.get('bucketOnlyPolicy').get('enabled')
+                if not bop_was_enabled and bop_enabled:
+                    # Set the locked time (arbitrarily) to 7 days from now.
+                    locked_time = time.gmtime(time.time() + 7 * 24 * 3600)
+                    config.get('bucketOnlyPolicy').set(
+                        'lockedTime', time.strftime(
+                            '%Y-%m-%dT%H:%M:%SZ', locked_time))
         self.metadata = tmp
         self.increase_metageneration()
 

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -178,6 +178,11 @@ TEST_F(BucketIntegrationTest, FullPatch) {
   // encryption()
   // TODO(#1003) - need a valid KMS entry to set the encryption.
 
+  // iam_configuration()
+  BucketIamConfiguration iam_configuration;
+  iam_configuration.bucket_only_policy = BucketOnlyPolicy{true};
+  desired_state.set_iam_configuration(std::move(iam_configuration));
+
   // labels()
   desired_state.mutable_labels().emplace("test-label", "testing-full-patch");
 


### PR DESCRIPTION
This adds support for the bucket-only policies in GCS buckets. The
feature is in EAP / Alpha, so still subject to change, but we want to
have it available so we can test early.

This fixes #1596.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1614)
<!-- Reviewable:end -->
