### PR TITLE
Fix build breakage with bazel 0.21.

### DIFF
--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -49,6 +49,7 @@ export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/service-account.json"
 bazel test \
     --copt=-DGRPC_BAZEL_BUILD \
     --action_env=GOOGLE_APPLICATION_CREDENTIALS="${GOOGLE_APPLICATION_CREDENTIALS}" \
+    --incompatible_package_name_is_a_function=false \
     --test_output=errors \
     --verbose_failures=true \
     --keep_going \
@@ -60,6 +61,7 @@ echo "================================================================"
 bazel build \
     --copt=-DGRPC_BAZEL_BUILD \
     --action_env=GOOGLE_APPLICATION_CREDENTIALS="${GOOGLE_APPLICATION_CREDENTIALS}" \
+    --incompatible_package_name_is_a_function=false \
     --test_output=errors \
     --verbose_failures=true \
     --keep_going \


### PR DESCRIPTION
Bazel release 0.21 breaks protobuf, add the backwards compatibility
flag as a quick fix because I cannot figure out (quickly) how to
pin the Bazel version to 0.20 or how to fix protobuf. Both would be
"better" solutions, of course.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1717)
<!-- Reviewable:end -->
