### PR TITLE
Use backwards compatible native.http_archive in Bazel.

### DIFF
--- a/ci/kokoro/ubuntu/build.sh
+++ b/ci/kokoro/ubuntu/build.sh
@@ -55,6 +55,7 @@ bazel test \
     --test_output=errors \
     --verbose_failures=true \
     --keep_going \
+    --incompatible_remove_native_http_archive=false \
     -- //google/cloud/...:all
 
 echo
@@ -73,6 +74,7 @@ bazel build \
     --test_output=errors \
     --verbose_failures=true \
     --keep_going \
+    --incompatible_remove_native_http_archive=false \
     -- //google/cloud/...:all
 
 # The integration tests need further configuration and tools.

--- a/ci/travis/build-bazel.sh
+++ b/ci/travis/build-bazel.sh
@@ -26,7 +26,7 @@ if [ "${TEST_BAZEL_AS_DEPENDENCY:-}" = "yes" ]; then
   echo "${COLOR_YELLOW}Testing Bazel files as dependency${COLOR_RESET}"
   (cd ci/test-install && bazel --batch build \
       --incompatible_remove_native_http_archive=false \
-      -- "//google/cloud/...:all")
+      -- "//...:all")
 else
   # We cannot simply use //...:all because when submodules are checked out that
   # includes the BUILD files for gRPC, protobuf, etc.

--- a/ci/travis/build-bazel.sh
+++ b/ci/travis/build-bazel.sh
@@ -24,16 +24,20 @@ export PATH=$PATH:$HOME/bin
 if [ "${TEST_BAZEL_AS_DEPENDENCY:-}" = "yes" ]; then
   echo
   echo "${COLOR_YELLOW}Testing Bazel files as dependency${COLOR_RESET}"
-  (cd ci/test-install && bazel --batch build //...:all)
+  (cd ci/test-install && bazel --batch build \
+      --incompatible_remove_native_http_archive=false \
+      -- "//google/cloud/...:all")
 else
   # We cannot simply use //...:all because when submodules are checked out that
   # includes the BUILD files for gRPC, protobuf, etc.
   bazel --batch build \
       --test_output=errors \
       --action_env="GTEST_COLOR=1" \
-      "//google/cloud/...:all"
+      --incompatible_remove_native_http_archive=false \
+      -- "//google/cloud/...:all"
   bazel --batch test \
       --test_output=errors \
       --action_env="GTEST_COLOR=1" \
-      "//google/cloud/...:all"
+      --incompatible_remove_native_http_archive=false \
+      -- "//google/cloud/...:all"
 fi


### PR DESCRIPTION
Bazel is deprecating the native.http_archive() rule, with recent
Bazel versions the build actually breaks. Both our WORKSPACE file and
the gRPC WORKSPACE file use this rule though. We can easily stop using
it, but changing gRPC may take a few weeks. For the moment turn on the
backwards compatible mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1688)
<!-- Reviewable:end -->
