### PR TITLE
Require rvalue-ref for as_proto_move().

### DIFF
--- a/google/cloud/bigtable/app_profile_config.h
+++ b/google/cloud/bigtable/app_profile_config.h
@@ -56,7 +56,7 @@ class AppProfileConfig {
   }
 
   // NOLINT: accessors can (and should) be snake_case.
-  google::bigtable::admin::v2::CreateAppProfileRequest as_proto_move() {
+  google::bigtable::admin::v2::CreateAppProfileRequest as_proto_move() && {
     return std::move(proto_);
   }
 
@@ -111,7 +111,7 @@ class AppProfileUpdateConfig {
   }
 
   // NOLINT: accessors can (and should) be snake_case.
-  google::bigtable::admin::v2::UpdateAppProfileRequest as_proto_move() {
+  google::bigtable::admin::v2::UpdateAppProfileRequest as_proto_move() && {
     return std::move(proto_);
   }
 

--- a/google/cloud/bigtable/app_profile_config.h
+++ b/google/cloud/bigtable/app_profile_config.h
@@ -51,12 +51,13 @@ class AppProfileConfig {
   }
 
   // NOLINT: accessors can (and should) be snake_case.
-  google::bigtable::admin::v2::CreateAppProfileRequest const& as_proto() const {
+  google::bigtable::admin::v2::CreateAppProfileRequest const& as_proto()
+      const& {
     return proto_;
   }
 
   // NOLINT: accessors can (and should) be snake_case.
-  google::bigtable::admin::v2::CreateAppProfileRequest as_proto_move() && {
+  google::bigtable::admin::v2::CreateAppProfileRequest&& as_proto() && {
     return std::move(proto_);
   }
 
@@ -106,12 +107,13 @@ class AppProfileUpdateConfig {
   }
 
   // NOLINT: accessors can (and should) be snake_case.
-  google::bigtable::admin::v2::UpdateAppProfileRequest const& as_proto() const {
+  google::bigtable::admin::v2::UpdateAppProfileRequest const& as_proto()
+      const& {
     return proto_;
   }
 
   // NOLINT: accessors can (and should) be snake_case.
-  google::bigtable::admin::v2::UpdateAppProfileRequest as_proto_move() && {
+  google::bigtable::admin::v2::UpdateAppProfileRequest&& as_proto() && {
     return std::move(proto_);
   }
 

--- a/google/cloud/bigtable/app_profile_config_test.cc
+++ b/google/cloud/bigtable/app_profile_config_test.cc
@@ -25,6 +25,12 @@ TEST(AppProfileConfig, MultiClusterUseAny) {
                    .as_proto();
   EXPECT_EQ("my-profile", proto.app_profile_id());
   EXPECT_TRUE(proto.app_profile().has_multi_cluster_routing_use_any());
+
+  // Verify that as_proto() for rvalue-references returns the right type.
+  static_assert(
+      std::is_rvalue_reference<decltype(
+          std::move(std::declval<AppProfileConfig>()).as_proto())>::value,
+      "Return type from as_proto() must be rvalue-reference");
 }
 
 TEST(AppProfileConfig, SetIgnoreWarnings) {

--- a/google/cloud/bigtable/cluster_config.h
+++ b/google/cloud/bigtable/cluster_config.h
@@ -49,7 +49,7 @@ class ClusterConfig {
   }
 
   // NOLINT: accessors can (and should) be snake_case.
-  google::bigtable::admin::v2::Cluster as_proto_move() const {
+  google::bigtable::admin::v2::Cluster as_proto_move() && {
     return std::move(proto_);
   }
 

--- a/google/cloud/bigtable/cluster_config.h
+++ b/google/cloud/bigtable/cluster_config.h
@@ -44,12 +44,12 @@ class ClusterConfig {
   std::string const& GetName() { return proto_.name(); }
 
   // NOLINT: accessors can (and should) be snake_case.
-  google::bigtable::admin::v2::Cluster const& as_proto() const {
+  google::bigtable::admin::v2::Cluster const& as_proto() const& {
     return proto_;
   }
 
   // NOLINT: accessors can (and should) be snake_case.
-  google::bigtable::admin::v2::Cluster as_proto_move() && {
+  google::bigtable::admin::v2::Cluster&& as_proto() && {
     return std::move(proto_);
   }
 

--- a/google/cloud/bigtable/cluster_config_test.cc
+++ b/google/cloud/bigtable/cluster_config_test.cc
@@ -27,7 +27,7 @@ TEST(ClusterConfigTest, Constructor) {
 
 TEST(ClusterConfigTest, Move) {
   bigtable::ClusterConfig config("somewhere", 7, bigtable::ClusterConfig::HDD);
-  auto proto = config.as_proto_move();
+  auto proto = std::move(config).as_proto_move();
   EXPECT_EQ("somewhere", proto.location());
   EXPECT_EQ(7, proto.serve_nodes());
   EXPECT_EQ(bigtable::ClusterConfig::HDD, proto.default_storage_type());

--- a/google/cloud/bigtable/cluster_config_test.cc
+++ b/google/cloud/bigtable/cluster_config_test.cc
@@ -27,7 +27,7 @@ TEST(ClusterConfigTest, Constructor) {
 
 TEST(ClusterConfigTest, Move) {
   bigtable::ClusterConfig config("somewhere", 7, bigtable::ClusterConfig::HDD);
-  auto proto = std::move(config).as_proto_move();
+  auto proto = std::move(config).as_proto();
   EXPECT_EQ("somewhere", proto.location());
   EXPECT_EQ(7, proto.serve_nodes());
   EXPECT_EQ(bigtable::ClusterConfig::HDD, proto.default_storage_type());

--- a/google/cloud/bigtable/cluster_config_test.cc
+++ b/google/cloud/bigtable/cluster_config_test.cc
@@ -28,6 +28,11 @@ TEST(ClusterConfigTest, Constructor) {
 TEST(ClusterConfigTest, Move) {
   bigtable::ClusterConfig config("somewhere", 7, bigtable::ClusterConfig::HDD);
   auto proto = std::move(config).as_proto();
+  // Verify that as_proto() for rvalue-references returns the right type.
+  static_assert(std::is_rvalue_reference<decltype(
+                    std::move(std::declval<bigtable::ClusterConfig>())
+                        .as_proto())>::value,
+                "Return type from as_proto() must be rvalue-reference");
   EXPECT_EQ("somewhere", proto.location());
   EXPECT_EQ(7, proto.serve_nodes());
   EXPECT_EQ(bigtable::ClusterConfig::HDD, proto.default_storage_type());

--- a/google/cloud/bigtable/column_family.h
+++ b/google/cloud/bigtable/column_family.h
@@ -135,10 +135,12 @@ class GcRule {
   }
 
   /// Convert to the proto form.
-  google::bigtable::admin::v2::GcRule as_proto() const { return gc_rule_; }
+  google::bigtable::admin::v2::GcRule const& as_proto() const& {
+    return gc_rule_;
+  }
 
   /// Move the internal proto out.
-  google::bigtable::admin::v2::GcRule as_proto_move() && {
+  google::bigtable::admin::v2::GcRule&& as_proto() && {
     return std::move(gc_rule_);
   }
 
@@ -174,8 +176,7 @@ class ColumnFamilyModification {
   static ColumnFamilyModification Create(std::string id, GcRule gc) {
     ColumnFamilyModification tmp;
     tmp.mod_.set_id(std::move(id));
-    *tmp.mod_.mutable_create()->mutable_gc_rule() =
-        std::move(gc).as_proto_move();
+    *tmp.mod_.mutable_create()->mutable_gc_rule() = std::move(gc).as_proto();
     return tmp;
   }
 
@@ -183,8 +184,7 @@ class ColumnFamilyModification {
   static ColumnFamilyModification Update(std::string id, GcRule gc) {
     ColumnFamilyModification tmp;
     tmp.mod_.set_id(std::move(id));
-    *tmp.mod_.mutable_update()->mutable_gc_rule() =
-        std::move(gc).as_proto_move();
+    *tmp.mod_.mutable_update()->mutable_gc_rule() = std::move(gc).as_proto();
     return tmp;
   }
 
@@ -197,14 +197,15 @@ class ColumnFamilyModification {
   }
 
   /// Convert to the proto form.
-  ::google::bigtable::admin::v2::ModifyColumnFamiliesRequest::Modification
-  as_proto() const {
+  ::google::bigtable::admin::v2::ModifyColumnFamiliesRequest::
+      Modification const&
+      as_proto() const& {
     return mod_;
   }
 
   /// Move out the underlying proto contents.
-  ::google::bigtable::admin::v2::ModifyColumnFamiliesRequest::Modification
-  as_proto_move() && {
+  ::google::bigtable::admin::v2::ModifyColumnFamiliesRequest::Modification&&
+  as_proto() && {
     return std::move(mod_);
   }
 

--- a/google/cloud/bigtable/column_family.h
+++ b/google/cloud/bigtable/column_family.h
@@ -138,7 +138,7 @@ class GcRule {
   google::bigtable::admin::v2::GcRule as_proto() const { return gc_rule_; }
 
   /// Move the internal proto out.
-  google::bigtable::admin::v2::GcRule as_proto_move() {
+  google::bigtable::admin::v2::GcRule as_proto_move() && {
     return std::move(gc_rule_);
   }
 
@@ -174,7 +174,8 @@ class ColumnFamilyModification {
   static ColumnFamilyModification Create(std::string id, GcRule gc) {
     ColumnFamilyModification tmp;
     tmp.mod_.set_id(std::move(id));
-    *tmp.mod_.mutable_create()->mutable_gc_rule() = gc.as_proto_move();
+    *tmp.mod_.mutable_create()->mutable_gc_rule() =
+        std::move(gc).as_proto_move();
     return tmp;
   }
 
@@ -182,7 +183,8 @@ class ColumnFamilyModification {
   static ColumnFamilyModification Update(std::string id, GcRule gc) {
     ColumnFamilyModification tmp;
     tmp.mod_.set_id(std::move(id));
-    *tmp.mod_.mutable_update()->mutable_gc_rule() = gc.as_proto_move();
+    *tmp.mod_.mutable_update()->mutable_gc_rule() =
+        std::move(gc).as_proto_move();
     return tmp;
   }
 
@@ -202,7 +204,7 @@ class ColumnFamilyModification {
 
   /// Move out the underlying proto contents.
   ::google::bigtable::admin::v2::ModifyColumnFamiliesRequest::Modification
-  as_proto_move() {
+  as_proto_move() && {
     return std::move(mod_);
   }
 

--- a/google/cloud/bigtable/filters.h
+++ b/google/cloud/bigtable/filters.h
@@ -594,7 +594,7 @@ class Filter {
   ::google::bigtable::v2::RowFilter as_proto() const { return filter_; }
 
   /// Move out the underlying protobuf value.
-  ::google::bigtable::v2::RowFilter as_proto_move() {
+  ::google::bigtable::v2::RowFilter as_proto_move() && {
     return std::move(filter_);
   }
 

--- a/google/cloud/bigtable/filters.h
+++ b/google/cloud/bigtable/filters.h
@@ -591,10 +591,10 @@ class Filter {
   //@}
 
   /// Return the filter expression as a protobuf.
-  ::google::bigtable::v2::RowFilter as_proto() const { return filter_; }
+  ::google::bigtable::v2::RowFilter const& as_proto() const& { return filter_; }
 
   /// Move out the underlying protobuf value.
-  ::google::bigtable::v2::RowFilter as_proto_move() && {
+  ::google::bigtable::v2::RowFilter&& as_proto() && {
     return std::move(filter_);
   }
 

--- a/google/cloud/bigtable/filters_test.cc
+++ b/google/cloud/bigtable/filters_test.cc
@@ -288,13 +288,13 @@ TEST(FiltersTest, Sink) {
   ASSERT_TRUE(proto.sink());
 }
 
-/// @test Verify that `bigtable::Filter::as_proto_move` works as expected.
+/// @test Verify that `bigtable::Filter::as_proto` works as expected.
 TEST(FiltersTest, MoveProto) {
   using F = bigtable::Filter;
   auto filter = F::Chain(F::FamilyRegex("fam"), F::ColumnRegex("col"),
                          F::CellsRowOffset(2), F::Latest(1));
   auto proto_copy = filter.as_proto();
-  auto proto_move = std::move(filter).as_proto_move();
+  auto proto_move = std::move(filter).as_proto();
   ASSERT_FALSE(filter.as_proto().has_chain());
 
   std::string delta;

--- a/google/cloud/bigtable/filters_test.cc
+++ b/google/cloud/bigtable/filters_test.cc
@@ -294,7 +294,7 @@ TEST(FiltersTest, MoveProto) {
   auto filter = F::Chain(F::FamilyRegex("fam"), F::ColumnRegex("col"),
                          F::CellsRowOffset(2), F::Latest(1));
   auto proto_copy = filter.as_proto();
-  auto proto_move = filter.as_proto_move();
+  auto proto_move = std::move(filter).as_proto_move();
   ASSERT_FALSE(filter.as_proto().has_chain());
 
   std::string delta;

--- a/google/cloud/bigtable/filters_test.cc
+++ b/google/cloud/bigtable/filters_test.cc
@@ -297,6 +297,11 @@ TEST(FiltersTest, MoveProto) {
   auto proto_move = std::move(filter).as_proto();
   ASSERT_FALSE(filter.as_proto().has_chain());
 
+  // Verify that as_proto() for rvalue-references returns the right type.
+  static_assert(std::is_rvalue_reference<decltype(
+                    std::move(std::declval<F>()).as_proto())>::value,
+                "Return type from as_proto() must be rvalue-reference");
+
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);

--- a/google/cloud/bigtable/instance_admin.cc
+++ b/google/cloud/bigtable/instance_admin.cc
@@ -59,7 +59,7 @@ google::bigtable::admin::v2::Instance InstanceAdmin::CreateInstanceImpl(
   auto backoff_policy = impl_.rpc_backoff_policy_->clone();
 
   // Build the RPC request, try to minimize copying.
-  auto request = std::move(instance_config).as_proto_move();
+  auto request = std::move(instance_config).as_proto();
   request.set_parent(project_name());
   for (auto& kv : *request.mutable_clusters()) {
     kv.second.set_location(project_name() + "/locations/" +
@@ -106,7 +106,7 @@ google::bigtable::admin::v2::Instance InstanceAdmin::UpdateInstanceImpl(
   MetadataUpdatePolicy metadata_update_policy(instance_update_config.GetName(),
                                               MetadataParamTypes::NAME);
 
-  auto request = std::move(instance_update_config).as_proto_move();
+  auto request = std::move(instance_update_config).as_proto();
 
   using ClientUtils =
       bigtable::internal::noex::UnaryClientUtils<InstanceAdminClient>;
@@ -190,7 +190,7 @@ google::bigtable::admin::v2::Cluster InstanceAdmin::UpdateClusterImpl(
   MetadataUpdatePolicy metadata_update_policy(cluster_config.GetName(),
                                               MetadataParamTypes::NAME);
 
-  auto request = std::move(cluster_config).as_proto_move();
+  auto request = std::move(cluster_config).as_proto();
 
   using ClientUtils =
       bigtable::internal::noex::UnaryClientUtils<InstanceAdminClient>;

--- a/google/cloud/bigtable/instance_admin.cc
+++ b/google/cloud/bigtable/instance_admin.cc
@@ -59,7 +59,7 @@ google::bigtable::admin::v2::Instance InstanceAdmin::CreateInstanceImpl(
   auto backoff_policy = impl_.rpc_backoff_policy_->clone();
 
   // Build the RPC request, try to minimize copying.
-  auto request = instance_config.as_proto_move();
+  auto request = std::move(instance_config).as_proto_move();
   request.set_parent(project_name());
   for (auto& kv : *request.mutable_clusters()) {
     kv.second.set_location(project_name() + "/locations/" +
@@ -106,7 +106,7 @@ google::bigtable::admin::v2::Instance InstanceAdmin::UpdateInstanceImpl(
   MetadataUpdatePolicy metadata_update_policy(instance_update_config.GetName(),
                                               MetadataParamTypes::NAME);
 
-  auto request = instance_update_config.as_proto_move();
+  auto request = std::move(instance_update_config).as_proto_move();
 
   using ClientUtils =
       bigtable::internal::noex::UnaryClientUtils<InstanceAdminClient>;
@@ -190,7 +190,7 @@ google::bigtable::admin::v2::Cluster InstanceAdmin::UpdateClusterImpl(
   MetadataUpdatePolicy metadata_update_policy(cluster_config.GetName(),
                                               MetadataParamTypes::NAME);
 
-  auto request = cluster_config.as_proto_move();
+  auto request = std::move(cluster_config).as_proto_move();
 
   using ClientUtils =
       bigtable::internal::noex::UnaryClientUtils<InstanceAdminClient>;
@@ -283,7 +283,7 @@ google::bigtable::admin::v2::Cluster InstanceAdmin::CreateClusterImpl(
   auto backoff_policy = impl_.rpc_backoff_policy_->clone();
 
   // Build the RPC request, try to minimize copying.
-  auto cluster = cluster_config.as_proto_move();
+  auto cluster = cluster_config.as_proto();
   cluster.set_location(project_name() + "/locations/" + cluster.location());
 
   btadmin::CreateClusterRequest request;

--- a/google/cloud/bigtable/instance_config.h
+++ b/google/cloud/bigtable/instance_config.h
@@ -37,8 +37,7 @@ class InstanceConfig {
     proto_.set_instance_id(std::move(instance_id.get()));
     proto_.mutable_instance()->set_display_name(std::move(display_name.get()));
     for (auto& kv : clusters) {
-      (*proto_.mutable_clusters())[kv.first] =
-          std::move(kv.second).as_proto_move();
+      (*proto_.mutable_clusters())[kv.first] = std::move(kv.second).as_proto();
     }
   }
 
@@ -70,12 +69,12 @@ class InstanceConfig {
   }
 
   // NOLINT: accessors can (and should) be snake_case.
-  google::bigtable::admin::v2::CreateInstanceRequest const& as_proto() const {
+  google::bigtable::admin::v2::CreateInstanceRequest const& as_proto() const& {
     return proto_;
   }
 
   // NOLINT: accessors can (and should) be snake_case.
-  google::bigtable::admin::v2::CreateInstanceRequest as_proto_move() && {
+  google::bigtable::admin::v2::CreateInstanceRequest&& as_proto() && {
     return std::move(proto_);
   }
 

--- a/google/cloud/bigtable/instance_config.h
+++ b/google/cloud/bigtable/instance_config.h
@@ -37,7 +37,8 @@ class InstanceConfig {
     proto_.set_instance_id(std::move(instance_id.get()));
     proto_.mutable_instance()->set_display_name(std::move(display_name.get()));
     for (auto& kv : clusters) {
-      (*proto_.mutable_clusters())[kv.first] = kv.second.as_proto_move();
+      (*proto_.mutable_clusters())[kv.first] =
+          std::move(kv.second).as_proto_move();
     }
   }
 
@@ -74,7 +75,7 @@ class InstanceConfig {
   }
 
   // NOLINT: accessors can (and should) be snake_case.
-  google::bigtable::admin::v2::CreateInstanceRequest as_proto_move() {
+  google::bigtable::admin::v2::CreateInstanceRequest as_proto_move() && {
     return std::move(proto_);
   }
 

--- a/google/cloud/bigtable/instance_update_config.h
+++ b/google/cloud/bigtable/instance_update_config.h
@@ -97,12 +97,12 @@ class InstanceUpdateConfig {
 
   // NOLINT: accessors can (and should) be snake_case.
   google::bigtable::admin::v2::PartialUpdateInstanceRequest const& as_proto()
-      const {
+      const& {
     return proto_;
   }
 
   // NOLINT: accessors can (and should) be snake_case.
-  google::bigtable::admin::v2::PartialUpdateInstanceRequest as_proto_move() && {
+  google::bigtable::admin::v2::PartialUpdateInstanceRequest&& as_proto() && {
     return std::move(proto_);
   }
 

--- a/google/cloud/bigtable/instance_update_config.h
+++ b/google/cloud/bigtable/instance_update_config.h
@@ -102,7 +102,7 @@ class InstanceUpdateConfig {
   }
 
   // NOLINT: accessors can (and should) be snake_case.
-  google::bigtable::admin::v2::PartialUpdateInstanceRequest as_proto_move() {
+  google::bigtable::admin::v2::PartialUpdateInstanceRequest as_proto_move() && {
     return std::move(proto_);
   }
 

--- a/google/cloud/bigtable/internal/instance_admin.cc
+++ b/google/cloud/bigtable/internal/instance_admin.cc
@@ -152,7 +152,7 @@ void InstanceAdmin::DeleteCluster(bigtable::InstanceId const& instance_id,
 btadmin::AppProfile InstanceAdmin::CreateAppProfile(
     bigtable::InstanceId const& instance_id, AppProfileConfig config,
     grpc::Status& status) {
-  auto request = config.as_proto_move();
+  auto request = std::move(config).as_proto_move();
   request.set_parent(InstanceName(instance_id.get()));
 
   // This API is not idempotent, call it without retry.
@@ -178,7 +178,7 @@ btadmin::AppProfile InstanceAdmin::GetAppProfile(
 ::google::longrunning::Operation InstanceAdmin::UpdateAppProfile(
     bigtable::InstanceId instance_id, bigtable::AppProfileId profile_id,
     AppProfileUpdateConfig config, grpc::Status& status) {
-  auto request = config.as_proto_move();
+  auto request = std::move(config).as_proto_move();
   request.mutable_app_profile()->set_name(
       InstanceName(instance_id.get() + "/appProfiles/" + profile_id.get()));
 

--- a/google/cloud/bigtable/internal/instance_admin.cc
+++ b/google/cloud/bigtable/internal/instance_admin.cc
@@ -152,7 +152,7 @@ void InstanceAdmin::DeleteCluster(bigtable::InstanceId const& instance_id,
 btadmin::AppProfile InstanceAdmin::CreateAppProfile(
     bigtable::InstanceId const& instance_id, AppProfileConfig config,
     grpc::Status& status) {
-  auto request = std::move(config).as_proto_move();
+  auto request = std::move(config).as_proto();
   request.set_parent(InstanceName(instance_id.get()));
 
   // This API is not idempotent, call it without retry.
@@ -178,7 +178,7 @@ btadmin::AppProfile InstanceAdmin::GetAppProfile(
 ::google::longrunning::Operation InstanceAdmin::UpdateAppProfile(
     bigtable::InstanceId instance_id, bigtable::AppProfileId profile_id,
     AppProfileUpdateConfig config, grpc::Status& status) {
-  auto request = std::move(config).as_proto_move();
+  auto request = std::move(config).as_proto();
   request.mutable_app_profile()->set_name(
       InstanceName(instance_id.get() + "/appProfiles/" + profile_id.get()));
 

--- a/google/cloud/bigtable/internal/instance_admin.h
+++ b/google/cloud/bigtable/internal/instance_admin.h
@@ -197,7 +197,7 @@ class InstanceAdmin {
         InstanceAdminClient, google::bigtable::admin::v2::Instance,
         MemberFunction, internal::ConstantIdempotencyPolicy, Functor>;
 
-    auto request = instance_config.as_proto_move();
+    auto request = std::move(instance_config).as_proto_move();
     request.set_parent(project_name());
     for (auto& kv : *request.mutable_clusters()) {
       kv.second.set_location(project_name() + "/locations/" +
@@ -258,7 +258,7 @@ class InstanceAdmin {
         InstanceAdminClient, google::bigtable::admin::v2::Instance,
         MemberFunction, internal::ConstantIdempotencyPolicy, Functor>;
 
-    auto request = instance_update_config.as_proto_move();
+    auto request = std::move(instance_update_config).as_proto_move();
     auto op = std::make_shared<Operation>(
         __func__, polling_policy_->clone(), rpc_retry_policy_->clone(),
         rpc_backoff_policy_->clone(), internal::ConstantIdempotencyPolicy(true),
@@ -527,7 +527,7 @@ class InstanceAdmin {
         InstanceAdminClient, google::bigtable::admin::v2::Cluster,
         MemberFunction, internal::ConstantIdempotencyPolicy, Functor>;
 
-    auto cluster = cluster_config.as_proto_move();
+    auto cluster = std::move(cluster_config).as_proto_move();
     cluster.set_location(project_name() + "/locations/" + cluster.location());
 
     google::bigtable::admin::v2::CreateClusterRequest request;
@@ -587,7 +587,7 @@ class InstanceAdmin {
         InstanceAdminClient, google::bigtable::admin::v2::Cluster,
         MemberFunction, internal::ConstantIdempotencyPolicy, Functor>;
 
-    auto request = cluster_config.as_proto_move();
+    auto request = std::move(cluster_config).as_proto_move();
     auto op = std::make_shared<Operation>(
         __func__, polling_policy_->clone(), rpc_retry_policy_->clone(),
         rpc_backoff_policy_->clone(), internal::ConstantIdempotencyPolicy(true),
@@ -712,7 +712,7 @@ class InstanceAdmin {
         InstanceAdminClient, google::bigtable::admin::v2::AppProfile,
         MemberFunction, internal::ConstantIdempotencyPolicy, Functor>;
 
-    auto request = config.as_proto_move();
+    auto request = std::move(config).as_proto_move();
     request.mutable_app_profile()->set_name(
         InstanceName(instance_id.get() + "/appProfiles/" + profile_id.get()));
 
@@ -760,7 +760,7 @@ class InstanceAdmin {
   std::shared_ptr<AsyncOperation> AsyncCreateAppProfile(
       bigtable::InstanceId const& instance_id, AppProfileConfig config,
       CompletionQueue& cq, Functor&& callback) {
-    auto request = config.as_proto_move();
+    auto request = std::move(config).as_proto_move();
     request.set_parent(InstanceName(instance_id.get()));
 
     static_assert(internal::ExtractMemberFunctionType<decltype(

--- a/google/cloud/bigtable/internal/instance_admin.h
+++ b/google/cloud/bigtable/internal/instance_admin.h
@@ -197,7 +197,7 @@ class InstanceAdmin {
         InstanceAdminClient, google::bigtable::admin::v2::Instance,
         MemberFunction, internal::ConstantIdempotencyPolicy, Functor>;
 
-    auto request = std::move(instance_config).as_proto_move();
+    auto request = std::move(instance_config).as_proto();
     request.set_parent(project_name());
     for (auto& kv : *request.mutable_clusters()) {
       kv.second.set_location(project_name() + "/locations/" +
@@ -258,7 +258,7 @@ class InstanceAdmin {
         InstanceAdminClient, google::bigtable::admin::v2::Instance,
         MemberFunction, internal::ConstantIdempotencyPolicy, Functor>;
 
-    auto request = std::move(instance_update_config).as_proto_move();
+    auto request = std::move(instance_update_config).as_proto();
     auto op = std::make_shared<Operation>(
         __func__, polling_policy_->clone(), rpc_retry_policy_->clone(),
         rpc_backoff_policy_->clone(), internal::ConstantIdempotencyPolicy(true),
@@ -527,7 +527,7 @@ class InstanceAdmin {
         InstanceAdminClient, google::bigtable::admin::v2::Cluster,
         MemberFunction, internal::ConstantIdempotencyPolicy, Functor>;
 
-    auto cluster = std::move(cluster_config).as_proto_move();
+    auto cluster = std::move(cluster_config).as_proto();
     cluster.set_location(project_name() + "/locations/" + cluster.location());
 
     google::bigtable::admin::v2::CreateClusterRequest request;
@@ -587,7 +587,7 @@ class InstanceAdmin {
         InstanceAdminClient, google::bigtable::admin::v2::Cluster,
         MemberFunction, internal::ConstantIdempotencyPolicy, Functor>;
 
-    auto request = std::move(cluster_config).as_proto_move();
+    auto request = std::move(cluster_config).as_proto();
     auto op = std::make_shared<Operation>(
         __func__, polling_policy_->clone(), rpc_retry_policy_->clone(),
         rpc_backoff_policy_->clone(), internal::ConstantIdempotencyPolicy(true),
@@ -712,7 +712,7 @@ class InstanceAdmin {
         InstanceAdminClient, google::bigtable::admin::v2::AppProfile,
         MemberFunction, internal::ConstantIdempotencyPolicy, Functor>;
 
-    auto request = std::move(config).as_proto_move();
+    auto request = std::move(config).as_proto();
     request.mutable_app_profile()->set_name(
         InstanceName(instance_id.get() + "/appProfiles/" + profile_id.get()));
 
@@ -760,7 +760,7 @@ class InstanceAdmin {
   std::shared_ptr<AsyncOperation> AsyncCreateAppProfile(
       bigtable::InstanceId const& instance_id, AppProfileConfig config,
       CompletionQueue& cq, Functor&& callback) {
-    auto request = std::move(config).as_proto_move();
+    auto request = std::move(config).as_proto();
     request.set_parent(InstanceName(instance_id.get()));
 
     static_assert(internal::ExtractMemberFunctionType<decltype(

--- a/google/cloud/bigtable/internal/table.cc
+++ b/google/cloud/bigtable/internal/table.cc
@@ -173,7 +173,7 @@ bool Table::CheckAndMutateRow(std::string row_key, Filter filter,
   bigtable::internal::SetCommonTableOperationRequest<
       btproto::CheckAndMutateRowRequest>(request, app_profile_id_.get(),
                                          table_name_.get());
-  *request.mutable_predicate_filter() = std::move(filter).as_proto_move();
+  *request.mutable_predicate_filter() = std::move(filter).as_proto();
   for (auto& m : true_mutations) {
     *request.add_true_mutations() = std::move(m.op);
   }

--- a/google/cloud/bigtable/internal/table.cc
+++ b/google/cloud/bigtable/internal/table.cc
@@ -173,7 +173,7 @@ bool Table::CheckAndMutateRow(std::string row_key, Filter filter,
   bigtable::internal::SetCommonTableOperationRequest<
       btproto::CheckAndMutateRowRequest>(request, app_profile_id_.get(),
                                          table_name_.get());
-  *request.mutable_predicate_filter() = filter.as_proto_move();
+  *request.mutable_predicate_filter() = std::move(filter).as_proto_move();
   for (auto& m : true_mutations) {
     *request.add_true_mutations() = std::move(m.op);
   }

--- a/google/cloud/bigtable/internal/table.h
+++ b/google/cloud/bigtable/internal/table.h
@@ -301,7 +301,7 @@ class Table {
     bigtable::internal::SetCommonTableOperationRequest<
         google::bigtable::v2::CheckAndMutateRowRequest>(
         request, app_profile_id_.get(), table_name_.get());
-    *request.mutable_predicate_filter() = std::move(filter).as_proto_move();
+    *request.mutable_predicate_filter() = std::move(filter).as_proto();
     for (auto& m : true_mutations) {
       *request.add_true_mutations() = std::move(m.op);
     }
@@ -336,7 +336,7 @@ class Table {
         "The arguments passed to ReadModifyWriteRow(row_key,...) must be "
         "convertible to bigtable::ReadModifyWriteRule");
 
-    *request.add_rules() = std::move(rule).as_proto_move();
+    *request.add_rules() = std::move(rule).as_proto();
     AddRules(request, std::forward<Args>(rules)...);
 
     return CallReadModifyWriteRowRequest(request, status);
@@ -440,7 +440,7 @@ class Table {
   template <typename... Args>
   void AddRules(google::bigtable::v2::ReadModifyWriteRowRequest& request,
                 bigtable::ReadModifyWriteRule rule, Args&&... args) {
-    *request.add_rules() = std::move(rule).as_proto_move();
+    *request.add_rules() = std::move(rule).as_proto();
     AddRules(request, std::forward<Args>(args)...);
   }
 

--- a/google/cloud/bigtable/internal/table.h
+++ b/google/cloud/bigtable/internal/table.h
@@ -301,7 +301,7 @@ class Table {
     bigtable::internal::SetCommonTableOperationRequest<
         google::bigtable::v2::CheckAndMutateRowRequest>(
         request, app_profile_id_.get(), table_name_.get());
-    *request.mutable_predicate_filter() = filter.as_proto_move();
+    *request.mutable_predicate_filter() = std::move(filter).as_proto_move();
     for (auto& m : true_mutations) {
       *request.add_true_mutations() = std::move(m.op);
     }
@@ -336,7 +336,7 @@ class Table {
         "The arguments passed to ReadModifyWriteRow(row_key,...) must be "
         "convertible to bigtable::ReadModifyWriteRule");
 
-    *request.add_rules() = rule.as_proto_move();
+    *request.add_rules() = std::move(rule).as_proto_move();
     AddRules(request, std::forward<Args>(rules)...);
 
     return CallReadModifyWriteRowRequest(request, status);
@@ -440,7 +440,7 @@ class Table {
   template <typename... Args>
   void AddRules(google::bigtable::v2::ReadModifyWriteRowRequest& request,
                 bigtable::ReadModifyWriteRule rule, Args&&... args) {
-    *request.add_rules() = rule.as_proto_move();
+    *request.add_rules() = std::move(rule).as_proto_move();
     AddRules(request, std::forward<Args>(args)...);
   }
 

--- a/google/cloud/bigtable/internal/table_admin.cc
+++ b/google/cloud/bigtable/internal/table_admin.cc
@@ -34,7 +34,7 @@ using ClientUtils = bigtable::internal::noex::UnaryClientUtils<AdminClient>;
 
 btadmin::Table TableAdmin::CreateTable(std::string table_id, TableConfig config,
                                        grpc::Status& status) {
-  auto request = config.as_proto_move();
+  auto request = std::move(config).as_proto_move();
   request.set_parent(instance_name());
   request.set_table_id(std::move(table_id));
 
@@ -108,7 +108,7 @@ btadmin::Table TableAdmin::ModifyColumnFamilies(
   btadmin::ModifyColumnFamiliesRequest request;
   request.set_name(TableName(table_id));
   for (auto& m : modifications) {
-    *request.add_modifications() = m.as_proto_move();
+    *request.add_modifications() = std::move(m).as_proto_move();
   }
   MetadataUpdatePolicy metadata_update_policy(
       instance_name(), MetadataParamTypes::NAME, table_id);

--- a/google/cloud/bigtable/internal/table_admin.cc
+++ b/google/cloud/bigtable/internal/table_admin.cc
@@ -34,7 +34,7 @@ using ClientUtils = bigtable::internal::noex::UnaryClientUtils<AdminClient>;
 
 btadmin::Table TableAdmin::CreateTable(std::string table_id, TableConfig config,
                                        grpc::Status& status) {
-  auto request = std::move(config).as_proto_move();
+  auto request = std::move(config).as_proto();
   request.set_parent(instance_name());
   request.set_table_id(std::move(table_id));
 
@@ -108,7 +108,7 @@ btadmin::Table TableAdmin::ModifyColumnFamilies(
   btadmin::ModifyColumnFamiliesRequest request;
   request.set_name(TableName(table_id));
   for (auto& m : modifications) {
-    *request.add_modifications() = std::move(m).as_proto_move();
+    *request.add_modifications() = std::move(m).as_proto();
   }
   MetadataUpdatePolicy metadata_update_policy(
       instance_name(), MetadataParamTypes::NAME, table_id);

--- a/google/cloud/bigtable/internal/table_admin.h
+++ b/google/cloud/bigtable/internal/table_admin.h
@@ -146,7 +146,7 @@ class TableAdmin {
                                                    TableConfig config,
                                                    CompletionQueue& cq,
                                                    Functor&& callback) {
-    auto request = std::move(config).as_proto_move();
+    auto request = std::move(config).as_proto();
     request.set_parent(instance_name());
     request.set_table_id(std::move(table_id));
 
@@ -364,7 +364,7 @@ class TableAdmin {
     google::bigtable::admin::v2::ModifyColumnFamiliesRequest request;
     request.set_name(TableName(table_id));
     for (auto& m : modifications) {
-      *request.add_modifications() = std::move(m).as_proto_move();
+      *request.add_modifications() = std::move(m).as_proto();
     }
     MetadataUpdatePolicy metadata_update_policy(
         instance_name(), MetadataParamTypes::NAME, table_id);

--- a/google/cloud/bigtable/internal/table_admin.h
+++ b/google/cloud/bigtable/internal/table_admin.h
@@ -146,7 +146,7 @@ class TableAdmin {
                                                    TableConfig config,
                                                    CompletionQueue& cq,
                                                    Functor&& callback) {
-    auto request = config.as_proto_move();
+    auto request = std::move(config).as_proto_move();
     request.set_parent(instance_name());
     request.set_table_id(std::move(table_id));
 
@@ -364,7 +364,7 @@ class TableAdmin {
     google::bigtable::admin::v2::ModifyColumnFamiliesRequest request;
     request.set_name(TableName(table_id));
     for (auto& m : modifications) {
-      *request.add_modifications() = m.as_proto_move();
+      *request.add_modifications() = std::move(m).as_proto_move();
     }
     MetadataUpdatePolicy metadata_update_policy(
         instance_name(), MetadataParamTypes::NAME, table_id);

--- a/google/cloud/bigtable/read_modify_write_rule.h
+++ b/google/cloud/bigtable/read_modify_write_rule.h
@@ -62,10 +62,12 @@ class ReadModifyWriteRule {
   }
 
   /// Return the filter expression as a protobuf.
-  google::bigtable::v2::ReadModifyWriteRule as_proto() const { return rule_; }
+  google::bigtable::v2::ReadModifyWriteRule const& as_proto() const& {
+    return rule_;
+  }
 
   /// Move out the underlying protobuf value.
-  google::bigtable::v2::ReadModifyWriteRule as_proto_move() && {
+  google::bigtable::v2::ReadModifyWriteRule&& as_proto() && {
     return std::move(rule_);
   }
 

--- a/google/cloud/bigtable/read_modify_write_rule.h
+++ b/google/cloud/bigtable/read_modify_write_rule.h
@@ -65,7 +65,7 @@ class ReadModifyWriteRule {
   google::bigtable::v2::ReadModifyWriteRule as_proto() const { return rule_; }
 
   /// Move out the underlying protobuf value.
-  google::bigtable::v2::ReadModifyWriteRule as_proto_move() {
+  google::bigtable::v2::ReadModifyWriteRule as_proto_move() && {
     return std::move(rule_);
   }
 

--- a/google/cloud/bigtable/row_range.h
+++ b/google/cloud/bigtable/row_range.h
@@ -148,10 +148,12 @@ class RowRange {
   bool operator!=(RowRange const& rhs) const { return !(*this == rhs); }
 
   /// Return the filter expression as a protobuf.
-  ::google::bigtable::v2::RowRange as_proto() const { return row_range_; }
+  ::google::bigtable::v2::RowRange const& as_proto() const& {
+    return row_range_;
+  }
 
   /// Move out the underlying protobuf value.
-  ::google::bigtable::v2::RowRange as_proto_move() && {
+  ::google::bigtable::v2::RowRange&& as_proto() && {
     return std::move(row_range_);
   }
 

--- a/google/cloud/bigtable/row_range.h
+++ b/google/cloud/bigtable/row_range.h
@@ -151,7 +151,7 @@ class RowRange {
   ::google::bigtable::v2::RowRange as_proto() const { return row_range_; }
 
   /// Move out the underlying protobuf value.
-  ::google::bigtable::v2::RowRange as_proto_move() {
+  ::google::bigtable::v2::RowRange as_proto_move() && {
     return std::move(row_range_);
   }
 

--- a/google/cloud/bigtable/row_set.cc
+++ b/google/cloud/bigtable/row_set.cc
@@ -34,7 +34,7 @@ RowSet RowSet::Intersect(bigtable::RowRange const& range) const {
   for (auto const& r : row_set_.row_ranges()) {
     auto i = range.Intersect(RowRange(r));
     if (std::get<0>(i)) {
-      *result.row_set_.add_row_ranges() = std::get<1>(i).as_proto_move();
+      *result.row_set_.add_row_ranges() = std::move(std::get<1>(i)).as_proto_move();
     }
   }
   // Another special case: a RowSet() with no entries

--- a/google/cloud/bigtable/row_set.cc
+++ b/google/cloud/bigtable/row_set.cc
@@ -34,7 +34,7 @@ RowSet RowSet::Intersect(bigtable::RowRange const& range) const {
   for (auto const& r : row_set_.row_ranges()) {
     auto i = range.Intersect(RowRange(r));
     if (std::get<0>(i)) {
-      *result.row_set_.add_row_ranges() = std::move(std::get<1>(i)).as_proto_move();
+      *result.row_set_.add_row_ranges() = std::move(std::get<1>(i)).as_proto();
     }
   }
   // Another special case: a RowSet() with no entries

--- a/google/cloud/bigtable/row_set.h
+++ b/google/cloud/bigtable/row_set.h
@@ -49,7 +49,7 @@ class RowSet {
 
   /// Add @p range to the set.
   void Append(RowRange range) {
-    *row_set_.add_row_ranges() = range.as_proto_move();
+    *row_set_.add_row_ranges() = std::move(range).as_proto_move();
   }
 
   /**
@@ -81,7 +81,9 @@ class RowSet {
   bool IsEmpty() const;
 
   ::google::bigtable::v2::RowSet as_proto() const { return row_set_; }
-  ::google::bigtable::v2::RowSet as_proto_move() { return std::move(row_set_); }
+  ::google::bigtable::v2::RowSet as_proto_move() && {
+    return std::move(row_set_);
+  }
 
  private:
   template <typename T>

--- a/google/cloud/bigtable/row_set.h
+++ b/google/cloud/bigtable/row_set.h
@@ -49,7 +49,7 @@ class RowSet {
 
   /// Add @p range to the set.
   void Append(RowRange range) {
-    *row_set_.add_row_ranges() = std::move(range).as_proto_move();
+    *row_set_.add_row_ranges() = std::move(range).as_proto();
   }
 
   /**
@@ -80,10 +80,8 @@ class RowSet {
    */
   bool IsEmpty() const;
 
-  ::google::bigtable::v2::RowSet as_proto() const { return row_set_; }
-  ::google::bigtable::v2::RowSet as_proto_move() && {
-    return std::move(row_set_);
-  }
+  ::google::bigtable::v2::RowSet const& as_proto() const& { return row_set_; }
+  ::google::bigtable::v2::RowSet&& as_proto() && { return std::move(row_set_); }
 
  private:
   template <typename T>

--- a/google/cloud/bigtable/table_config.cc
+++ b/google/cloud/bigtable/table_config.cc
@@ -19,7 +19,7 @@ namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 // NOLINTNEXTLINE(readability-identifier-naming)
-::google::bigtable::admin::v2::CreateTableRequest TableConfig::as_proto_move() {
+::google::bigtable::admin::v2::CreateTableRequest TableConfig::as_proto_move() && {
   // As a challenge, we implement the strong exception guarantee in this
   // function.
   // First create a temporary value to hold intermediate computations.
@@ -38,7 +38,7 @@ inline namespace BIGTABLE_CLIENT_NS {
 
   // None of the operations that follow can fail, they are all `noexcept`:
   for (auto& kv : column_families_) {
-    *families[kv.first].mutable_gc_rule() = kv.second.as_proto_move();
+    *families[kv.first].mutable_gc_rule() = std::move(kv.second).as_proto_move();
   }
   for (auto& split : initial_splits_) {
     tmp.add_initial_splits()->set_key(std::move(split));

--- a/google/cloud/bigtable/table_config.cc
+++ b/google/cloud/bigtable/table_config.cc
@@ -19,7 +19,7 @@ namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 // NOLINTNEXTLINE(readability-identifier-naming)
-::google::bigtable::admin::v2::CreateTableRequest TableConfig::as_proto_move() && {
+::google::bigtable::admin::v2::CreateTableRequest TableConfig::as_proto() && {
   // As a challenge, we implement the strong exception guarantee in this
   // function.
   // First create a temporary value to hold intermediate computations.
@@ -38,7 +38,7 @@ inline namespace BIGTABLE_CLIENT_NS {
 
   // None of the operations that follow can fail, they are all `noexcept`:
   for (auto& kv : column_families_) {
-    *families[kv.first].mutable_gc_rule() = std::move(kv.second).as_proto_move();
+    *families[kv.first].mutable_gc_rule() = std::move(kv.second).as_proto();
   }
   for (auto& split : initial_splits_) {
     tmp.add_initial_splits()->set_key(std::move(split));

--- a/google/cloud/bigtable/table_config.h
+++ b/google/cloud/bigtable/table_config.h
@@ -36,7 +36,7 @@ class TableConfig {
         granularity_(TIMESTAMP_GRANULARITY_UNSPECIFIED) {}
 
   /// Move the contents to the proto to create tables.
-  ::google::bigtable::admin::v2::CreateTableRequest as_proto_move();
+  ::google::bigtable::admin::v2::CreateTableRequest as_proto_move() &&;
 
   using TimestampGranularity =
       ::google::bigtable::admin::v2::Table::TimestampGranularity;

--- a/google/cloud/bigtable/table_config.h
+++ b/google/cloud/bigtable/table_config.h
@@ -36,7 +36,10 @@ class TableConfig {
         granularity_(TIMESTAMP_GRANULARITY_UNSPECIFIED) {}
 
   /// Move the contents to the proto to create tables.
-  ::google::bigtable::admin::v2::CreateTableRequest as_proto_move() &&;
+  // Note that this function returns a copy intentionally, the object does not
+  // have the proto as a member variable, it constructs the proto from its own
+  // data structures for "reasons".
+  ::google::bigtable::admin::v2::CreateTableRequest as_proto() &&;
 
   using TimestampGranularity =
       ::google::bigtable::admin::v2::Table::TimestampGranularity;

--- a/google/cloud/bigtable/table_config_test.cc
+++ b/google/cloud/bigtable/table_config_test.cc
@@ -56,7 +56,7 @@ initial_splits { key: 'qux' }
   ASSERT_TRUE(
       google::protobuf::TextFormat::ParseFromString(expected_text, &expected));
 
-  auto request = std::move(config).as_proto_move();
+  auto request = std::move(config).as_proto();
 
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;

--- a/google/cloud/bigtable/table_config_test.cc
+++ b/google/cloud/bigtable/table_config_test.cc
@@ -56,7 +56,7 @@ initial_splits { key: 'qux' }
   ASSERT_TRUE(
       google::protobuf::TextFormat::ParseFromString(expected_text, &expected));
 
-  auto request = config.as_proto_move();
+  auto request = std::move(config).as_proto_move();
 
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;


### PR DESCRIPTION
The as_proto_move() member functions are destructive, the steal the
contents of the wrapper class. This change limits their use to
rvalue references, so the developer (this is mostly us) notices that
they are destroying the thing (and sometimes get a nice warning).

This is a breaking change, it modifies the public API in a minor way,
but does break existing code. It also breaks the ABI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1618)
<!-- Reviewable:end -->
