### PR TITLE
Always use the NoexPolicy in the noex::Client.

### DIFF
--- a/google/cloud/storage/internal/noex_client.h
+++ b/google/cloud/storage/internal/noex_client.h
@@ -109,7 +109,8 @@ class Client {
     // TODO(#1694) - remove all the code duplicated in `storage::Client`.
     auto logging = std::make_shared<internal::LoggingClient>(std::move(client));
     auto retry = std::make_shared<internal::RetryClient>(
-        std::move(logging), std::forward<Policies>(policies)...);
+        std::move(logging), internal::RetryClient::NoexPolicy{},
+        std::forward<Policies>(policies)...);
     return retry;
   }
 


### PR DESCRIPTION
Now that the skeleton noex::Client exists, and the RetryClient has a
policy to disable exceptions go and use the policy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1703)
<!-- Reviewable:end -->
