### PR TITLE
Fix macOS+Bazel build on Kokoro.

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -31,7 +31,9 @@ def google_cloud_cpp_deps():
         http_archive(
             name = "com_google_googletest",
             strip_prefix = "googletest-release-1.8.1",
-            url = "https://github.com/google/googletest/archive/release-1.8.1.tar.gz",
+            urls = [
+                "https://github.com/google/googletest/archive/release-1.8.1.tar.gz",
+            ],
             sha256 = "9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c",
         )
 
@@ -39,7 +41,9 @@ def google_cloud_cpp_deps():
     if "com_github_googleapis_googleapis" not in native.existing_rules():
         http_archive(
             name = "com_github_googleapis_googleapis",
-            url = "https://github.com/google/googleapis/archive/6a3277c0656219174ff7c345f31fb20a90b30b97.zip",
+            urls = [
+                "https://github.com/google/googleapis/archive/6a3277c0656219174ff7c345f31fb20a90b30b97.zip",
+            ],
             strip_prefix = "googleapis-6a3277c0656219174ff7c345f31fb20a90b30b97",
             sha256 = "82ba91a41fb01305de4e8805c0a9270ed2035007161aa5a4ec60f887a499f5e9",
             build_file = "@com_github_googlecloudplatform_google_cloud_cpp//bazel:googleapis.BUILD",

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -26,82 +26,41 @@ readonly PROJECT_ROOT="${PWD}"
 echo
 echo "================================================================"
 echo "================================================================"
-echo "Download dependencies for integration tests."
-# Download the gRPC `roots.pem` file. Somewhere inside the bowels of Bazel, this
-# file might exist, but my attempts at using it have failed.
-echo "    Getting roots.pem for gRPC."
-wget -q https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem
-echo "    Getting cbt tool"
-export GOPATH="${KOKORO_ROOT}/golang"
-go get -u cloud.google.com/go/bigtable/cmd/cbt
-echo "End of download."
+echo "Update Bazel."
+echo
+ls -ld /usr/local/bin
+sudo rm /usr/local/bin/bazel
+brew tap bazelbuild/tap
+brew tap-pin bazelbuild/tap
+brew install bazelbuild/tap/bazel
+bazel version
 
+# We need this environment variable because on macOS gRPC crashes if it cannot
+# find the credentials, even if you do not use them. Some of the unit tests do
+# exactly that.
 echo
 echo "================================================================"
 echo "================================================================"
 echo "Define GOOGLE_APPLICATION_CREDENTIALS."
 export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/service-account.json"
 
-echo
-echo "================================================================"
-echo "================================================================"
-echo "Define GRC_DEFAULT_SSL_ROOTS_FILE_PATH."
-export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$PWD/roots.pem"
-
-echo
-echo "================================================================"
-echo "================================================================"
-echo "Create kokoro-bazelrc."
-cat >>kokoro-bazelrc <<_EOF_
-# Set flags for uploading to BES without Remote Build Execution.
-startup --host_jvm_args=-Dbazel.DigestFunction=SHA256
-build:results-local --remote_cache=remotebuildexecution.googleapis.com
-build:results-local --spawn_strategy=local
-build:results-local --remote_timeout=3600
-build:results-local --bes_backend="buildeventservice.googleapis.com"
-build:results-local --bes_timeout=10m
-build:results-local --tls_enabled=true
-build:results-local --auth_enabled=true
-build:results-local --auth_scope=https://www.googleapis.com/auth/cloud-source-tools
-_EOF_
-
-echo
-echo "================================================================"
-echo "================================================================"
-# First build and run the unit tests.
-invocation_id="$(python -c 'import uuid; print uuid.uuid4()')"
-echo "Configure and start Bazel: " ${invocation_id}
-echo "================================================================"
-echo "https://source.cloud.google.com/results/invocations/${invocation_id}"
-echo "================================================================"
-echo ${invocation_id} >> "${KOKORO_ARTIFACTS_DIR}/bazel_invocation_ids"
-
-bazel --bazelrc=kokoro-bazelrc test \
+# The -DGRPC_BAZEL_BUILD is needed because gRPC does not compile on macOS unless
+# it is set.
+bazel test \
     --copt=-DGRPC_BAZEL_BUILD \
     --action_env=GOOGLE_APPLICATION_CREDENTIALS="${GOOGLE_APPLICATION_CREDENTIALS}" \
     --test_output=errors \
     --verbose_failures=true \
     --keep_going \
-    --project_id=${KOKORO_PROJECT_ID} \
-    --auth_credentials="${KOKORO_GFILE_DIR}/build-results-service-account.json" \
-    --remote_instance_name="projects/${KOKORO_PROJECT_ID}" \
-    --invocation_id="${invocation_id}" \
-    --config=results-local \
     -- //google/cloud/...:all
 
 echo
 echo "================================================================"
 echo "================================================================"
-bazel --bazelrc=kokoro-bazelrc build \
+bazel build \
     --copt=-DGRPC_BAZEL_BUILD \
     --action_env=GOOGLE_APPLICATION_CREDENTIALS="${GOOGLE_APPLICATION_CREDENTIALS}" \
     --test_output=errors \
     --verbose_failures=true \
     --keep_going \
-    --project_id=${KOKORO_PROJECT_ID} \
-    --auth_credentials="${KOKORO_GFILE_DIR}/build-results-service-account.json" \
-    --remote_instance_name="projects/${KOKORO_PROJECT_ID}" \
-    --invocation_id="${invocation_id}" \
-    --config=results-local \
     -- //google/cloud/...:all
-


### PR DESCRIPTION
For some reason the version of Bazel installed on macOS (0.11 when
I checked, but others are reported in the documentation) does not
support the `url` attribute in the `http_archive` rule. All versions
seem to support `urls`, so use that instead. That is not enough
though, because gRPC still uses the `url` attribute.

I have sent a PR to the gRPC folks, and filed a bug to update the
default version of Bazel on Kokoro. Meanwhile, the script manually
updates the Bazel version on each build.

To debug this I removed a lot of unused stuff in the build script, I
like it better as a smaller script so I left those changes too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1702)
<!-- Reviewable:end -->
