### PR TITLE
For builds with ExternalProject disable ldap in libcurl.

### DIFF
--- a/cmake/external/curl.cmake
+++ b/cmake/external/curl.cmake
@@ -46,6 +46,14 @@ if (NOT TARGET curl_project)
         URL ${GOOGLE_CLOUD_CPP_CURL_URL}
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_CURL_SHA256}
         CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+                   # libcurl automatically enables a number of protocols. With
+                   # static libraries this is a problem. The indirect
+                   # dependencies, such as libldap, become hard to predict and
+                   # manage. Setting HTTP_ONLY=ON disables all optional
+                   # protocols and meets our needs. If the application needs
+                   # a version of libcurl with other protocols enabled they
+                   # can select it using GOOGLE_CLOUD_CPP_CURL_PROVIDER=package.
+                   -DHTTP_ONLY=ON
                    -DCMAKE_BUILD_TYPE=Release
                    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                    -DENABLE_ARES=ON


### PR DESCRIPTION
libcurl automatically discovers available libraries to support
additional protocols, such as LDAP, or SSH. That is hard to use with
ExternalProject_Add() because it requires to maintain the list of
indirect dependencies when using static libraries. With shared objects
it is not a problem (the .so loads anything else it needs).

With this change we disable all protocols that are not interesting in
libcurl. For applications that want to build with a richer libcurl
library they can simply set `GOOGLE_CLOUD_CPP_CURL_PROVIDER` to
`package`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1721)
<!-- Reviewable:end -->
