### PR TITLE
Allow the ability to disable tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,7 @@ matrix:
       os: linux
       compiler: gcc
       env:
+        BUILD_TESTING=no
         CMAKE_FLAGS=-DBUILD_TESTING=OFF
         DISTRO=ubuntu
         DISTRO_VERSION=18.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,13 @@ matrix:
         BUILD_TYPE=Coverage
         DISTRO=ubuntu
         DISTRO_VERSION=18.04
+    - # Compile with tests disabled.
+      os: linux
+      compiler: gcc
+      env:
+        CMAKE_FLAGS=-DBUILD_TESTING=OFF
+        DISTRO=ubuntu
+        DISTRO_VERSION=18.04
     - # Compile with exceptions disabled.
       os: linux
       compiler: gcc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,8 +143,9 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 # interested in compiling and running the gRPC tests.
 include(IncludeGrpc)
 
-# Enable testing in this directory so we can do a top-level `make test`.
-enable_testing()
+# Enable testing in this directory so we can do a top-level `make test`. This
+# also includes the BUILD_TESTING option, which is on by default.
+include(CTest)
 
 # Each subproject adds dependencies to this target to have their docs generated.
 add_custom_target(doxygen-docs)

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ after cloning this repo:
 
 ```bash
 git submodule update --init
+# Add -DBUILD_TESTING=Off to disable tests
 cmake -H. -Bbuild-output
 
 # Adjust the number of threads used by modifying parameter for `-j 4`
@@ -245,6 +246,7 @@ You will find compiled binaries in `build-output/` respective to their source pa
 ```bash
 git submodule update --init
 export OPENSSL_ROOT_DIR=/usr/local/opt/libressl
+# Add -DBUILD_TESTING=Off to disable tests
 cmake -H. -Bbuild-output
 
 # Adjust the number of threads used by modifying parameter for `-j 4`

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ after cloning this repo:
 
 ```bash
 git submodule update --init
-# Add -DBUILD_TESTING=Off to disable tests
+# Add -DBUILD_TESTING=OFF to disable tests
 cmake -H. -Bbuild-output
 
 # Adjust the number of threads used by modifying parameter for `-j 4`
@@ -246,7 +246,7 @@ You will find compiled binaries in `build-output/` respective to their source pa
 ```bash
 git submodule update --init
 export OPENSSL_ROOT_DIR=/usr/local/opt/libressl
-# Add -DBUILD_TESTING=Off to disable tests
+# Add -DBUILD_TESTING=OFF to disable tests
 cmake -H. -Bbuild-output
 
 # Adjust the number of threads used by modifying parameter for `-j 4`

--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -224,20 +224,22 @@ if [ -n "${ccache_command}" ]; then
   "${ccache_command}" --zero-stats --cleanup --max-size="${max_size}"
 fi
 
-# Run the tests and output any failures.
-echo
-echo "${COLOR_YELLOW}Running unit and integration tests $(date)${COLOR_RESET}"
-echo
-cd "${BUILD_DIR}"
-ctest --output-on-failure
-
-# Run the integration tests. Not all projects have them, so just iterate over
-# the ones that do.
-for subdir in google/cloud google/cloud/bigtable google/cloud/storage; do
+if [ "${BUILD_TESTING:-}" != "no" ]; then
+  # Run the tests and output any failures.
   echo
-  echo "${COLOR_GREEN}Running integration tests for ${subdir}${COLOR_RESET}"
-  /v/${subdir}/ci/run_integration_tests.sh
-done
+  echo "${COLOR_YELLOW}Running unit and integration tests $(date)${COLOR_RESET}"
+  echo
+  cd "${BUILD_DIR}"
+  ctest --output-on-failure
+
+  # Run the integration tests. Not all projects have them, so just iterate over
+  # the ones that do.
+  for subdir in google/cloud google/cloud/bigtable google/cloud/storage; do
+    echo
+    echo "${COLOR_GREEN}Running integration tests for ${subdir}${COLOR_RESET}"
+    /v/${subdir}/ci/run_integration_tests.sh
+  done
+if
 
 # Test the install rule and that the installation works.
 if [ "${TEST_INSTALL:-}" = "yes" ]; then

--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -239,7 +239,7 @@ if [ "${BUILD_TESTING:-}" != "no" ]; then
     echo "${COLOR_GREEN}Running integration tests for ${subdir}${COLOR_RESET}"
     /v/${subdir}/ci/run_integration_tests.sh
   done
-if
+fi
 
 # Test the install rule and that the installation works.
 if [ "${TEST_INSTALL:-}" = "yes" ]; then

--- a/ci/travis/build-linux.sh
+++ b/ci/travis/build-linux.sh
@@ -51,6 +51,7 @@ sudo docker run \
      --env CC="${CC}" \
      --env NCPU="${NCPU:-2}" \
      --env BUILD_TYPE="${BUILD_TYPE:-Release}" \
+     --env BUILD_TESTING="${BUILD_TESTING:-}" \
      --env CHECK_ABI="${CHECK_ABI:-}" \
      --env CHECK_STYLE="${CHECK_STYLE:-}" \
      --env SCAN_BUILD="${SCAN_BUILD:-}" \

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -154,66 +154,68 @@ set_target_properties(
 create_bazel_config(google_cloud_cpp_common)
 google_cloud_cpp_add_clang_tidy(google_cloud_cpp_common)
 
-add_library(google_cloud_cpp_testing
-            testing_util/capture_log_lines_backend.h
-            testing_util/capture_log_lines_backend.cc
-            testing_util/check_predicate_becomes_false.h
-            testing_util/chrono_literals.h
-            testing_util/environment_variable_restore.h
-            testing_util/environment_variable_restore.cc
-            testing_util/expect_exception.h
-            testing_util/expect_future_error.h
-            testing_util/custom_google_mock_main.cc
-            testing_util/init_google_mock.h
-            testing_util/init_google_mock.cc
-            testing_util/testing_types.h
-            testing_util/testing_types.cc)
-target_link_libraries(google_cloud_cpp_testing
-                      PUBLIC google_cloud_cpp_common GTest::gmock)
+if (BUILD_TESTING)
+    add_library(google_cloud_cpp_testing
+                testing_util/capture_log_lines_backend.h
+                testing_util/capture_log_lines_backend.cc
+                testing_util/check_predicate_becomes_false.h
+                testing_util/chrono_literals.h
+                testing_util/environment_variable_restore.h
+                testing_util/environment_variable_restore.cc
+                testing_util/expect_exception.h
+                testing_util/expect_future_error.h
+                testing_util/custom_google_mock_main.cc
+                testing_util/init_google_mock.h
+                testing_util/init_google_mock.cc
+                testing_util/testing_types.h
+                testing_util/testing_types.cc)
+    target_link_libraries(google_cloud_cpp_testing
+                          PUBLIC google_cloud_cpp_common GTest::gmock)
 
-create_bazel_config(google_cloud_cpp_testing)
+    create_bazel_config(google_cloud_cpp_testing)
 
-set(google_cloud_cpp_common_unit_tests
-    future_generic_test.cc
-    future_generic_then_test.cc
-    future_void_test.cc
-    future_void_then_test.cc
-    iam_bindings_test.cc
-    internal/backoff_policy_test.cc
-    internal/big_endian_test.cc
-    internal/filesystem_test.cc
-    internal/future_impl_test.cc
-    internal/invoke_result_test.cc
-    internal/random_test.cc
-    internal/retry_policy_test.cc
-    internal/throw_delegate_test.cc
-    log_test.cc
-    optional_test.cc
-    terminate_handler_test.cc)
+    set(google_cloud_cpp_common_unit_tests
+        future_generic_test.cc
+        future_generic_then_test.cc
+        future_void_test.cc
+        future_void_then_test.cc
+        iam_bindings_test.cc
+        internal/backoff_policy_test.cc
+        internal/big_endian_test.cc
+        internal/filesystem_test.cc
+        internal/future_impl_test.cc
+        internal/invoke_result_test.cc
+        internal/random_test.cc
+        internal/retry_policy_test.cc
+        internal/throw_delegate_test.cc
+        log_test.cc
+        optional_test.cc
+        terminate_handler_test.cc)
 
-# Export the list of unit tests so the Bazel BUILD file can pick it up.
-export_list_to_bazel("google_cloud_cpp_common_unit_tests.bzl"
-                     "google_cloud_cpp_common_unit_tests")
+    # Export the list of unit tests so the Bazel BUILD file can pick it up.
+    export_list_to_bazel("google_cloud_cpp_common_unit_tests.bzl"
+                         "google_cloud_cpp_common_unit_tests")
 
-foreach (fname ${google_cloud_cpp_common_unit_tests})
-    string(REPLACE "/"
-                   "_"
-                   target
-                   ${fname})
-    string(REPLACE ".cc"
-                   ""
-                   target
-                   ${target})
-    add_executable(${target} ${fname})
-    target_link_libraries(${target}
-                          PRIVATE google_cloud_cpp_testing
-                                  google_cloud_cpp_common
-                                  GTest::gmock_main
-                                  GTest::gmock
-                                  GTest::gtest
-                                  google_cloud_cpp_common_options)
-    add_test(NAME ${target} COMMAND ${target})
-endforeach ()
+    foreach (fname ${google_cloud_cpp_common_unit_tests})
+        string(REPLACE "/"
+                       "_"
+                       target
+                       ${fname})
+        string(REPLACE ".cc"
+                       ""
+                       target
+                       ${target})
+        add_executable(${target} ${fname})
+        target_link_libraries(${target}
+                              PRIVATE google_cloud_cpp_testing
+                                      google_cloud_cpp_common
+                                      GTest::gmock_main
+                                      GTest::gmock
+                                      GTest::gtest
+                                      google_cloud_cpp_common_options)
+        add_test(NAME ${target} COMMAND ${target})
+    endforeach ()
+endif ()
 
 # Export the CMake targets to make it easy to create configuration files.
 install(EXPORT google_cloud_cpp_common-targets

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -108,7 +108,7 @@ set_target_properties(
 add_library(bigtable::protos ALIAS bigtable_protos)
 
 # Enable unit tests
-enable_testing()
+include(CTest)
 
 add_dependencies(skip-scanbuild-targets bigtable_protos)
 
@@ -255,133 +255,135 @@ include(CreateBazelConfig)
 create_bazel_config(bigtable_client)
 google_cloud_cpp_add_clang_tidy(bigtable_client)
 
-add_library(bigtable_client_testing
-            testing/embedded_server_test_fixture.h
-            testing/embedded_server_test_fixture.cc
-            testing/internal_table_test_fixture.h
-            testing/internal_table_test_fixture.cc
-            testing/mock_admin_client.h
-            testing/mock_data_client.h
-            testing/mock_instance_admin_client.h
-            testing/inprocess_data_client.h
-            testing/inprocess_data_client.cc
-            testing/inprocess_admin_client.h
-            testing/inprocess_admin_client.cc
-            testing/mock_completion_queue.h
-            testing/mock_mutate_rows_reader.h
-            testing/mock_read_rows_reader.h
-            testing/mock_response_reader.h
-            testing/mock_sample_row_keys_reader.h
-            testing/table_integration_test.h
-            testing/table_integration_test.cc
-            testing/table_test_fixture.h
-            testing/table_test_fixture.cc)
-target_link_libraries(bigtable_client_testing
-                      PUBLIC bigtable_client
-                             bigtable_protos
-                             GTest::gmock_main
-                             GTest::gmock
-                             GTest::gtest
-                             gRPC::grpc++
-                             gRPC::grpc
-                             protobuf::libprotobuf
-                      PRIVATE bigtable_common_options)
+if (BUILD_TESTING)
+    add_library(bigtable_client_testing
+                testing/embedded_server_test_fixture.h
+                testing/embedded_server_test_fixture.cc
+                testing/internal_table_test_fixture.h
+                testing/internal_table_test_fixture.cc
+                testing/mock_admin_client.h
+                testing/mock_data_client.h
+                testing/mock_instance_admin_client.h
+                testing/inprocess_data_client.h
+                testing/inprocess_data_client.cc
+                testing/inprocess_admin_client.h
+                testing/inprocess_admin_client.cc
+                testing/mock_completion_queue.h
+                testing/mock_mutate_rows_reader.h
+                testing/mock_read_rows_reader.h
+                testing/mock_response_reader.h
+                testing/mock_sample_row_keys_reader.h
+                testing/table_integration_test.h
+                testing/table_integration_test.cc
+                testing/table_test_fixture.h
+                testing/table_test_fixture.cc)
+    target_link_libraries(bigtable_client_testing
+                          PUBLIC bigtable_client
+                                 bigtable_protos
+                                 GTest::gmock_main
+                                 GTest::gmock
+                                 GTest::gtest
+                                 gRPC::grpc++
+                                 gRPC::grpc
+                                 protobuf::libprotobuf
+                          PRIVATE bigtable_common_options)
 
-create_bazel_config(bigtable_client_testing)
+    create_bazel_config(bigtable_client_testing)
 
-# List the unit tests, then setup the targets and dependencies.
-set(bigtable_client_unit_tests
-    admin_client_test.cc
-    app_profile_config_test.cc
-    bigtable_version_test.cc
-    cell_test.cc
-    client_options_test.cc
-    cluster_config_test.cc
-    column_family_test.cc
-    completion_queue_test.cc
-    data_client_test.cc
-    filters_test.cc
-    force_sanitizer_failures_test.cc
-    grpc_error_test.cc
-    idempotent_mutation_policy_test.cc
-    instance_admin_client_test.cc
-    instance_admin_test.cc
-    instance_config_test.cc
-    instance_update_config_test.cc
-    internal/async_check_consistency_test.cc
-    internal/async_future_from_callback_test.cc
-    internal/async_list_app_profiles_test.cc
-    internal/async_list_clusters_test.cc
-    internal/async_list_instances_test.cc
-    internal/async_longrunning_op_test.cc
-    internal/async_poll_op_test.cc
-    internal/async_retry_multi_page_test.cc
-    internal/async_retry_op_test.cc
-    internal/async_retry_unary_rpc_and_poll_test.cc
-    internal/bulk_mutator_test.cc
-    internal/table_async_check_and_mutate_row_test.cc
-    internal/instance_admin_test.cc
-    internal/grpc_error_delegate_test.cc
-    internal/prefix_range_end_test.cc
-    internal/table_admin_test.cc
-    internal/table_async_apply_test.cc
-    internal/table_async_bulk_apply_test.cc
-    internal/table_async_sample_row_keys_test.cc
-    internal/table_test.cc
-    mutations_test.cc
-    table_admin_test.cc
-    table_apply_test.cc
-    table_bulk_apply_test.cc
-    table_check_and_mutate_row_test.cc
-    table_config_test.cc
-    table_readrow_test.cc
-    table_readrows_test.cc
-    table_sample_row_keys_test.cc
-    table_test.cc
-    table_readmodifywriterow_test.cc
-    read_modify_write_rule_test.cc
-    row_reader_test.cc
-    row_test.cc
-    row_range_test.cc
-    row_set_test.cc
-    rpc_backoff_policy_test.cc
-    metadata_update_policy_test.cc
-    rpc_retry_policy_test.cc
-    polling_policy_test.cc)
+    # List the unit tests, then setup the targets and dependencies.
+    set(bigtable_client_unit_tests
+        admin_client_test.cc
+        app_profile_config_test.cc
+        bigtable_version_test.cc
+        cell_test.cc
+        client_options_test.cc
+        cluster_config_test.cc
+        column_family_test.cc
+        completion_queue_test.cc
+        data_client_test.cc
+        filters_test.cc
+        force_sanitizer_failures_test.cc
+        grpc_error_test.cc
+        idempotent_mutation_policy_test.cc
+        instance_admin_client_test.cc
+        instance_admin_test.cc
+        instance_config_test.cc
+        instance_update_config_test.cc
+        internal/async_check_consistency_test.cc
+        internal/async_future_from_callback_test.cc
+        internal/async_list_app_profiles_test.cc
+        internal/async_list_clusters_test.cc
+        internal/async_list_instances_test.cc
+        internal/async_longrunning_op_test.cc
+        internal/async_poll_op_test.cc
+        internal/async_retry_multi_page_test.cc
+        internal/async_retry_op_test.cc
+        internal/async_retry_unary_rpc_and_poll_test.cc
+        internal/bulk_mutator_test.cc
+        internal/table_async_check_and_mutate_row_test.cc
+        internal/instance_admin_test.cc
+        internal/grpc_error_delegate_test.cc
+        internal/prefix_range_end_test.cc
+        internal/table_admin_test.cc
+        internal/table_async_apply_test.cc
+        internal/table_async_bulk_apply_test.cc
+        internal/table_async_sample_row_keys_test.cc
+        internal/table_test.cc
+        mutations_test.cc
+        table_admin_test.cc
+        table_apply_test.cc
+        table_bulk_apply_test.cc
+        table_check_and_mutate_row_test.cc
+        table_config_test.cc
+        table_readrow_test.cc
+        table_readrows_test.cc
+        table_sample_row_keys_test.cc
+        table_test.cc
+        table_readmodifywriterow_test.cc
+        read_modify_write_rule_test.cc
+        row_reader_test.cc
+        row_test.cc
+        row_range_test.cc
+        row_set_test.cc
+        rpc_backoff_policy_test.cc
+        metadata_update_policy_test.cc
+        rpc_retry_policy_test.cc
+        polling_policy_test.cc)
 
-# Export the list of unit tests so the Bazel BUILD file can pick it up.
-export_list_to_bazel("bigtable_client_unit_tests.bzl"
-                     "bigtable_client_unit_tests")
+    # Export the list of unit tests so the Bazel BUILD file can pick it up.
+    export_list_to_bazel("bigtable_client_unit_tests.bzl"
+                         "bigtable_client_unit_tests")
 
-# Append this unit test after exporting to Bazel because it requires special
-# treatment
-list(APPEND bigtable_client_unit_tests internal/readrowsparser_test.cc)
+    # Append this unit test after exporting to Bazel because it requires special
+    # treatment
+    list(APPEND bigtable_client_unit_tests internal/readrowsparser_test.cc)
 
-foreach (fname ${bigtable_client_unit_tests})
-    string(REPLACE "/"
-                   "_"
-                   target
-                   ${fname})
-    string(REPLACE ".cc"
-                   ""
-                   target
-                   ${target})
-    add_executable(${target} ${fname})
-    target_link_libraries(${target}
-                          PRIVATE bigtable_client_testing
-                                  bigtable_client
-                                  bigtable_protos
-                                  google_cloud_cpp_testing
-                                  google_cloud_cpp_common
-                                  GTest::gmock_main
-                                  GTest::gmock
-                                  GTest::gtest
-                                  gRPC::grpc++
-                                  gRPC::grpc
-                                  protobuf::libprotobuf
-                                  bigtable_common_options)
-    add_test(NAME ${target} COMMAND ${target})
-endforeach ()
+    foreach (fname ${bigtable_client_unit_tests})
+        string(REPLACE "/"
+                       "_"
+                       target
+                       ${fname})
+        string(REPLACE ".cc"
+                       ""
+                       target
+                       ${target})
+        add_executable(${target} ${fname})
+        target_link_libraries(${target}
+                              PRIVATE bigtable_client_testing
+                                      bigtable_client
+                                      bigtable_protos
+                                      google_cloud_cpp_testing
+                                      google_cloud_cpp_common
+                                      GTest::gmock_main
+                                      GTest::gmock
+                                      GTest::gtest
+                                      gRPC::grpc++
+                                      gRPC::grpc
+                                      protobuf::libprotobuf
+                                      bigtable_common_options)
+        add_test(NAME ${target} COMMAND ${target})
+    endforeach ()
+endif ()
 
 option(FORCE_SANITIZER_ERRORS
        "If set, enable tests that force errors detected by the sanitizers." "")
@@ -399,7 +401,9 @@ if (FORCE_STATIC_ANALYZER_ERRORS)
                                -DBIGTABLE_CLIENT_FORCE_STATIC_ANALYZER_ERRORS)
 endif (FORCE_STATIC_ANALYZER_ERRORS)
 
-add_subdirectory(tests)
+if (BUILD_TESTING)
+    add_subdirectory(tests)
+endif ()
 
 if (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_subdirectory(benchmarks)

--- a/google/cloud/bigtable/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigtable/benchmarks/CMakeLists.txt
@@ -33,8 +33,6 @@ target_link_libraries(bigtable_benchmark_common
                       bigtable_common_options)
 
 if (BUILD_TESTING)
-    target_link_libraries(bigtable_benchmark_common bigtable_client_testing)
-
     # List the unit tests, then setup the targets and dependencies.
     set(bigtable_benchmarks_unit_tests
         bigtable_benchmark_test.cc

--- a/google/cloud/bigtable/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigtable/benchmarks/CMakeLists.txt
@@ -52,6 +52,7 @@ if (BUILD_TESTING)
         target_link_libraries(${target}
                               PRIVATE bigtable_benchmark_common
                                       bigtable_client
+                                      bigtable_client_testing
                                       bigtable_protos
                                       bigtable_common_options
                                       google_cloud_cpp_testing

--- a/google/cloud/bigtable/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigtable/benchmarks/CMakeLists.txt
@@ -25,7 +25,6 @@ add_library(bigtable_benchmark_common
             setup.h
             setup.cc)
 target_link_libraries(bigtable_benchmark_common
-                      bigtable_client_testing
                       bigtable_client
                       bigtable_protos
                       gRPC::grpc++
@@ -33,37 +32,41 @@ target_link_libraries(bigtable_benchmark_common
                       protobuf::libprotobuf
                       bigtable_common_options)
 
-# List the unit tests, then setup the targets and dependencies.
-set(bigtable_benchmarks_unit_tests
-    bigtable_benchmark_test.cc
-    embedded_server_test.cc
-    format_duration_test.cc
-    setup_test.cc)
-foreach (fname ${bigtable_benchmarks_unit_tests})
-    string(REPLACE "/"
-                   "_"
-                   target
-                   ${fname})
-    string(REPLACE ".cc"
-                   ""
-                   target
-                   ${target})
-    add_executable(${target} ${fname})
-    target_link_libraries(${target}
-                          PRIVATE bigtable_benchmark_common
-                                  bigtable_client
-                                  bigtable_protos
-                                  bigtable_common_options
-                                  google_cloud_cpp_testing
-                                  google_cloud_cpp_common
-                                  GTest::gmock_main
-                                  GTest::gmock
-                                  GTest::gtest
-                                  gRPC::grpc++
-                                  gRPC::grpc
-                                  protobuf::libprotobuf)
-    add_test(NAME ${target} COMMAND ${target})
-endforeach ()
+if (BUILD_TESTING)
+    target_link_libraries(bigtable_benchmark_common bigtable_client_testing)
+
+    # List the unit tests, then setup the targets and dependencies.
+    set(bigtable_benchmarks_unit_tests
+        bigtable_benchmark_test.cc
+        embedded_server_test.cc
+        format_duration_test.cc
+        setup_test.cc)
+    foreach (fname ${bigtable_benchmarks_unit_tests})
+        string(REPLACE "/"
+                       "_"
+                       target
+                       ${fname})
+        string(REPLACE ".cc"
+                       ""
+                       target
+                       ${target})
+        add_executable(${target} ${fname})
+        target_link_libraries(${target}
+                              PRIVATE bigtable_benchmark_common
+                                      bigtable_client
+                                      bigtable_protos
+                                      bigtable_common_options
+                                      google_cloud_cpp_testing
+                                      google_cloud_cpp_common
+                                      GTest::gmock_main
+                                      GTest::gmock
+                                      GTest::gtest
+                                      gRPC::grpc++
+                                      gRPC::grpc
+                                      protobuf::libprotobuf)
+        add_test(NAME ${target} COMMAND ${target})
+    endforeach ()
+endif ()
 
 # Benchmark Table::ReadRows().
 add_executable(scan_throughput_benchmark scan_throughput_benchmark.cc)

--- a/google/cloud/firestore/CMakeLists.txt
+++ b/google/cloud/firestore/CMakeLists.txt
@@ -44,7 +44,7 @@ add_library(firestore_common_options INTERFACE)
 google_cloud_cpp_add_common_options(firestore_common_options)
 
 # Enable unit tests
-enable_testing()
+include(CTest)
 
 # Generate the version information from the CMake values.
 configure_file(version_info.h.in version_info.h)
@@ -77,33 +77,35 @@ add_library(firestore::client ALIAS firestore_client)
 create_bazel_config(firestore_client)
 google_cloud_cpp_add_clang_tidy(firestore_client)
 
-# List the unit tests, then setup the targets and dependencies.
-set(firestore_client_unit_tests field_path_test.cc)
+if (BUILD_TESTING)
+    # List the unit tests, then setup the targets and dependencies.
+    set(firestore_client_unit_tests field_path_test.cc)
 
-# Export the list of unit tests so the Bazel BUILD file can pick it up.
-export_list_to_bazel("firestore_client_unit_tests.bzl"
-                     "firestore_client_unit_tests")
+    # Export the list of unit tests so the Bazel BUILD file can pick it up.
+    export_list_to_bazel("firestore_client_unit_tests.bzl"
+                         "firestore_client_unit_tests")
 
-foreach (fname ${firestore_client_unit_tests})
-    string(REPLACE "/"
-                   "_"
-                   target
-                   ${fname})
-    string(REPLACE ".cc"
-                   ""
-                   target
-                   ${target})
-    add_executable(${target} ${fname})
-    target_link_libraries(${target}
-                          PRIVATE firestore_client
-                                  google_cloud_cpp_testing
-                                  google_cloud_cpp_common
-                                  GTest::gmock_main
-                                  GTest::gmock
-                                  GTest::gtest
-                                  firestore_common_options)
-    add_test(NAME ${target} COMMAND ${target})
-endforeach ()
+    foreach (fname ${firestore_client_unit_tests})
+        string(REPLACE "/"
+                       "_"
+                       target
+                       ${fname})
+        string(REPLACE ".cc"
+                       ""
+                       target
+                       ${target})
+        add_executable(${target} ${fname})
+        target_link_libraries(${target}
+                              PRIVATE firestore_client
+                                      google_cloud_cpp_testing
+                                      google_cloud_cpp_common
+                                      GTest::gmock_main
+                                      GTest::gmock
+                                      GTest::gtest
+                                      firestore_common_options)
+        add_test(NAME ${target} COMMAND ${target})
+    endforeach ()
+endif ()
 
 # Install the libraries and headers in the locations determined by
 # GNUInstallDirs

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -61,7 +61,7 @@ add_library(storage_common_options INTERFACE)
 google_cloud_cpp_add_common_options(storage_common_options)
 
 # Enable unit tests
-enable_testing()
+include(CTest)
 
 include(IncludeCurl)
 
@@ -247,129 +247,136 @@ set_target_properties(
         SOVERSION
         ${STORAGE_CLIENT_VERSION_MAJOR})
 
-add_library(storage_client_testing
-            testing/canonical_errors.h
-            testing/mock_client.h
-            testing/mock_http_request.h
-            testing/mock_http_request.cc
-            testing/retry_tests.h
-            testing/storage_integration_test.h
-            testing/storage_integration_test.cc)
-target_link_libraries(storage_client_testing
-                      PUBLIC storage_client
-                             nlohmann_json
-                             GTest::gmock_main
-                             GTest::gmock
-                             GTest::gtest
-                      PRIVATE storage_common_options)
-target_include_directories(storage_client_testing
-                           PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                                  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-                                  $<INSTALL_INTERFACE:include>)
-target_compile_options(storage_client_testing
-                       PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+if (BUILD_TESTING)
+    add_library(storage_client_testing
+                testing/canonical_errors.h
+                testing/mock_client.h
+                testing/mock_http_request.h
+                testing/mock_http_request.cc
+                testing/retry_tests.h
+                testing/storage_integration_test.h
+                testing/storage_integration_test.cc)
+    target_link_libraries(storage_client_testing
+                          PUBLIC storage_client
+                                 nlohmann_json
+                                 GTest::gmock_main
+                                 GTest::gmock
+                                 GTest::gtest
+                          PRIVATE storage_common_options)
+    target_include_directories(storage_client_testing
+                               PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                                      $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+                                      $<INSTALL_INTERFACE:include>)
+    target_compile_options(storage_client_testing
+                           PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+endif ()
 
 create_bazel_config(storage_client)
 google_cloud_cpp_add_clang_tidy(storage_client)
-create_bazel_config(storage_client_testing)
 
-# List the unit tests, then setup the targets and dependencies.
-set(storage_client_unit_tests
-    bucket_access_control_test.cc
-    bucket_metadata_test.cc
-    bucket_test.cc
-    client_bucket_acl_test.cc
-    client_default_object_acl_test.cc
-    client_object_acl_test.cc
-    client_object_copy_test.cc
-    client_service_account_test.cc
-    client_notifications_test.cc
-    client_sign_url_test.cc
-    client_test.cc
-    client_write_object_test.cc
-    hashing_options_test.cc
-    idempotency_policy_test.cc
-    internal/access_control_common_test.cc
-    internal/binary_data_as_debug_string_test.cc
-    internal/bucket_acl_requests_test.cc
-    internal/bucket_requests_test.cc
-    internal/compute_engine_util_test.cc
-    internal/curl_client_test.cc
-    internal/curl_resumable_upload_session_test.cc
-    internal/curl_wrappers_locking_already_present_test.cc
-    internal/curl_wrappers_locking_enabled_test.cc
-    internal/curl_wrappers_locking_disabled_test.cc
-    internal/default_object_acl_requests_test.cc
-    internal/format_rfc3339_test.cc
-    internal/generate_message_boundary_test.cc
-    internal/hash_validator_test.cc
-    internal/http_response_test.cc
-    internal/logging_client_test.cc
-    internal/logging_resumable_upload_session_test.cc
-    internal/metadata_parser_test.cc
-    internal/nljson_test.cc
-    internal/noex_client_test.cc
-    internal/notification_requests_test.cc
-    internal/object_acl_requests_test.cc
-    internal/object_requests_test.cc
-    internal/parse_rfc3339_test.cc
-    internal/patch_builder_test.cc
-    internal/retry_client_test.cc
-    internal/retry_resumable_upload_session_test.cc
-    internal/service_account_requests_test.cc
-    internal/signed_url_requests_test.cc
-    internal/throw_status_delegate_test.cc
-    lifecycle_rule_test.cc
-    list_buckets_reader_test.cc
-    list_objects_reader_test.cc
-    oauth2/anonymous_credentials_test.cc
-    oauth2/authorized_user_credentials_test.cc
-    oauth2/compute_engine_credentials_test.cc
-    oauth2/google_application_default_credentials_file_test.cc
-    oauth2/google_credentials_test.cc
-    oauth2/service_account_credentials_test.cc
-    object_access_control_test.cc
-    object_metadata_test.cc
-    object_test.cc
-    notification_metadata_test.cc
-    retry_policy_test.cc
-    service_account_test.cc
-    signed_url_options_test.cc
-    status_or_test.cc
-    storage_class_test.cc
-    storage_client_options_test.cc
-    storage_version_test.cc
-    well_known_headers_test.cc)
+if (BUILD_TESTING)
+    create_bazel_config(storage_client_testing)
 
-foreach (fname ${storage_client_unit_tests})
-    string(REPLACE "/"
-                   "_"
-                   target
-                   ${fname})
-    string(REPLACE ".cc"
-                   ""
-                   target
-                   ${target})
-    add_executable(${target} ${fname})
-    target_link_libraries(${target}
-                          PRIVATE storage_client_testing
-                                  google_cloud_cpp_testing
-                                  storage_client
-                                  google_cloud_cpp_testing
-                                  GTest::gmock_main
-                                  GTest::gmock
-                                  GTest::gtest
-                                  CURL::CURL
-                                  storage_common_options
-                                  nlohmann_json)
-    add_test(NAME ${target} COMMAND ${target})
-endforeach ()
+    # List the unit tests, then setup the targets and dependencies.
+    set(storage_client_unit_tests
+        bucket_access_control_test.cc
+        bucket_metadata_test.cc
+        bucket_test.cc
+        client_bucket_acl_test.cc
+        client_default_object_acl_test.cc
+        client_object_acl_test.cc
+        client_object_copy_test.cc
+        client_service_account_test.cc
+        client_notifications_test.cc
+        client_sign_url_test.cc
+        client_test.cc
+        client_write_object_test.cc
+        hashing_options_test.cc
+        idempotency_policy_test.cc
+        internal/access_control_common_test.cc
+        internal/binary_data_as_debug_string_test.cc
+        internal/bucket_acl_requests_test.cc
+        internal/bucket_requests_test.cc
+        internal/compute_engine_util_test.cc
+        internal/curl_client_test.cc
+        internal/curl_resumable_upload_session_test.cc
+        internal/curl_wrappers_locking_already_present_test.cc
+        internal/curl_wrappers_locking_enabled_test.cc
+        internal/curl_wrappers_locking_disabled_test.cc
+        internal/default_object_acl_requests_test.cc
+        internal/format_rfc3339_test.cc
+        internal/generate_message_boundary_test.cc
+        internal/hash_validator_test.cc
+        internal/http_response_test.cc
+        internal/logging_client_test.cc
+        internal/logging_resumable_upload_session_test.cc
+        internal/metadata_parser_test.cc
+        internal/nljson_test.cc
+        internal/noex_client_test.cc
+        internal/notification_requests_test.cc
+        internal/object_acl_requests_test.cc
+        internal/object_requests_test.cc
+        internal/parse_rfc3339_test.cc
+        internal/patch_builder_test.cc
+        internal/retry_client_test.cc
+        internal/retry_resumable_upload_session_test.cc
+        internal/service_account_requests_test.cc
+        internal/signed_url_requests_test.cc
+        internal/throw_status_delegate_test.cc
+        lifecycle_rule_test.cc
+        list_buckets_reader_test.cc
+        list_objects_reader_test.cc
+        oauth2/anonymous_credentials_test.cc
+        oauth2/authorized_user_credentials_test.cc
+        oauth2/compute_engine_credentials_test.cc
+        oauth2/google_application_default_credentials_file_test.cc
+        oauth2/google_credentials_test.cc
+        oauth2/service_account_credentials_test.cc
+        object_access_control_test.cc
+        object_metadata_test.cc
+        object_test.cc
+        notification_metadata_test.cc
+        retry_policy_test.cc
+        service_account_test.cc
+        signed_url_options_test.cc
+        status_or_test.cc
+        storage_class_test.cc
+        storage_client_options_test.cc
+        storage_version_test.cc
+        well_known_headers_test.cc)
 
-# Export the list of unit tests so the Bazel BUILD file can pick it up.
-export_list_to_bazel(
-    "storage_client_unit_tests.bzl" "storage_client_unit_tests")
+    foreach (fname ${storage_client_unit_tests})
+        string(REPLACE "/"
+                       "_"
+                       target
+                       ${fname})
+        string(REPLACE ".cc"
+                       ""
+                       target
+                       ${target})
+        add_executable(${target} ${fname})
+        if (BUILD_TESTING)
+            target_link_libraries(${target}
+                                  PRIVATE storage_client_testing
+                                          google_cloud_cpp_testing
+                                          storage_client
+                                          google_cloud_cpp_testing
+                                          GTest::gmock_main
+                                          GTest::gmock
+                                          GTest::gtest
+                                          CURL::CURL
+                                          storage_common_options
+                                          nlohmann_json)
+            add_test(NAME ${target} COMMAND ${target})
+        endif ()
+    endforeach ()
 
-add_subdirectory(tests)
+    # Export the list of unit tests so the Bazel BUILD file can pick it up.
+    export_list_to_bazel("storage_client_unit_tests.bzl"
+                         "storage_client_unit_tests")
+
+    add_subdirectory(tests)
+endif ()
 
 if (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_subdirectory(benchmarks)

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -247,6 +247,9 @@ set_target_properties(
         SOVERSION
         ${STORAGE_CLIENT_VERSION_MAJOR})
 
+create_bazel_config(storage_client)
+google_cloud_cpp_add_clang_tidy(storage_client)
+
 if (BUILD_TESTING)
     add_library(storage_client_testing
                 testing/canonical_errors.h
@@ -269,12 +272,7 @@ if (BUILD_TESTING)
                                       $<INSTALL_INTERFACE:include>)
     target_compile_options(storage_client_testing
                            PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
-endif ()
 
-create_bazel_config(storage_client)
-google_cloud_cpp_add_clang_tidy(storage_client)
-
-if (BUILD_TESTING)
     create_bazel_config(storage_client_testing)
 
     # List the unit tests, then setup the targets and dependencies.

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -358,7 +358,6 @@ if (BUILD_TESTING)
                                   PRIVATE storage_client_testing
                                           google_cloud_cpp_testing
                                           storage_client
-                                          google_cloud_cpp_testing
                                           GTest::gmock_main
                                           GTest::gmock
                                           GTest::gtest


### PR DESCRIPTION
Fixes #1617 

Per the [docs](https://gitlab.kitware.com/cmake/community/wikis/doc/ctest/Testing-With-CTest), `include(CTest)` will automatically call `enable_testing()` and add the `BUILD_TESTING` option. The rest of the PR just wraps relevant blocks in `if (BUILD_TESTING)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1707)
<!-- Reviewable:end -->
