### PR TITLE
Remove unused packages in build images.

### DIFF
--- a/ci/travis/Dockerfile.centos
+++ b/ci/travis/Dockerfile.centos
@@ -31,8 +31,6 @@ RUN yum makecache && yum install -y \
     curl \
     curl-devel \
     git \
-    golang \
-    graphviz \
     openssl-devel \
     pkgconfig \
     python \

--- a/ci/travis/Dockerfile.fedora
+++ b/ci/travis/Dockerfile.fedora
@@ -29,9 +29,6 @@ RUN dnf makecache && dnf install -y \
     doxygen \
     gcc-c++ \
     git \
-    golang \
-    graphviz \
-    lcov \
     libcurl-devel \
     libtool \
     make \

--- a/ci/travis/Dockerfile.ubuntu
+++ b/ci/travis/Dockerfile.ubuntu
@@ -32,7 +32,6 @@ RUN apt update && \
         git \
         gcc \
         g++ \
-        golang \
         cmake \
         libcurl4-openssl-dev \
         libssl-dev \

--- a/ci/travis/Dockerfile.ubuntu
+++ b/ci/travis/Dockerfile.ubuntu
@@ -38,6 +38,7 @@ RUN apt update && \
         libtool \
         lsb-release \
         make \
+        pkg-config \
         python-pip \
         tar \
         wget \

--- a/ci/travis/Dockerfile.ubuntu-trusty
+++ b/ci/travis/Dockerfile.ubuntu-trusty
@@ -29,11 +29,9 @@ RUN apt update && apt install -y software-properties-common && \
         clang-3.8 \
         cmake3 \
         curl \
-        doxygen \
         gcc-4.9 \
         g++-4.9 \
         git \
-        golang \
         libcurl4-openssl-dev \
         libssl-dev \
         libtool \


### PR DESCRIPTION
This saves ~20 seconds from the build. Not sure if we care, but was easy to do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1622)
<!-- Reviewable:end -->
