### PR TITLE
Added the ColumnName() filter

### DIFF
--- a/google/cloud/bigtable/filters.h
+++ b/google/cloud/bigtable/filters.h
@@ -129,6 +129,19 @@ class Filter {
   }
 
   /**
+   * Return the filter that accepts the named @p column within the @p family
+   * column family.
+   *
+   * This function makes no attempt to validate the column family or column
+   * range before sending them to the server.
+   */
+  static Filter ColumnName(std::string family, std::string column) {
+    std::string end = column;
+    return ColumnRangeClosed(std::move(family), std::move(column),
+                             std::move(end));
+  }
+
+  /**
    * Return a filter that accepts cells with timestamps in the range
    * [@p start, @p end).
    *

--- a/google/cloud/bigtable/filters_test.cc
+++ b/google/cloud/bigtable/filters_test.cc
@@ -56,6 +56,13 @@ TEST(FiltersTest, ColumnRange) {
   EXPECT_EQ("colF", proto.column_range_filter().end_qualifier_open());
 }
 
+TEST(FiltersTest, ColumnName) {
+  auto proto = bigtable::Filter::ColumnName("fam", "colA").as_proto();
+  EXPECT_EQ("fam", proto.column_range_filter().family_name());
+  EXPECT_EQ("colA", proto.column_range_filter().start_qualifier_closed());
+  EXPECT_EQ("colA", proto.column_range_filter().end_qualifier_closed());
+}
+
 TEST(FiltersTest, TimestampRangeMicros) {
   auto proto = bigtable::Filter::TimestampRangeMicros(0, 10).as_proto();
   EXPECT_EQ(0, proto.timestamp_range_filter().start_timestamp_micros());


### PR DESCRIPTION
Adds a `bigtable::Filter::ColumnName(family, column)` factory for selecting exactly one column.

Fixes #1562

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1625)
<!-- Reviewable:end -->
