### PR TITLE
Implement an exception to wrap storage::Status.

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -161,6 +161,7 @@ add_library(google_cloud_cpp_testing
             testing_util/chrono_literals.h
             testing_util/environment_variable_restore.h
             testing_util/environment_variable_restore.cc
+            testing_util/expect_exception.h
             testing_util/expect_future_error.h
             testing_util/custom_google_mock_main.cc
             testing_util/init_google_mock.h

--- a/google/cloud/google_cloud_cpp_testing.bzl
+++ b/google/cloud/google_cloud_cpp_testing.bzl
@@ -21,6 +21,7 @@ google_cloud_cpp_testing_hdrs = [
     "testing_util/check_predicate_becomes_false.h",
     "testing_util/chrono_literals.h",
     "testing_util/environment_variable_restore.h",
+    "testing_util/expect_exception.h",
     "testing_util/expect_future_error.h",
     "testing_util/init_google_mock.h",
     "testing_util/testing_types.h",

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -158,6 +158,8 @@ add_library(storage_client
             internal/service_account_requests.cc
             internal/signed_url_requests.h
             internal/signed_url_requests.cc
+            internal/throw_status_delegate.h
+            internal/throw_status_delegate.cc
             lifecycle_rule.h
             lifecycle_rule.cc
             list_buckets_reader.h
@@ -195,6 +197,7 @@ add_library(storage_client
             signed_url_options.h
             signed_url_options.cc
             status.h
+            status.cc
             storage_class.h
             upload_options.h
             version.h
@@ -308,6 +311,7 @@ set(storage_client_unit_tests
     internal/retry_resumable_upload_session_test.cc
     internal/service_account_requests_test.cc
     internal/signed_url_requests_test.cc
+    internal/throw_status_delegate_test.cc
     lifecycle_rule_test.cc
     list_buckets_reader_test.cc
     list_objects_reader_test.cc

--- a/google/cloud/storage/internal/throw_status_delegate.cc
+++ b/google/cloud/storage/internal/throw_status_delegate.cc
@@ -1,0 +1,37 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/throw_status_delegate.h"
+#include "google/cloud/terminate_handler.h"
+#include <sstream>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+[[noreturn]] void ThrowStatus(Status&& status) {
+#ifdef GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  throw storage::RuntimeStatusError(std::move(status));
+#else
+  std::ostringstream os;
+  os << status;
+  google::cloud::Terminate(os.str().c_str());
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/throw_status_delegate.cc
+++ b/google/cloud/storage/internal/throw_status_delegate.cc
@@ -21,7 +21,7 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
-[[noreturn]] void ThrowStatus(Status&& status) {
+[[noreturn]] void ThrowStatus(Status status) {
 #ifdef GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   throw storage::RuntimeStatusError(std::move(status));
 #else

--- a/google/cloud/storage/internal/throw_status_delegate.h
+++ b/google/cloud/storage/internal/throw_status_delegate.h
@@ -23,7 +23,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 /// Throw an exception wrapping @p status.
-[[noreturn]] void ThrowStatus(Status&& status);
+[[noreturn]] void ThrowStatus(Status status);
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/throw_status_delegate.h
+++ b/google/cloud/storage/internal/throw_status_delegate.h
@@ -1,0 +1,33 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_THROW_STATUS_DELEGATE_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_THROW_STATUS_DELEGATE_H_
+
+#include "google/cloud/storage/status.h"
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+/// Throw an exception wrapping @p status.
+[[noreturn]] void ThrowStatus(Status&& status);
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_THROW_STATUS_DELEGATE_H_

--- a/google/cloud/storage/internal/throw_status_delegate_test.cc
+++ b/google/cloud/storage/internal/throw_status_delegate_test.cc
@@ -1,0 +1,44 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/throw_status_delegate.h"
+#include "google/cloud/testing_util/expect_exception.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+TEST(ThrowStatusDelegateTest, TestThrow) {
+  testing_util::ExpectException<RuntimeStatusError>(
+      [&] {
+        Status status(404, "NOT FOUND", "oh noes!");
+        ThrowStatus(std::move(status));
+      },
+      [&](RuntimeStatusError const& ex) {
+        EXPECT_EQ(404, ex.status().status_code());
+        EXPECT_EQ("NOT FOUND", ex.status().error_message());
+        EXPECT_EQ("oh noes!", ex.status().error_details());
+      },
+      "Aborting because exceptions are disabled: "
+      "NOT FOUND \\[404\\], details=oh noes!");
+}
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/status.cc
+++ b/google/cloud/storage/status.cc
@@ -1,0 +1,36 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/status.h"
+#include <sstream>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+std::string StatusWhat(Status const& status) {
+  std::ostringstream os;
+  os << status;
+  return std::move(os).str();
+}
+}  // namespace
+
+RuntimeStatusError::RuntimeStatusError(Status status)
+    : std::runtime_error(StatusWhat(status)), status_(std::move(status)) {}
+
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/status.h
+++ b/google/cloud/storage/status.h
@@ -77,6 +77,16 @@ inline std::ostream& operator<<(std::ostream& os, Status const& rhs) {
             << "], details=" << rhs.error_details();
 }
 
+class RuntimeStatusError : public std::runtime_error {
+ public:
+  explicit RuntimeStatusError(Status status);
+
+  Status const& status() const { return status_; }
+
+ private:
+  Status status_;
+};
+
 /**
  * Report checksum mismatches as exceptions.
  */

--- a/google/cloud/storage/storage_client.bzl
+++ b/google/cloud/storage/storage_client.bzl
@@ -67,6 +67,7 @@ storage_client_hdrs = [
     "internal/retry_resumable_upload_session.h",
     "internal/service_account_requests.h",
     "internal/signed_url_requests.h",
+    "internal/throw_status_delegate.h",
     "lifecycle_rule.h",
     "list_buckets_reader.h",
     "list_objects_reader.h",
@@ -137,6 +138,7 @@ storage_client_srcs = [
     "internal/retry_resumable_upload_session.cc",
     "internal/service_account_requests.cc",
     "internal/signed_url_requests.cc",
+    "internal/throw_status_delegate.cc",
     "lifecycle_rule.cc",
     "list_buckets_reader.cc",
     "list_objects_reader.cc",
@@ -152,6 +154,7 @@ storage_client_srcs = [
     "object_stream.cc",
     "service_account.cc",
     "signed_url_options.cc",
+    "status.cc",
     "version.cc",
     "well_known_headers.cc",
 ]

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -58,6 +58,7 @@ storage_client_unit_tests = [
     "internal/retry_resumable_upload_session_test.cc",
     "internal/service_account_requests_test.cc",
     "internal/signed_url_requests_test.cc",
+    "internal/throw_status_delegate_test.cc",
     "lifecycle_rule_test.cc",
     "list_buckets_reader_test.cc",
     "list_objects_reader_test.cc",

--- a/google/cloud/testing_util/expect_exception.h
+++ b/google/cloud/testing_util/expect_exception.h
@@ -1,0 +1,94 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_EXPECT_EXCEPTION_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_EXPECT_EXCEPTION_H_
+
+#include "google/cloud/version.h"
+#include <gmock/gmock.h>
+#include <future>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace testing_util {
+/**
+ * Verify that a given functor raises `T` and run a test if it does.
+ *
+ * `EXPECT_THROW()` validates the type of an exception, but does not validate
+ * its contents. Most of the time the type is enough, but in some tests need to
+ * be more detailed. The common idiom in that case is to write an explicit
+ * try/catch to validate the values and then rethrow:
+ *
+ * @code
+ * EXPECT_THROW(
+ *     try { something_that_throws(); }
+ *     catch(ExpectedException const& ex) {
+ *       // Validate the contents of ex, e.g. EXPECT_EQ(..., ex.what());
+ *       throw;
+ *     }, ExpectedException);
+ * @endcode
+ *
+ * That works, but we need to compile (and run) the tests with
+ * `-fno-exceptions`. In that case the test becomes:
+ *
+ * @code
+ * EXPECT_DEATH_IF_SUPPORTED(something_that_throws(), "expected death message");
+ * @endcode
+ *
+ * And, of course, these two cases need a `#%ifdef` to detect if exceptions are
+ * enabled. This was getting tedious, so we refactor to this function. The
+ * expected use is:
+ *
+ * @code
+ * ExpectException<MyException>(
+ *     [&] { something_that_throws(); },
+ *     [&](MyException const& ex) {
+ *         EXPECT_EQ("everything is terrible", ex.what());
+ *     },
+ *     "terminating program: everything is terrible");
+ * @endcode
+ *
+ *
+ * @param expression the expression (typically a lambda) that is expected to
+ *     raise an exception of type `ExpectedException`.
+ * @param validator a functor to validate the exception contents.
+ * @param expected_message if exceptions are disabled the program is expected
+ *     to terminate, and @p expected_message is a regular expression matched
+ *     against the program output.
+ * @tparam ExpectedException the type of exception.
+ */
+template <typename ExpectedException>
+void ExpectException(
+    std::function<void()> const& expression,
+    std::function<void(ExpectedException const& ex)> const& validator,
+    char const* expected_message) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_THROW(try { expression(); } catch (ExpectedException const& ex) {
+    validator(ex);
+    throw;
+  },
+               ExpectedException);
+  (void)expected_message;  // suppress clang-tidy warning.
+#else
+  (void)validator;  // suppress clang-tidy warning.
+  EXPECT_DEATH_IF_SUPPORTED(expression(), expected_message);
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+}
+}  // namespace testing_util
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_EXPECT_EXCEPTION_H_


### PR DESCRIPTION
This will be used by `StatusOr<T>::value()` when the value is not set.

Part of the work for #1686.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1690)
<!-- Reviewable:end -->
