### PR TITLE
In GCP_LOG() the level should be concatenated without expansion.

### DIFF
--- a/google/cloud/log.h
+++ b/google/cloud/log.h
@@ -142,14 +142,16 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
        GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER.LogTo(sink))                     \
   GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER.Stream()
 
+// Note that we do not use GOOGLE_CLOUD_CPP_PP_CONCAT here, we actually want
+// to concatenate the literal `level` with `GCP_LS`. In some platforms the level
+// names are used for macros (e.g. on macOS DEBUG is often a macro with value 1
+// for debug builds). If we use GOOGLE_CLOUD_CPP_PP_CONCAT and `level` is a
+// a macro then we would get `GCP_LS_<macro_value>`.
 /**
  * Log a message with the Google Cloud Platform C++ Libraries logging framework.
- *
- *
  */
-#define GCP_LOG(level)                                               \
-  GOOGLE_CLOUD_CPP_LOG_I(GOOGLE_CLOUD_CPP_PP_CONCAT(GCP_LS_, level), \
-                         ::google::cloud::LogSink::Instance())
+#define GCP_LOG(level) \
+  GOOGLE_CLOUD_CPP_LOG_I(GCP_LS_##level, ::google::cloud::LogSink::Instance())
 
 #ifndef GOOGLE_CLOUD_CPP_LOGGING_MIN_SEVERITY_ENABLED
 #define GOOGLE_CLOUD_CPP_LOGGING_MIN_SEVERITY_ENABLED GCP_LS_DEBUG


### PR DESCRIPTION
This fixes #1623. On macOS certain system headers use DEBUG as a
macro to detect, well, if the code is being built for debugging,
and Bazel obliges (as it should) by defining the macro to 1. If
we expand the macro before concatenation then GCP_LOG(DEBUG) has
a GCP_LS_1 in its expansion, while we want GCP_LS_DEBUG.

See this for additional background:

https://github.com/bazelbuild/bazel/issues/3513

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1628)
<!-- Reviewable:end -->
