### PR TITLE
Allow generation of dependency graphs with CMake.

### DIFF
--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -182,6 +182,14 @@ echo
 echo "travis_fold:end:configure-cmake"
 echo "${COLOR_YELLOW}Finished CMake config at: $(date)${COLOR_RESET}"
 
+# CMake can generate dependency graphs, which are useful to understand and
+# troubleshoot dependencies.
+if [[ "${CREATE_GRAPHVIZ:-}" = "yes" ]]; then
+  ${CMAKE_COMMAND} \
+      --graphviz="${BUILD_DIR}/graphviz/google-cloud-cpp" \
+      --build "${BUILD_DIR}"
+fi
+
 # If scan-build is enabled, we need to manually compile the dependencies;
 # otherwise, the static analyzer finds issues in them, and there is no way to
 # ignore them.  When scan-build is not enabled, this is still useful because

--- a/ci/travis/build-linux.sh
+++ b/ci/travis/build-linux.sh
@@ -56,6 +56,7 @@ sudo docker run \
      --env SCAN_BUILD="${SCAN_BUILD:-}" \
      --env GENERATE_DOCS="${GENERATE_DOCS:-}" \
      --env TEST_INSTALL="${TEST_INSTALL:-}" \
+     --env CREATE_GRAPHVIZ="${CREATE_GRAPHVIZ:-}" \
      --env CMAKE_FLAGS="${CMAKE_FLAGS:-}" \
      --env CBT=/usr/local/google-cloud-sdk/bin/cbt \
      --env CBT_EMULATOR=/usr/local/google-cloud-sdk/platform/bigtable-emulator/cbtemulator \


### PR DESCRIPTION
Sometimes it is good to have a dependency graph, either to be able to
explain things, or to debug build problems. CMake can generate them for
us (with the `--graphviz=...` option), but it produces better results
when executed in the CI builds with `TEST_INSTALL=yes`.

This PR changes the build scripts to generate the dependency graphs if the
`CREATE_GRAPHVIZ` environment variable is set.

For example, this is the dependency graph for `gcs2cbt` an example that
reads a CSV file from GCS and uploads to Cloud Bigtable:

![gcs2cbt d](https://user-images.githubusercontent.com/6241635/50047446-197f4e00-0083-11e9-891e-a58359e8093e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1692)
<!-- Reviewable:end -->
