### PR TITLE
Fix formatting for comments.

### DIFF
--- a/google/cloud/log.h
+++ b/google/cloud/log.h
@@ -143,9 +143,9 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
   GOOGLE_CLOUD_CPP_LOGGER_IDENTIFIER.Stream()
 
 // Note that we do not use `GOOGLE_CLOUD_CPP_PP_CONCAT` here: we actually want
-// to concatenate `GCP_LS` with the literal `level`. On some platforms, the level
-// names are used as macros (e.g., on macOS, `DEBUG` is often a macro with value
-// 1 for debug builds). If we were to use `GOOGLE_CLOUD_CPP_PP_CONCAT` and
+// to concatenate `GCP_LS` with the literal `level`. On some platforms, the
+// level names are used as macros (e.g., on macOS, `DEBUG` is often a macro with
+// value 1 for debug builds). If we were to use `GOOGLE_CLOUD_CPP_PP_CONCAT` and
 // `level` is a a macro, then we would get `GCP_LS_<macro_value>`, i.e.,
 // `GCP_LS_1` (incorrect) instead of `GCP_LS_DEBUG` (correct).
 /**


### PR DESCRIPTION
They comments exceeded the 80 character limit. That reminds us
that `skip ci` is not safe even for comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1631)
<!-- Reviewable:end -->
