### PR TITLE
Improves Credentials-related docs.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -55,8 +55,8 @@ inline namespace STORAGE_CLIENT_NS {
  *
  * @par Credentials
  * The default constructor for this class will attempt to load Application
- * Default Credentials (ADCs). If you wish to use no credentials or to supply a
- * specific credential type, you can use the functions declared in
+ * Default %Credentials (ADCs). If you wish to use no credentials or to supply a
+ * specific Credentials type, you can use the functions declared in
  * google_credentials.h:
  * @code
  * namespace gcs = google::cloud::storage;
@@ -86,7 +86,7 @@ inline namespace STORAGE_CLIENT_NS {
  *     underlying API.
  *
  * @see https://cloud.google.com/docs/authentication/production for details
- *     about Application Default Credentials.
+ *     about Application Default %Credentials.
  *
  */
 class Client {

--- a/google/cloud/storage/doc/storage-main.dox
+++ b/google/cloud/storage/doc/storage-main.dox
@@ -59,18 +59,18 @@ automatically compiled when you follow said instructions.
 
 ### Configuring authentication for the C++ Client Library
 
-This library uses the `GOOGLE_APPLICATION_DEFAULT_CREDENTIALS` environment
-variable to find the credentials file. This is the recommended way to configure
-the authentication preferences, though if the environment variable is not set,
-the library searches for a credentials file in the same location as the
-[Cloud SDK](https://cloud.google.com/sdk/).
+This library uses the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to
+find the credentials file. This is the recommended way to configure the
+authentication preferences, though if the environment variable is not set, the
+library searches for a credentials file in the same location as the [Cloud
+SDK](https://cloud.google.com/sdk/).
 
 ### Create a bucket
 
 This is a short example to create a
 [GCS bucket](https://cloud.google.com/storage/docs/key-terms#buckets).
 This example assumes you have configured the authentication using
-`GOOGLE_APPLICATION_DEFAULT_CREDENTIALS`:
+`GOOGLE_APPLICATION_CREDENTIALS`:
 
 @snippet storage_quickstart.cc full quickstart
 

--- a/google/cloud/storage/internal/openssl_util.h
+++ b/google/cloud/storage/internal/openssl_util.h
@@ -137,7 +137,7 @@ struct OpenSslUtils {
 
     std::size_t signed_str_size = 0;
     // Calling this method with a nullptr buffer will populate our size var
-    // with, the resulting buffer's size. This allows us to then call it again,
+    // with the resulting buffer's size. This allows us to then call it again,
     // with the correct buffer and size, which actually populates the buffer.
     if (DIGEST_SIGN_SUCCESS_CODE !=
         EVP_DigestSignFinal(static_cast<EVP_MD_CTX*>(digest_ctx.get()),
@@ -175,12 +175,12 @@ struct OpenSslUtils {
  private:
   static std::unique_ptr<BIO, decltype(&BIO_free_all)>
   MakeBioChainForBase64Transcoding() {
-    std::ostringstream err_builder;
     auto base64_io = std::unique_ptr<BIO, decltype(&BIO_free)>(
         BIO_new(BIO_f_base64()), &BIO_free);
     auto mem_io = std::unique_ptr<BIO, decltype(&BIO_free)>(
         BIO_new(BIO_s_mem()), &BIO_free);
     if (not(base64_io and mem_io)) {
+      std::ostringstream err_builder;
       err_builder << "Permanent error in " << __func__ << ": "
                   << "Could not allocate BIO* for Base64 encoding.";
       google::cloud::internal::RaiseRuntimeError(err_builder.str());
@@ -196,7 +196,8 @@ struct OpenSslUtils {
     return bio_chain;
   }
 
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L)  // Older than version 1.1.0
+// The name of the function to free an EVP_MD_CTX changed in OpenSSL 1.1.0.
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)  // Older than version 1.1.0.
   inline static std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_destroy)>
   GetDigestCtx() {
     return std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_destroy)>(

--- a/google/cloud/storage/oauth2/authorized_user_credentials.h
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.h
@@ -29,24 +29,25 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
-/// A plain object to hold the result of parsing authorized user credentials.
+/// Object to hold the result of parsing a user credentials JSON file.
 struct AuthorizedUserCredentialsInfo {
   std::string client_id;
   std::string client_secret;
   std::string refresh_token;
 };
 
-/// Parse a JSON object string as an AuthorizedUserCredentials.
+/// Parses a user credentials JSON string into an AuthorizedUserCredentialsInfo.
 AuthorizedUserCredentialsInfo ParseAuthorizedUserCredentials(
     std::string const& content, std::string const& source);
 
 /**
  * Wrapper class for Google OAuth 2.0 user account credentials.
  *
- * Takes a JSON object with a client id, client secret, and the user's refresh
- * token, and obtains access tokens from the Google Authorization Service as
- * needed. Instances of this class should usually be created via the convenience
- * methods declared in google_credentials.h.
+ * Takes a string representing JSON contents including a client id, client
+ * secret, and the user's refresh token, and obtains access tokens from the
+ * Google Authorization Service as needed. Instances of this class should
+ * usually be created via the convenience methods declared in
+ * google_credentials.h.
  *
  * An HTTP Authorization header, with an access token as its value,
  * can be obtained by calling the AuthorizationHeader() method; if the current

--- a/google/cloud/storage/oauth2/compute_engine_credentials.h
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.h
@@ -95,8 +95,15 @@ class ComputeEngineCredentials : public Credentials {
   }
 
  private:
+  /**
+   * Sends an HTTP GET request to the GCE metadata server.
+   *
+   * @see https://cloud.google.com/compute/docs/storing-retrieving-metadata for
+   * an overview of retrieving information from the GCE metadata server.
+   */
   storage::internal::HttpResponse DoMetadataServerGetRequest(std::string path,
                                                              bool recursive) {
+    // Allows mocking the metadata server hostname for testing.
     std::string metadata_server_hostname =
         google::cloud::storage::internal::GceMetadataHostname();
 
@@ -110,6 +117,13 @@ class ComputeEngineCredentials : public Credentials {
     return request_builder.BuildRequest().MakeRequest("");
   }
 
+  /**
+   * Fetches metadata for an instance's service account.
+   *
+   * @see
+   * https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances
+   * for more details.
+   */
   storage::Status RetrieveServiceAccountInfo() {
     namespace nl = google::cloud::storage::internal::nl;
     auto response = DoMetadataServerGetRequest(

--- a/google/cloud/storage/oauth2/google_application_default_credentials_file.h
+++ b/google/cloud/storage/oauth2/google_application_default_credentials_file.h
@@ -25,10 +25,10 @@ inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 
 /**
- * Returns the Application Default Credentials environment variable name.
+ * Returns the Application Default %Credentials environment variable name.
  *
  * This environment variable should be checked for a valid file path when
- * attempting to load Google Application Default Credentials.
+ * attempting to load Google Application Default %Credentials.
  */
 inline char const* GoogleAdcEnvVar() {
   static constexpr char kEnvVarName[] = "GOOGLE_APPLICATION_CREDENTIALS";
@@ -36,20 +36,20 @@ inline char const* GoogleAdcEnvVar() {
 }
 
 /**
- * Returns the path to the Application Default Credentials file, if set.
+ * Returns the path to the Application Default %Credentials file, if set.
  *
- * If the Application Default Credentials environment variable is set, we check
+ * If the Application Default %Credentials environment variable is set, we check
  * the path specified by its value for a file containing ADCs. Returns an
  * empty string if no such path exists or the environment variable is not set.
  */
 std::string GoogleAdcFilePathFromEnvVarOrEmpty();
 
 /**
- * Returns the path to the Application Default Credentials file, if set.
+ * Returns the path to the Application Default %Credentials file, if set.
  *
- * If the gcloud utility has configured an Application Default Credentials file,
- * the path to that file is returned. Returns an empty string if no such file
- * exists at the well known path.
+ * If the gcloud utility has configured an Application Default %Credentials
+ * file, the path to that file is returned. Returns an empty string if no such
+ * file exists at the well known path.
  */
 std::string GoogleAdcFilePathFromWellKnownPathOrEmpty();
 
@@ -57,7 +57,7 @@ std::string GoogleAdcFilePathFromWellKnownPathOrEmpty();
  * Returns the environment variable to override the gcloud ADC path.
  *
  * This environment variable is used for testing to override the path that
- * should be searched for the gcloud Application Default Credentials file.
+ * should be searched for the gcloud Application Default %Credentials file.
  */
 inline char const* GoogleGcloudAdcFileEnvVar() {
   static constexpr char kEnvVarName[] = "GOOGLE_GCLOUD_ADC_PATH_OVERRIDE";

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -32,6 +32,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 
+/// Parses the JSON file at `path` and creates the appropriate Credentials type.
 std::unique_ptr<Credentials> LoadCredsFromPath(std::string const& path) {
   using google::cloud::internal::RaiseRuntimeError;
   namespace nl = google::cloud::storage::internal::nl;
@@ -86,23 +87,24 @@ std::unique_ptr<Credentials> MaybeLoadCredsFromGcloudAdcFile() {
 }
 
 std::shared_ptr<Credentials> GoogleDefaultCredentials() {
-  // Check if the GOOGLE_APPLICATION_CREDENTIALS environment variable is set.
+  // 1) Check if the GOOGLE_APPLICATION_CREDENTIALS environment variable is set.
   auto creds = MaybeLoadCredsFromAdcEnvVar();
   if (creds) {
     return std::move(creds);
   }
 
-  // If no path was specified via environment variable, check if the gcloud
+  // 2) If no path was specified via environment variable, check if the gcloud
   // ADC file exists.
   creds = MaybeLoadCredsFromGcloudAdcFile();
   if (creds) {
     return std::move(creds);
   }
 
-  // Check for implicit environment-based credentials.
-
-  // TODO(#579): Check if running on App Engine flexible environment.
-
+  // 3) Check for implicit environment-based credentials (GCE, GAE Flexible
+  // Environment).
+  // Note: GCE credentials *should* also work when running on a VM instance in
+  // the App Engine Flexible Environment, but this has not been explicitly
+  // tested, as it requires a custom GAEF runtime.
   if (storage::internal::RunningOnComputeEngineVm()) {
     return std::make_shared<ComputeEngineCredentials<>>();
   }

--- a/google/cloud/storage/oauth2/google_credentials.h
+++ b/google/cloud/storage/oauth2/google_credentials.h
@@ -25,7 +25,7 @@ inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 
 /**
- * Produces a credential type based on the runtime environment.
+ * Produces a Credentials type based on the runtime environment.
  *
  * If the GOOGLE_APPLICATION_CREDENTIALS environment variable is set, the JSON
  * file it points to will be loaded and used to create a credential of the
@@ -34,7 +34,7 @@ namespace oauth2 {
  * account will be used.
  *
  * @see https://cloud.google.com/docs/authentication/production for details
- * about Application Default Credentials.
+ * about Application Default %Credentials.
  */
 std::shared_ptr<Credentials> GoogleDefaultCredentials();
 
@@ -43,11 +43,11 @@ std::shared_ptr<Credentials> GoogleDefaultCredentials();
  * @name Functions to manually create specific credential types.
  */
 
-/// Creates an "anonymous" credential.
+/// Creates an AnonymousCredentials.
 std::shared_ptr<Credentials> CreateAnonymousCredentials();
 
 /**
- * Creates an AuthorizedUserCredentials from a JSON file at the given path.
+ * Creates an AuthorizedUserCredentials from a JSON file at the specified path.
  *
  * @note It is strongly preferred to instead use service account credentials
  * with Cloud Storage client libraries.
@@ -64,7 +64,7 @@ std::shared_ptr<Credentials> CreateAuthorizedUserCredentialsFromJsonFilePath(
 std::shared_ptr<Credentials> CreateAuthorizedUserCredentialsFromJsonContents(
     std::string const&);
 
-/// Creates a ServiceAccountCredentials rom a JSON file at the given path.
+/// Creates a ServiceAccountCredentials rom a JSON file at the specified path.
 std::shared_ptr<Credentials> CreateServiceAccountCredentialsFromJsonFilePath(
     std::string const&);
 

--- a/google/cloud/storage/oauth2/refreshing_credentials_wrapper.h
+++ b/google/cloud/storage/oauth2/refreshing_credentials_wrapper.h
@@ -42,8 +42,25 @@ class RefreshingCredentialsWrapper {
                           status.ok() ? authorization_header : std::string{});
   }
 
+  /**
+   * Returns whether the current access token should be considered expired.
+   *
+   * When determining if a Credentials object needs to be refreshed, the IsValid
+   * method should be used instead; there may be cases where a Credentials is
+   * not expired but should be considered invalid.
+   *
+   * If a Credentials is close to expiration but not quite expired, this method
+   * may still return false. This helps prevent the case where an access token
+   * expires between when it is obtained and when it is used.
+   */
   bool IsExpired();
 
+  /**
+   * Returns whether the current access token should be considered valid.
+   *
+   * This method should be used to determine whether a Credentials object needs
+   * to be refreshed.
+   */
   bool IsValid();
 
   std::string authorization_header;

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -31,7 +31,7 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
-/// A plain object to hold the result of parsing a service account credentials.
+/// Object to hold the result of parsing a service account JSON keyfile.
 struct ServiceAccountCredentialsInfo {
   std::string private_key_id;
   std::string private_key;
@@ -39,7 +39,7 @@ struct ServiceAccountCredentialsInfo {
   std::string client_email;
 };
 
-/// Parse a JSON object as a ServiceAccountCredentials.
+/// Parses the contents of a JSON keyfile into a ServiceAccountCredentialsInfo.
 ServiceAccountCredentialsInfo ParseServiceAccountCredentials(
     std::string const& content, std::string const& source,
     std::string const& default_token_uri);
@@ -47,7 +47,7 @@ ServiceAccountCredentialsInfo ParseServiceAccountCredentials(
 /**
  * Wrapper class for Google OAuth 2.0 service account credentials.
  *
- * Takes a JSON object representing the contents of a service account keyfile,
+ * Takes a string representing the JSON contents of a service account keyfile
  * and obtains access tokens from the Google Authorization Service as needed.
  * Instances of this class should usually be created via the convenience methods
  * declared in google_credentials.h.


### PR DESCRIPTION
I tried running over the docs as if I had no knowledge about the
library and changed the docstrings that weren't clear.  I also added
Doxygen autolink escaping to words that were being autolinked to
classes/functions by mistake (e.g. "Credentials" -> "%Credentials").

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1696)
<!-- Reviewable:end -->
