### PR TITLE
Idempotency policies for conditional mutations.

### DIFF
--- a/google/cloud/bigtable/idempotent_mutation_policy.cc
+++ b/google/cloud/bigtable/idempotent_mutation_policy.cc
@@ -37,6 +37,12 @@ bool SafeIdempotentMutationPolicy::is_idempotent(
   return m.set_cell().timestamp_micros() != ServerSetTimestamp();
 }
 
+bool SafeIdempotentMutationPolicy::is_idempotent(
+    google::bigtable::v2::CheckAndMutateRowRequest const&) {
+  // TODO(#1715): this is overly conservative
+  return false;
+}
+
 std::unique_ptr<IdempotentMutationPolicy> AlwaysRetryMutationPolicy::clone()
     const {
   return std::unique_ptr<IdempotentMutationPolicy>(
@@ -47,6 +53,12 @@ bool AlwaysRetryMutationPolicy::is_idempotent(
     google::bigtable::v2::Mutation const&) {
   return true;
 }
+
+bool AlwaysRetryMutationPolicy::is_idempotent(
+    google::bigtable::v2::CheckAndMutateRowRequest const&) {
+  return true;
+}
+
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/idempotent_mutation_policy.h
+++ b/google/cloud/bigtable/idempotent_mutation_policy.h
@@ -36,6 +36,9 @@ class IdempotentMutationPolicy {
 
   /// Return true if the mutation is idempotent.
   virtual bool is_idempotent(google::bigtable::v2::Mutation const&) = 0;
+  /// Return true if a conditional mutation is idempotent
+  virtual bool is_idempotent(
+      google::bigtable::v2::CheckAndMutateRowRequest const&) = 0;
 };
 
 /// Return an instance of the default IdempotentMutationPolicy.
@@ -54,6 +57,8 @@ class SafeIdempotentMutationPolicy : public IdempotentMutationPolicy {
 
   std::unique_ptr<IdempotentMutationPolicy> clone() const override;
   bool is_idempotent(google::bigtable::v2::Mutation const&) override;
+  bool is_idempotent(
+      google::bigtable::v2::CheckAndMutateRowRequest const&) override;
 };
 
 /**
@@ -72,6 +77,8 @@ class AlwaysRetryMutationPolicy : public IdempotentMutationPolicy {
 
   std::unique_ptr<IdempotentMutationPolicy> clone() const override;
   bool is_idempotent(google::bigtable::v2::Mutation const&) override;
+  bool is_idempotent(
+      google::bigtable::v2::CheckAndMutateRowRequest const&) override;
 };
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable


### PR DESCRIPTION
This fixes #1390.

Conditional mutations are sometimes idempotent, e.g. setting a value in
one column if another satisfies a condition. This PR adds an overridable
member function to IdempotentMutationPolicy to allow users to define
custom behavior.

The general solution needs much more design a work, hence #1715 was
created to address it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1716)
<!-- Reviewable:end -->
