### PR TITLE
Add missing compiler options.

### DIFF
--- a/google/cloud/bigtable/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigtable/benchmarks/CMakeLists.txt
@@ -30,7 +30,8 @@ target_link_libraries(bigtable_benchmark_common
                       bigtable_protos
                       gRPC::grpc++
                       gRPC::grpc
-                      protobuf::libprotobuf)
+                      protobuf::libprotobuf
+                      bigtable_common_options)
 
 # List the unit tests, then setup the targets and dependencies.
 set(bigtable_benchmarks_unit_tests

--- a/google/cloud/bigtable/examples/CMakeLists.txt
+++ b/google/cloud/bigtable/examples/CMakeLists.txt
@@ -19,30 +19,37 @@
 # part of the examples.
 
 add_executable(bigtable_hello_world bigtable_hello_world.cc)
-target_link_libraries(bigtable_hello_world bigtable_client)
+target_link_libraries(bigtable_hello_world bigtable_client
+                      bigtable_common_options)
 
 add_executable(bigtable_hello_app_profile bigtable_hello_app_profile.cc)
-target_link_libraries(bigtable_hello_app_profile bigtable_client)
+target_link_libraries(bigtable_hello_app_profile bigtable_client
+                      bigtable_common_options)
 
 add_executable(bigtable_quickstart bigtable_quickstart.cc)
-target_link_libraries(bigtable_quickstart bigtable_client)
+target_link_libraries(bigtable_quickstart bigtable_client
+                      bigtable_common_options)
 
 add_executable(bigtable_samples bigtable_samples.cc)
-target_link_libraries(bigtable_samples bigtable_client)
+target_link_libraries(bigtable_samples bigtable_client bigtable_common_options)
 
 add_executable(bigtable_samples_instance_admin
                bigtable_samples_instance_admin.cc)
-target_link_libraries(bigtable_samples_instance_admin bigtable_client)
+target_link_libraries(bigtable_samples_instance_admin bigtable_client
+                      bigtable_common_options)
 
 add_executable(bigtable_samples_instance_admin_ext
                bigtable_samples_instance_admin_ext.cc)
-target_link_libraries(bigtable_samples_instance_admin_ext bigtable_client)
+target_link_libraries(bigtable_samples_instance_admin_ext bigtable_client
+                      bigtable_common_options)
 
 add_executable(table_admin_async_snippets table_admin_async_snippets.cc)
-target_link_libraries(table_admin_async_snippets bigtable_client)
+target_link_libraries(table_admin_async_snippets bigtable_client
+                      bigtable_common_options)
 
 add_executable(table_admin_snippets table_admin_snippets.cc)
-target_link_libraries(table_admin_snippets bigtable_client)
+target_link_libraries(table_admin_snippets bigtable_client
+                      bigtable_common_options)
 
 add_executable(data_snippets data_snippets.cc)
-target_link_libraries(data_snippets bigtable_client)
+target_link_libraries(data_snippets bigtable_client bigtable_common_options)

--- a/google/cloud/bigtable/examples/data_snippets.cc
+++ b/google/cloud/bigtable/examples/data_snippets.cc
@@ -275,8 +275,6 @@ void ReadModifyWrite(google::cloud::bigtable::Table table, int argc,
         google::cloud::bigtable::ReadModifyWriteRule::AppendValue("fam", "list",
                                                                   ";element"));
     std::cout << row.row_key() << "\n";
-    for (auto const& cell : row.cells()) {
-    }
   }
   //! [read modify write]
   (std::move(table));

--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -15,9 +15,13 @@
 # ~~~
 
 add_executable(storage_latency_benchmark storage_latency_benchmark.cc)
-target_link_libraries(storage_latency_benchmark storage_client
+target_link_libraries(storage_latency_benchmark
+                      storage_client
+                      storage_common_options
                       google_cloud_cpp_common_options)
 
 add_executable(storage_throughput_benchmark storage_throughput_benchmark.cc)
-target_link_libraries(storage_throughput_benchmark storage_client
+target_link_libraries(storage_throughput_benchmark
+                      storage_client
+                      storage_common_options
                       google_cloud_cpp_common_options)

--- a/google/cloud/storage/examples/CMakeLists.txt
+++ b/google/cloud/storage/examples/CMakeLists.txt
@@ -19,27 +19,36 @@
 # part of the examples.
 
 add_executable(storage_bucket_samples storage_bucket_samples.cc)
-target_link_libraries(storage_bucket_samples storage_client)
+target_link_libraries(storage_bucket_samples storage_client
+                      storage_common_options)
 
 add_executable(storage_bucket_acl_samples storage_bucket_acl_samples.cc)
-target_link_libraries(storage_bucket_acl_samples storage_client)
+target_link_libraries(storage_bucket_acl_samples storage_client
+                      storage_common_options)
 
 add_executable(storage_bucket_iam_samples storage_bucket_iam_samples.cc)
-target_link_libraries(storage_bucket_iam_samples storage_client)
+target_link_libraries(storage_bucket_iam_samples storage_client
+                      storage_common_options)
 
 add_executable(storage_default_object_acl_samples
                storage_default_object_acl_samples.cc)
-target_link_libraries(storage_default_object_acl_samples storage_client)
+target_link_libraries(storage_default_object_acl_samples storage_client
+                      storage_common_options)
 
 add_executable(storage_object_samples storage_object_samples.cc)
-target_link_libraries(storage_object_samples storage_client)
+target_link_libraries(storage_object_samples storage_client
+                      storage_common_options)
 
 add_executable(storage_object_acl_samples storage_object_acl_samples.cc)
-target_link_libraries(storage_object_acl_samples storage_client)
+target_link_libraries(storage_object_acl_samples storage_client
+                      storage_common_options)
 
 add_executable(storage_notification_samples storage_notification_samples.cc)
-target_link_libraries(storage_notification_samples storage_client)
+target_link_libraries(storage_notification_samples storage_client
+                      storage_common_options)
 
 add_executable(storage_quickstart storage_quickstart.cc)
-target_link_libraries(storage_quickstart storage_client
+target_link_libraries(storage_quickstart
+                      storage_client
+                      storage_common_options
                       google_cloud_cpp_common_options)


### PR DESCRIPTION
We use an interface library to set options across all targets by just
"linking" the library. This is better than manually setting the options
on each target, but only works if you actually do link the library. I
missed that in a few tests and examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1633)
<!-- Reviewable:end -->
