### PR TITLE
Enable bugprone-* clang-tidy checks.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@
 #  -google-readability-namespace-comments the BIGTABLE_CLIENT_NS is a macro, and
 #   clang-tidy fails to match it against the initial value.
 Checks: >-
+  bugprone-*,
   google-readability-*,
   misc-*,
   modernize-*,
@@ -15,6 +16,7 @@ Checks: >-
 
 # Enable most warnings as errors.
 WarningsAsErrors: >-
+  bugprone-*,
   clang-*,
   google-*,
   misc-*,

--- a/google/cloud/storage/internal/curl_handle_factory.cc
+++ b/google/cloud/storage/internal/curl_handle_factory.cc
@@ -90,7 +90,8 @@ void PooledCurlHandleFactory::CleanupHandle(CurlPtr&& h) {
     curl_easy_cleanup(tmp);
   }
   handles_.push_back(h.get());
-  h.release();
+  // The handles_ vector now has ownership, so release it.
+  (void)h.release();
 }
 
 CurlMulti PooledCurlHandleFactory::CreateMultiHandle() {
@@ -111,7 +112,8 @@ void PooledCurlHandleFactory::CleanupMultiHandle(CurlMulti&& m) {
     curl_multi_cleanup(tmp);
   }
   multi_handles_.push_back(m.get());
-  m.release();
+  // The multi_handles_ vector now has ownership, so release it.
+  (void)m.release();
 }
 
 }  // namespace internal


### PR DESCRIPTION
Fixed the code and turn on the warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1627)
<!-- Reviewable:end -->
