### PR TITLE
Prototype nothrow overloads

### DIFF
--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -59,7 +59,7 @@ ObjectMetadata Client::UploadFileSimple(
   std::string payload(std::istreambuf_iterator<char>{is}, {});
   request.set_contents(std::move(payload));
 
-  return raw_client_->InsertObjectMedia(request).second;
+  return ThrowOnError(raw_client_->InsertObjectMedia(request));
 }
 
 ObjectMetadata Client::UploadFileResumable(
@@ -94,7 +94,7 @@ integrity checks using the DisableMD5Hash() and DisableCrc32cChecksum() options.
 
   auto result = UploadStreamResumable(source, source_size, request);
   if (not result.first.ok()) {
-    google::cloud::internal::RaiseRuntimeError(result.first.error_message());
+    internal::ThrowStatus(std::move(result.first));
   }
   return result.second;
 }

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -32,9 +32,6 @@ static_assert(std::is_copy_constructible<storage::Client>::value,
 static_assert(std::is_copy_assignable<storage::Client>::value,
               "storage::Client must be assignable");
 
-// NOLINTNEXTLINE(readability-identifier-naming)
-nothrow_t const nothrow = nothrow_t{};
-
 std::shared_ptr<internal::RawClient> Client::CreateDefaultClient(
     ClientOptions options) {
   return internal::CurlClient::Create(std::move(options));

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -32,6 +32,9 @@ static_assert(std::is_copy_constructible<storage::Client>::value,
 static_assert(std::is_copy_assignable<storage::Client>::value,
               "storage::Client must be assignable");
 
+// NOLINTNEXTLINE(readability-identifier-naming)
+nothrow_t const nothrow = nothrow_t{};
+
 std::shared_ptr<internal::RawClient> Client::CreateDefaultClient(
     ClientOptions options) {
   return internal::CurlClient::Create(std::move(options));

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2286,9 +2286,9 @@ class Client {
   }
 
   /**
-   * This overload works exactly the `ListNotifications()` without a `nothrow_t`
-   * parameter, except that it returns a `Status` on error, and the normal
-   * return value on success.
+   * This overload works exactly like `ListNotifications()` without a
+   * `nothrow_t` parameter, except that it returns a `Status` on error, and the
+   * normal return value on success.
    */
   template <typename... Options>
   StatusOr<std::vector<NotificationMetadata>> ListNotifications(
@@ -2351,7 +2351,7 @@ class Client {
   }
 
   /**
-   * This overload works exactly the `CreateNotifications()` without a
+   * This overload works exactly like `CreateNotifications()` without a
    * `nothrow_t` parameter, except that it returns a `Status` on error, and the
    * normal return value on success.
    */
@@ -2452,7 +2452,7 @@ class Client {
     return std::move(result.second);
   }
 
-  Status AsStatusOr(std::pair<Status, internal::EmptyResponse> result) {
+  Status AsStatus(std::pair<Status, internal::EmptyResponse> result) {
     return std::move(result.first);
   }
 

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -35,12 +35,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-/// A tag to dispatch the non-throwing versions of the API.
-struct nothrow_t {};
-
-// NOLINTNEXTLINE(readability-identifier-naming)
-extern nothrow_t const nothrow;
-
 /**
  * The Google Cloud Storage (GCS) Client.
  *
@@ -2286,7 +2280,7 @@ class Client {
   template <typename... Options>
   std::vector<NotificationMetadata> ListNotifications(
       std::string const& bucket_name, Options&&... options) {
-    return ListNotifications(nothrow, bucket_name,
+    return ListNotifications(std::nothrow, bucket_name,
                              std::forward<Options>(options)...)
         .value();
   }
@@ -2298,7 +2292,7 @@ class Client {
    */
   template <typename... Options>
   StatusOr<std::vector<NotificationMetadata>> ListNotifications(
-      nothrow_t, std::string const& bucket_name, Options&&... options) {
+      std::nothrow_t, std::string const& bucket_name, Options&&... options) {
     internal::ListNotificationsRequest request(bucket_name);
     request.set_multiple_options(std::forward<Options>(options)...);
     auto result = raw_client_->ListNotifications(request);
@@ -2350,8 +2344,8 @@ class Client {
                                           std::string const& payload_format,
                                           NotificationMetadata metadata,
                                           Options&&... options) {
-    return CreateNotification(nothrow, bucket_name, topic_name, payload_format,
-                              std::move(metadata),
+    return CreateNotification(std::nothrow, bucket_name, topic_name,
+                              payload_format, std::move(metadata),
                               std::forward<Options>(options)...)
         .value();
   }
@@ -2363,9 +2357,9 @@ class Client {
    */
   template <typename... Options>
   StatusOr<NotificationMetadata> CreateNotification(
-      nothrow_t, std::string const& bucket_name, std::string const& topic_name,
-      std::string const& payload_format, NotificationMetadata metadata,
-      Options&&... options) {
+      std::nothrow_t, std::string const& bucket_name,
+      std::string const& topic_name, std::string const& payload_format,
+      NotificationMetadata metadata, Options&&... options) {
     metadata.set_topic(topic_name).set_payload_format(payload_format);
     internal::CreateNotificationRequest request(bucket_name, metadata);
     request.set_multiple_options(std::forward<Options>(options)...);

--- a/google/cloud/storage/internal/noex_client.h
+++ b/google/cloud/storage/internal/noex_client.h
@@ -109,8 +109,7 @@ class Client {
     // TODO(#1694) - remove all the code duplicated in `storage::Client`.
     auto logging = std::make_shared<internal::LoggingClient>(std::move(client));
     auto retry = std::make_shared<internal::RetryClient>(
-        std::move(logging), internal::RetryClient::NoexPolicy{},
-        std::forward<Policies>(policies)...);
+        std::move(logging), std::forward<Policies>(policies)...);
     return retry;
   }
 

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -69,14 +69,9 @@ typename std::enable_if<
 MakeCall(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
          bool is_idempotent, RawClient& client, MemberFunction function,
          typename CheckSignature<MemberFunction>::RequestType const& request,
-         bool enable_exceptions, char const* error_message) {
+         char const* error_message) {
   google::cloud::storage::Status last_status;
-  // TODO(#1694) - remove the code to support enable_exceptions == true when
-  //   the storage::Client class no longer needs it.
-  auto error = [&last_status, enable_exceptions](std::string const& msg) {
-    if (enable_exceptions) {
-      google::cloud::internal::RaiseRuntimeError(msg);
-    }
+  auto error = [&last_status](std::string const& msg) {
     Status status(last_status.status_code(), msg, last_status.error_details());
     using Pair = typename CheckSignature<MemberFunction>::ReturnType;
     return Pair(status, typename Pair::second_type{});
@@ -138,7 +133,7 @@ std::pair<Status, ListBucketsResponse> RetryClient::ListBuckets(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::ListBuckets, request, enable_exceptions_,
+                  &RawClient::ListBuckets, request,
                   __func__);
 }
 
@@ -148,7 +143,7 @@ std::pair<Status, BucketMetadata> RetryClient::CreateBucket(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::CreateBucket, request, enable_exceptions_,
+                  &RawClient::CreateBucket, request,
                   __func__);
 }
 
@@ -158,7 +153,7 @@ std::pair<Status, BucketMetadata> RetryClient::GetBucketMetadata(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::GetBucketMetadata, request, enable_exceptions_,
+                  &RawClient::GetBucketMetadata, request,
                   __func__);
 }
 
@@ -168,7 +163,7 @@ std::pair<Status, EmptyResponse> RetryClient::DeleteBucket(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::DeleteBucket, request, enable_exceptions_,
+                  &RawClient::DeleteBucket, request,
                   __func__);
 }
 
@@ -178,7 +173,7 @@ std::pair<Status, BucketMetadata> RetryClient::UpdateBucket(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::UpdateBucket, request, enable_exceptions_,
+                  &RawClient::UpdateBucket, request,
                   __func__);
 }
 
@@ -188,7 +183,7 @@ std::pair<Status, BucketMetadata> RetryClient::PatchBucket(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::PatchBucket, request, enable_exceptions_,
+                  &RawClient::PatchBucket, request,
                   __func__);
 }
 
@@ -198,7 +193,7 @@ std::pair<Status, IamPolicy> RetryClient::GetBucketIamPolicy(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::GetBucketIamPolicy, request, enable_exceptions_,
+                  &RawClient::GetBucketIamPolicy, request,
                   __func__);
 }
 
@@ -208,7 +203,7 @@ std::pair<Status, IamPolicy> RetryClient::SetBucketIamPolicy(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::SetBucketIamPolicy, request, enable_exceptions_,
+                  &RawClient::SetBucketIamPolicy, request,
                   __func__);
 }
 
@@ -220,7 +215,7 @@ RetryClient::TestBucketIamPermissions(
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
                   &RawClient::TestBucketIamPermissions, request,
-                  enable_exceptions_, __func__);
+                   __func__);
 }
 
 std::pair<Status, EmptyResponse> RetryClient::LockBucketRetentionPolicy(
@@ -230,7 +225,7 @@ std::pair<Status, EmptyResponse> RetryClient::LockBucketRetentionPolicy(
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
                   &RawClient::LockBucketRetentionPolicy, request,
-                  enable_exceptions_, __func__);
+                   __func__);
 }
 
 std::pair<Status, ObjectMetadata> RetryClient::InsertObjectMedia(
@@ -239,7 +234,7 @@ std::pair<Status, ObjectMetadata> RetryClient::InsertObjectMedia(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::InsertObjectMedia, request, enable_exceptions_,
+                  &RawClient::InsertObjectMedia, request,
                   __func__);
 }
 
@@ -249,7 +244,7 @@ std::pair<Status, ObjectMetadata> RetryClient::CopyObject(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::CopyObject, request, enable_exceptions_,
+                  &RawClient::CopyObject, request,
                   __func__);
 }
 
@@ -259,7 +254,7 @@ std::pair<Status, ObjectMetadata> RetryClient::GetObjectMetadata(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::GetObjectMetadata, request, enable_exceptions_,
+                  &RawClient::GetObjectMetadata, request,
                   __func__);
 }
 
@@ -269,7 +264,7 @@ std::pair<Status, std::unique_ptr<ObjectReadStreambuf>> RetryClient::ReadObject(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::ReadObject, request, enable_exceptions_,
+                  &RawClient::ReadObject, request,
                   __func__);
 }
 
@@ -280,7 +275,7 @@ RetryClient::WriteObject(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::WriteObject, request, enable_exceptions_,
+                  &RawClient::WriteObject, request,
                   __func__);
 }
 
@@ -290,7 +285,7 @@ std::pair<Status, ListObjectsResponse> RetryClient::ListObjects(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::ListObjects, request, enable_exceptions_,
+                  &RawClient::ListObjects, request,
                   __func__);
 }
 
@@ -300,7 +295,7 @@ std::pair<Status, EmptyResponse> RetryClient::DeleteObject(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::DeleteObject, request, enable_exceptions_,
+                  &RawClient::DeleteObject, request,
                   __func__);
 }
 
@@ -310,7 +305,7 @@ std::pair<Status, ObjectMetadata> RetryClient::UpdateObject(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::UpdateObject, request, enable_exceptions_,
+                  &RawClient::UpdateObject, request,
                   __func__);
 }
 
@@ -320,7 +315,7 @@ std::pair<Status, ObjectMetadata> RetryClient::PatchObject(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::PatchObject, request, enable_exceptions_,
+                  &RawClient::PatchObject, request,
                   __func__);
 }
 
@@ -330,7 +325,7 @@ std::pair<Status, ObjectMetadata> RetryClient::ComposeObject(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::ComposeObject, request, enable_exceptions_,
+                  &RawClient::ComposeObject, request,
                   __func__);
 }
 
@@ -340,7 +335,7 @@ std::pair<Status, RewriteObjectResponse> RetryClient::RewriteObject(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::RewriteObject, request, enable_exceptions_,
+                  &RawClient::RewriteObject, request,
                   __func__);
 }
 
@@ -351,7 +346,7 @@ RetryClient::CreateResumableSession(ResumableUploadRequest const& request) {
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   auto result = MakeCall(*retry_policy, *backoff_policy, is_idempotent,
                          *client_, &RawClient::CreateResumableSession, request,
-                         enable_exceptions_, __func__);
+                          __func__);
   if (not result.first.ok()) {
     return result;
   }
@@ -370,7 +365,7 @@ RetryClient::RestoreResumableSession(std::string const& request) {
   auto is_idempotent = true;
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
                   &RawClient::RestoreResumableSession, request,
-                  enable_exceptions_, __func__);
+                   __func__);
 }
 
 std::pair<Status, ListBucketAclResponse> RetryClient::ListBucketAcl(
@@ -379,7 +374,7 @@ std::pair<Status, ListBucketAclResponse> RetryClient::ListBucketAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::ListBucketAcl, request, enable_exceptions_,
+                  &RawClient::ListBucketAcl, request,
                   __func__);
 }
 
@@ -389,7 +384,7 @@ std::pair<Status, BucketAccessControl> RetryClient::GetBucketAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::GetBucketAcl, request, enable_exceptions_,
+                  &RawClient::GetBucketAcl, request,
                   __func__);
 }
 
@@ -399,7 +394,7 @@ std::pair<Status, BucketAccessControl> RetryClient::CreateBucketAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::CreateBucketAcl, request, enable_exceptions_,
+                  &RawClient::CreateBucketAcl, request,
                   __func__);
 }
 
@@ -409,7 +404,7 @@ std::pair<Status, EmptyResponse> RetryClient::DeleteBucketAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::DeleteBucketAcl, request, enable_exceptions_,
+                  &RawClient::DeleteBucketAcl, request,
                   __func__);
 }
 
@@ -419,7 +414,7 @@ std::pair<Status, ListObjectAclResponse> RetryClient::ListObjectAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::ListObjectAcl, request, enable_exceptions_,
+                  &RawClient::ListObjectAcl, request,
                   __func__);
 }
 
@@ -429,7 +424,7 @@ std::pair<Status, BucketAccessControl> RetryClient::UpdateBucketAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::UpdateBucketAcl, request, enable_exceptions_,
+                  &RawClient::UpdateBucketAcl, request,
                   __func__);
 }
 
@@ -439,7 +434,7 @@ std::pair<Status, BucketAccessControl> RetryClient::PatchBucketAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::PatchBucketAcl, request, enable_exceptions_,
+                  &RawClient::PatchBucketAcl, request,
                   __func__);
 }
 
@@ -449,7 +444,7 @@ std::pair<Status, ObjectAccessControl> RetryClient::CreateObjectAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::CreateObjectAcl, request, enable_exceptions_,
+                  &RawClient::CreateObjectAcl, request,
                   __func__);
 }
 
@@ -459,7 +454,7 @@ std::pair<Status, EmptyResponse> RetryClient::DeleteObjectAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::DeleteObjectAcl, request, enable_exceptions_,
+                  &RawClient::DeleteObjectAcl, request,
                   __func__);
 }
 
@@ -469,7 +464,7 @@ std::pair<Status, ObjectAccessControl> RetryClient::GetObjectAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::GetObjectAcl, request, enable_exceptions_,
+                  &RawClient::GetObjectAcl, request,
                   __func__);
 }
 
@@ -479,7 +474,7 @@ std::pair<Status, ObjectAccessControl> RetryClient::UpdateObjectAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::UpdateObjectAcl, request, enable_exceptions_,
+                  &RawClient::UpdateObjectAcl, request,
                   __func__);
 }
 
@@ -489,7 +484,7 @@ std::pair<Status, ObjectAccessControl> RetryClient::PatchObjectAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::PatchObjectAcl, request, enable_exceptions_,
+                  &RawClient::PatchObjectAcl, request,
                   __func__);
 }
 
@@ -499,7 +494,7 @@ RetryClient::ListDefaultObjectAcl(ListDefaultObjectAclRequest const& request) {
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::ListDefaultObjectAcl, request, enable_exceptions_,
+                  &RawClient::ListDefaultObjectAcl, request,
                   __func__);
 }
 
@@ -510,7 +505,7 @@ std::pair<Status, ObjectAccessControl> RetryClient::CreateDefaultObjectAcl(
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
                   &RawClient::CreateDefaultObjectAcl, request,
-                  enable_exceptions_, __func__);
+                   __func__);
 }
 
 std::pair<Status, EmptyResponse> RetryClient::DeleteDefaultObjectAcl(
@@ -520,7 +515,7 @@ std::pair<Status, EmptyResponse> RetryClient::DeleteDefaultObjectAcl(
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
                   &RawClient::DeleteDefaultObjectAcl, request,
-                  enable_exceptions_, __func__);
+                   __func__);
 }
 
 std::pair<Status, ObjectAccessControl> RetryClient::GetDefaultObjectAcl(
@@ -529,7 +524,7 @@ std::pair<Status, ObjectAccessControl> RetryClient::GetDefaultObjectAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::GetDefaultObjectAcl, request, enable_exceptions_,
+                  &RawClient::GetDefaultObjectAcl, request,
                   __func__);
 }
 
@@ -540,7 +535,7 @@ std::pair<Status, ObjectAccessControl> RetryClient::UpdateDefaultObjectAcl(
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
                   &RawClient::UpdateDefaultObjectAcl, request,
-                  enable_exceptions_, __func__);
+                   __func__);
 }
 
 std::pair<Status, ObjectAccessControl> RetryClient::PatchDefaultObjectAcl(
@@ -550,7 +545,7 @@ std::pair<Status, ObjectAccessControl> RetryClient::PatchDefaultObjectAcl(
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
                   &RawClient::PatchDefaultObjectAcl, request,
-                  enable_exceptions_, __func__);
+                   __func__);
 }
 
 std::pair<Status, ServiceAccount> RetryClient::GetServiceAccount(
@@ -559,7 +554,7 @@ std::pair<Status, ServiceAccount> RetryClient::GetServiceAccount(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::GetServiceAccount, request, enable_exceptions_,
+                  &RawClient::GetServiceAccount, request,
                   __func__);
 }
 
@@ -569,7 +564,7 @@ std::pair<Status, ListNotificationsResponse> RetryClient::ListNotifications(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::ListNotifications, request, enable_exceptions_,
+                  &RawClient::ListNotifications, request,
                   __func__);
 }
 
@@ -579,7 +574,7 @@ std::pair<Status, NotificationMetadata> RetryClient::CreateNotification(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::CreateNotification, request, enable_exceptions_,
+                  &RawClient::CreateNotification, request,
                   __func__);
 }
 
@@ -589,7 +584,7 @@ std::pair<Status, NotificationMetadata> RetryClient::GetNotification(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::GetNotification, request, enable_exceptions_,
+                  &RawClient::GetNotification, request,
                   __func__);
 }
 
@@ -599,7 +594,7 @@ std::pair<Status, EmptyResponse> RetryClient::DeleteNotification(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::DeleteNotification, request, enable_exceptions_,
+                  &RawClient::DeleteNotification, request,
                   __func__);
 }
 

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -31,7 +31,6 @@ namespace internal {
 class RetryClient : public RawClient {
  public:
   struct DefaultPolicies {};
-  struct NoexPolicy {};
 
   explicit RetryClient(std::shared_ptr<RawClient> client,
                        DefaultPolicies unused);
@@ -157,8 +156,6 @@ class RetryClient : public RawClient {
     idempotency_policy_ = policy.clone();
   }
 
-  void Apply(NoexPolicy const&) { enable_exceptions_ = false; }
-
   void ApplyPolicies() {}
 
   template <typename P, typename... Policies>
@@ -171,9 +168,6 @@ class RetryClient : public RawClient {
   std::shared_ptr<RetryPolicy> retry_policy_;
   std::shared_ptr<BackoffPolicy> backoff_policy_;
   std::shared_ptr<IdempotencyPolicy> idempotency_policy_;
-  // TODO(#1694) - remove the code to support enable_exceptions == true when
-  //   the storage::Client class no longer needs it.
-  bool enable_exceptions_ = true;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/retry_client_test.cc
+++ b/google/cloud/storage/internal/retry_client_test.cc
@@ -44,8 +44,7 @@ TEST_F(RetryClientTest, NonIdempotentErrorHandling) {
   RetryClient client(std::shared_ptr<internal::RawClient>(mock),
                      LimitedErrorCountRetryPolicy(3), StrictIdempotencyPolicy(),
                      // Make the tests faster.
-                     ExponentialBackoffPolicy(1_us, 2_us, 2),
-                     RetryClient::NoexPolicy{});
+                     ExponentialBackoffPolicy(1_us, 2_us, 2));
 
   EXPECT_CALL(*mock, DeleteObject(_))
       .WillOnce(Return(std::make_pair(TransientError(), EmptyResponse{})));
@@ -62,8 +61,7 @@ TEST_F(RetryClientTest, PermanentErrorHandling) {
   RetryClient client(std::shared_ptr<internal::RawClient>(mock),
                      LimitedErrorCountRetryPolicy(3),
                      // Make the tests faster.
-                     ExponentialBackoffPolicy(1_us, 2_us, 2),
-                     RetryClient::NoexPolicy{});
+                     ExponentialBackoffPolicy(1_us, 2_us, 2));
 
   // Use a read-only operation because these are always idempotent.
   EXPECT_CALL(*mock, GetObjectMetadata(_))
@@ -80,8 +78,7 @@ TEST_F(RetryClientTest, TooManyTransientsHandling) {
   RetryClient client(std::shared_ptr<internal::RawClient>(mock),
                      LimitedErrorCountRetryPolicy(3),
                      // Make the tests faster.
-                     ExponentialBackoffPolicy(1_us, 2_us, 2),
-                     RetryClient::NoexPolicy{});
+                     ExponentialBackoffPolicy(1_us, 2_us, 2));
 
   // Use a read-only operation because these are always idempotent.
   EXPECT_CALL(*mock, GetObjectMetadata(_))

--- a/google/cloud/storage/list_buckets_reader.cc
+++ b/google/cloud/storage/list_buckets_reader.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/list_buckets_reader.h"
+#include "google/cloud/storage/internal/throw_status_delegate.h"
 
 namespace google {
 namespace cloud {
@@ -88,6 +89,9 @@ google::cloud::optional<BucketMetadata> ListBucketsReader::GetNext() {
     }
     request_.set_page_token(std::move(next_page_token_));
     auto response = client_->ListBuckets(request_);
+    if (not response.first.ok()) {
+      internal::ThrowStatus(std::move(response.first));
+    }
     next_page_token_ = std::move(response.second.next_page_token);
     current_buckets_ = std::move(response.second.items);
     current_ = current_buckets_.begin();

--- a/google/cloud/storage/list_objects_reader.cc
+++ b/google/cloud/storage/list_objects_reader.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/list_objects_reader.h"
+#include "google/cloud/storage/internal/throw_status_delegate.h"
 
 namespace google {
 namespace cloud {
@@ -88,6 +89,9 @@ google::cloud::optional<ObjectMetadata> ListObjectsReader::GetNext() {
     }
     request_.set_page_token(std::move(next_page_token_));
     auto response = client_->ListObjects(request_);
+    if (not response.first.ok()) {
+      internal::ThrowStatus(std::move(response.first));
+    }
     next_page_token_ = std::move(response.second.next_page_token);
     current_objects_ = std::move(response.second.items);
     current_ = current_objects_.begin();

--- a/google/cloud/storage/object_rewriter.cc
+++ b/google/cloud/storage/object_rewriter.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/object_rewriter.h"
 #include "google/cloud/storage/internal/raw_client.h"
+#include "google/cloud/storage/internal/throw_status_delegate.h"
 
 namespace google {
 namespace cloud {
@@ -26,8 +27,11 @@ ObjectRewriter::ObjectRewriter(std::shared_ptr<internal::RawClient> client,
       progress_{0, 0, false} {}
 
 RewriteProgress ObjectRewriter::Iterate() {
-  internal::RewriteObjectResponse response =
-      client_->RewriteObject(request_).second;
+  auto result = client_->RewriteObject(request_);
+  if (not result.first.ok()) {
+    internal::ThrowStatus(std::move(result.first));
+  }
+  internal::RewriteObjectResponse response = std::move(result.second);
   progress_ = RewriteProgress{response.total_bytes_rewritten,
                               response.object_size, response.done};
   if (response.done) {


### PR DESCRIPTION
This includes two changes, that could be separated if desired.

First, it changes `gcs::internal::RetryClient` to never throw, that way `gcs::Client` can have some overloads that throw and others that return `gcs::StatusOr<T>`.

Second, it adds a couple of overloads in `gcs::Client` that return `StatusOr<T>`, and reimplements the existing overloads in terms of these.

Note that no examples or tests were harmed in the filming of this movie.

/cc: @devbww

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1713)
<!-- Reviewable:end -->
