### PR TITLE
Add no exceptions policy to internal::RetryClient.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -310,6 +310,7 @@ set(storage_client_unit_tests
     internal/object_requests_test.cc
     internal/parse_rfc3339_test.cc
     internal/patch_builder_test.cc
+    internal/retry_client_test.cc
     internal/retry_resumable_upload_session_test.cc
     internal/service_account_requests_test.cc
     internal/signed_url_requests_test.cc

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -31,6 +31,8 @@ namespace internal {
 class RetryClient : public RawClient {
  public:
   struct DefaultPolicies {};
+  struct NoexPolicy {};
+
   explicit RetryClient(std::shared_ptr<RawClient> client,
                        DefaultPolicies unused);
 
@@ -155,6 +157,8 @@ class RetryClient : public RawClient {
     idempotency_policy_ = policy.clone();
   }
 
+  void Apply(NoexPolicy const&) { enable_exceptions_ = false; }
+
   void ApplyPolicies() {}
 
   template <typename P, typename... Policies>
@@ -167,6 +171,9 @@ class RetryClient : public RawClient {
   std::shared_ptr<RetryPolicy> retry_policy_;
   std::shared_ptr<BackoffPolicy> backoff_policy_;
   std::shared_ptr<IdempotencyPolicy> idempotency_policy_;
+  // TODO(#1694) - remove the code to support enable_exceptions == true when
+  //   the storage::Client class no longer needs it.
+  bool enable_exceptions_ = true;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/retry_client_test.cc
+++ b/google/cloud/storage/internal/retry_client_test.cc
@@ -1,0 +1,101 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/retry_client.h"
+#include "google/cloud/storage/testing/canonical_errors.h"
+#include "google/cloud/storage/testing/mock_client.h"
+#include "google/cloud/testing_util/chrono_literals.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+using ::testing::_;
+using ::testing::HasSubstr;
+using ::testing::Return;
+using testing::canonical_errors::PermanentError;
+using testing::canonical_errors::TransientError;
+using namespace testing_util::chrono_literals;
+
+class RetryClientTest : public ::testing::Test {
+ protected:
+  void SetUp() override { mock = std::make_shared<testing::MockClient>(); }
+  void TearDown() override { mock.reset(); }
+
+  std::shared_ptr<testing::MockClient> mock;
+};
+
+/// @test Verify that non-idempotent operations return on the first failure.
+TEST_F(RetryClientTest, NonIdempotentErrorHandling) {
+  RetryClient client(std::shared_ptr<internal::RawClient>(mock),
+                     LimitedErrorCountRetryPolicy(3), StrictIdempotencyPolicy(),
+                     // Make the tests faster.
+                     ExponentialBackoffPolicy(1_us, 2_us, 2),
+                     RetryClient::NoexPolicy{});
+
+  EXPECT_CALL(*mock, DeleteObject(_))
+      .WillOnce(Return(std::make_pair(TransientError(), EmptyResponse{})));
+
+  // Use a delete operation because this is idempotent only if the it has
+  // the IfGenerationMatch() and/or Generation() option set.
+  std::pair<Status, EmptyResponse> result =
+      client.DeleteObject(DeleteObjectRequest("test-bucket", "test-object"));
+  EXPECT_EQ(TransientError().status_code(), result.first.status_code());
+}
+
+/// @test Verify that the retry loop returns on the first permanent failure.
+TEST_F(RetryClientTest, PermanentErrorHandling) {
+  RetryClient client(std::shared_ptr<internal::RawClient>(mock),
+                     LimitedErrorCountRetryPolicy(3),
+                     // Make the tests faster.
+                     ExponentialBackoffPolicy(1_us, 2_us, 2),
+                     RetryClient::NoexPolicy{});
+
+  // Use a read-only operation because these are always idempotent.
+  EXPECT_CALL(*mock, GetObjectMetadata(_))
+      .WillOnce(Return(std::make_pair(TransientError(), ObjectMetadata{})))
+      .WillOnce(Return(std::make_pair(PermanentError(), ObjectMetadata{})));
+
+  std::pair<Status, ObjectMetadata> result = client.GetObjectMetadata(
+      GetObjectMetadataRequest("test-bucket", "test-object"));
+  EXPECT_EQ(PermanentError().status_code(), result.first.status_code());
+}
+
+/// @test Verify that the retry loop returns on the first permanent failure.
+TEST_F(RetryClientTest, TooManyTransientsHandling) {
+  RetryClient client(std::shared_ptr<internal::RawClient>(mock),
+                     LimitedErrorCountRetryPolicy(3),
+                     // Make the tests faster.
+                     ExponentialBackoffPolicy(1_us, 2_us, 2),
+                     RetryClient::NoexPolicy{});
+
+  // Use a read-only operation because these are always idempotent.
+  EXPECT_CALL(*mock, GetObjectMetadata(_))
+      .WillRepeatedly(
+          Return(std::make_pair(TransientError(), ObjectMetadata{})));
+
+  std::pair<Status, ObjectMetadata> result = client.GetObjectMetadata(
+      GetObjectMetadataRequest("test-bucket", "test-object"));
+  EXPECT_EQ(TransientError().status_code(), result.first.status_code());
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -56,6 +56,7 @@ storage_client_unit_tests = [
     "internal/object_requests_test.cc",
     "internal/parse_rfc3339_test.cc",
     "internal/patch_builder_test.cc",
+    "internal/retry_client_test.cc",
     "internal/retry_resumable_upload_session_test.cc",
     "internal/service_account_requests_test.cc",
     "internal/signed_url_requests_test.cc",


### PR DESCRIPTION
internal::RetryClient can be configured to not raise exceptions by
setting a policy. The intention is to use this policy in noex::Client
for now, but it should be removed when storage::Client is refactored
over noex::Clien (#1694).

This fixes #1687.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1698)
<!-- Reviewable:end -->
