### PR TITLE
Use StatusOr<T> to return errors.

### DIFF
--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -104,7 +104,7 @@ StatusOr<ObjectMetadata> Client::UploadStreamResumable(
     return std::move(session_status).status();
   }
 
-  auto session = *std::move(session_status);
+  auto session = std::move(*session_status);
 
   // GCS requires chunks to be a multiple of 256KiB.
   auto chunk_size = internal::UploadChunkRequest::RoundUpToQuantum(

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -59,7 +59,7 @@ ObjectMetadata Client::UploadFileSimple(
   std::string payload(std::istreambuf_iterator<char>{is}, {});
   request.set_contents(std::move(payload));
 
-  return ThrowOnError(raw_client_->InsertObjectMedia(request));
+  return raw_client_->InsertObjectMedia(request).value();
 }
 
 ObjectMetadata Client::UploadFileResumable(
@@ -92,31 +92,30 @@ integrity checks using the DisableMD5Hash() and DisableCrc32cChecksum() options.
   // class checks before calling it.
   std::uint64_t source_size = google::cloud::internal::file_size(file_name);
 
-  auto result = UploadStreamResumable(source, source_size, request);
-  if (not result.first.ok()) {
-    internal::ThrowStatus(std::move(result.first));
-  }
-  return result.second;
+  return UploadStreamResumable(source, source_size, request).value();
 }
 
-std::pair<Status, ObjectMetadata> Client::UploadStreamResumable(
+StatusOr<ObjectMetadata> Client::UploadStreamResumable(
     std::istream& source, std::uint64_t source_size,
     internal::ResumableUploadRequest const& request) {
-  Status status;
-  std::unique_ptr<internal::ResumableUploadSession> session;
-  std::tie(status, session) = raw_client()->CreateResumableSession(request);
-  if (not status.ok()) {
-    return std::make_pair(status, ObjectMetadata{});
+  StatusOr<std::unique_ptr<internal::ResumableUploadSession>> session_status =
+      raw_client()->CreateResumableSession(request);
+  if (not session_status.ok()) {
+    return std::move(session_status).status();
   }
+
+  auto session = *std::move(session_status);
 
   // GCS requires chunks to be a multiple of 256KiB.
   auto chunk_size = internal::UploadChunkRequest::RoundUpToQuantum(
       raw_client()->client_options().upload_buffer_size());
 
-  internal::ResumableUploadResponse upload_response;
+  StatusOr<internal::ResumableUploadResponse> upload_response(
+      internal::ResumableUploadResponse{});
   // We iterate while `source` is good and the retry policy has not been
   // exhausted.
-  while (not source.eof() and upload_response.payload.empty()) {
+  while (not source.eof() and upload_response.ok() and
+         upload_response->payload.empty()) {
     // Read a chunk of data from the source file.
     std::string buffer(chunk_size, '\0');
     source.read(&buffer[0], buffer.size());
@@ -127,10 +126,9 @@ std::pair<Status, ObjectMetadata> Client::UploadStreamResumable(
     buffer.resize(gcount);
 
     auto expected = session->next_expected_byte() + gcount - 1;
-    std::tie(status, upload_response) =
-        session->UploadChunk(buffer, source_size);
-    if (not status.ok()) {
-      return std::make_pair(Status(), ObjectMetadata());
+    upload_response = session->UploadChunk(buffer, source_size);
+    if (not upload_response.ok()) {
+      return std::move(upload_response).status();
     }
     if (session->next_expected_byte() != expected) {
       GCP_LOG(WARNING) << "unexpected last committed byte "
@@ -140,18 +138,17 @@ std::pair<Status, ObjectMetadata> Client::UploadStreamResumable(
     }
   }
 
-  if (not status.ok()) {
-    return std::make_pair(status, ObjectMetadata{});
+  if (not upload_response.ok()) {
+    return std::move(upload_response).status();
   }
 
-  return std::make_pair(
-      Status(), ObjectMetadata::ParseFromString(upload_response.payload));
+  return ObjectMetadata::ParseFromString(upload_response->payload);
 }
 
 void Client::DownloadFileImpl(internal::ReadObjectRangeRequest const& request,
                               std::string const& file_name) {
   std::unique_ptr<internal::ObjectReadStreambuf> streambuf =
-      raw_client_->ReadObject(request).second;
+      raw_client_->ReadObject(request).value();
   ObjectReadStream stream(std::move(streambuf));
   if (stream.eof() and not stream.IsOpen()) {
     std::string msg = __func__;

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -278,7 +278,7 @@ class Client {
     internal::CreateBucketRequest request(std::move(project_id),
                                           std::move(metadata));
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->CreateBucket(request));
+    return raw_client_->CreateBucket(request).value();
   }
 
   /**
@@ -303,7 +303,7 @@ class Client {
                                    Options&&... options) {
     internal::GetBucketMetadataRequest request(bucket_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->GetBucketMetadata(request));
+    return raw_client_->GetBucketMetadata(request).value();
   }
 
   /**
@@ -328,7 +328,7 @@ class Client {
   void DeleteBucket(std::string const& bucket_name, Options&&... options) {
     internal::DeleteBucketRequest request(bucket_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    ThrowOnError(raw_client_->DeleteBucket(request));
+    raw_client_->DeleteBucket(request).value();
   }
 
   /**
@@ -361,7 +361,7 @@ class Client {
     metadata.set_name(std::move(bucket_name));
     internal::UpdateBucketRequest request(std::move(metadata));
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->UpdateBucket(request));
+    return raw_client_->UpdateBucket(request).value();
   }
 
   /**
@@ -398,7 +398,7 @@ class Client {
     internal::PatchBucketRequest request(std::move(bucket_name), original,
                                          updated);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->PatchBucket(request));
+    return raw_client_->PatchBucket(request).value();
   }
 
   /**
@@ -428,7 +428,7 @@ class Client {
                              Options&&... options) {
     internal::PatchBucketRequest request(std::move(bucket_name), builder);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->PatchBucket(request));
+    return raw_client_->PatchBucket(request).value();
   }
 
   /**
@@ -469,7 +469,7 @@ class Client {
                                Options&&... options) {
     internal::GetBucketIamPolicyRequest request(bucket_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->GetBucketIamPolicy(request));
+    return raw_client_->GetBucketIamPolicy(request).value();
   }
 
   /**
@@ -523,7 +523,7 @@ class Client {
                                Options&&... options) {
     internal::SetBucketIamPolicyRequest request(bucket_name, iam_policy);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->SetBucketIamPolicy(request));
+    return raw_client_->SetBucketIamPolicy(request).value();
   }
 
   /**
@@ -563,11 +563,7 @@ class Client {
     internal::TestBucketIamPermissionsRequest request(std::move(bucket_name),
                                                       std::move(permissions));
     request.set_multiple_options(std::forward<Options>(options)...);
-    auto result = raw_client_->TestBucketIamPermissions(request);
-    if (result.first.ok()) {
-      return result.second.permissions;
-    }
-    internal::ThrowStatus(std::move(result.first));
+    return raw_client_->TestBucketIamPermissions(request).value().permissions;
   }
 
   /**
@@ -626,7 +622,7 @@ class Client {
     internal::LockBucketRetentionPolicyRequest request(bucket_name,
                                                        metageneration);
     request.set_multiple_options(std::forward<Options>(options)...);
-    ThrowOnError(raw_client_->LockBucketRetentionPolicy(request));
+    raw_client_->LockBucketRetentionPolicy(request).value();
   }
   //@}
 
@@ -674,7 +670,7 @@ class Client {
     internal::InsertObjectMediaRequest request(bucket_name, object_name,
                                                std::move(contents));
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->InsertObjectMedia(request));
+    return raw_client_->InsertObjectMedia(request).value();
   }
 
   /**
@@ -730,7 +726,7 @@ class Client {
         std::move(source_bucket_name), std::move(source_object_name),
         std::move(destination_bucket_name), std::move(destination_object_name));
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->CopyObject(request));
+    return raw_client_->CopyObject(request).value();
   }
 
   /**
@@ -759,7 +755,7 @@ class Client {
                                    Options&&... options) {
     internal::GetObjectMetadataRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->GetObjectMetadata(request));
+    return raw_client_->GetObjectMetadata(request).value();
   }
 
   /**
@@ -816,7 +812,7 @@ class Client {
                               Options&&... options) {
     internal::ReadObjectRangeRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ObjectReadStream(ThrowOnError(raw_client_->ReadObject(request)));
+    return ObjectReadStream(raw_client_->ReadObject(request).value());
   }
 
   /**
@@ -885,7 +881,7 @@ class Client {
                                 Options&&... options) {
     internal::InsertObjectStreamingRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ObjectWriteStream(ThrowOnError(raw_client_->WriteObject(request)));
+    return ObjectWriteStream(raw_client_->WriteObject(request).value());
   }
 
   /**
@@ -988,7 +984,7 @@ class Client {
                     std::string const& object_name, Options&&... options) {
     internal::DeleteObjectRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    ThrowOnError(raw_client_->DeleteObject(request));
+    raw_client_->DeleteObject(request).value();
   }
 
   /**
@@ -1022,7 +1018,7 @@ class Client {
     internal::UpdateObjectRequest request(
         std::move(bucket_name), std::move(object_name), std::move(metadata));
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->UpdateObject(request));
+    return raw_client_->UpdateObject(request).value();
   }
 
   /**
@@ -1062,7 +1058,7 @@ class Client {
     internal::PatchObjectRequest request(
         std::move(bucket_name), std::move(object_name), original, updated);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->PatchObject(request));
+    return raw_client_->PatchObject(request).value();
   }
 
   /**
@@ -1099,7 +1095,7 @@ class Client {
     internal::PatchObjectRequest request(std::move(bucket_name),
                                          std::move(object_name), builder);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->PatchObject(request));
+    return raw_client_->PatchObject(request).value();
   }
 
   /**
@@ -1137,7 +1133,7 @@ class Client {
                                            std::move(source_objects),
                                            std::move(destination_object_name));
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->ComposeObject(request));
+    return raw_client_->ComposeObject(request).value();
   }
 
   /**
@@ -1348,11 +1344,7 @@ class Client {
                                                  Options&&... options) {
     internal::ListBucketAclRequest request(bucket_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    auto result = raw_client_->ListBucketAcl(request);
-    if (result.first.ok()) {
-      return result.second.items;
-    }
-    internal::ThrowStatus(std::move(result.first));
+    return raw_client_->ListBucketAcl(request).value().items;
   }
 
   /**
@@ -1381,7 +1373,7 @@ class Client {
                                       Options&&... options) {
     internal::CreateBucketAclRequest request(bucket_name, entity, role);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->CreateBucketAcl(request));
+    return raw_client_->CreateBucketAcl(request).value();
   }
 
   /**
@@ -1407,7 +1399,7 @@ class Client {
                        std::string const& entity, Options&&... options) {
     internal::DeleteBucketAclRequest request(bucket_name, entity);
     request.set_multiple_options(std::forward<Options>(options)...);
-    ThrowOnError(raw_client_->DeleteBucketAcl(request));
+    raw_client_->DeleteBucketAcl(request).value();
   }
 
   /**
@@ -1433,7 +1425,7 @@ class Client {
                                    Options&&... options) {
     internal::GetBucketAclRequest request(bucket_name, entity);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->GetBucketAcl(request));
+    return raw_client_->GetBucketAcl(request).value();
   }
 
   /**
@@ -1465,7 +1457,7 @@ class Client {
     internal::UpdateBucketAclRequest request(bucket_name, acl.entity(),
                                              acl.role());
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->UpdateBucketAcl(request));
+    return raw_client_->UpdateBucketAcl(request).value();
   }
 
   /**
@@ -1513,7 +1505,7 @@ class Client {
     internal::PatchBucketAclRequest request(bucket_name, entity, original_acl,
                                             new_acl);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->PatchBucketAcl(request));
+    return raw_client_->PatchBucketAcl(request).value();
   }
 
   /**
@@ -1557,7 +1549,7 @@ class Client {
       BucketAccessControlPatchBuilder const& builder, Options&&... options) {
     internal::PatchBucketAclRequest request(bucket_name, entity, builder);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->PatchBucketAcl(request));
+    return raw_client_->PatchBucketAcl(request).value();
   }
   //@}
 
@@ -1604,11 +1596,7 @@ class Client {
                                                  Options&&... options) {
     internal::ListObjectAclRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    auto result = raw_client_->ListObjectAcl(request);
-    if (result.first.ok()) {
-      return result.second.items;
-    }
-    internal::ThrowStatus(std::move(result.first));
+    return raw_client_->ListObjectAcl(request).value().items;
   }
 
   /**
@@ -1640,7 +1628,7 @@ class Client {
     internal::CreateObjectAclRequest request(bucket_name, object_name, entity,
                                              role);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->CreateObjectAcl(request));
+    return raw_client_->CreateObjectAcl(request).value();
   }
 
   /**
@@ -1669,7 +1657,7 @@ class Client {
                        std::string const& entity, Options&&... options) {
     internal::DeleteObjectAclRequest request(bucket_name, object_name, entity);
     request.set_multiple_options(std::forward<Options>(options)...);
-    ThrowOnError(raw_client_->DeleteObjectAcl(request));
+    raw_client_->DeleteObjectAcl(request).value();
   }
 
   /**
@@ -1697,7 +1685,7 @@ class Client {
                                    Options&&... options) {
     internal::GetObjectAclRequest request(bucket_name, object_name, entity);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->GetObjectAcl(request));
+    return raw_client_->GetObjectAcl(request).value();
   }
 
   /**
@@ -1731,7 +1719,7 @@ class Client {
     internal::UpdateObjectAclRequest request(bucket_name, object_name,
                                              acl.entity(), acl.role());
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->UpdateObjectAcl(request));
+    return raw_client_->UpdateObjectAcl(request).value();
   }
 
   /**
@@ -1781,7 +1769,7 @@ class Client {
     internal::PatchObjectAclRequest request(bucket_name, object_name, entity,
                                             original_acl, new_acl);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->PatchObjectAcl(request));
+    return raw_client_->PatchObjectAcl(request).value();
   }
 
   /**
@@ -1827,7 +1815,7 @@ class Client {
     internal::PatchObjectAclRequest request(bucket_name, object_name, entity,
                                             builder);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->PatchObjectAcl(request));
+    return raw_client_->PatchObjectAcl(request).value();
   }
   //@}
 
@@ -1870,11 +1858,7 @@ class Client {
       std::string const& bucket_name, Options&&... options) {
     internal::ListDefaultObjectAclRequest request(bucket_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    auto result = raw_client_->ListDefaultObjectAcl(request);
-    if (result.first.ok()) {
-      return result.second.items;
-    }
-    internal::ThrowStatus(result.first);
+    return raw_client_->ListDefaultObjectAcl(request).value().items;
   }
 
   /**
@@ -1909,7 +1893,7 @@ class Client {
                                              Options&&... options) {
     internal::CreateDefaultObjectAclRequest request(bucket_name, entity, role);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->CreateDefaultObjectAcl(request));
+    return raw_client_->CreateDefaultObjectAcl(request).value();
   }
 
   /**
@@ -1941,7 +1925,7 @@ class Client {
                               std::string const& entity, Options&&... options) {
     internal::DeleteDefaultObjectAclRequest request(bucket_name, entity);
     request.set_multiple_options(std::forward<Options>(options)...);
-    ThrowOnError(raw_client_->DeleteDefaultObjectAcl(request));
+    raw_client_->DeleteDefaultObjectAcl(request).value();
   }
 
   /**
@@ -1973,7 +1957,7 @@ class Client {
                                           Options&&... options) {
     internal::GetDefaultObjectAclRequest request(bucket_name, entity);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->GetDefaultObjectAcl(request));
+    return raw_client_->GetDefaultObjectAcl(request).value();
   }
 
   /**
@@ -2008,7 +1992,7 @@ class Client {
     internal::UpdateDefaultObjectAclRequest request(bucket_name, acl.entity(),
                                                     acl.role());
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->UpdateDefaultObjectAcl(request));
+    return raw_client_->UpdateDefaultObjectAcl(request).value();
   }
 
   /**
@@ -2056,7 +2040,7 @@ class Client {
     internal::PatchDefaultObjectAclRequest request(bucket_name, entity,
                                                    original_acl, new_acl);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->PatchDefaultObjectAcl(request));
+    return raw_client_->PatchDefaultObjectAcl(request).value();
   }
 
   /**
@@ -2102,7 +2086,7 @@ class Client {
     internal::PatchDefaultObjectAclRequest request(bucket_name, entity,
                                                    builder);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->PatchDefaultObjectAcl(request));
+    return raw_client_->PatchDefaultObjectAcl(request).value();
   }
   //@}
 
@@ -2147,7 +2131,7 @@ class Client {
                                              Options&&... options) {
     internal::GetProjectServiceAccountRequest request(project_id);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->GetServiceAccount(request));
+    return raw_client_->GetServiceAccount(request).value();
   }
 
   /**
@@ -2295,11 +2279,7 @@ class Client {
       std::nothrow_t, std::string const& bucket_name, Options&&... options) {
     internal::ListNotificationsRequest request(bucket_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    auto result = raw_client_->ListNotifications(request);
-    if (result.first.ok()) {
-      return std::move(result.second.items);
-    }
-    return std::move(result.first);
+    return raw_client_->ListNotifications(request).value().items;
   }
 
   /**
@@ -2363,7 +2343,7 @@ class Client {
     metadata.set_topic(topic_name).set_payload_format(payload_format);
     internal::CreateNotificationRequest request(bucket_name, metadata);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return AsStatusOr(raw_client_->CreateNotification(request));
+    return raw_client_->CreateNotification(request);
   }
 
   /**
@@ -2400,7 +2380,7 @@ class Client {
                                        Options&&... options) {
     internal::GetNotificationRequest request(bucket_name, notification_id);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ThrowOnError(raw_client_->GetNotification(request));
+    return raw_client_->GetNotification(request).value();
   }
 
   /**
@@ -2439,23 +2419,11 @@ class Client {
                           Options&&... options) {
     internal::DeleteNotificationRequest request(bucket_name, notification_id);
     request.set_multiple_options(std::forward<Options>(options)...);
-    ThrowOnError(raw_client_->DeleteNotification(request));
+    raw_client_->DeleteNotification(request).value();
   }
   //@}
 
  private:
-  template <typename T>
-  StatusOr<T> AsStatusOr(std::pair<Status, T> result) {
-    if (not result.first.ok()) {
-      return std::move(result.first);
-    }
-    return std::move(result.second);
-  }
-
-  Status AsStatus(std::pair<Status, internal::EmptyResponse> result) {
-    return std::move(result.first);
-  }
-
   static std::shared_ptr<internal::RawClient> CreateDefaultClient(
       ClientOptions options);
 
@@ -2510,7 +2478,7 @@ class Client {
       std::string const& file_name,
       internal::ResumableUploadRequest const& request);
 
-  std::pair<Status, ObjectMetadata> UploadStreamResumable(
+  StatusOr<ObjectMetadata> UploadStreamResumable(
       std::istream& source, std::uint64_t source_size,
       internal::ResumableUploadRequest const& request);
 
@@ -2518,14 +2486,6 @@ class Client {
                         std::string const& file_name);
 
   std::string SignUrl(internal::SignUrlRequest const& request);
-
-  template <typename T>
-  T ThrowOnError(std::pair<Status, T> result) {
-    if (result.first.ok()) {
-      return std::move(result.second);
-    }
-    internal::ThrowStatus(std::move(result.first));
-  }
 
   std::shared_ptr<internal::RawClient> raw_client_;
 };

--- a/google/cloud/storage/client_bucket_acl_test.cc
+++ b/google/cloud/storage/client_bucket_acl_test.cc
@@ -70,12 +70,11 @@ TEST_F(BucketAccessControlsTest, ListBucketAcl) {
 
   EXPECT_CALL(*mock, ListBucketAcl(_))
       .WillOnce(Return(
-          std::make_pair(TransientError(), internal::ListBucketAclResponse{})))
+          StatusOr<internal::ListBucketAclResponse>(TransientError())))
       .WillOnce(Invoke([&expected](internal::ListBucketAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
 
-        return std::make_pair(Status(),
-                              internal::ListBucketAclResponse{expected});
+        return make_status_or(internal::ListBucketAclResponse{expected});
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -105,13 +104,13 @@ TEST_F(BucketAccessControlsTest, CreateBucketAcl) {
       })""");
 
   EXPECT_CALL(*mock, CreateBucketAcl(_))
-      .WillOnce(Return(std::make_pair(TransientError(), BucketAccessControl{})))
+      .WillOnce(Return(StatusOr<BucketAccessControl>(TransientError())))
       .WillOnce(Invoke([&expected](internal::CreateBucketAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("user-test-user-1", r.entity());
         EXPECT_EQ("READER", r.role());
 
-        return std::make_pair(Status(), expected);
+        return make_status_or(expected);
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -150,12 +149,12 @@ TEST_F(BucketAccessControlsTest, CreateBucketAclPermanentFailure) {
 TEST_F(BucketAccessControlsTest, DeleteBucketAcl) {
   EXPECT_CALL(*mock, DeleteBucketAcl(_))
       .WillOnce(
-          Return(std::make_pair(TransientError(), internal::EmptyResponse{})))
+          Return(StatusOr<internal::EmptyResponse>(TransientError())))
       .WillOnce(Invoke([](internal::DeleteBucketAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("user-test-user-1", r.entity());
 
-        return std::make_pair(Status(), internal::EmptyResponse{});
+        return make_status_or(internal::EmptyResponse{});
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -192,12 +191,12 @@ TEST_F(BucketAccessControlsTest, GetBucketAcl) {
       })""");
 
   EXPECT_CALL(*mock, GetBucketAcl(_))
-      .WillOnce(Return(std::make_pair(TransientError(), BucketAccessControl{})))
+      .WillOnce(Return(StatusOr<BucketAccessControl>(TransientError())))
       .WillOnce(Invoke([&expected](internal::GetBucketAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("user-test-user-1", r.entity());
 
-        return std::make_pair(Status(), expected);
+        return make_status_or(expected);
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -232,13 +231,13 @@ TEST_F(BucketAccessControlsTest, UpdateBucketAcl) {
       })""");
 
   EXPECT_CALL(*mock, UpdateBucketAcl(_))
-      .WillOnce(Return(std::make_pair(TransientError(), BucketAccessControl{})))
+      .WillOnce(Return(StatusOr<BucketAccessControl>(TransientError())))
       .WillOnce(Invoke([&expected](internal::UpdateBucketAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("user-test-user-1", r.entity());
         EXPECT_EQ("OWNER", r.role());
 
-        return std::make_pair(Status(), expected);
+        return make_status_or(expected);
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -287,7 +286,7 @@ TEST_F(BucketAccessControlsTest, PatchBucketAcl) {
       })""");
 
   EXPECT_CALL(*mock, PatchBucketAcl(_))
-      .WillOnce(Return(std::make_pair(TransientError(), BucketAccessControl{})))
+      .WillOnce(Return(StatusOr<BucketAccessControl>(TransientError())))
       .WillOnce(Invoke([&result](internal::PatchBucketAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("user-test-user-1", r.entity());
@@ -295,7 +294,7 @@ TEST_F(BucketAccessControlsTest, PatchBucketAcl) {
         auto payload = internal::nl::json::parse(r.payload());
         EXPECT_EQ(expected, payload);
 
-        return std::make_pair(Status(), result);
+        return make_status_or(result);
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 

--- a/google/cloud/storage/client_default_object_acl_test.cc
+++ b/google/cloud/storage/client_default_object_acl_test.cc
@@ -69,14 +69,13 @@ TEST_F(DefaultObjectAccessControlsTest, ListDefaultObjectAcl) {
   };
 
   EXPECT_CALL(*mock, ListDefaultObjectAcl(_))
-      .WillOnce(Return(std::make_pair(
-          TransientError(), internal::ListDefaultObjectAclResponse{})))
+      .WillOnce(Return(StatusOr<internal::ListDefaultObjectAclResponse>(
+          TransientError())))
       .WillOnce(
           Invoke([&expected](internal::ListDefaultObjectAclRequest const& r) {
             EXPECT_EQ("test-bucket", r.bucket_name());
 
-            return std::make_pair(
-                Status(), internal::ListDefaultObjectAclResponse{expected});
+            return make_status_or(internal::ListDefaultObjectAclResponse{expected});
           }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -107,14 +106,14 @@ TEST_F(DefaultObjectAccessControlsTest, CreateDefaultObjectAcl) {
       })""");
 
   EXPECT_CALL(*mock, CreateDefaultObjectAcl(_))
-      .WillOnce(Return(std::make_pair(TransientError(), ObjectAccessControl{})))
+      .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
       .WillOnce(
           Invoke([&expected](internal::CreateDefaultObjectAclRequest const& r) {
             EXPECT_EQ("test-bucket", r.bucket_name());
             EXPECT_EQ("user-test-user-1", r.entity());
             EXPECT_EQ("READER", r.role());
 
-            return std::make_pair(Status(), expected);
+            return make_status_or( expected);
           }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -155,12 +154,12 @@ TEST_F(DefaultObjectAccessControlsTest,
 TEST_F(DefaultObjectAccessControlsTest, DeleteDefaultObjectAcl) {
   EXPECT_CALL(*mock, DeleteDefaultObjectAcl(_))
       .WillOnce(
-          Return(std::make_pair(TransientError(), internal::EmptyResponse{})))
+          Return(StatusOr<internal::EmptyResponse>(TransientError())))
       .WillOnce(Invoke([](internal::DeleteDefaultObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("user-test-user", r.entity());
 
-        return std::make_pair(Status(), internal::EmptyResponse{});
+        return make_status_or( internal::EmptyResponse{});
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -199,13 +198,13 @@ TEST_F(DefaultObjectAccessControlsTest, GetDefaultObjectAcl) {
       })""");
 
   EXPECT_CALL(*mock, GetDefaultObjectAcl(_))
-      .WillOnce(Return(std::make_pair(TransientError(), ObjectAccessControl{})))
+      .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
       .WillOnce(
           Invoke([&expected](internal::GetDefaultObjectAclRequest const& r) {
             EXPECT_EQ("test-bucket", r.bucket_name());
             EXPECT_EQ("user-test-user-1", r.entity());
 
-            return std::make_pair(Status(), expected);
+            return make_status_or( expected);
           }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -240,14 +239,14 @@ TEST_F(DefaultObjectAccessControlsTest, UpdateDefaultObjectAcl) {
       })""");
 
   EXPECT_CALL(*mock, UpdateDefaultObjectAcl(_))
-      .WillOnce(Return(std::make_pair(TransientError(), ObjectAccessControl{})))
+      .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
       .WillOnce(
           Invoke([&expected](internal::UpdateDefaultObjectAclRequest const& r) {
             EXPECT_EQ("test-bucket", r.bucket_name());
             EXPECT_EQ("user-test-user-1", r.entity());
             EXPECT_EQ("READER", r.role());
 
-            return std::make_pair(Status(), expected);
+            return make_status_or( expected);
           }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -294,7 +293,7 @@ TEST_F(DefaultObjectAccessControlsTest, PatchDefaultObjectAcl) {
           "role": "OWNER"
       })""");
   EXPECT_CALL(*mock, PatchDefaultObjectAcl(_))
-      .WillOnce(Return(std::make_pair(TransientError(), ObjectAccessControl{})))
+      .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
       .WillOnce(
           Invoke([result](internal::PatchDefaultObjectAclRequest const& r) {
             EXPECT_EQ("test-bucket", r.bucket_name());
@@ -303,7 +302,7 @@ TEST_F(DefaultObjectAccessControlsTest, PatchDefaultObjectAcl) {
             auto payload = internal::nl::json::parse(r.payload());
             EXPECT_EQ(expected, payload);
 
-            return std::make_pair(Status(), result);
+            return make_status_or( result);
           }));
 
   Client client{std::shared_ptr<internal::RawClient>(mock)};

--- a/google/cloud/storage/client_default_object_acl_test.cc
+++ b/google/cloud/storage/client_default_object_acl_test.cc
@@ -113,7 +113,7 @@ TEST_F(DefaultObjectAccessControlsTest, CreateDefaultObjectAcl) {
             EXPECT_EQ("user-test-user-1", r.entity());
             EXPECT_EQ("READER", r.role());
 
-            return make_status_or( expected);
+            return make_status_or(expected);
           }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -159,7 +159,7 @@ TEST_F(DefaultObjectAccessControlsTest, DeleteDefaultObjectAcl) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("user-test-user", r.entity());
 
-        return make_status_or( internal::EmptyResponse{});
+        return make_status_or(internal::EmptyResponse{});
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -204,7 +204,7 @@ TEST_F(DefaultObjectAccessControlsTest, GetDefaultObjectAcl) {
             EXPECT_EQ("test-bucket", r.bucket_name());
             EXPECT_EQ("user-test-user-1", r.entity());
 
-            return make_status_or( expected);
+            return make_status_or(expected);
           }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -246,7 +246,7 @@ TEST_F(DefaultObjectAccessControlsTest, UpdateDefaultObjectAcl) {
             EXPECT_EQ("user-test-user-1", r.entity());
             EXPECT_EQ("READER", r.role());
 
-            return make_status_or( expected);
+            return make_status_or(expected);
           }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -302,7 +302,7 @@ TEST_F(DefaultObjectAccessControlsTest, PatchDefaultObjectAcl) {
             auto payload = internal::nl::json::parse(r.payload());
             EXPECT_EQ(expected, payload);
 
-            return make_status_or( result);
+            return make_status_or(result);
           }));
 
   Client client{std::shared_ptr<internal::RawClient>(mock)};

--- a/google/cloud/storage/client_notifications_test.cc
+++ b/google/cloud/storage/client_notifications_test.cc
@@ -70,14 +70,13 @@ TEST_F(NotificationsTest, ListNotifications) {
   };
 
   EXPECT_CALL(*mock_, ListNotifications(_))
-      .WillOnce(Return(std::make_pair(TransientError(),
-                                      internal::ListNotificationsResponse{})))
+      .WillOnce(Return(StatusOr<internal::ListNotificationsResponse>(TransientError()
+                                      )))
       .WillOnce(
           Invoke([&expected](internal::ListNotificationsRequest const& r) {
             EXPECT_EQ("test-bucket", r.bucket_name());
 
-            return std::make_pair(
-                Status(), internal::ListNotificationsResponse{expected});
+            return make_status_or(internal::ListNotificationsResponse{expected});
           }));
   Client client{std::shared_ptr<internal::RawClient>(mock_)};
 
@@ -111,7 +110,7 @@ TEST_F(NotificationsTest, CreateNotification) {
 
   EXPECT_CALL(*mock_, CreateNotification(_))
       .WillOnce(
-          Return(std::make_pair(TransientError(), NotificationMetadata{})))
+          Return(StatusOr<NotificationMetadata>(TransientError())))
       .WillOnce(
           Invoke([&expected](internal::CreateNotificationRequest const& r) {
             EXPECT_EQ("test-bucket", r.bucket_name());
@@ -120,7 +119,7 @@ TEST_F(NotificationsTest, CreateNotification) {
             EXPECT_THAT(r.json_payload(), HasSubstr("test-object-prefix-"));
             EXPECT_THAT(r.json_payload(), HasSubstr("OBJECT_FINALIZE"));
 
-            return std::make_pair(Status(), expected);
+            return make_status_or( expected);
           }));
   Client client{std::shared_ptr<internal::RawClient>(mock_)};
 
@@ -165,12 +164,12 @@ TEST_F(NotificationsTest, GetNotification) {
 
   EXPECT_CALL(*mock_, GetNotification(_))
       .WillOnce(
-          Return(std::make_pair(TransientError(), NotificationMetadata{})))
+          Return(StatusOr<NotificationMetadata>(TransientError())))
       .WillOnce(Invoke([&expected](internal::GetNotificationRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-notification-1", r.notification_id());
 
-        return std::make_pair(Status(), expected);
+        return make_status_or( expected);
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock_)};
 
@@ -200,12 +199,12 @@ TEST_F(NotificationsTest, GetNotificationPermanentFailure) {
 TEST_F(NotificationsTest, DeleteNotification) {
   EXPECT_CALL(*mock_, DeleteNotification(_))
       .WillOnce(
-          Return(std::make_pair(TransientError(), internal::EmptyResponse{})))
+          Return(StatusOr<internal::EmptyResponse>(TransientError())))
       .WillOnce(Invoke([](internal::DeleteNotificationRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-notification-1", r.notification_id());
 
-        return std::make_pair(Status(), internal::EmptyResponse{});
+        return make_status_or( internal::EmptyResponse{});
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock_)};
 

--- a/google/cloud/storage/client_notifications_test.cc
+++ b/google/cloud/storage/client_notifications_test.cc
@@ -119,7 +119,7 @@ TEST_F(NotificationsTest, CreateNotification) {
             EXPECT_THAT(r.json_payload(), HasSubstr("test-object-prefix-"));
             EXPECT_THAT(r.json_payload(), HasSubstr("OBJECT_FINALIZE"));
 
-            return make_status_or( expected);
+            return make_status_or(expected);
           }));
   Client client{std::shared_ptr<internal::RawClient>(mock_)};
 
@@ -169,7 +169,7 @@ TEST_F(NotificationsTest, GetNotification) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-notification-1", r.notification_id());
 
-        return make_status_or( expected);
+        return make_status_or(expected);
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock_)};
 
@@ -204,7 +204,7 @@ TEST_F(NotificationsTest, DeleteNotification) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-notification-1", r.notification_id());
 
-        return make_status_or( internal::EmptyResponse{});
+        return make_status_or(internal::EmptyResponse{});
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock_)};
 

--- a/google/cloud/storage/client_object_acl_test.cc
+++ b/google/cloud/storage/client_object_acl_test.cc
@@ -71,12 +71,12 @@ TEST_F(ObjectAccessControlsTest, ListObjectAcl) {
 
   EXPECT_CALL(*mock, ListObjectAcl(_))
       .WillOnce(Return(
-          std::make_pair(TransientError(), internal::ListObjectAclResponse{})))
+          StatusOr<internal::ListObjectAclResponse>(TransientError())))
       .WillOnce(Invoke([&expected](internal::ListObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-object", r.object_name());
 
-        return std::make_pair(Status(),
+        return make_status_or(
                               internal::ListObjectAclResponse{expected});
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
@@ -113,14 +113,14 @@ TEST_F(ObjectAccessControlsTest, CreateObjectAcl) {
       })""");
 
   EXPECT_CALL(*mock, CreateObjectAcl(_))
-      .WillOnce(Return(std::make_pair(TransientError(), ObjectAccessControl{})))
+      .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
       .WillOnce(Invoke([&expected](internal::CreateObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-object", r.object_name());
         EXPECT_EQ("user-test-user-1", r.entity());
         EXPECT_EQ("READER", r.role());
 
-        return std::make_pair(Status(), expected);
+        return make_status_or( expected);
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -163,13 +163,13 @@ TEST_F(ObjectAccessControlsTest, CreateObjectAclPermanentFailure) {
 TEST_F(ObjectAccessControlsTest, DeleteObjectAcl) {
   EXPECT_CALL(*mock, DeleteObjectAcl(_))
       .WillOnce(
-          Return(std::make_pair(TransientError(), internal::EmptyResponse{})))
+          Return(StatusOr<internal::EmptyResponse>(TransientError())))
       .WillOnce(Invoke([](internal::DeleteObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-object", r.object_name());
         EXPECT_EQ("user-test-user", r.entity());
 
-        return std::make_pair(Status(), internal::EmptyResponse{});
+        return make_status_or( internal::EmptyResponse{});
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -210,13 +210,13 @@ TEST_F(ObjectAccessControlsTest, GetObjectAcl) {
       })""");
 
   EXPECT_CALL(*mock, GetObjectAcl(_))
-      .WillOnce(Return(std::make_pair(TransientError(), ObjectAccessControl{})))
+      .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
       .WillOnce(Invoke([&expected](internal::GetObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-object", r.object_name());
         EXPECT_EQ("user-test-user-1", r.entity());
 
-        return std::make_pair(Status(), expected);
+        return make_status_or( expected);
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -253,14 +253,14 @@ TEST_F(ObjectAccessControlsTest, UpdateObjectAcl) {
           "role": "OWNER"
       })""");
   EXPECT_CALL(*mock, UpdateObjectAcl(_))
-      .WillOnce(Return(std::make_pair(TransientError(), ObjectAccessControl{})))
+      .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
       .WillOnce(Invoke([expected](internal::UpdateObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-object", r.object_name());
         EXPECT_EQ("user-test-user", r.entity());
         EXPECT_EQ("OWNER", r.role());
 
-        return std::make_pair(Status(), expected);
+        return make_status_or( expected);
       }));
 
   Client client{std::shared_ptr<internal::RawClient>(mock)};
@@ -302,7 +302,7 @@ TEST_F(ObjectAccessControlsTest, PatchObjectAcl) {
           "role": "OWNER"
       })""");
   EXPECT_CALL(*mock, PatchObjectAcl(_))
-      .WillOnce(Return(std::make_pair(TransientError(), ObjectAccessControl{})))
+      .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
       .WillOnce(Invoke([result](internal::PatchObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-object", r.object_name());
@@ -311,7 +311,7 @@ TEST_F(ObjectAccessControlsTest, PatchObjectAcl) {
         auto payload = internal::nl::json::parse(r.payload());
         EXPECT_EQ(expected, payload);
 
-        return std::make_pair(Status(), result);
+        return make_status_or( result);
       }));
 
   Client client{std::shared_ptr<internal::RawClient>(mock)};

--- a/google/cloud/storage/client_object_acl_test.cc
+++ b/google/cloud/storage/client_object_acl_test.cc
@@ -76,8 +76,7 @@ TEST_F(ObjectAccessControlsTest, ListObjectAcl) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-object", r.object_name());
 
-        return make_status_or(
-                              internal::ListObjectAclResponse{expected});
+        return make_status_or(internal::ListObjectAclResponse{expected});
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -120,7 +119,7 @@ TEST_F(ObjectAccessControlsTest, CreateObjectAcl) {
         EXPECT_EQ("user-test-user-1", r.entity());
         EXPECT_EQ("READER", r.role());
 
-        return make_status_or( expected);
+        return make_status_or(expected);
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -169,7 +168,7 @@ TEST_F(ObjectAccessControlsTest, DeleteObjectAcl) {
         EXPECT_EQ("test-object", r.object_name());
         EXPECT_EQ("user-test-user", r.entity());
 
-        return make_status_or( internal::EmptyResponse{});
+        return make_status_or(internal::EmptyResponse{});
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -216,7 +215,7 @@ TEST_F(ObjectAccessControlsTest, GetObjectAcl) {
         EXPECT_EQ("test-object", r.object_name());
         EXPECT_EQ("user-test-user-1", r.entity());
 
-        return make_status_or( expected);
+        return make_status_or(expected);
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
@@ -260,7 +259,7 @@ TEST_F(ObjectAccessControlsTest, UpdateObjectAcl) {
         EXPECT_EQ("user-test-user", r.entity());
         EXPECT_EQ("OWNER", r.role());
 
-        return make_status_or( expected);
+        return make_status_or(expected);
       }));
 
   Client client{std::shared_ptr<internal::RawClient>(mock)};
@@ -311,7 +310,7 @@ TEST_F(ObjectAccessControlsTest, PatchObjectAcl) {
         auto payload = internal::nl::json::parse(r.payload());
         EXPECT_EQ(expected, payload);
 
-        return make_status_or( result);
+        return make_status_or(result);
       }));
 
   Client client{std::shared_ptr<internal::RawClient>(mock)};

--- a/google/cloud/storage/client_object_copy_test.cc
+++ b/google/cloud/storage/client_object_copy_test.cc
@@ -144,7 +144,7 @@ TEST_F(ObjectCopyTest, ComposeObject) {
             {"kind", "storage#composeRequest"},
             {"sourceObjects", {{{"name", "object1"}}, {{"name", "object2"}}}}};
         EXPECT_EQ(expected_payload, actual_payload);
-        return make_status_or( expected);
+        return make_status_or(expected);
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock),
                 LimitedErrorCountRetryPolicy(2)};
@@ -197,8 +197,7 @@ TEST_F(ObjectCopyTest, RewriteObject) {
             "done": false,
             "rewriteToken": "abcd-test-token-0"
         })""";
-        return make_status_or(
-                              internal::RewriteObjectResponse::FromHttpResponse(
+        return make_status_or(internal::RewriteObjectResponse::FromHttpResponse(
                                   internal::HttpResponse{200, response, {}}));
       }))
       .WillOnce(Invoke([](internal::RewriteObjectRequest const& r) {
@@ -215,8 +214,7 @@ TEST_F(ObjectCopyTest, RewriteObject) {
             "done": false,
             "rewriteToken": "abcd-test-token-2"
         })""";
-        return make_status_or(
-                              internal::RewriteObjectResponse::FromHttpResponse(
+        return make_status_or(internal::RewriteObjectResponse::FromHttpResponse(
                                   internal::HttpResponse{200, response, {}}));
       }))
       .WillOnce(Invoke([](internal::RewriteObjectRequest const& r) {
@@ -237,8 +235,7 @@ TEST_F(ObjectCopyTest, RewriteObject) {
                "name": "test-destination-object-name"
             }
         })""";
-        return make_status_or(
-                              internal::RewriteObjectResponse::FromHttpResponse(
+        return make_status_or(internal::RewriteObjectResponse::FromHttpResponse(
                                   internal::HttpResponse{200, response, {}}));
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock),

--- a/google/cloud/storage/client_service_account_test.cc
+++ b/google/cloud/storage/client_service_account_test.cc
@@ -60,12 +60,12 @@ TEST_F(ServiceAccountTest, GetProjectServiceAccount) {
       })""");
 
   EXPECT_CALL(*mock, GetServiceAccount(_))
-      .WillOnce(Return(std::make_pair(TransientError(), ServiceAccount{})))
+      .WillOnce(Return(StatusOr<ServiceAccount>(TransientError())))
       .WillOnce(Invoke(
           [&expected](internal::GetProjectServiceAccountRequest const& r) {
             EXPECT_EQ("test-project", r.project_id());
 
-            return std::make_pair(Status(), expected);
+            return make_status_or(expected);
           }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 

--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -89,8 +89,8 @@ TEST_F(ClientTest, OverrideRetryPolicy) {
   // Call an API (any API) on the client, we do not care about the status, just
   // that our policy is called.
   EXPECT_CALL(*mock, GetBucketMetadata(_))
-      .WillOnce(Return(std::make_pair(TransientError(), BucketMetadata{})))
-      .WillOnce(Return(std::make_pair(Status(), BucketMetadata{})));
+      .WillOnce(Return(StatusOr<BucketMetadata>(TransientError())))
+      .WillOnce(Return(make_status_or(BucketMetadata{})));
   (void)client.GetBucketMetadata("foo-bar-baz");
   EXPECT_LE(1, ObservableRetryPolicy::is_exhausted_call_count);
   EXPECT_EQ(0, ObservableBackoffPolicy::on_completion_call_count);
@@ -104,8 +104,8 @@ TEST_F(ClientTest, OverrideBackoffPolicy) {
   // Call an API (any API) on the client, we do not care about the status, just
   // that our policy is called.
   EXPECT_CALL(*mock, GetBucketMetadata(_))
-      .WillOnce(Return(std::make_pair(TransientError(), BucketMetadata{})))
-      .WillOnce(Return(std::make_pair(Status(), BucketMetadata{})));
+      .WillOnce(Return(StatusOr<BucketMetadata>(TransientError())))
+      .WillOnce(Return(make_status_or( BucketMetadata{})));
   (void)client.GetBucketMetadata("foo-bar-baz");
   EXPECT_EQ(0, ObservableRetryPolicy::is_exhausted_call_count);
   EXPECT_LE(1, ObservableBackoffPolicy::on_completion_call_count);
@@ -120,8 +120,8 @@ TEST_F(ClientTest, OverrideBothPolicies) {
   // Call an API (any API) on the client, we do not care about the status, just
   // that our policy is called.
   EXPECT_CALL(*mock, GetBucketMetadata(_))
-      .WillOnce(Return(std::make_pair(TransientError(), BucketMetadata{})))
-      .WillOnce(Return(std::make_pair(Status(), BucketMetadata{})));
+      .WillOnce(Return(StatusOr<BucketMetadata>(TransientError())))
+      .WillOnce(Return(make_status_or( BucketMetadata{})));
   (void)client.GetBucketMetadata("foo-bar-baz");
   EXPECT_LE(1, ObservableRetryPolicy::is_exhausted_call_count);
   EXPECT_LE(1, ObservableBackoffPolicy::on_completion_call_count);

--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -105,7 +105,7 @@ TEST_F(ClientTest, OverrideBackoffPolicy) {
   // that our policy is called.
   EXPECT_CALL(*mock, GetBucketMetadata(_))
       .WillOnce(Return(StatusOr<BucketMetadata>(TransientError())))
-      .WillOnce(Return(make_status_or( BucketMetadata{})));
+      .WillOnce(Return(make_status_or(BucketMetadata{})));
   (void)client.GetBucketMetadata("foo-bar-baz");
   EXPECT_EQ(0, ObservableRetryPolicy::is_exhausted_call_count);
   EXPECT_LE(1, ObservableBackoffPolicy::on_completion_call_count);
@@ -121,7 +121,7 @@ TEST_F(ClientTest, OverrideBothPolicies) {
   // that our policy is called.
   EXPECT_CALL(*mock, GetBucketMetadata(_))
       .WillOnce(Return(StatusOr<BucketMetadata>(TransientError())))
-      .WillOnce(Return(make_status_or( BucketMetadata{})));
+      .WillOnce(Return(make_status_or(BucketMetadata{})));
   (void)client.GetBucketMetadata("foo-bar-baz");
   EXPECT_LE(1, ObservableRetryPolicy::is_exhausted_call_count);
   EXPECT_LE(1, ObservableBackoffPolicy::on_completion_call_count);

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -60,114 +60,113 @@ class CurlClient : public RawClient,
   // them is very different from the standard retry loop. Also note that these
   // are virtual functions only because we need to override them in the unit
   // tests.
-  virtual std::pair<Status, ResumableUploadResponse> UploadChunk(
+  virtual StatusOr<ResumableUploadResponse> UploadChunk(
       UploadChunkRequest const&);
-  virtual std::pair<Status, ResumableUploadResponse> QueryResumableUpload(
+  virtual StatusOr<ResumableUploadResponse> QueryResumableUpload(
       QueryResumableUploadRequest const&);
   //@}
 
   ClientOptions const& client_options() const override { return options_; }
 
-  std::pair<Status, ListBucketsResponse> ListBuckets(
+  StatusOr<ListBucketsResponse> ListBuckets(
       ListBucketsRequest const& request) override;
-  std::pair<Status, BucketMetadata> CreateBucket(
+  StatusOr<BucketMetadata> CreateBucket(
       CreateBucketRequest const& request) override;
-  std::pair<Status, BucketMetadata> GetBucketMetadata(
+  StatusOr<BucketMetadata> GetBucketMetadata(
       GetBucketMetadataRequest const& request) override;
-  std::pair<Status, EmptyResponse> DeleteBucket(
-      DeleteBucketRequest const&) override;
-  std::pair<Status, BucketMetadata> UpdateBucket(
+  StatusOr<EmptyResponse> DeleteBucket(DeleteBucketRequest const&) override;
+  StatusOr<BucketMetadata> UpdateBucket(
       UpdateBucketRequest const& request) override;
-  std::pair<Status, BucketMetadata> PatchBucket(
+  StatusOr<BucketMetadata> PatchBucket(
       PatchBucketRequest const& request) override;
-  std::pair<Status, IamPolicy> GetBucketIamPolicy(
+  StatusOr<IamPolicy> GetBucketIamPolicy(
       GetBucketIamPolicyRequest const& request) override;
-  std::pair<Status, IamPolicy> SetBucketIamPolicy(
+  StatusOr<IamPolicy> SetBucketIamPolicy(
       SetBucketIamPolicyRequest const& request) override;
-  std::pair<Status, TestBucketIamPermissionsResponse> TestBucketIamPermissions(
+  StatusOr<TestBucketIamPermissionsResponse> TestBucketIamPermissions(
       TestBucketIamPermissionsRequest const& request) override;
-  std::pair<Status, EmptyResponse> LockBucketRetentionPolicy(
+  StatusOr<EmptyResponse> LockBucketRetentionPolicy(
       LockBucketRetentionPolicyRequest const& request) override;
 
-  std::pair<Status, ObjectMetadata> InsertObjectMedia(
+  StatusOr<ObjectMetadata> InsertObjectMedia(
       InsertObjectMediaRequest const& request) override;
-  std::pair<Status, ObjectMetadata> GetObjectMetadata(
+  StatusOr<ObjectMetadata> GetObjectMetadata(
       GetObjectMetadataRequest const& request) override;
-  std::pair<Status, std::unique_ptr<ObjectReadStreambuf>> ReadObject(
+  StatusOr<std::unique_ptr<ObjectReadStreambuf>> ReadObject(
       ReadObjectRangeRequest const&) override;
-  std::pair<Status, std::unique_ptr<ObjectWriteStreambuf>> WriteObject(
+  StatusOr<std::unique_ptr<ObjectWriteStreambuf>> WriteObject(
       InsertObjectStreamingRequest const&) override;
-  std::pair<Status, ListObjectsResponse> ListObjects(
+  StatusOr<ListObjectsResponse> ListObjects(
       ListObjectsRequest const& request) override;
-  std::pair<Status, EmptyResponse> DeleteObject(
+  StatusOr<EmptyResponse> DeleteObject(
       DeleteObjectRequest const& request) override;
-  std::pair<Status, ObjectMetadata> UpdateObject(
+  StatusOr<ObjectMetadata> UpdateObject(
       UpdateObjectRequest const& request) override;
-  std::pair<Status, ObjectMetadata> PatchObject(
+  StatusOr<ObjectMetadata> PatchObject(
       PatchObjectRequest const& request) override;
-  std::pair<Status, ObjectMetadata> ComposeObject(
+  StatusOr<ObjectMetadata> ComposeObject(
       ComposeObjectRequest const& request) override;
-  std::pair<Status, std::unique_ptr<ResumableUploadSession>>
-  CreateResumableSession(ResumableUploadRequest const& request) override;
-  std::pair<Status, std::unique_ptr<ResumableUploadSession>>
-  RestoreResumableSession(std::string const& session_id) override;
+  StatusOr<std::unique_ptr<ResumableUploadSession>> CreateResumableSession(
+      ResumableUploadRequest const& request) override;
+  StatusOr<std::unique_ptr<ResumableUploadSession>> RestoreResumableSession(
+      std::string const& session_id) override;
 
-  std::pair<Status, ListBucketAclResponse> ListBucketAcl(
+  StatusOr<ListBucketAclResponse> ListBucketAcl(
       ListBucketAclRequest const& request) override;
-  std::pair<Status, ObjectMetadata> CopyObject(
+  StatusOr<ObjectMetadata> CopyObject(
       CopyObjectRequest const& request) override;
-  std::pair<Status, BucketAccessControl> CreateBucketAcl(
+  StatusOr<BucketAccessControl> CreateBucketAcl(
       CreateBucketAclRequest const&) override;
-  std::pair<Status, BucketAccessControl> GetBucketAcl(
+  StatusOr<BucketAccessControl> GetBucketAcl(
       GetBucketAclRequest const&) override;
-  std::pair<Status, EmptyResponse> DeleteBucketAcl(
+  StatusOr<EmptyResponse> DeleteBucketAcl(
       DeleteBucketAclRequest const&) override;
-  std::pair<Status, BucketAccessControl> UpdateBucketAcl(
+  StatusOr<BucketAccessControl> UpdateBucketAcl(
       UpdateBucketAclRequest const&) override;
-  std::pair<Status, BucketAccessControl> PatchBucketAcl(
+  StatusOr<BucketAccessControl> PatchBucketAcl(
       PatchBucketAclRequest const&) override;
 
-  std::pair<Status, ListObjectAclResponse> ListObjectAcl(
+  StatusOr<ListObjectAclResponse> ListObjectAcl(
       ListObjectAclRequest const& request) override;
-  std::pair<Status, ObjectAccessControl> CreateObjectAcl(
+  StatusOr<ObjectAccessControl> CreateObjectAcl(
       CreateObjectAclRequest const&) override;
-  std::pair<Status, EmptyResponse> DeleteObjectAcl(
+  StatusOr<EmptyResponse> DeleteObjectAcl(
       DeleteObjectAclRequest const&) override;
-  std::pair<Status, ObjectAccessControl> GetObjectAcl(
+  StatusOr<ObjectAccessControl> GetObjectAcl(
       GetObjectAclRequest const&) override;
-  std::pair<Status, ObjectAccessControl> UpdateObjectAcl(
+  StatusOr<ObjectAccessControl> UpdateObjectAcl(
       UpdateObjectAclRequest const&) override;
-  std::pair<Status, ObjectAccessControl> PatchObjectAcl(
+  StatusOr<ObjectAccessControl> PatchObjectAcl(
       PatchObjectAclRequest const&) override;
-  std::pair<Status, RewriteObjectResponse> RewriteObject(
+  StatusOr<RewriteObjectResponse> RewriteObject(
       RewriteObjectRequest const&) override;
 
-  std::pair<Status, ListDefaultObjectAclResponse> ListDefaultObjectAcl(
+  StatusOr<ListDefaultObjectAclResponse> ListDefaultObjectAcl(
       ListDefaultObjectAclRequest const& request) override;
-  std::pair<Status, ObjectAccessControl> CreateDefaultObjectAcl(
+  StatusOr<ObjectAccessControl> CreateDefaultObjectAcl(
       CreateDefaultObjectAclRequest const&) override;
-  std::pair<Status, EmptyResponse> DeleteDefaultObjectAcl(
+  StatusOr<EmptyResponse> DeleteDefaultObjectAcl(
       DeleteDefaultObjectAclRequest const&) override;
-  std::pair<Status, ObjectAccessControl> GetDefaultObjectAcl(
+  StatusOr<ObjectAccessControl> GetDefaultObjectAcl(
       GetDefaultObjectAclRequest const&) override;
-  std::pair<Status, ObjectAccessControl> UpdateDefaultObjectAcl(
+  StatusOr<ObjectAccessControl> UpdateDefaultObjectAcl(
       UpdateDefaultObjectAclRequest const&) override;
-  std::pair<Status, ObjectAccessControl> PatchDefaultObjectAcl(
+  StatusOr<ObjectAccessControl> PatchDefaultObjectAcl(
       PatchDefaultObjectAclRequest const&) override;
 
-  std::pair<Status, ServiceAccount> GetServiceAccount(
+  StatusOr<ServiceAccount> GetServiceAccount(
       GetProjectServiceAccountRequest const&) override;
 
-  std::pair<Status, ListNotificationsResponse> ListNotifications(
+  StatusOr<ListNotificationsResponse> ListNotifications(
       ListNotificationsRequest const&) override;
-  std::pair<Status, NotificationMetadata> CreateNotification(
+  StatusOr<NotificationMetadata> CreateNotification(
       CreateNotificationRequest const&) override;
-  std::pair<Status, NotificationMetadata> GetNotification(
+  StatusOr<NotificationMetadata> GetNotification(
       GetNotificationRequest const&) override;
-  std::pair<Status, EmptyResponse> DeleteNotification(
+  StatusOr<EmptyResponse> DeleteNotification(
       DeleteNotificationRequest const&) override;
 
-  std::pair<Status, std::string> AuthorizationHeader(
+  StatusOr<std::string> AuthorizationHeader(
       std::shared_ptr<google::cloud::storage::oauth2::Credentials> const&);
 
   void LockShared();
@@ -187,32 +186,32 @@ class CurlClient : public RawClient,
   Status SetupBuilder(CurlRequestBuilder& builder, Request const& request,
                       char const* method);
 
-  std::pair<Status, ObjectMetadata> InsertObjectMediaXml(
+  StatusOr<ObjectMetadata> InsertObjectMediaXml(
       InsertObjectMediaRequest const& request);
-  std::pair<Status, std::unique_ptr<ObjectReadStreambuf>> ReadObjectXml(
+  StatusOr<std::unique_ptr<ObjectReadStreambuf>> ReadObjectXml(
       ReadObjectRangeRequest const& request);
-  std::pair<Status, std::unique_ptr<ObjectWriteStreambuf>> WriteObjectXml(
+  StatusOr<std::unique_ptr<ObjectWriteStreambuf>> WriteObjectXml(
       InsertObjectStreamingRequest const& request);
 
   /// Insert an object using uploadType=multipart.
-  std::pair<Status, ObjectMetadata> InsertObjectMediaMultipart(
+  StatusOr<ObjectMetadata> InsertObjectMediaMultipart(
       InsertObjectMediaRequest const& request);
   std::string PickBoundary(std::string const& text_to_avoid);
 
   /// Insert an object using uploadType=media.
-  std::pair<Status, ObjectMetadata> InsertObjectMediaSimple(
+  StatusOr<ObjectMetadata> InsertObjectMediaSimple(
       InsertObjectMediaRequest const& request);
 
   /// Upload an object using uploadType=simple.
-  std::pair<Status, std::unique_ptr<ObjectWriteStreambuf>> WriteObjectSimple(
+  StatusOr<std::unique_ptr<ObjectWriteStreambuf>> WriteObjectSimple(
       InsertObjectStreamingRequest const& request);
 
   /// Upload an object using uploadType=resumable.
-  std::pair<Status, std::unique_ptr<ObjectWriteStreambuf>> WriteObjectResumable(
+  StatusOr<std::unique_ptr<ObjectWriteStreambuf>> WriteObjectResumable(
       InsertObjectStreamingRequest const& request);
 
   template <typename RequestType>
-  std::pair<Status, std::unique_ptr<ResumableUploadSession>>
+  StatusOr<std::unique_ptr<ResumableUploadSession>>
   CreateResumableSessionGeneric(RequestType const& request);
 
   ClientOptions options_;

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -41,8 +41,8 @@ std::string const STATUS_ERROR_MSG =
 // could simply mock those out instead via MOCK_METHOD<N> macros.
 class FailingCredentials : public Credentials {
  public:
-  std::pair<Status, std::string> AuthorizationHeader() override {
-    return std::make_pair(Status(STATUS_ERROR_CODE, STATUS_ERROR_MSG), "");
+  StatusOr<std::string> AuthorizationHeader() override {
+    return Status(STATUS_ERROR_CODE, STATUS_ERROR_MSG);
   }
 };
 
@@ -65,285 +65,285 @@ void TestCorrectFailureStatus(Status const& status) {
 }
 
 TEST_F(CurlClientTest, UploadChunk) {
-  auto status_and_foo = client_->UploadChunk(
+  auto status_or_foo = client_->UploadChunk(
       UploadChunkRequest("http://unused.googleapis.com/invalid-session-id", 0U,
                          std::string{}, 0U));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, QueryResumableUpload) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->QueryResumableUpload(QueryResumableUploadRequest(
           "http://unused.googleapis.com/invalid-session-id"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, ListBuckets) {
-  auto status_and_foo = client_->ListBuckets(ListBucketsRequest{"project_id"});
-  TestCorrectFailureStatus(status_and_foo.first);
+  auto status_or_foo = client_->ListBuckets(ListBucketsRequest{"project_id"});
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, CreateBucket) {
-  auto status_and_foo = client_->CreateBucket(
+  auto status_or_foo = client_->CreateBucket(
       CreateBucketRequest("bkt", BucketMetadata().set_name("bkt")));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, GetBucketMetadata) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->GetBucketMetadata(GetBucketMetadataRequest("bkt"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, DeleteBucket) {
-  auto status_and_foo = client_->DeleteBucket(DeleteBucketRequest("bkt"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  auto status_or_foo = client_->DeleteBucket(DeleteBucketRequest("bkt"));
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, UpdateBucket) {
-  auto status_and_foo = client_->UpdateBucket(
+  auto status_or_foo = client_->UpdateBucket(
       UpdateBucketRequest(BucketMetadata().set_name("bkt")));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, PatchBucket) {
-  auto status_and_foo = client_->PatchBucket(
+  auto status_or_foo = client_->PatchBucket(
       PatchBucketRequest("bkt", BucketMetadata().set_name("bkt"),
                          BucketMetadata().set_name("bkt")));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, GetBucketIamPolicy) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->GetBucketIamPolicy(GetBucketIamPolicyRequest("bkt"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, SetBucketIamPolicy) {
-  auto status_and_foo = client_->SetBucketIamPolicy(
+  auto status_or_foo = client_->SetBucketIamPolicy(
       SetBucketIamPolicyRequest("bkt", google::cloud::IamPolicy{}));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, TestBucketIamPermissions) {
-  auto status_and_foo = client_->TestBucketIamPermissions(
+  auto status_or_foo = client_->TestBucketIamPermissions(
       TestBucketIamPermissionsRequest("bkt", {}));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, LockBucketRetentionPolicy) {
-  auto status_and_foo = client_->LockBucketRetentionPolicy(
+  auto status_or_foo = client_->LockBucketRetentionPolicy(
       LockBucketRetentionPolicyRequest("bkt", 0U));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, InsertObjectMedia) {
-  auto status_and_foo = client_->InsertObjectMedia(
+  auto status_or_foo = client_->InsertObjectMedia(
       InsertObjectMediaRequest("bkt", "obj", "contents"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, GetObjectMetadata) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->GetObjectMetadata(GetObjectMetadataRequest("bkt", "obj"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, ReadObject) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->ReadObject(ReadObjectRangeRequest("bkt", "obj"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, WriteObject) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->WriteObject(InsertObjectStreamingRequest("bkt", "obj"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, ListObjects) {
-  auto status_and_foo = client_->ListObjects(ListObjectsRequest("bkt"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  auto status_or_foo = client_->ListObjects(ListObjectsRequest("bkt"));
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, DeleteObject) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->DeleteObject(DeleteObjectRequest("bkt", "obj"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, UpdateObject) {
-  auto status_and_foo = client_->UpdateObject(
+  auto status_or_foo = client_->UpdateObject(
       UpdateObjectRequest("bkt", "obj", ObjectMetadata()));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, PatchObject) {
-  auto status_and_foo = client_->PatchObject(
+  auto status_or_foo = client_->PatchObject(
       PatchObjectRequest("bkt", "obj", ObjectMetadata(), ObjectMetadata()));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, ComposeObject) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->ComposeObject(ComposeObjectRequest("bkt", {}, "obj"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, ListBucketAcl) {
-  auto status_and_foo = client_->ListBucketAcl(ListBucketAclRequest("bkt"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  auto status_or_foo = client_->ListBucketAcl(ListBucketAclRequest("bkt"));
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, CopyObject) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->CopyObject(CopyObjectRequest("bkt", "obj1", "bkt", "obj2"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, CreateBucketAcl) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->CreateBucketAcl(CreateBucketAclRequest("bkt", "entity", "role"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, GetBucketAcl) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->GetBucketAcl(GetBucketAclRequest("bkt", "entity"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, DeleteBucketAcl) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->DeleteBucketAcl(DeleteBucketAclRequest("bkt", "entity"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, UpdateBucketAcl) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->UpdateBucketAcl(UpdateBucketAclRequest("bkt", "entity", "role"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, PatchBucketAcl) {
-  auto status_and_foo = client_->PatchBucketAcl(PatchBucketAclRequest(
+  auto status_or_foo = client_->PatchBucketAcl(PatchBucketAclRequest(
       "bkt", "entity", BucketAccessControl(), BucketAccessControl()));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, ListObjectAcl) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->ListObjectAcl(ListObjectAclRequest("bkt", "obj"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, CreateObjectAcl) {
-  auto status_and_foo = client_->CreateObjectAcl(
+  auto status_or_foo = client_->CreateObjectAcl(
       CreateObjectAclRequest("bkt", "obj", "entity", "role"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, DeleteObjectAcl) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->DeleteObjectAcl(DeleteObjectAclRequest("bkt", "obj", "entity"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, GetObjectAcl) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->GetObjectAcl(GetObjectAclRequest("bkt", "obj", "entity"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, UpdateObjectAcl) {
-  auto status_and_foo = client_->UpdateObjectAcl(
+  auto status_or_foo = client_->UpdateObjectAcl(
       UpdateObjectAclRequest("bkt", "obj", "entity", "role"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, PatchObjectAcl) {
-  auto status_and_foo = client_->PatchObjectAcl(PatchObjectAclRequest(
+  auto status_or_foo = client_->PatchObjectAcl(PatchObjectAclRequest(
       "bkt", "obj", "entity", ObjectAccessControl(), ObjectAccessControl()));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, RewriteObject) {
-  auto status_and_foo = client_->RewriteObject(
+  auto status_or_foo = client_->RewriteObject(
       RewriteObjectRequest("bkt", "obj", "bkt2", "obj2", "token"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, CreateResumableSession) {
-  auto status_and_foo = client_->CreateResumableSession(
+  auto status_or_foo = client_->CreateResumableSession(
       ResumableUploadRequest("test-bucket", "test-object"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, ListDefaultObjectAcl) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->ListDefaultObjectAcl(ListDefaultObjectAclRequest("bkt"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, CreateDefaultObjectAcl) {
-  auto status_and_foo = client_->CreateDefaultObjectAcl(
+  auto status_or_foo = client_->CreateDefaultObjectAcl(
       CreateDefaultObjectAclRequest("bkt", "entity", "role"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, DeleteDefaultObjectAcl) {
-  auto status_and_foo = client_->DeleteDefaultObjectAcl(
+  auto status_or_foo = client_->DeleteDefaultObjectAcl(
       DeleteDefaultObjectAclRequest("bkt", "entity"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, GetDefaultObjectAcl) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->GetDefaultObjectAcl(GetDefaultObjectAclRequest("bkt", "entity"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, UpdateDefaultObjectAcl) {
-  auto status_and_foo = client_->UpdateDefaultObjectAcl(
+  auto status_or_foo = client_->UpdateDefaultObjectAcl(
       UpdateDefaultObjectAclRequest("bkt", "entity", "role"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, PatchDefaultObjectAcl) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->PatchDefaultObjectAcl(PatchDefaultObjectAclRequest(
           "bkt", "entity", ObjectAccessControl(), ObjectAccessControl()));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, GetServiceAccount) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->GetServiceAccount(GetProjectServiceAccountRequest("project_id"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, ListNotifications) {
-  auto status_and_foo =
+  auto status_or_foo =
       client_->ListNotifications(ListNotificationsRequest("bkt"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, CreateNotification) {
-  auto status_and_foo = client_->CreateNotification(
+  auto status_or_foo = client_->CreateNotification(
       CreateNotificationRequest("bkt", NotificationMetadata()));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, GetNotification) {
-  auto status_and_foo = client_->GetNotification(
+  auto status_or_foo = client_->GetNotification(
       GetNotificationRequest("bkt", "notification_id"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 TEST_F(CurlClientTest, DeleteNotification) {
-  auto status_and_foo = client_->DeleteNotification(
+  auto status_or_foo = client_->DeleteNotification(
       DeleteNotificationRequest("bkt", "notification_id"));
-  TestCorrectFailureStatus(status_and_foo.first);
+  TestCorrectFailureStatus(status_or_foo.status());
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/curl_resumable_streambuf.cc
+++ b/google/cloud/storage/internal/curl_resumable_streambuf.cc
@@ -116,7 +116,7 @@ HttpResponse CurlResumableStreambuf::Flush(bool final_chunk) {
   }
 
   last_response_ = HttpResponse{
-      result.first.status_code(), std::move(result.second.payload), {}};
+      result.status().status_code(), std::move(result).value().payload, {}};
   return last_response_;
 }
 

--- a/google/cloud/storage/internal/curl_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.cc
@@ -20,7 +20,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
-std::pair<Status, ResumableUploadResponse>
+StatusOr<ResumableUploadResponse>
 CurlResumableUploadSession::UploadChunk(std::string const& buffer,
                                         std::uint64_t upload_size) {
   UploadChunkRequest request(session_id_, next_expected_, buffer, upload_size);
@@ -29,7 +29,7 @@ CurlResumableUploadSession::UploadChunk(std::string const& buffer,
   return result;
 }
 
-std::pair<Status, ResumableUploadResponse>
+StatusOr<ResumableUploadResponse>
 CurlResumableUploadSession::ResetSession() {
   QueryResumableUploadRequest request(session_id_);
   auto result = client_->QueryResumableUpload(request);
@@ -42,17 +42,17 @@ std::uint64_t CurlResumableUploadSession::next_expected_byte() const {
 }
 
 void CurlResumableUploadSession::Update(
-    std::pair<Status, ResumableUploadResponse> const& result) {
-  if (not result.first.ok()) {
+    StatusOr<ResumableUploadResponse> const& result) {
+  if (not result.ok()) {
     return;
   }
-  if (result.second.last_committed_byte == 0) {
+  if (result->last_committed_byte == 0) {
     next_expected_ = 0;
   } else {
-    next_expected_ = result.second.last_committed_byte + 1;
+    next_expected_ = result->last_committed_byte + 1;
   }
-  if (not result.second.upload_session_url.empty()) {
-    session_id_ = result.second.upload_session_url;
+  if (not result->upload_session_url.empty()) {
+    session_id_ = result->upload_session_url;
   }
 }
 

--- a/google/cloud/storage/internal/curl_resumable_upload_session.h
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.h
@@ -32,17 +32,17 @@ class CurlResumableUploadSession : public ResumableUploadSession {
                                       std::string session_id)
       : client_(std::move(client)), session_id_(std::move(session_id)) {}
 
-  std::pair<Status, ResumableUploadResponse> UploadChunk(
+  StatusOr<ResumableUploadResponse> UploadChunk(
       std::string const& buffer, std::uint64_t upload_size) override;
 
-  std::pair<Status, ResumableUploadResponse> ResetSession() override;
+  StatusOr<ResumableUploadResponse> ResetSession() override;
 
   std::uint64_t next_expected_byte() const override;
 
   std::string const& session_id() const override { return session_id_; }
 
  private:
-  void Update(std::pair<Status, ResumableUploadResponse> const& result);
+  void Update(StatusOr<ResumableUploadResponse> const& result);
 
   std::shared_ptr<CurlClient> client_;
   std::string session_id_;

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -43,10 +43,13 @@ static typename std::enable_if<
 MakeCall(RawClient& client, MemberFunction function,
          typename CheckSignature<MemberFunction>::RequestType const& request,
          char const* context) {
-  GCP_LOG(INFO) << context << " << " << request;
+  GCP_LOG(INFO) << context << "() << " << request;
   auto response = (client.*function)(request);
-  GCP_LOG(INFO) << context << " >> status={" << response.first << "}, payload={"
-                << response.second << "}";
+  if (response.ok()) {
+    GCP_LOG(INFO) << context << "() >> payload={" << response.value() << "}";
+  } else {
+    GCP_LOG(INFO) << context << "() >> status={" << response.status() << "}";
+  }
   return response;
 }
 
@@ -72,9 +75,8 @@ MakeCallNoResponseLogging(
     MemberFunction function,
     typename CheckSignature<MemberFunction>::RequestType const& request,
     char const* context) {
-  GCP_LOG(INFO) << context << " << " << request;
-  auto response = (client.*function)(request);
-  return response;
+  GCP_LOG(INFO) << context << "() << " << request;
+  return (client.*function)(request);
 }
 }  // namespace
 
@@ -85,252 +87,251 @@ ClientOptions const& LoggingClient::client_options() const {
   return client_->client_options();
 }
 
-std::pair<Status, ListBucketsResponse> LoggingClient::ListBuckets(
+StatusOr<ListBucketsResponse> LoggingClient::ListBuckets(
     ListBucketsRequest const& request) {
   return MakeCall(*client_, &RawClient::ListBuckets, request, __func__);
 }
 
-std::pair<Status, BucketMetadata> LoggingClient::CreateBucket(
+StatusOr<BucketMetadata> LoggingClient::CreateBucket(
     CreateBucketRequest const& request) {
   return MakeCall(*client_, &RawClient::CreateBucket, request, __func__);
 }
 
-std::pair<Status, BucketMetadata> LoggingClient::GetBucketMetadata(
+StatusOr<BucketMetadata> LoggingClient::GetBucketMetadata(
     GetBucketMetadataRequest const& request) {
   return MakeCall(*client_, &RawClient::GetBucketMetadata, request, __func__);
 }
 
-std::pair<Status, EmptyResponse> LoggingClient::DeleteBucket(
+StatusOr<EmptyResponse> LoggingClient::DeleteBucket(
     DeleteBucketRequest const& request) {
   return MakeCall(*client_, &RawClient::DeleteBucket, request, __func__);
 }
 
-std::pair<Status, BucketMetadata> LoggingClient::UpdateBucket(
+StatusOr<BucketMetadata> LoggingClient::UpdateBucket(
     UpdateBucketRequest const& request) {
   return MakeCall(*client_, &RawClient::UpdateBucket, request, __func__);
 }
 
-std::pair<Status, BucketMetadata> LoggingClient::PatchBucket(
+StatusOr<BucketMetadata> LoggingClient::PatchBucket(
     PatchBucketRequest const& request) {
   return MakeCall(*client_, &RawClient::PatchBucket, request, __func__);
 }
 
-std::pair<Status, IamPolicy> LoggingClient::GetBucketIamPolicy(
+StatusOr<IamPolicy> LoggingClient::GetBucketIamPolicy(
     GetBucketIamPolicyRequest const& request) {
   return MakeCall(*client_, &RawClient::GetBucketIamPolicy, request, __func__);
 }
 
-std::pair<Status, IamPolicy> LoggingClient::SetBucketIamPolicy(
+StatusOr<IamPolicy> LoggingClient::SetBucketIamPolicy(
     SetBucketIamPolicyRequest const& request) {
   return MakeCall(*client_, &RawClient::SetBucketIamPolicy, request, __func__);
 }
 
-std::pair<Status, TestBucketIamPermissionsResponse>
+StatusOr<TestBucketIamPermissionsResponse>
 LoggingClient::TestBucketIamPermissions(
     TestBucketIamPermissionsRequest const& request) {
   return MakeCall(*client_, &RawClient::TestBucketIamPermissions, request,
                   __func__);
 }
 
-std::pair<Status, EmptyResponse> LoggingClient::LockBucketRetentionPolicy(
+StatusOr<EmptyResponse> LoggingClient::LockBucketRetentionPolicy(
     LockBucketRetentionPolicyRequest const& request) {
   return MakeCall(*client_, &RawClient::LockBucketRetentionPolicy, request,
                   __func__);
 }
 
-std::pair<Status, ObjectMetadata> LoggingClient::InsertObjectMedia(
+StatusOr<ObjectMetadata> LoggingClient::InsertObjectMedia(
     InsertObjectMediaRequest const& request) {
   return MakeCall(*client_, &RawClient::InsertObjectMedia, request, __func__);
 }
 
-std::pair<Status, ObjectMetadata> LoggingClient::CopyObject(
+StatusOr<ObjectMetadata> LoggingClient::CopyObject(
     CopyObjectRequest const& request) {
   return MakeCall(*client_, &RawClient::CopyObject, request, __func__);
 }
 
-std::pair<Status, ObjectMetadata> LoggingClient::GetObjectMetadata(
+StatusOr<ObjectMetadata> LoggingClient::GetObjectMetadata(
     GetObjectMetadataRequest const& request) {
   return MakeCall(*client_, &RawClient::GetObjectMetadata, request, __func__);
 }
 
-std::pair<Status, std::unique_ptr<ObjectReadStreambuf>>
+StatusOr<std::unique_ptr<ObjectReadStreambuf>>
 LoggingClient::ReadObject(ReadObjectRangeRequest const& request) {
   return MakeCallNoResponseLogging(*client_, &RawClient::ReadObject, request,
                                    __func__);
 }
 
-std::pair<Status, std::unique_ptr<ObjectWriteStreambuf>>
+StatusOr<std::unique_ptr<ObjectWriteStreambuf>>
 LoggingClient::WriteObject(InsertObjectStreamingRequest const& request) {
   return MakeCallNoResponseLogging(*client_, &RawClient::WriteObject, request,
                                    __func__);
 }
 
-std::pair<Status, ListObjectsResponse> LoggingClient::ListObjects(
+StatusOr<ListObjectsResponse> LoggingClient::ListObjects(
     ListObjectsRequest const& request) {
   return MakeCall(*client_, &RawClient::ListObjects, request, __func__);
 }
 
-std::pair<Status, EmptyResponse> LoggingClient::DeleteObject(
+StatusOr<EmptyResponse> LoggingClient::DeleteObject(
     DeleteObjectRequest const& request) {
   return MakeCall(*client_, &RawClient::DeleteObject, request, __func__);
 }
 
-std::pair<Status, ObjectMetadata> LoggingClient::UpdateObject(
+StatusOr<ObjectMetadata> LoggingClient::UpdateObject(
     UpdateObjectRequest const& request) {
   return MakeCall(*client_, &RawClient::UpdateObject, request, __func__);
 }
 
-std::pair<Status, ObjectMetadata> LoggingClient::PatchObject(
+StatusOr<ObjectMetadata> LoggingClient::PatchObject(
     PatchObjectRequest const& request) {
   return MakeCall(*client_, &RawClient::PatchObject, request, __func__);
 }
 
-std::pair<Status, ObjectMetadata> LoggingClient::ComposeObject(
+StatusOr<ObjectMetadata> LoggingClient::ComposeObject(
     ComposeObjectRequest const& request) {
   return MakeCall(*client_, &RawClient::ComposeObject, request, __func__);
 }
 
-std::pair<Status, RewriteObjectResponse> LoggingClient::RewriteObject(
+StatusOr<RewriteObjectResponse> LoggingClient::RewriteObject(
     RewriteObjectRequest const& request) {
   return MakeCall(*client_, &RawClient::RewriteObject, request, __func__);
 }
 
-std::pair<Status, std::unique_ptr<ResumableUploadSession>>
+StatusOr<std::unique_ptr<ResumableUploadSession>>
 LoggingClient::CreateResumableSession(ResumableUploadRequest const& request) {
   auto result = MakeCallNoResponseLogging(
       *client_, &RawClient::CreateResumableSession, request, __func__);
-  if (not result.first.ok()) {
-    return result;
+  if (not result.ok()) {
+    return std::move(result).status();
   }
-  return std::make_pair(
-      Status(),
+  return std::unique_ptr<ResumableUploadSession>(
       google::cloud::internal::make_unique<LoggingResumableUploadSession>(
-          std::move(result.second)));
+          std::move(result).value()));
 }
 
-std::pair<Status, std::unique_ptr<ResumableUploadSession>>
+StatusOr<std::unique_ptr<ResumableUploadSession>>
 LoggingClient::RestoreResumableSession(std::string const &request){
   return MakeCallNoResponseLogging(
       *client_, &RawClient::RestoreResumableSession, request, __func__);
 }
 
-std::pair<Status, ListBucketAclResponse> LoggingClient::ListBucketAcl(
+StatusOr<ListBucketAclResponse> LoggingClient::ListBucketAcl(
     ListBucketAclRequest const& request) {
   return MakeCall(*client_, &RawClient::ListBucketAcl, request, __func__);
 }
 
-std::pair<Status, BucketAccessControl> LoggingClient::GetBucketAcl(
+StatusOr<BucketAccessControl> LoggingClient::GetBucketAcl(
     GetBucketAclRequest const& request) {
   return MakeCall(*client_, &RawClient::GetBucketAcl, request, __func__);
 }
 
-std::pair<Status, BucketAccessControl> LoggingClient::CreateBucketAcl(
+StatusOr<BucketAccessControl> LoggingClient::CreateBucketAcl(
     CreateBucketAclRequest const& request) {
   return MakeCall(*client_, &RawClient::CreateBucketAcl, request, __func__);
 }
 
-std::pair<Status, EmptyResponse> LoggingClient::DeleteBucketAcl(
+StatusOr<EmptyResponse> LoggingClient::DeleteBucketAcl(
     DeleteBucketAclRequest const& request) {
   return MakeCall(*client_, &RawClient::DeleteBucketAcl, request, __func__);
 }
 
-std::pair<Status, BucketAccessControl> LoggingClient::UpdateBucketAcl(
+StatusOr<BucketAccessControl> LoggingClient::UpdateBucketAcl(
     UpdateBucketAclRequest const& request) {
   return MakeCall(*client_, &RawClient::UpdateBucketAcl, request, __func__);
 }
 
-std::pair<Status, BucketAccessControl> LoggingClient::PatchBucketAcl(
+StatusOr<BucketAccessControl> LoggingClient::PatchBucketAcl(
     PatchBucketAclRequest const& request) {
   return MakeCall(*client_, &RawClient::PatchBucketAcl, request, __func__);
 }
 
-std::pair<Status, ListObjectAclResponse> LoggingClient::ListObjectAcl(
+StatusOr<ListObjectAclResponse> LoggingClient::ListObjectAcl(
     ListObjectAclRequest const& request) {
   return MakeCall(*client_, &RawClient::ListObjectAcl, request, __func__);
 }
 
-std::pair<Status, ObjectAccessControl> LoggingClient::CreateObjectAcl(
+StatusOr<ObjectAccessControl> LoggingClient::CreateObjectAcl(
     CreateObjectAclRequest const& request) {
   return MakeCall(*client_, &RawClient::CreateObjectAcl, request, __func__);
 }
 
-std::pair<Status, EmptyResponse> LoggingClient::DeleteObjectAcl(
+StatusOr<EmptyResponse> LoggingClient::DeleteObjectAcl(
     DeleteObjectAclRequest const& request) {
   return MakeCall(*client_, &RawClient::DeleteObjectAcl, request, __func__);
 }
 
-std::pair<Status, ObjectAccessControl> LoggingClient::GetObjectAcl(
+StatusOr<ObjectAccessControl> LoggingClient::GetObjectAcl(
     GetObjectAclRequest const& request) {
   return MakeCall(*client_, &RawClient::GetObjectAcl, request, __func__);
 }
 
-std::pair<Status, ObjectAccessControl> LoggingClient::UpdateObjectAcl(
+StatusOr<ObjectAccessControl> LoggingClient::UpdateObjectAcl(
     UpdateObjectAclRequest const& request) {
   return MakeCall(*client_, &RawClient::UpdateObjectAcl, request, __func__);
 }
 
-std::pair<Status, ObjectAccessControl> LoggingClient::PatchObjectAcl(
+StatusOr<ObjectAccessControl> LoggingClient::PatchObjectAcl(
     PatchObjectAclRequest const& request) {
   return MakeCall(*client_, &RawClient::PatchObjectAcl, request, __func__);
 }
 
-std::pair<Status, ListDefaultObjectAclResponse>
+StatusOr<ListDefaultObjectAclResponse>
 LoggingClient::ListDefaultObjectAcl(
     ListDefaultObjectAclRequest const& request) {
   return MakeCall(*client_, &RawClient::ListDefaultObjectAcl, request,
                   __func__);
 }
 
-std::pair<Status, ObjectAccessControl> LoggingClient::CreateDefaultObjectAcl(
+StatusOr<ObjectAccessControl> LoggingClient::CreateDefaultObjectAcl(
     CreateDefaultObjectAclRequest const& request) {
   return MakeCall(*client_, &RawClient::CreateDefaultObjectAcl, request,
                   __func__);
 }
 
-std::pair<Status, EmptyResponse> LoggingClient::DeleteDefaultObjectAcl(
+StatusOr<EmptyResponse> LoggingClient::DeleteDefaultObjectAcl(
     DeleteDefaultObjectAclRequest const& request) {
   return MakeCall(*client_, &RawClient::DeleteDefaultObjectAcl, request,
                   __func__);
 }
 
-std::pair<Status, ObjectAccessControl> LoggingClient::GetDefaultObjectAcl(
+StatusOr<ObjectAccessControl> LoggingClient::GetDefaultObjectAcl(
     GetDefaultObjectAclRequest const& request) {
   return MakeCall(*client_, &RawClient::GetDefaultObjectAcl, request, __func__);
 }
 
-std::pair<Status, ObjectAccessControl> LoggingClient::UpdateDefaultObjectAcl(
+StatusOr<ObjectAccessControl> LoggingClient::UpdateDefaultObjectAcl(
     UpdateDefaultObjectAclRequest const& request) {
   return MakeCall(*client_, &RawClient::UpdateDefaultObjectAcl, request,
                   __func__);
 }
 
-std::pair<Status, ObjectAccessControl> LoggingClient::PatchDefaultObjectAcl(
+StatusOr<ObjectAccessControl> LoggingClient::PatchDefaultObjectAcl(
     PatchDefaultObjectAclRequest const& request) {
   return MakeCall(*client_, &RawClient::PatchDefaultObjectAcl, request,
                   __func__);
 }
 
-std::pair<Status, ServiceAccount> LoggingClient::GetServiceAccount(
+StatusOr<ServiceAccount> LoggingClient::GetServiceAccount(
     GetProjectServiceAccountRequest const& request) {
   return MakeCall(*client_, &RawClient::GetServiceAccount, request, __func__);
 }
 
-std::pair<Status, ListNotificationsResponse> LoggingClient::ListNotifications(
+StatusOr<ListNotificationsResponse> LoggingClient::ListNotifications(
     ListNotificationsRequest const& request) {
   return MakeCall(*client_, &RawClient::ListNotifications, request, __func__);
 }
 
-std::pair<Status, NotificationMetadata> LoggingClient::CreateNotification(
+StatusOr<NotificationMetadata> LoggingClient::CreateNotification(
     CreateNotificationRequest const& request) {
   return MakeCall(*client_, &RawClient::CreateNotification, request, __func__);
 }
 
-std::pair<Status, NotificationMetadata> LoggingClient::GetNotification(
+StatusOr<NotificationMetadata> LoggingClient::GetNotification(
     GetNotificationRequest const& request) {
   return MakeCall(*client_, &RawClient::GetNotification, request, __func__);
 }
 
-std::pair<Status, EmptyResponse> LoggingClient::DeleteNotification(
+StatusOr<EmptyResponse> LoggingClient::DeleteNotification(
     DeleteNotificationRequest const& request) {
   return MakeCall(*client_, &RawClient::DeleteNotification, request, __func__);
 }

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -32,103 +32,100 @@ class LoggingClient : public RawClient {
 
   ClientOptions const& client_options() const override;
 
-  std::pair<Status, ListBucketsResponse> ListBuckets(
+  StatusOr<ListBucketsResponse> ListBuckets(
       ListBucketsRequest const& request) override;
-  std::pair<Status, BucketMetadata> CreateBucket(
+  StatusOr<BucketMetadata> CreateBucket(
       CreateBucketRequest const& request) override;
-  std::pair<Status, BucketMetadata> GetBucketMetadata(
+  StatusOr<BucketMetadata> GetBucketMetadata(
       GetBucketMetadataRequest const& request) override;
-  std::pair<Status, EmptyResponse> DeleteBucket(
-      DeleteBucketRequest const&) override;
-  std::pair<Status, BucketMetadata> UpdateBucket(
+  StatusOr<EmptyResponse> DeleteBucket(DeleteBucketRequest const&) override;
+  StatusOr<BucketMetadata> UpdateBucket(
       UpdateBucketRequest const& request) override;
-  std::pair<Status, BucketMetadata> PatchBucket(
+  StatusOr<BucketMetadata> PatchBucket(
       PatchBucketRequest const& request) override;
-  std::pair<Status, IamPolicy> GetBucketIamPolicy(
+  StatusOr<IamPolicy> GetBucketIamPolicy(
       GetBucketIamPolicyRequest const& request) override;
-  std::pair<Status, IamPolicy> SetBucketIamPolicy(
+  StatusOr<IamPolicy> SetBucketIamPolicy(
       SetBucketIamPolicyRequest const& request) override;
-  std::pair<Status, TestBucketIamPermissionsResponse> TestBucketIamPermissions(
+  StatusOr<TestBucketIamPermissionsResponse> TestBucketIamPermissions(
       TestBucketIamPermissionsRequest const& request) override;
-  std::pair<Status, EmptyResponse> LockBucketRetentionPolicy(
+  StatusOr<EmptyResponse> LockBucketRetentionPolicy(
       LockBucketRetentionPolicyRequest const& request) override;
 
-  std::pair<Status, ObjectMetadata> InsertObjectMedia(
+  StatusOr<ObjectMetadata> InsertObjectMedia(
       InsertObjectMediaRequest const& request) override;
-  std::pair<Status, ObjectMetadata> CopyObject(
+  StatusOr<ObjectMetadata> CopyObject(
       CopyObjectRequest const& request) override;
-  std::pair<Status, ObjectMetadata> GetObjectMetadata(
+  StatusOr<ObjectMetadata> GetObjectMetadata(
       GetObjectMetadataRequest const& request) override;
-  std::pair<Status, std::unique_ptr<ObjectReadStreambuf>> ReadObject(
+  StatusOr<std::unique_ptr<ObjectReadStreambuf>> ReadObject(
       ReadObjectRangeRequest const&) override;
-  std::pair<Status, std::unique_ptr<ObjectWriteStreambuf>> WriteObject(
+  StatusOr<std::unique_ptr<ObjectWriteStreambuf>> WriteObject(
       InsertObjectStreamingRequest const&) override;
-  std::pair<Status, ListObjectsResponse> ListObjects(
-      ListObjectsRequest const&) override;
-  std::pair<Status, EmptyResponse> DeleteObject(
-      DeleteObjectRequest const&) override;
-  std::pair<Status, ObjectMetadata> UpdateObject(
+  StatusOr<ListObjectsResponse> ListObjects(ListObjectsRequest const&) override;
+  StatusOr<EmptyResponse> DeleteObject(DeleteObjectRequest const&) override;
+  StatusOr<ObjectMetadata> UpdateObject(
       UpdateObjectRequest const& request) override;
-  std::pair<Status, ObjectMetadata> PatchObject(
+  StatusOr<ObjectMetadata> PatchObject(
       PatchObjectRequest const& request) override;
-  std::pair<Status, ObjectMetadata> ComposeObject(
+  StatusOr<ObjectMetadata> ComposeObject(
       ComposeObjectRequest const& request) override;
-  std::pair<Status, RewriteObjectResponse> RewriteObject(
+  StatusOr<RewriteObjectResponse> RewriteObject(
       RewriteObjectRequest const&) override;
-  std::pair<Status, std::unique_ptr<ResumableUploadSession>>
-  CreateResumableSession(ResumableUploadRequest const& request) override;
-  std::pair<Status, std::unique_ptr<ResumableUploadSession>>
-  RestoreResumableSession(std::string const& request) override;
+  StatusOr<std::unique_ptr<ResumableUploadSession>> CreateResumableSession(
+      ResumableUploadRequest const& request) override;
+  StatusOr<std::unique_ptr<ResumableUploadSession>> RestoreResumableSession(
+      std::string const& request) override;
 
-  std::pair<Status, ListBucketAclResponse> ListBucketAcl(
+  StatusOr<ListBucketAclResponse> ListBucketAcl(
       ListBucketAclRequest const& request) override;
-  std::pair<Status, BucketAccessControl> CreateBucketAcl(
+  StatusOr<BucketAccessControl> CreateBucketAcl(
       CreateBucketAclRequest const&) override;
-  std::pair<Status, EmptyResponse> DeleteBucketAcl(
+  StatusOr<EmptyResponse> DeleteBucketAcl(
       DeleteBucketAclRequest const&) override;
-  std::pair<Status, BucketAccessControl> GetBucketAcl(
+  StatusOr<BucketAccessControl> GetBucketAcl(
       GetBucketAclRequest const&) override;
-  std::pair<Status, BucketAccessControl> UpdateBucketAcl(
+  StatusOr<BucketAccessControl> UpdateBucketAcl(
       UpdateBucketAclRequest const&) override;
-  std::pair<Status, BucketAccessControl> PatchBucketAcl(
+  StatusOr<BucketAccessControl> PatchBucketAcl(
       PatchBucketAclRequest const&) override;
 
-  std::pair<Status, ListObjectAclResponse> ListObjectAcl(
+  StatusOr<ListObjectAclResponse> ListObjectAcl(
       ListObjectAclRequest const& request) override;
-  std::pair<Status, ObjectAccessControl> CreateObjectAcl(
+  StatusOr<ObjectAccessControl> CreateObjectAcl(
       CreateObjectAclRequest const&) override;
-  std::pair<Status, EmptyResponse> DeleteObjectAcl(
+  StatusOr<EmptyResponse> DeleteObjectAcl(
       DeleteObjectAclRequest const&) override;
-  std::pair<Status, ObjectAccessControl> GetObjectAcl(
+  StatusOr<ObjectAccessControl> GetObjectAcl(
       GetObjectAclRequest const&) override;
-  std::pair<Status, ObjectAccessControl> UpdateObjectAcl(
+  StatusOr<ObjectAccessControl> UpdateObjectAcl(
       UpdateObjectAclRequest const&) override;
-  std::pair<Status, ObjectAccessControl> PatchObjectAcl(
+  StatusOr<ObjectAccessControl> PatchObjectAcl(
       PatchObjectAclRequest const&) override;
 
-  std::pair<Status, ListDefaultObjectAclResponse> ListDefaultObjectAcl(
+  StatusOr<ListDefaultObjectAclResponse> ListDefaultObjectAcl(
       ListDefaultObjectAclRequest const& request) override;
-  std::pair<Status, ObjectAccessControl> CreateDefaultObjectAcl(
+  StatusOr<ObjectAccessControl> CreateDefaultObjectAcl(
       CreateDefaultObjectAclRequest const&) override;
-  std::pair<Status, EmptyResponse> DeleteDefaultObjectAcl(
+  StatusOr<EmptyResponse> DeleteDefaultObjectAcl(
       DeleteDefaultObjectAclRequest const&) override;
-  std::pair<Status, ObjectAccessControl> GetDefaultObjectAcl(
+  StatusOr<ObjectAccessControl> GetDefaultObjectAcl(
       GetDefaultObjectAclRequest const&) override;
-  std::pair<Status, ObjectAccessControl> UpdateDefaultObjectAcl(
+  StatusOr<ObjectAccessControl> UpdateDefaultObjectAcl(
       UpdateDefaultObjectAclRequest const&) override;
-  std::pair<Status, ObjectAccessControl> PatchDefaultObjectAcl(
+  StatusOr<ObjectAccessControl> PatchDefaultObjectAcl(
       PatchDefaultObjectAclRequest const&) override;
 
-  std::pair<Status, ServiceAccount> GetServiceAccount(
+  StatusOr<ServiceAccount> GetServiceAccount(
       GetProjectServiceAccountRequest const&) override;
 
-  std::pair<Status, ListNotificationsResponse> ListNotifications(
+  StatusOr<ListNotificationsResponse> ListNotifications(
       ListNotificationsRequest const&) override;
-  std::pair<Status, NotificationMetadata> CreateNotification(
+  StatusOr<NotificationMetadata> CreateNotification(
       CreateNotificationRequest const&) override;
-  std::pair<Status, NotificationMetadata> GetNotification(
+  StatusOr<NotificationMetadata> GetNotification(
       GetNotificationRequest const&) override;
-  std::pair<Status, EmptyResponse> DeleteNotification(
+  StatusOr<EmptyResponse> DeleteNotification(
       DeleteNotificationRequest const&) override;
 
   std::shared_ptr<RawClient> client() const { return client_; }

--- a/google/cloud/storage/internal/logging_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session.cc
@@ -21,23 +21,29 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
-std::pair<Status, ResumableUploadResponse>
+StatusOr<ResumableUploadResponse>
 LoggingResumableUploadSession::UploadChunk(std::string const& buffer,
                                            std::uint64_t upload_size) {
-  GCP_LOG(INFO) << __func__ << " << upload_size=" << upload_size
+  GCP_LOG(INFO) << __func__ << "() << upload_size=" << upload_size
                 << ", buffer.size=" << buffer.size();
   auto response = session_->UploadChunk(buffer, upload_size);
-  GCP_LOG(INFO) << __func__ << " >> status={" << response.first
-                << "}, payload={" << response.second << "}";
+  if (response.ok()) {
+    GCP_LOG(INFO) << __func__ << " >> payload={" << response.value() << "}";
+  } else {
+    GCP_LOG(INFO) << __func__ << " >> status={" << response.status() << "}";
+  }
   return response;
 }
 
-std::pair<Status, ResumableUploadResponse>
+StatusOr<ResumableUploadResponse>
 LoggingResumableUploadSession::ResetSession() {
   GCP_LOG(INFO) << __func__ << " << ()";
   auto response = session_->ResetSession();
-  GCP_LOG(INFO) << __func__ << " >> status={" << response.first
-                << "}, payload={" << response.second << "}";
+  if (response.ok()) {
+    GCP_LOG(INFO) << __func__ << " >> payload={" << response.value() << "}";
+  } else {
+    GCP_LOG(INFO) << __func__ << " >> status={" << response.status() << "}";
+  }
   return response;
 }
 

--- a/google/cloud/storage/internal/logging_resumable_upload_session.h
+++ b/google/cloud/storage/internal/logging_resumable_upload_session.h
@@ -31,9 +31,9 @@ class LoggingResumableUploadSession : public ResumableUploadSession {
       std::unique_ptr<ResumableUploadSession> session)
       : session_(std::move(session)) {}
 
-  std::pair<Status, ResumableUploadResponse> UploadChunk(
+  StatusOr<ResumableUploadResponse> UploadChunk(
       std::string const& buffer, std::uint64_t upload_size) override;
-  std::pair<Status, ResumableUploadResponse> ResetSession() override;
+  StatusOr<ResumableUploadResponse> ResetSession() override;
   std::uint64_t next_expected_byte() const override;
   std::string const& session_id() const override;
 

--- a/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
@@ -64,14 +64,14 @@ TEST_F(LoggingResumableUploadSessionTest, UploadChunk) {
       .WillOnce(Invoke([&](std::string const& p, std::uint64_t s) {
         EXPECT_EQ(payload, p);
         EXPECT_EQ(513 * 1024, s);
-        return std::make_pair(Status(503, "uh oh"), ResumableUploadResponse{});
+        return StatusOr<ResumableUploadResponse>(Status(503, "uh oh"));
       }));
 
   LoggingResumableUploadSession session(std::move(mock));
 
   auto result = session.UploadChunk(payload, 513 * 1024);
-  EXPECT_EQ(503, result.first.status_code());
-  EXPECT_EQ("uh oh", result.first.error_message());
+  EXPECT_EQ(503, result.status().status_code());
+  EXPECT_EQ("uh oh", result.status().error_message());
 
   EXPECT_EQ(1U, CountLines("upload_size=" + std::to_string(513 * 1024UL)));
   EXPECT_EQ(1U, CountLines("[503]"));
@@ -83,14 +83,14 @@ TEST_F(LoggingResumableUploadSessionTest, ResetSession) {
 
   EXPECT_CALL(*mock, ResetSession())
       .WillOnce(Invoke([&]() {
-        return std::make_pair(Status(308, "uh oh"), ResumableUploadResponse{});
+        return StatusOr<ResumableUploadResponse>(Status(308, "uh oh"));
       }));
 
   LoggingResumableUploadSession session(std::move(mock));
 
   auto result = session.ResetSession();
-  EXPECT_EQ(308, result.first.status_code());
-  EXPECT_EQ("uh oh", result.first.error_message());
+  EXPECT_EQ(308, result.status().status_code());
+  EXPECT_EQ("uh oh", result.status().error_message());
 
   EXPECT_EQ(1U, CountLines("[308]"));
 }

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -31,6 +31,7 @@
 #include "google/cloud/storage/object_metadata.h"
 #include "google/cloud/storage/service_account.h"
 #include "google/cloud/storage/status.h"
+#include "google/cloud/storage/status_or.h"
 
 namespace google {
 namespace cloud {
@@ -48,119 +49,113 @@ class RawClient {
 
   //@{
   /// @name Bucket resource operations
-  virtual std::pair<Status, ListBucketsResponse> ListBuckets(
+  virtual StatusOr<ListBucketsResponse> ListBuckets(
       ListBucketsRequest const& request) = 0;
-  virtual std::pair<Status, BucketMetadata> CreateBucket(
-      CreateBucketRequest const&) = 0;
-  virtual std::pair<Status, BucketMetadata> GetBucketMetadata(
+  virtual StatusOr<BucketMetadata> CreateBucket(CreateBucketRequest const&) = 0;
+  virtual StatusOr<BucketMetadata> GetBucketMetadata(
       GetBucketMetadataRequest const& request) = 0;
-  virtual std::pair<Status, EmptyResponse> DeleteBucket(
+  virtual StatusOr<EmptyResponse> DeleteBucket(
       DeleteBucketRequest const& request) = 0;
-  virtual std::pair<Status, BucketMetadata> UpdateBucket(
-      UpdateBucketRequest const&) = 0;
-  virtual std::pair<Status, BucketMetadata> PatchBucket(
+  virtual StatusOr<BucketMetadata> UpdateBucket(UpdateBucketRequest const&) = 0;
+  virtual StatusOr<BucketMetadata> PatchBucket(
       PatchBucketRequest const& request) = 0;
-  virtual std::pair<Status, IamPolicy> GetBucketIamPolicy(
+  virtual StatusOr<IamPolicy> GetBucketIamPolicy(
       GetBucketIamPolicyRequest const& request) = 0;
-  virtual std::pair<Status, IamPolicy> SetBucketIamPolicy(
+  virtual StatusOr<IamPolicy> SetBucketIamPolicy(
       SetBucketIamPolicyRequest const& request) = 0;
-  virtual std::pair<Status, TestBucketIamPermissionsResponse>
-  TestBucketIamPermissions(TestBucketIamPermissionsRequest const& request) = 0;
-  virtual std::pair<Status, EmptyResponse> LockBucketRetentionPolicy(
+  virtual StatusOr<TestBucketIamPermissionsResponse> TestBucketIamPermissions(
+      TestBucketIamPermissionsRequest const& request) = 0;
+  virtual StatusOr<EmptyResponse> LockBucketRetentionPolicy(
       LockBucketRetentionPolicyRequest const& request) = 0;
   //@}
 
   //@{
   /// @name Object resource operations
-  virtual std::pair<Status, ObjectMetadata> InsertObjectMedia(
+  virtual StatusOr<ObjectMetadata> InsertObjectMedia(
       InsertObjectMediaRequest const&) = 0;
-  virtual std::pair<Status, ObjectMetadata> CopyObject(
-      CopyObjectRequest const&) = 0;
-  virtual std::pair<Status, ObjectMetadata> GetObjectMetadata(
+  virtual StatusOr<ObjectMetadata> CopyObject(CopyObjectRequest const&) = 0;
+  virtual StatusOr<ObjectMetadata> GetObjectMetadata(
       GetObjectMetadataRequest const& request) = 0;
-  virtual std::pair<Status, std::unique_ptr<ObjectReadStreambuf>> ReadObject(
+  virtual StatusOr<std::unique_ptr<ObjectReadStreambuf>> ReadObject(
       ReadObjectRangeRequest const&) = 0;
-  virtual std::pair<Status, std::unique_ptr<ObjectWriteStreambuf>> WriteObject(
+  virtual StatusOr<std::unique_ptr<ObjectWriteStreambuf>> WriteObject(
       InsertObjectStreamingRequest const&) = 0;
-  virtual std::pair<Status, ListObjectsResponse> ListObjects(
+  virtual StatusOr<ListObjectsResponse> ListObjects(
       ListObjectsRequest const&) = 0;
-  virtual std::pair<Status, EmptyResponse> DeleteObject(
-      DeleteObjectRequest const&) = 0;
-  virtual std::pair<Status, ObjectMetadata> UpdateObject(
-      UpdateObjectRequest const&) = 0;
-  virtual std::pair<Status, ObjectMetadata> PatchObject(
-      PatchObjectRequest const&) = 0;
-  virtual std::pair<Status, ObjectMetadata> ComposeObject(
+  virtual StatusOr<EmptyResponse> DeleteObject(DeleteObjectRequest const&) = 0;
+  virtual StatusOr<ObjectMetadata> UpdateObject(UpdateObjectRequest const&) = 0;
+  virtual StatusOr<ObjectMetadata> PatchObject(PatchObjectRequest const&) = 0;
+  virtual StatusOr<ObjectMetadata> ComposeObject(
       ComposeObjectRequest const&) = 0;
-  virtual std::pair<Status, RewriteObjectResponse> RewriteObject(
+  virtual StatusOr<RewriteObjectResponse> RewriteObject(
       RewriteObjectRequest const&) = 0;
-  virtual std::pair<Status, std::unique_ptr<ResumableUploadSession>>
+  virtual StatusOr<std::unique_ptr<ResumableUploadSession>>
   CreateResumableSession(ResumableUploadRequest const& request) = 0;
-  virtual std::pair<Status, std::unique_ptr<ResumableUploadSession>>
+  virtual StatusOr<std::unique_ptr<ResumableUploadSession>>
   RestoreResumableSession(std::string const& session_id) = 0;
   //@}
 
   //@{
   /// @name BucketAccessControls resource operations
-  virtual std::pair<Status, ListBucketAclResponse> ListBucketAcl(
+  virtual StatusOr<ListBucketAclResponse> ListBucketAcl(
       ListBucketAclRequest const&) = 0;
-  virtual std::pair<Status, BucketAccessControl> CreateBucketAcl(
+  virtual StatusOr<BucketAccessControl> CreateBucketAcl(
       CreateBucketAclRequest const&) = 0;
-  virtual std::pair<Status, EmptyResponse> DeleteBucketAcl(
+  virtual StatusOr<EmptyResponse> DeleteBucketAcl(
       DeleteBucketAclRequest const&) = 0;
-  virtual std::pair<Status, BucketAccessControl> GetBucketAcl(
+  virtual StatusOr<BucketAccessControl> GetBucketAcl(
       GetBucketAclRequest const&) = 0;
-  virtual std::pair<Status, BucketAccessControl> UpdateBucketAcl(
+  virtual StatusOr<BucketAccessControl> UpdateBucketAcl(
       UpdateBucketAclRequest const&) = 0;
-  virtual std::pair<Status, BucketAccessControl> PatchBucketAcl(
+  virtual StatusOr<BucketAccessControl> PatchBucketAcl(
       PatchBucketAclRequest const&) = 0;
   //@}
 
   //@{
   /// @name ObjectAccessControls operations
-  virtual std::pair<Status, ListObjectAclResponse> ListObjectAcl(
+  virtual StatusOr<ListObjectAclResponse> ListObjectAcl(
       ListObjectAclRequest const&) = 0;
-  virtual std::pair<Status, ObjectAccessControl> CreateObjectAcl(
+  virtual StatusOr<ObjectAccessControl> CreateObjectAcl(
       CreateObjectAclRequest const&) = 0;
-  virtual std::pair<Status, EmptyResponse> DeleteObjectAcl(
+  virtual StatusOr<EmptyResponse> DeleteObjectAcl(
       DeleteObjectAclRequest const&) = 0;
-  virtual std::pair<Status, ObjectAccessControl> GetObjectAcl(
+  virtual StatusOr<ObjectAccessControl> GetObjectAcl(
       GetObjectAclRequest const&) = 0;
-  virtual std::pair<Status, ObjectAccessControl> UpdateObjectAcl(
+  virtual StatusOr<ObjectAccessControl> UpdateObjectAcl(
       UpdateObjectAclRequest const&) = 0;
-  virtual std::pair<Status, ObjectAccessControl> PatchObjectAcl(
+  virtual StatusOr<ObjectAccessControl> PatchObjectAcl(
       PatchObjectAclRequest const&) = 0;
   //@}
 
   //@{
   /// @name DefaultObjectAccessControls operations.
-  virtual std::pair<Status, ListDefaultObjectAclResponse> ListDefaultObjectAcl(
+  virtual StatusOr<ListDefaultObjectAclResponse> ListDefaultObjectAcl(
       ListDefaultObjectAclRequest const&) = 0;
-  virtual std::pair<Status, ObjectAccessControl> CreateDefaultObjectAcl(
+  virtual StatusOr<ObjectAccessControl> CreateDefaultObjectAcl(
       CreateDefaultObjectAclRequest const&) = 0;
-  virtual std::pair<Status, EmptyResponse> DeleteDefaultObjectAcl(
+  virtual StatusOr<EmptyResponse> DeleteDefaultObjectAcl(
       DeleteDefaultObjectAclRequest const&) = 0;
-  virtual std::pair<Status, ObjectAccessControl> GetDefaultObjectAcl(
+  virtual StatusOr<ObjectAccessControl> GetDefaultObjectAcl(
       GetDefaultObjectAclRequest const&) = 0;
-  virtual std::pair<Status, ObjectAccessControl> UpdateDefaultObjectAcl(
+  virtual StatusOr<ObjectAccessControl> UpdateDefaultObjectAcl(
       UpdateDefaultObjectAclRequest const&) = 0;
-  virtual std::pair<Status, ObjectAccessControl> PatchDefaultObjectAcl(
+  virtual StatusOr<ObjectAccessControl> PatchDefaultObjectAcl(
       PatchDefaultObjectAclRequest const&) = 0;
   //@}
 
   //@{
-  virtual std::pair<Status, ServiceAccount> GetServiceAccount(
+  virtual StatusOr<ServiceAccount> GetServiceAccount(
       GetProjectServiceAccountRequest const&) = 0;
   //@}
 
   //@{
-  virtual std::pair<Status, ListNotificationsResponse> ListNotifications(
+  virtual StatusOr<ListNotificationsResponse> ListNotifications(
       ListNotificationsRequest const&) = 0;
-  virtual std::pair<Status, NotificationMetadata> CreateNotification(
+  virtual StatusOr<NotificationMetadata> CreateNotification(
       CreateNotificationRequest const&) = 0;
-  virtual std::pair<Status, NotificationMetadata> GetNotification(
+  virtual StatusOr<NotificationMetadata> GetNotification(
       GetNotificationRequest const&) = 0;
-  virtual std::pair<Status, EmptyResponse> DeleteNotification(
+  virtual StatusOr<EmptyResponse> DeleteNotification(
       DeleteNotificationRequest const&) = 0;
   //@}
 };

--- a/google/cloud/storage/internal/raw_client_wrapper_utils.h
+++ b/google/cloud/storage/internal/raw_client_wrapper_utils.h
@@ -37,7 +37,7 @@ namespace raw_client_wrapper_utils {
  * Checks the expected signature for a `RawClient` member function.
  */
 template <typename Request, typename Response>
-using DesiredSignature = std::pair<google::cloud::storage::Status, Response> (
+using DesiredSignature = StatusOr<Response> (
     google::cloud::storage::internal::RawClient::*)(Request const&);
 
 /**
@@ -74,7 +74,7 @@ struct CheckSignature<DesiredSignature<Request, Response>>
   using ResponseType = Response;
   using RequestType = Request;
   using MemberFunctionType = DesiredSignature<Request, Response>;
-  using ReturnType = std::pair<google::cloud::storage::Status, ResponseType>;
+  using ReturnType = StatusOr<ResponseType>;
 };
 }  // namespace raw_client_wrapper_utils
 }  // namespace internal

--- a/google/cloud/storage/internal/resumable_upload_session.h
+++ b/google/cloud/storage/internal/resumable_upload_session.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_RESUMABLE_UPLOAD_SESSION_H_
 
 #include "google/cloud/storage/internal/object_requests.h"
-#include "google/cloud/storage/status.h"
+#include "google/cloud/storage/status_or.h"
 
 namespace google {
 namespace cloud {
@@ -38,11 +38,11 @@ class ResumableUploadSession {
    *   known.
    * @return The result of uploading the chunk.
    */
-  virtual std::pair<Status, ResumableUploadResponse> UploadChunk(
+  virtual StatusOr<ResumableUploadResponse> UploadChunk(
       std::string const& buffer, std::uint64_t upload_size) = 0;
 
   /// Resets the session by querying its current state.
-  virtual std::pair<Status, ResumableUploadResponse> ResetSession() = 0;
+  virtual StatusOr<ResumableUploadResponse> ResetSession() = 0;
 
   /**
    * Returns the next expected byte in the server.

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -72,17 +72,15 @@ MakeCall(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
          char const* error_message) {
   google::cloud::storage::Status last_status;
   auto error = [&last_status](std::string const& msg) {
-    Status status(last_status.status_code(), msg, last_status.error_details());
-    using Pair = typename CheckSignature<MemberFunction>::ReturnType;
-    return Pair(status, typename Pair::second_type{});
+    return Status(last_status.status_code(), msg, last_status.error_details());
   };
 
   while (not retry_policy.IsExhausted()) {
     auto result = (client.*function)(request);
-    if (result.first.ok()) {
+    if (result.ok()) {
       return result;
     }
-    last_status = std::move(result.first);
+    last_status = std::move(result).status();
     if (not is_idempotent) {
       std::ostringstream os;
       os << "Error in non-idempotent operation " << error_message << ": "
@@ -127,7 +125,7 @@ ClientOptions const& RetryClient::client_options() const {
   return client_->client_options();
 }
 
-std::pair<Status, ListBucketsResponse> RetryClient::ListBuckets(
+StatusOr<ListBucketsResponse> RetryClient::ListBuckets(
     ListBucketsRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -137,7 +135,7 @@ std::pair<Status, ListBucketsResponse> RetryClient::ListBuckets(
                   __func__);
 }
 
-std::pair<Status, BucketMetadata> RetryClient::CreateBucket(
+StatusOr<BucketMetadata> RetryClient::CreateBucket(
     CreateBucketRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -147,7 +145,7 @@ std::pair<Status, BucketMetadata> RetryClient::CreateBucket(
                   __func__);
 }
 
-std::pair<Status, BucketMetadata> RetryClient::GetBucketMetadata(
+StatusOr<BucketMetadata> RetryClient::GetBucketMetadata(
     GetBucketMetadataRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -157,7 +155,7 @@ std::pair<Status, BucketMetadata> RetryClient::GetBucketMetadata(
                   __func__);
 }
 
-std::pair<Status, EmptyResponse> RetryClient::DeleteBucket(
+StatusOr<EmptyResponse> RetryClient::DeleteBucket(
     DeleteBucketRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -167,7 +165,7 @@ std::pair<Status, EmptyResponse> RetryClient::DeleteBucket(
                   __func__);
 }
 
-std::pair<Status, BucketMetadata> RetryClient::UpdateBucket(
+StatusOr<BucketMetadata> RetryClient::UpdateBucket(
     UpdateBucketRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -177,7 +175,7 @@ std::pair<Status, BucketMetadata> RetryClient::UpdateBucket(
                   __func__);
 }
 
-std::pair<Status, BucketMetadata> RetryClient::PatchBucket(
+StatusOr<BucketMetadata> RetryClient::PatchBucket(
     PatchBucketRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -187,7 +185,7 @@ std::pair<Status, BucketMetadata> RetryClient::PatchBucket(
                   __func__);
 }
 
-std::pair<Status, IamPolicy> RetryClient::GetBucketIamPolicy(
+StatusOr<IamPolicy> RetryClient::GetBucketIamPolicy(
     GetBucketIamPolicyRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -197,7 +195,7 @@ std::pair<Status, IamPolicy> RetryClient::GetBucketIamPolicy(
                   __func__);
 }
 
-std::pair<Status, IamPolicy> RetryClient::SetBucketIamPolicy(
+StatusOr<IamPolicy> RetryClient::SetBucketIamPolicy(
     SetBucketIamPolicyRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -207,7 +205,7 @@ std::pair<Status, IamPolicy> RetryClient::SetBucketIamPolicy(
                   __func__);
 }
 
-std::pair<Status, TestBucketIamPermissionsResponse>
+StatusOr<TestBucketIamPermissionsResponse>
 RetryClient::TestBucketIamPermissions(
     TestBucketIamPermissionsRequest const& request) {
   auto retry_policy = retry_policy_->clone();
@@ -218,7 +216,7 @@ RetryClient::TestBucketIamPermissions(
                    __func__);
 }
 
-std::pair<Status, EmptyResponse> RetryClient::LockBucketRetentionPolicy(
+StatusOr<EmptyResponse> RetryClient::LockBucketRetentionPolicy(
     LockBucketRetentionPolicyRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -228,7 +226,7 @@ std::pair<Status, EmptyResponse> RetryClient::LockBucketRetentionPolicy(
                    __func__);
 }
 
-std::pair<Status, ObjectMetadata> RetryClient::InsertObjectMedia(
+StatusOr<ObjectMetadata> RetryClient::InsertObjectMedia(
     InsertObjectMediaRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -238,7 +236,7 @@ std::pair<Status, ObjectMetadata> RetryClient::InsertObjectMedia(
                   __func__);
 }
 
-std::pair<Status, ObjectMetadata> RetryClient::CopyObject(
+StatusOr<ObjectMetadata> RetryClient::CopyObject(
     CopyObjectRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -248,7 +246,7 @@ std::pair<Status, ObjectMetadata> RetryClient::CopyObject(
                   __func__);
 }
 
-std::pair<Status, ObjectMetadata> RetryClient::GetObjectMetadata(
+StatusOr<ObjectMetadata> RetryClient::GetObjectMetadata(
     GetObjectMetadataRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -258,7 +256,7 @@ std::pair<Status, ObjectMetadata> RetryClient::GetObjectMetadata(
                   __func__);
 }
 
-std::pair<Status, std::unique_ptr<ObjectReadStreambuf>> RetryClient::ReadObject(
+StatusOr<std::unique_ptr<ObjectReadStreambuf>> RetryClient::ReadObject(
     ReadObjectRangeRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -268,7 +266,7 @@ std::pair<Status, std::unique_ptr<ObjectReadStreambuf>> RetryClient::ReadObject(
                   __func__);
 }
 
-std::pair<Status, std::unique_ptr<ObjectWriteStreambuf>>
+StatusOr<std::unique_ptr<ObjectWriteStreambuf>>
 RetryClient::WriteObject(
     internal::InsertObjectStreamingRequest const& request) {
   auto retry_policy = retry_policy_->clone();
@@ -279,7 +277,7 @@ RetryClient::WriteObject(
                   __func__);
 }
 
-std::pair<Status, ListObjectsResponse> RetryClient::ListObjects(
+StatusOr<ListObjectsResponse> RetryClient::ListObjects(
     ListObjectsRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -289,7 +287,7 @@ std::pair<Status, ListObjectsResponse> RetryClient::ListObjects(
                   __func__);
 }
 
-std::pair<Status, EmptyResponse> RetryClient::DeleteObject(
+StatusOr<EmptyResponse> RetryClient::DeleteObject(
     DeleteObjectRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -299,7 +297,7 @@ std::pair<Status, EmptyResponse> RetryClient::DeleteObject(
                   __func__);
 }
 
-std::pair<Status, ObjectMetadata> RetryClient::UpdateObject(
+StatusOr<ObjectMetadata> RetryClient::UpdateObject(
     UpdateObjectRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -309,7 +307,7 @@ std::pair<Status, ObjectMetadata> RetryClient::UpdateObject(
                   __func__);
 }
 
-std::pair<Status, ObjectMetadata> RetryClient::PatchObject(
+StatusOr<ObjectMetadata> RetryClient::PatchObject(
     PatchObjectRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -319,7 +317,7 @@ std::pair<Status, ObjectMetadata> RetryClient::PatchObject(
                   __func__);
 }
 
-std::pair<Status, ObjectMetadata> RetryClient::ComposeObject(
+StatusOr<ObjectMetadata> RetryClient::ComposeObject(
     ComposeObjectRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -329,7 +327,7 @@ std::pair<Status, ObjectMetadata> RetryClient::ComposeObject(
                   __func__);
 }
 
-std::pair<Status, RewriteObjectResponse> RetryClient::RewriteObject(
+StatusOr<RewriteObjectResponse> RetryClient::RewriteObject(
     RewriteObjectRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -339,26 +337,25 @@ std::pair<Status, RewriteObjectResponse> RetryClient::RewriteObject(
                   __func__);
 }
 
-std::pair<Status, std::unique_ptr<ResumableUploadSession>>
+StatusOr<std::unique_ptr<ResumableUploadSession>>
 RetryClient::CreateResumableSession(ResumableUploadRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   auto result = MakeCall(*retry_policy, *backoff_policy, is_idempotent,
                          *client_, &RawClient::CreateResumableSession, request,
-                          __func__);
-  if (not result.first.ok()) {
+                         __func__);
+  if (not result.ok()) {
     return result;
   }
 
-  return std::make_pair(
-      Status(),
+  return std::unique_ptr<ResumableUploadSession>(
       google::cloud::internal::make_unique<RetryResumableUploadSession>(
-          std::move(result.second), std::move(retry_policy),
+          std::move(result).value(), std::move(retry_policy),
           std::move(backoff_policy)));
 }
 
-std::pair<Status, std::unique_ptr<ResumableUploadSession>>
+StatusOr<std::unique_ptr<ResumableUploadSession>>
 RetryClient::RestoreResumableSession(std::string const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -368,7 +365,7 @@ RetryClient::RestoreResumableSession(std::string const& request) {
                    __func__);
 }
 
-std::pair<Status, ListBucketAclResponse> RetryClient::ListBucketAcl(
+StatusOr<ListBucketAclResponse> RetryClient::ListBucketAcl(
     ListBucketAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -378,7 +375,7 @@ std::pair<Status, ListBucketAclResponse> RetryClient::ListBucketAcl(
                   __func__);
 }
 
-std::pair<Status, BucketAccessControl> RetryClient::GetBucketAcl(
+StatusOr<BucketAccessControl> RetryClient::GetBucketAcl(
     GetBucketAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -388,7 +385,7 @@ std::pair<Status, BucketAccessControl> RetryClient::GetBucketAcl(
                   __func__);
 }
 
-std::pair<Status, BucketAccessControl> RetryClient::CreateBucketAcl(
+StatusOr<BucketAccessControl> RetryClient::CreateBucketAcl(
     CreateBucketAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -398,7 +395,7 @@ std::pair<Status, BucketAccessControl> RetryClient::CreateBucketAcl(
                   __func__);
 }
 
-std::pair<Status, EmptyResponse> RetryClient::DeleteBucketAcl(
+StatusOr<EmptyResponse> RetryClient::DeleteBucketAcl(
     DeleteBucketAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -408,7 +405,7 @@ std::pair<Status, EmptyResponse> RetryClient::DeleteBucketAcl(
                   __func__);
 }
 
-std::pair<Status, ListObjectAclResponse> RetryClient::ListObjectAcl(
+StatusOr<ListObjectAclResponse> RetryClient::ListObjectAcl(
     ListObjectAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -418,7 +415,7 @@ std::pair<Status, ListObjectAclResponse> RetryClient::ListObjectAcl(
                   __func__);
 }
 
-std::pair<Status, BucketAccessControl> RetryClient::UpdateBucketAcl(
+StatusOr<BucketAccessControl> RetryClient::UpdateBucketAcl(
     UpdateBucketAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -428,7 +425,7 @@ std::pair<Status, BucketAccessControl> RetryClient::UpdateBucketAcl(
                   __func__);
 }
 
-std::pair<Status, BucketAccessControl> RetryClient::PatchBucketAcl(
+StatusOr<BucketAccessControl> RetryClient::PatchBucketAcl(
     PatchBucketAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -438,7 +435,7 @@ std::pair<Status, BucketAccessControl> RetryClient::PatchBucketAcl(
                   __func__);
 }
 
-std::pair<Status, ObjectAccessControl> RetryClient::CreateObjectAcl(
+StatusOr<ObjectAccessControl> RetryClient::CreateObjectAcl(
     CreateObjectAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -448,7 +445,7 @@ std::pair<Status, ObjectAccessControl> RetryClient::CreateObjectAcl(
                   __func__);
 }
 
-std::pair<Status, EmptyResponse> RetryClient::DeleteObjectAcl(
+StatusOr<EmptyResponse> RetryClient::DeleteObjectAcl(
     DeleteObjectAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -458,7 +455,7 @@ std::pair<Status, EmptyResponse> RetryClient::DeleteObjectAcl(
                   __func__);
 }
 
-std::pair<Status, ObjectAccessControl> RetryClient::GetObjectAcl(
+StatusOr<ObjectAccessControl> RetryClient::GetObjectAcl(
     GetObjectAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -468,7 +465,7 @@ std::pair<Status, ObjectAccessControl> RetryClient::GetObjectAcl(
                   __func__);
 }
 
-std::pair<Status, ObjectAccessControl> RetryClient::UpdateObjectAcl(
+StatusOr<ObjectAccessControl> RetryClient::UpdateObjectAcl(
     UpdateObjectAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -478,7 +475,7 @@ std::pair<Status, ObjectAccessControl> RetryClient::UpdateObjectAcl(
                   __func__);
 }
 
-std::pair<Status, ObjectAccessControl> RetryClient::PatchObjectAcl(
+StatusOr<ObjectAccessControl> RetryClient::PatchObjectAcl(
     PatchObjectAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -488,7 +485,7 @@ std::pair<Status, ObjectAccessControl> RetryClient::PatchObjectAcl(
                   __func__);
 }
 
-std::pair<Status, ListDefaultObjectAclResponse>
+StatusOr<ListDefaultObjectAclResponse>
 RetryClient::ListDefaultObjectAcl(ListDefaultObjectAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -498,7 +495,7 @@ RetryClient::ListDefaultObjectAcl(ListDefaultObjectAclRequest const& request) {
                   __func__);
 }
 
-std::pair<Status, ObjectAccessControl> RetryClient::CreateDefaultObjectAcl(
+StatusOr<ObjectAccessControl> RetryClient::CreateDefaultObjectAcl(
     CreateDefaultObjectAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -508,7 +505,7 @@ std::pair<Status, ObjectAccessControl> RetryClient::CreateDefaultObjectAcl(
                    __func__);
 }
 
-std::pair<Status, EmptyResponse> RetryClient::DeleteDefaultObjectAcl(
+StatusOr<EmptyResponse> RetryClient::DeleteDefaultObjectAcl(
     DeleteDefaultObjectAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -518,7 +515,7 @@ std::pair<Status, EmptyResponse> RetryClient::DeleteDefaultObjectAcl(
                    __func__);
 }
 
-std::pair<Status, ObjectAccessControl> RetryClient::GetDefaultObjectAcl(
+StatusOr<ObjectAccessControl> RetryClient::GetDefaultObjectAcl(
     GetDefaultObjectAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -528,7 +525,7 @@ std::pair<Status, ObjectAccessControl> RetryClient::GetDefaultObjectAcl(
                   __func__);
 }
 
-std::pair<Status, ObjectAccessControl> RetryClient::UpdateDefaultObjectAcl(
+StatusOr<ObjectAccessControl> RetryClient::UpdateDefaultObjectAcl(
     UpdateDefaultObjectAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -538,7 +535,7 @@ std::pair<Status, ObjectAccessControl> RetryClient::UpdateDefaultObjectAcl(
                    __func__);
 }
 
-std::pair<Status, ObjectAccessControl> RetryClient::PatchDefaultObjectAcl(
+StatusOr<ObjectAccessControl> RetryClient::PatchDefaultObjectAcl(
     PatchDefaultObjectAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -548,7 +545,7 @@ std::pair<Status, ObjectAccessControl> RetryClient::PatchDefaultObjectAcl(
                    __func__);
 }
 
-std::pair<Status, ServiceAccount> RetryClient::GetServiceAccount(
+StatusOr<ServiceAccount> RetryClient::GetServiceAccount(
     GetProjectServiceAccountRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -558,7 +555,7 @@ std::pair<Status, ServiceAccount> RetryClient::GetServiceAccount(
                   __func__);
 }
 
-std::pair<Status, ListNotificationsResponse> RetryClient::ListNotifications(
+StatusOr<ListNotificationsResponse> RetryClient::ListNotifications(
     ListNotificationsRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -568,7 +565,7 @@ std::pair<Status, ListNotificationsResponse> RetryClient::ListNotifications(
                   __func__);
 }
 
-std::pair<Status, NotificationMetadata> RetryClient::CreateNotification(
+StatusOr<NotificationMetadata> RetryClient::CreateNotification(
     CreateNotificationRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -578,7 +575,7 @@ std::pair<Status, NotificationMetadata> RetryClient::CreateNotification(
                   __func__);
 }
 
-std::pair<Status, NotificationMetadata> RetryClient::GetNotification(
+StatusOr<NotificationMetadata> RetryClient::GetNotification(
     GetNotificationRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
@@ -588,7 +585,7 @@ std::pair<Status, NotificationMetadata> RetryClient::GetNotification(
                   __func__);
 }
 
-std::pair<Status, EmptyResponse> RetryClient::DeleteNotification(
+StatusOr<EmptyResponse> RetryClient::DeleteNotification(
     DeleteNotificationRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -46,103 +46,100 @@ class RetryClient : public RawClient {
 
   ClientOptions const& client_options() const override;
 
-  std::pair<Status, ListBucketsResponse> ListBuckets(
+  StatusOr<ListBucketsResponse> ListBuckets(
       ListBucketsRequest const& request) override;
-  std::pair<Status, BucketMetadata> CreateBucket(
+  StatusOr<BucketMetadata> CreateBucket(
       CreateBucketRequest const& request) override;
-  std::pair<Status, BucketMetadata> GetBucketMetadata(
+  StatusOr<BucketMetadata> GetBucketMetadata(
       GetBucketMetadataRequest const& request) override;
-  std::pair<Status, EmptyResponse> DeleteBucket(
-      DeleteBucketRequest const&) override;
-  std::pair<Status, BucketMetadata> UpdateBucket(
+  StatusOr<EmptyResponse> DeleteBucket(DeleteBucketRequest const&) override;
+  StatusOr<BucketMetadata> UpdateBucket(
       UpdateBucketRequest const& request) override;
-  std::pair<Status, BucketMetadata> PatchBucket(
+  StatusOr<BucketMetadata> PatchBucket(
       PatchBucketRequest const& request) override;
-  std::pair<Status, IamPolicy> GetBucketIamPolicy(
+  StatusOr<IamPolicy> GetBucketIamPolicy(
       GetBucketIamPolicyRequest const& request) override;
-  std::pair<Status, IamPolicy> SetBucketIamPolicy(
+  StatusOr<IamPolicy> SetBucketIamPolicy(
       SetBucketIamPolicyRequest const& request) override;
-  std::pair<Status, TestBucketIamPermissionsResponse> TestBucketIamPermissions(
+  StatusOr<TestBucketIamPermissionsResponse> TestBucketIamPermissions(
       TestBucketIamPermissionsRequest const& request) override;
-  std::pair<Status, EmptyResponse> LockBucketRetentionPolicy(
+  StatusOr<EmptyResponse> LockBucketRetentionPolicy(
       LockBucketRetentionPolicyRequest const& request) override;
 
-  std::pair<Status, ObjectMetadata> InsertObjectMedia(
+  StatusOr<ObjectMetadata> InsertObjectMedia(
       InsertObjectMediaRequest const& request) override;
-  std::pair<Status, ObjectMetadata> CopyObject(
+  StatusOr<ObjectMetadata> CopyObject(
       CopyObjectRequest const& request) override;
-  std::pair<Status, ObjectMetadata> GetObjectMetadata(
+  StatusOr<ObjectMetadata> GetObjectMetadata(
       GetObjectMetadataRequest const& request) override;
-  std::pair<Status, std::unique_ptr<ObjectReadStreambuf>> ReadObject(
+  StatusOr<std::unique_ptr<ObjectReadStreambuf>> ReadObject(
       ReadObjectRangeRequest const&) override;
-  std::pair<Status, std::unique_ptr<ObjectWriteStreambuf>> WriteObject(
+  StatusOr<std::unique_ptr<ObjectWriteStreambuf>> WriteObject(
       InsertObjectStreamingRequest const&) override;
-  std::pair<Status, ListObjectsResponse> ListObjects(
-      ListObjectsRequest const&) override;
-  std::pair<Status, EmptyResponse> DeleteObject(
-      DeleteObjectRequest const&) override;
-  std::pair<Status, ObjectMetadata> UpdateObject(
+  StatusOr<ListObjectsResponse> ListObjects(ListObjectsRequest const&) override;
+  StatusOr<EmptyResponse> DeleteObject(DeleteObjectRequest const&) override;
+  StatusOr<ObjectMetadata> UpdateObject(
       UpdateObjectRequest const& request) override;
-  std::pair<Status, ObjectMetadata> PatchObject(
+  StatusOr<ObjectMetadata> PatchObject(
       PatchObjectRequest const& request) override;
-  std::pair<Status, ObjectMetadata> ComposeObject(
+  StatusOr<ObjectMetadata> ComposeObject(
       ComposeObjectRequest const& request) override;
-  std::pair<Status, RewriteObjectResponse> RewriteObject(
+  StatusOr<RewriteObjectResponse> RewriteObject(
       RewriteObjectRequest const&) override;
-  std::pair<Status, std::unique_ptr<ResumableUploadSession>>
-  CreateResumableSession(ResumableUploadRequest const& request) override;
-  std::pair<Status, std::unique_ptr<ResumableUploadSession>>
-  RestoreResumableSession(std::string const& request) override;
+  StatusOr<std::unique_ptr<ResumableUploadSession>> CreateResumableSession(
+      ResumableUploadRequest const& request) override;
+  StatusOr<std::unique_ptr<ResumableUploadSession>> RestoreResumableSession(
+      std::string const& request) override;
 
-  std::pair<Status, ListBucketAclResponse> ListBucketAcl(
+  StatusOr<ListBucketAclResponse> ListBucketAcl(
       ListBucketAclRequest const& request) override;
-  std::pair<Status, BucketAccessControl> CreateBucketAcl(
+  StatusOr<BucketAccessControl> CreateBucketAcl(
       CreateBucketAclRequest const&) override;
-  std::pair<Status, EmptyResponse> DeleteBucketAcl(
+  StatusOr<EmptyResponse> DeleteBucketAcl(
       DeleteBucketAclRequest const&) override;
-  std::pair<Status, BucketAccessControl> GetBucketAcl(
+  StatusOr<BucketAccessControl> GetBucketAcl(
       GetBucketAclRequest const&) override;
-  std::pair<Status, BucketAccessControl> UpdateBucketAcl(
+  StatusOr<BucketAccessControl> UpdateBucketAcl(
       UpdateBucketAclRequest const&) override;
-  std::pair<Status, BucketAccessControl> PatchBucketAcl(
+  StatusOr<BucketAccessControl> PatchBucketAcl(
       PatchBucketAclRequest const&) override;
 
-  std::pair<Status, ListObjectAclResponse> ListObjectAcl(
+  StatusOr<ListObjectAclResponse> ListObjectAcl(
       ListObjectAclRequest const& request) override;
-  std::pair<Status, ObjectAccessControl> CreateObjectAcl(
+  StatusOr<ObjectAccessControl> CreateObjectAcl(
       CreateObjectAclRequest const&) override;
-  std::pair<Status, EmptyResponse> DeleteObjectAcl(
+  StatusOr<EmptyResponse> DeleteObjectAcl(
       DeleteObjectAclRequest const&) override;
-  std::pair<Status, ObjectAccessControl> GetObjectAcl(
+  StatusOr<ObjectAccessControl> GetObjectAcl(
       GetObjectAclRequest const&) override;
-  std::pair<Status, ObjectAccessControl> UpdateObjectAcl(
+  StatusOr<ObjectAccessControl> UpdateObjectAcl(
       UpdateObjectAclRequest const&) override;
-  std::pair<Status, ObjectAccessControl> PatchObjectAcl(
+  StatusOr<ObjectAccessControl> PatchObjectAcl(
       PatchObjectAclRequest const&) override;
 
-  std::pair<Status, ListDefaultObjectAclResponse> ListDefaultObjectAcl(
+  StatusOr<ListDefaultObjectAclResponse> ListDefaultObjectAcl(
       ListDefaultObjectAclRequest const& request) override;
-  std::pair<Status, ObjectAccessControl> CreateDefaultObjectAcl(
+  StatusOr<ObjectAccessControl> CreateDefaultObjectAcl(
       CreateDefaultObjectAclRequest const&) override;
-  std::pair<Status, EmptyResponse> DeleteDefaultObjectAcl(
+  StatusOr<EmptyResponse> DeleteDefaultObjectAcl(
       DeleteDefaultObjectAclRequest const&) override;
-  std::pair<Status, ObjectAccessControl> GetDefaultObjectAcl(
+  StatusOr<ObjectAccessControl> GetDefaultObjectAcl(
       GetDefaultObjectAclRequest const&) override;
-  std::pair<Status, ObjectAccessControl> UpdateDefaultObjectAcl(
+  StatusOr<ObjectAccessControl> UpdateDefaultObjectAcl(
       UpdateDefaultObjectAclRequest const&) override;
-  std::pair<Status, ObjectAccessControl> PatchDefaultObjectAcl(
+  StatusOr<ObjectAccessControl> PatchDefaultObjectAcl(
       PatchDefaultObjectAclRequest const&) override;
 
-  std::pair<Status, ServiceAccount> GetServiceAccount(
+  StatusOr<ServiceAccount> GetServiceAccount(
       GetProjectServiceAccountRequest const&) override;
 
-  std::pair<Status, ListNotificationsResponse> ListNotifications(
+  StatusOr<ListNotificationsResponse> ListNotifications(
       ListNotificationsRequest const&) override;
-  std::pair<Status, NotificationMetadata> CreateNotification(
+  StatusOr<NotificationMetadata> CreateNotification(
       CreateNotificationRequest const&) override;
-  std::pair<Status, NotificationMetadata> GetNotification(
+  StatusOr<NotificationMetadata> GetNotification(
       GetNotificationRequest const&) override;
-  std::pair<Status, EmptyResponse> DeleteNotification(
+  StatusOr<EmptyResponse> DeleteNotification(
       DeleteNotificationRequest const&) override;
 
   std::shared_ptr<RawClient> client() const { return client_; }

--- a/google/cloud/storage/internal/retry_resumable_upload_session.h
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.h
@@ -39,9 +39,9 @@ class RetryResumableUploadSession : public ResumableUploadSession {
         retry_policy_(std::move(retry_policy)),
         backoff_policy_(std::move(backoff_policy)) {}
 
-  std::pair<Status, ResumableUploadResponse> UploadChunk(
+  StatusOr<ResumableUploadResponse> UploadChunk(
       std::string const& buffer, std::uint64_t upload_size) override;
-  std::pair<Status, ResumableUploadResponse> ResetSession() override;
+  StatusOr<ResumableUploadResponse> ResetSession() override;
   std::uint64_t next_expected_byte() const override;
   std::string const& session_id() const override;
 

--- a/google/cloud/storage/list_buckets_reader.cc
+++ b/google/cloud/storage/list_buckets_reader.cc
@@ -88,12 +88,9 @@ google::cloud::optional<BucketMetadata> ListBucketsReader::GetNext() {
       return google::cloud::optional<BucketMetadata>();
     }
     request_.set_page_token(std::move(next_page_token_));
-    auto response = client_->ListBuckets(request_);
-    if (not response.first.ok()) {
-      internal::ThrowStatus(std::move(response.first));
-    }
-    next_page_token_ = std::move(response.second.next_page_token);
-    current_buckets_ = std::move(response.second.items);
+    auto response = client_->ListBuckets(request_).value();
+    next_page_token_ = std::move(response.next_page_token);
+    current_buckets_ = std::move(response.items);
     current_ = current_buckets_.begin();
     if (next_page_token_.empty()) {
       on_last_page_ = true;

--- a/google/cloud/storage/list_buckets_reader_test.cc
+++ b/google/cloud/storage/list_buckets_reader_test.cc
@@ -63,7 +63,7 @@ TEST(ListBucketsReaderTest, Basic) {
       response.items.push_back(expected[2 * i + 1]);
     }
     return [response](ListBucketsRequest const&) {
-      return std::make_pair(Status(), response);
+      return make_status_or( response);
     };
   };
 
@@ -84,7 +84,7 @@ TEST(ListBucketsReaderTest, Basic) {
 TEST(ListBucketsReaderTest, Empty) {
   auto mock = std::make_shared<MockClient>();
   EXPECT_CALL(*mock, ListBuckets(_))
-      .WillOnce(Return(std::make_pair(Status(), ListBucketsResponse())));
+      .WillOnce(Return(make_status_or( ListBucketsResponse())));
 
   ListBucketsReader reader(mock, "foo-bar-baz", Prefix("dir/"));
   auto count = std::distance(reader.begin(), reader.end());

--- a/google/cloud/storage/list_buckets_reader_test.cc
+++ b/google/cloud/storage/list_buckets_reader_test.cc
@@ -63,7 +63,7 @@ TEST(ListBucketsReaderTest, Basic) {
       response.items.push_back(expected[2 * i + 1]);
     }
     return [response](ListBucketsRequest const&) {
-      return make_status_or( response);
+      return make_status_or(response);
     };
   };
 
@@ -84,7 +84,7 @@ TEST(ListBucketsReaderTest, Basic) {
 TEST(ListBucketsReaderTest, Empty) {
   auto mock = std::make_shared<MockClient>();
   EXPECT_CALL(*mock, ListBuckets(_))
-      .WillOnce(Return(make_status_or( ListBucketsResponse())));
+      .WillOnce(Return(make_status_or(ListBucketsResponse())));
 
   ListBucketsReader reader(mock, "foo-bar-baz", Prefix("dir/"));
   auto count = std::distance(reader.begin(), reader.end());

--- a/google/cloud/storage/list_objects_reader.cc
+++ b/google/cloud/storage/list_objects_reader.cc
@@ -88,12 +88,9 @@ google::cloud::optional<ObjectMetadata> ListObjectsReader::GetNext() {
       return google::cloud::optional<ObjectMetadata>();
     }
     request_.set_page_token(std::move(next_page_token_));
-    auto response = client_->ListObjects(request_);
-    if (not response.first.ok()) {
-      internal::ThrowStatus(std::move(response.first));
-    }
-    next_page_token_ = std::move(response.second.next_page_token);
-    current_objects_ = std::move(response.second.items);
+    auto response = client_->ListObjects(request_).value();
+    next_page_token_ = std::move(response.next_page_token);
+    current_objects_ = std::move(response.items);
     current_ = current_objects_.begin();
     if (next_page_token_.empty()) {
       on_last_page_ = true;

--- a/google/cloud/storage/list_objects_reader_test.cc
+++ b/google/cloud/storage/list_objects_reader_test.cc
@@ -63,7 +63,7 @@ TEST(ListObjectsReaderTest, Basic) {
       response.items.push_back(expected[2 * i + 1]);
     }
     return [response](ListObjectsRequest const&) {
-      return std::make_pair(Status(), response);
+      return StatusOr<ListObjectsResponse>(response);
     };
   };
 
@@ -84,7 +84,7 @@ TEST(ListObjectsReaderTest, Basic) {
 TEST(ListObjectsReaderTest, Empty) {
   auto mock = std::make_shared<MockClient>();
   EXPECT_CALL(*mock, ListObjects(_))
-      .WillOnce(Return(std::make_pair(Status(), ListObjectsResponse())));
+      .WillOnce(Return(make_status_or(ListObjectsResponse{})));
 
   ListObjectsReader reader(mock, "foo-bar-baz", Prefix("dir/"));
   auto count = std::distance(reader.begin(), reader.end());

--- a/google/cloud/storage/oauth2/anonymous_credentials.cc
+++ b/google/cloud/storage/oauth2/anonymous_credentials.cc
@@ -20,9 +20,9 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 
-std::pair<google::cloud::storage::Status, std::string>
+StatusOr<std::string>
 AnonymousCredentials::AuthorizationHeader() {
-  return std::make_pair(google::cloud::storage::Status(), "");
+  return std::string{};
 }
 
 }  // namespace oauth2

--- a/google/cloud/storage/oauth2/anonymous_credentials.h
+++ b/google/cloud/storage/oauth2/anonymous_credentials.h
@@ -42,8 +42,7 @@ class AnonymousCredentials : public Credentials {
    * Authorization HTTP header from this method, this class always returns an
    * empty string.
    */
-  std::pair<google::cloud::storage::Status, std::string> AuthorizationHeader()
-      override;
+  StatusOr<std::string> AuthorizationHeader() override;
 };
 
 }  // namespace oauth2

--- a/google/cloud/storage/oauth2/anonymous_credentials_test.cc
+++ b/google/cloud/storage/oauth2/anonymous_credentials_test.cc
@@ -27,7 +27,9 @@ class AnonymousCredentialsTest : public ::testing::Test {};
 /// @test Verify `AnonymousCredentials` works as expected.
 TEST_F(AnonymousCredentialsTest, AuthorizationHeaderReturnsEmptyString) {
   AnonymousCredentials credentials;
-  EXPECT_EQ("", credentials.AuthorizationHeader().second);
+  auto header = credentials.AuthorizationHeader();
+  ASSERT_TRUE(header.ok());
+  EXPECT_EQ("", header.value());
 }
 
 }  // namespace

--- a/google/cloud/storage/oauth2/authorized_user_credentials.h
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.h
@@ -88,7 +88,7 @@ class AuthorizedUserCredentials : public Credentials {
     request_ = request_builder.BuildRequest();
   }
 
-  std::pair<storage::Status, std::string> AuthorizationHeader() override {
+  StatusOr<std::string> AuthorizationHeader() override {
     std::unique_lock<std::mutex> lock(mu_);
     return refreshing_creds_.AuthorizationHeader([this] { return Refresh(); });
   }

--- a/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
@@ -89,7 +89,7 @@ TEST_F(AuthorizedUserCredentialsTest, Simple) {
 
   AuthorizedUserCredentials<MockHttpRequestBuilder> credentials(config, "test");
   EXPECT_EQ("Authorization: Type access-token-value",
-            credentials.AuthorizationHeader().second);
+            credentials.AuthorizationHeader().value());
 }
 
 /// @test Verify that we can refresh service account credentials.
@@ -139,11 +139,11 @@ TEST_F(AuthorizedUserCredentialsTest, Refresh) {
 })""";
   AuthorizedUserCredentials<MockHttpRequestBuilder> credentials(config, "test");
   EXPECT_EQ("Authorization: Type access-token-r1",
-            credentials.AuthorizationHeader().second);
+            credentials.AuthorizationHeader().value());
   EXPECT_EQ("Authorization: Type access-token-r2",
-            credentials.AuthorizationHeader().second);
+            credentials.AuthorizationHeader().value());
   EXPECT_EQ("Authorization: Type access-token-r2",
-            credentials.AuthorizationHeader().second);
+            credentials.AuthorizationHeader().value());
 }
 
 /// @test Verify that invalid contents result in a readable error.

--- a/google/cloud/storage/oauth2/compute_engine_credentials.h
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.h
@@ -63,7 +63,7 @@ class ComputeEngineCredentials : public Credentials {
 
   explicit ComputeEngineCredentials(std::string const& service_account_email)
       : service_account_email_(service_account_email) {}
-  std::pair<storage::Status, std::string> AuthorizationHeader() override {
+  StatusOr<std::string> AuthorizationHeader() override {
     std::unique_lock<std::mutex> lock(mu_);
     return refreshing_creds_.AuthorizationHeader([this] { return Refresh(); });
   }

--- a/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
@@ -108,7 +108,7 @@ TEST_F(ComputeEngineCredentialsTest,
   ComputeEngineCredentials<MockHttpRequestBuilder> credentials(alias);
   // Calls Refresh to obtain the access token for our authorization header.
   EXPECT_EQ("Authorization: tokentype mysupersecrettoken",
-            credentials.AuthorizationHeader().second);
+            credentials.AuthorizationHeader().value());
   // Make sure we obtain the scopes and email from the metadata server.
   EXPECT_EQ(email, credentials.service_account_email());
   EXPECT_THAT(credentials.scopes(), UnorderedElementsAre("scope1", "scope2"));

--- a/google/cloud/storage/oauth2/credentials.h
+++ b/google/cloud/storage/oauth2/credentials.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_CREDENTIALS_H_
 
 #include "google/cloud/storage/status.h"
+#include "google/cloud/storage/status_or.h"
 #include <chrono>
 
 namespace google {
@@ -45,8 +46,7 @@ class Credentials {
    * - The value for the Authorization header in HTTP requests, or an empty
    *   string if we were unable to obtain one.
    */
-  virtual std::pair<google::cloud::storage::Status, std::string>
-  AuthorizationHeader() = 0;
+  virtual StatusOr<std::string> AuthorizationHeader() = 0;
 };
 
 }  // namespace oauth2

--- a/google/cloud/storage/oauth2/refreshing_credentials_wrapper.h
+++ b/google/cloud/storage/oauth2/refreshing_credentials_wrapper.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_REFRESHING_CREDENTIALS_WRAPPER_H_
 
 #include "google/cloud/storage/status.h"
+#include "google/cloud/storage/status_or.h"
 #include <chrono>
 #include <string>
 #include <utility>
@@ -31,15 +32,16 @@ namespace oauth2 {
 class RefreshingCredentialsWrapper {
  public:
   template <typename RefreshFunctor>
-  std::pair<storage::Status, std::string> AuthorizationHeader(
-      RefreshFunctor refresh_fn) {
+  StatusOr<std::string> AuthorizationHeader(RefreshFunctor refresh_fn) {
     if (IsValid()) {
-      return std::make_pair(storage::Status(), authorization_header);
+      return authorization_header;
     }
 
     storage::Status status = refresh_fn();
-    return std::make_pair(status,
-                          status.ok() ? authorization_header : std::string{});
+    if (status.ok()) {
+      return authorization_header;
+    }
+    return status;
   }
 
   /**

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -110,7 +110,7 @@ class ServiceAccountCredentials : public Credentials {
     info_ = std::move(info);
   }
 
-  std::pair<storage::Status, std::string> AuthorizationHeader() override {
+  StatusOr<std::string> AuthorizationHeader() override {
     std::unique_lock<std::mutex> lock(mu_);
     return refreshing_creds_.AuthorizationHeader([this] { return Refresh(); });
   }

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -130,7 +130,7 @@ TEST_F(ServiceAccountCredentialsTest,
 
   // Calls Refresh to obtain the access token for our authorization header.
   EXPECT_EQ("Authorization: Type access-token-value",
-            credentials.AuthorizationHeader().second);
+            credentials.AuthorizationHeader().value());
 }
 
 /// @test Verify that we refresh service account credentials appropriately.
@@ -179,13 +179,13 @@ TEST_F(ServiceAccountCredentialsTest,
       kJsonKeyfileContents, "test");
   // Calls Refresh to obtain the access token for our authorization header.
   EXPECT_EQ("Authorization: Type access-token-r1",
-            credentials.AuthorizationHeader().second);
+            credentials.AuthorizationHeader().value());
   // Token is expired, resulting in another call to Refresh.
   EXPECT_EQ("Authorization: Type access-token-r2",
-            credentials.AuthorizationHeader().second);
+            credentials.AuthorizationHeader().value());
   // Token still valid; should return cached token instead of calling Refresh.
   EXPECT_EQ("Authorization: Type access-token-r2",
-            credentials.AuthorizationHeader().second);
+            credentials.AuthorizationHeader().value());
 }
 
 /// @test Verify that nl::json::parse() failures are reported as is_discarded.

--- a/google/cloud/storage/object_rewriter.cc
+++ b/google/cloud/storage/object_rewriter.cc
@@ -27,11 +27,8 @@ ObjectRewriter::ObjectRewriter(std::shared_ptr<internal::RawClient> client,
       progress_{0, 0, false} {}
 
 RewriteProgress ObjectRewriter::Iterate() {
-  auto result = client_->RewriteObject(request_);
-  if (not result.first.ok()) {
-    internal::ThrowStatus(std::move(result.first));
-  }
-  internal::RewriteObjectResponse response = std::move(result.second);
+  internal::RewriteObjectResponse response =
+      client_->RewriteObject(request_).value();
   progress_ = RewriteProgress{response.total_bytes_rewritten,
                               response.object_size, response.done};
   if (response.done) {

--- a/google/cloud/storage/object_test.cc
+++ b/google/cloud/storage/object_test.cc
@@ -134,7 +134,7 @@ TEST_F(ObjectTest, GetObjectMetadata) {
           Invoke([&expected](internal::GetObjectMetadataRequest const& r) {
             EXPECT_EQ("test-bucket-name", r.bucket_name());
             EXPECT_EQ("test-object-name", r.object_name());
-            return make_status_or( expected);
+            return make_status_or(expected);
           }));
   Client client{std::shared_ptr<internal::RawClient>(mock),
                 LimitedErrorCountRetryPolicy(2)};
@@ -169,7 +169,7 @@ TEST_F(ObjectTest, DeleteObject) {
       .WillOnce(Invoke([](internal::DeleteObjectRequest const& r) {
         EXPECT_EQ("test-bucket-name", r.bucket_name());
         EXPECT_EQ("test-object-name", r.object_name());
-        return make_status_or( internal::EmptyResponse{});
+        return make_status_or(internal::EmptyResponse{});
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock),
                 LimitedErrorCountRetryPolicy(2),
@@ -250,7 +250,7 @@ TEST_F(ObjectTest, UpdateObject) {
              }},
         };
         EXPECT_EQ(expected_payload, actual_payload);
-        return make_status_or( expected);
+        return make_status_or(expected);
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock),
                 LimitedErrorCountRetryPolicy(2)};
@@ -329,7 +329,7 @@ TEST_F(ObjectTest, PatchObject) {
         EXPECT_EQ("test-object-name", r.object_name());
         EXPECT_THAT(r.payload(), HasSubstr("new-disposition"));
         EXPECT_THAT(r.payload(), HasSubstr("x-made-up-lang"));
-        return make_status_or( expected);
+        return make_status_or(expected);
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock),
                 LimitedErrorCountRetryPolicy(2)};

--- a/google/cloud/storage/status_or.h
+++ b/google/cloud/storage/status_or.h
@@ -330,6 +330,11 @@ class StatusOr<void> final {
   Status status_;
 };
 
+template <typename T>
+StatusOr<T> make_status_or(T rhs) {
+  return StatusOr<T>(std::move(rhs));
+}
+
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -26,148 +26,137 @@ namespace testing {
 
 class MockClient : public google::cloud::storage::internal::RawClient {
  public:
-  // The MOCK_* macros get confused if the return type is a compound template
-  // with a comma, that is because Foo<T,R> looks like two arguments to the
-  // preprocessor, but Foo<R> will look like a single argument.
-  template <typename R>
-  using ResponseWrapper = std::pair<google::cloud::storage::Status, R>;
-
   MOCK_CONST_METHOD0(client_options, ClientOptions const&());
-  MOCK_METHOD1(ListBuckets, ResponseWrapper<internal::ListBucketsResponse>(
+  MOCK_METHOD1(ListBuckets, StatusOr<internal::ListBucketsResponse>(
                                 internal::ListBucketsRequest const&));
-  MOCK_METHOD1(CreateBucket, ResponseWrapper<storage::BucketMetadata>(
+  MOCK_METHOD1(CreateBucket, StatusOr<storage::BucketMetadata>(
                                  internal::CreateBucketRequest const&));
   MOCK_METHOD1(GetBucketMetadata,
-               ResponseWrapper<storage::BucketMetadata>(
+               StatusOr<storage::BucketMetadata>(
                    internal::GetBucketMetadataRequest const&));
-  MOCK_METHOD1(DeleteBucket, ResponseWrapper<internal::EmptyResponse>(
+  MOCK_METHOD1(DeleteBucket, StatusOr<internal::EmptyResponse>(
                                  internal::DeleteBucketRequest const&));
-  MOCK_METHOD1(UpdateBucket, ResponseWrapper<storage::BucketMetadata>(
+  MOCK_METHOD1(UpdateBucket, StatusOr<storage::BucketMetadata>(
                                  internal::UpdateBucketRequest const&));
-  MOCK_METHOD1(PatchBucket, ResponseWrapper<storage::BucketMetadata>(
+  MOCK_METHOD1(PatchBucket, StatusOr<storage::BucketMetadata>(
                                 internal::PatchBucketRequest const&));
-  MOCK_METHOD1(
-      GetBucketIamPolicy,
-      ResponseWrapper<IamPolicy>(internal::GetBucketIamPolicyRequest const&));
-  MOCK_METHOD1(
-      SetBucketIamPolicy,
-      ResponseWrapper<IamPolicy>(internal::SetBucketIamPolicyRequest const&));
+  MOCK_METHOD1(GetBucketIamPolicy,
+               StatusOr<IamPolicy>(internal::GetBucketIamPolicyRequest const&));
+  MOCK_METHOD1(SetBucketIamPolicy,
+               StatusOr<IamPolicy>(internal::SetBucketIamPolicyRequest const&));
   MOCK_METHOD1(TestBucketIamPermissions,
-               ResponseWrapper<internal::TestBucketIamPermissionsResponse>(
+               StatusOr<internal::TestBucketIamPermissionsResponse>(
                    internal::TestBucketIamPermissionsRequest const&));
   MOCK_METHOD1(LockBucketRetentionPolicy,
-               ResponseWrapper<internal::EmptyResponse>(
+               StatusOr<internal::EmptyResponse>(
                    internal::LockBucketRetentionPolicyRequest const&));
 
   MOCK_METHOD1(InsertObjectMedia,
-               ResponseWrapper<storage::ObjectMetadata>(
+               StatusOr<storage::ObjectMetadata>(
                    internal::InsertObjectMediaRequest const&));
-  MOCK_METHOD1(CopyObject, ResponseWrapper<storage::ObjectMetadata>(
+  MOCK_METHOD1(CopyObject, StatusOr<storage::ObjectMetadata>(
                                internal::CopyObjectRequest const&));
   MOCK_METHOD1(GetObjectMetadata,
-               ResponseWrapper<storage::ObjectMetadata>(
+               StatusOr<storage::ObjectMetadata>(
                    internal::GetObjectMetadataRequest const&));
   MOCK_METHOD1(ReadObject,
-               ResponseWrapper<std::unique_ptr<internal::ObjectReadStreambuf>>(
+               StatusOr<std::unique_ptr<internal::ObjectReadStreambuf>>(
                    internal::ReadObjectRangeRequest const&));
   MOCK_METHOD1(WriteObject,
-               ResponseWrapper<std::unique_ptr<internal::ObjectWriteStreambuf>>(
+               StatusOr<std::unique_ptr<internal::ObjectWriteStreambuf>>(
                    internal::InsertObjectStreamingRequest const&));
-  MOCK_METHOD1(ListObjects, ResponseWrapper<internal::ListObjectsResponse>(
+  MOCK_METHOD1(ListObjects, StatusOr<internal::ListObjectsResponse>(
                                 internal::ListObjectsRequest const&));
-  MOCK_METHOD1(DeleteObject, ResponseWrapper<internal::EmptyResponse>(
+  MOCK_METHOD1(DeleteObject, StatusOr<internal::EmptyResponse>(
                                  internal::DeleteObjectRequest const&));
-  MOCK_METHOD1(UpdateObject, ResponseWrapper<storage::ObjectMetadata>(
+  MOCK_METHOD1(UpdateObject, StatusOr<storage::ObjectMetadata>(
                                  internal::UpdateObjectRequest const&));
-  MOCK_METHOD1(PatchObject, ResponseWrapper<storage::ObjectMetadata>(
+  MOCK_METHOD1(PatchObject, StatusOr<storage::ObjectMetadata>(
                                 internal::PatchObjectRequest const&));
-  MOCK_METHOD1(ComposeObject, ResponseWrapper<storage::ObjectMetadata>(
+  MOCK_METHOD1(ComposeObject, StatusOr<storage::ObjectMetadata>(
                                   internal::ComposeObjectRequest const&));
-  MOCK_METHOD1(RewriteObject, ResponseWrapper<internal::RewriteObjectResponse>(
+  MOCK_METHOD1(RewriteObject, StatusOr<internal::RewriteObjectResponse>(
                                   internal::RewriteObjectRequest const&));
-  MOCK_METHOD1(
-      CreateResumableSession,
-      ResponseWrapper<std::unique_ptr<internal::ResumableUploadSession>>(
-          internal::ResumableUploadRequest const&));
-  MOCK_METHOD1(
-      RestoreResumableSession,
-      ResponseWrapper<std::unique_ptr<internal::ResumableUploadSession>>(
-          std::string const&));
+  MOCK_METHOD1(CreateResumableSession,
+               StatusOr<std::unique_ptr<internal::ResumableUploadSession>>(
+                   internal::ResumableUploadRequest const&));
+  MOCK_METHOD1(RestoreResumableSession,
+               StatusOr<std::unique_ptr<internal::ResumableUploadSession>>(
+                   std::string const&));
 
-  MOCK_METHOD1(ListBucketAcl, ResponseWrapper<internal::ListBucketAclResponse>(
+  MOCK_METHOD1(ListBucketAcl, StatusOr<internal::ListBucketAclResponse>(
                                   internal::ListBucketAclRequest const&));
-  MOCK_METHOD1(CreateBucketAcl, ResponseWrapper<BucketAccessControl>(
+  MOCK_METHOD1(CreateBucketAcl, StatusOr<BucketAccessControl>(
                                     internal::CreateBucketAclRequest const&));
-  MOCK_METHOD1(DeleteBucketAcl, ResponseWrapper<internal::EmptyResponse>(
+  MOCK_METHOD1(DeleteBucketAcl, StatusOr<internal::EmptyResponse>(
                                     internal::DeleteBucketAclRequest const&));
-  MOCK_METHOD1(GetBucketAcl, ResponseWrapper<BucketAccessControl>(
+  MOCK_METHOD1(GetBucketAcl, StatusOr<BucketAccessControl>(
                                  internal::GetBucketAclRequest const&));
-  MOCK_METHOD1(UpdateBucketAcl, ResponseWrapper<BucketAccessControl>(
+  MOCK_METHOD1(UpdateBucketAcl, StatusOr<BucketAccessControl>(
                                     internal::UpdateBucketAclRequest const&));
-  MOCK_METHOD1(PatchBucketAcl, ResponseWrapper<BucketAccessControl>(
+  MOCK_METHOD1(PatchBucketAcl, StatusOr<BucketAccessControl>(
                                    internal::PatchBucketAclRequest const&));
 
-  MOCK_METHOD1(ListObjectAcl, ResponseWrapper<internal::ListObjectAclResponse>(
+  MOCK_METHOD1(ListObjectAcl, StatusOr<internal::ListObjectAclResponse>(
                                   internal::ListObjectAclRequest const&));
-  MOCK_METHOD1(CreateObjectAcl, ResponseWrapper<ObjectAccessControl>(
+  MOCK_METHOD1(CreateObjectAcl, StatusOr<ObjectAccessControl>(
                                     internal::CreateObjectAclRequest const&));
-  MOCK_METHOD1(DeleteObjectAcl, ResponseWrapper<internal::EmptyResponse>(
+  MOCK_METHOD1(DeleteObjectAcl, StatusOr<internal::EmptyResponse>(
                                     internal::DeleteObjectAclRequest const&));
-  MOCK_METHOD1(GetObjectAcl, ResponseWrapper<ObjectAccessControl>(
+  MOCK_METHOD1(GetObjectAcl, StatusOr<ObjectAccessControl>(
                                  internal::GetObjectAclRequest const&));
-  MOCK_METHOD1(UpdateObjectAcl, ResponseWrapper<ObjectAccessControl>(
+  MOCK_METHOD1(UpdateObjectAcl, StatusOr<ObjectAccessControl>(
                                     internal::UpdateObjectAclRequest const&));
-  MOCK_METHOD1(PatchObjectAcl, ResponseWrapper<ObjectAccessControl>(
+  MOCK_METHOD1(PatchObjectAcl, StatusOr<ObjectAccessControl>(
                                    internal::PatchObjectAclRequest const&));
 
   MOCK_METHOD1(ListDefaultObjectAcl,
-               ResponseWrapper<internal::ListDefaultObjectAclResponse>(
+               StatusOr<internal::ListDefaultObjectAclResponse>(
                    internal::ListDefaultObjectAclRequest const&));
   MOCK_METHOD1(CreateDefaultObjectAcl,
-               ResponseWrapper<ObjectAccessControl>(
+               StatusOr<ObjectAccessControl>(
                    internal::CreateDefaultObjectAclRequest const&));
   MOCK_METHOD1(DeleteDefaultObjectAcl,
-               ResponseWrapper<internal::EmptyResponse>(
+               StatusOr<internal::EmptyResponse>(
                    internal::DeleteDefaultObjectAclRequest const&));
   MOCK_METHOD1(GetDefaultObjectAcl,
-               ResponseWrapper<ObjectAccessControl>(
+               StatusOr<ObjectAccessControl>(
                    internal::GetDefaultObjectAclRequest const&));
   MOCK_METHOD1(UpdateDefaultObjectAcl,
-               ResponseWrapper<ObjectAccessControl>(
+               StatusOr<ObjectAccessControl>(
                    internal::UpdateDefaultObjectAclRequest const&));
   MOCK_METHOD1(PatchDefaultObjectAcl,
-               ResponseWrapper<ObjectAccessControl>(
+               StatusOr<ObjectAccessControl>(
                    internal::PatchDefaultObjectAclRequest const&));
 
   MOCK_METHOD1(GetServiceAccount,
-               ResponseWrapper<ServiceAccount>(
+               StatusOr<ServiceAccount>(
                    internal::GetProjectServiceAccountRequest const&));
 
   MOCK_METHOD1(ListNotifications,
-               ResponseWrapper<internal::ListNotificationsResponse>(
+               StatusOr<internal::ListNotificationsResponse>(
                    internal::ListNotificationsRequest const&));
   MOCK_METHOD1(CreateNotification,
-               ResponseWrapper<NotificationMetadata>(
+               StatusOr<NotificationMetadata>(
                    internal::CreateNotificationRequest const&));
-  MOCK_METHOD1(GetNotification, ResponseWrapper<NotificationMetadata>(
+  MOCK_METHOD1(GetNotification, StatusOr<NotificationMetadata>(
                                     internal::GetNotificationRequest const&));
   MOCK_METHOD1(DeleteNotification,
-               ResponseWrapper<internal::EmptyResponse>(
+               StatusOr<internal::EmptyResponse>(
                    internal::DeleteNotificationRequest const&));
   MOCK_METHOD1(
       AuthorizationHeader,
-      ResponseWrapper<std::string>(
+      StatusOr<std::string>(
           std::shared_ptr<google::cloud::storage::oauth2::Credentials> const&));
 };
 
 class MockResumableUploadSession
     : public google::cloud::storage::internal::ResumableUploadSession {
  public:
-  using ResponseType = std::pair<Status, internal::ResumableUploadResponse>;
-
-  MOCK_METHOD2(UploadChunk, ResponseType(std::string const& buffer,
-                                         std::uint64_t upload_size));
-  MOCK_METHOD0(ResetSession, ResponseType());
+  MOCK_METHOD2(UploadChunk,
+               StatusOr<internal::ResumableUploadResponse>(
+                   std::string const& buffer, std::uint64_t upload_size));
+  MOCK_METHOD0(ResetSession, StatusOr<internal::ResumableUploadResponse>());
   MOCK_CONST_METHOD0(next_expected_byte, std::uint64_t());
   MOCK_CONST_METHOD0(session_id, std::string const&());
 };

--- a/google/cloud/storage/testing/retry_tests.h
+++ b/google/cloud/storage/testing/retry_tests.h
@@ -65,9 +65,9 @@ void TooManyFailuresTest(
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   // Expect exactly 3 calls before the retry policy is exhausted and an
   // exception is raised.
-  oncall.WillOnce(Return(std::make_pair(TransientError(), ReturnType{})))
-      .WillOnce(Return(std::make_pair(TransientError(), ReturnType{})))
-      .WillOnce(Return(std::make_pair(TransientError(), ReturnType{})));
+  oncall.WillOnce(Return(StatusOr<ReturnType>(TransientError())))
+      .WillOnce(Return(StatusOr<ReturnType>(TransientError())))
+      .WillOnce(Return(StatusOr<ReturnType>(TransientError())));
 
   // Verify the right exception type, with the right content, is raised when
   // calling the operation.
@@ -82,7 +82,7 @@ void TooManyFailuresTest(
   // With EXPECT_DEATH*() the mocking framework cannot detect how many times
   // the operation is called, so we cannot set an exact number of calls to
   // expect.
-  oncall.WillRepeatedly(Return(std::make_pair(TransientError(), ReturnType{})));
+  oncall.WillRepeatedly(Return(StatusOr<ReturnType>(TransientError())));
   EXPECT_DEATH_IF_SUPPORTED(tested_operation(client),
                             "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
@@ -133,7 +133,7 @@ void NonIdempotentFailuresTest(
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   // The first transient error should stop the retries for non-idempotent
   // operations.
-  oncall.WillOnce(Return(std::make_pair(TransientError(), ReturnType{})));
+  oncall.WillOnce(Return(StatusOr<ReturnType>(TransientError())));
 
   // Verify the right exception type, with the right content, is raised when
   // calling the operation.
@@ -149,8 +149,7 @@ void NonIdempotentFailuresTest(
   // the operation is called, so we cannot set an exact number of calls to
   // expect.
   if (not has_will_repeatedly) {
-    oncall.WillRepeatedly(
-        Return(std::make_pair(TransientError(), ReturnType{})));
+    oncall.WillRepeatedly(Return(StatusOr<ReturnType>(TransientError())));
   }
   EXPECT_DEATH_IF_SUPPORTED(tested_operation(client),
                             "exceptions are disabled");
@@ -202,9 +201,9 @@ void IdempotentFailuresTest(
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   // Expect exactly 3 calls before the retry policy is exhausted and an
   // exception is raised.
-  oncall.WillOnce(Return(std::make_pair(TransientError(), ReturnType{})))
-      .WillOnce(Return(std::make_pair(TransientError(), ReturnType{})))
-      .WillOnce(Return(std::make_pair(TransientError(), ReturnType{})));
+  oncall.WillOnce(Return(StatusOr<ReturnType>(TransientError())))
+      .WillOnce(Return(StatusOr<ReturnType>(TransientError())))
+      .WillOnce(Return(StatusOr<ReturnType>(TransientError())));
 
   // Verify the right exception type, with the right content, is raised when
   // calling the operation.
@@ -220,8 +219,7 @@ void IdempotentFailuresTest(
   // the operation is called, so we cannot set an exact number of calls to
   // expect.
   if (not has_will_repeatedly) {
-    oncall.WillRepeatedly(
-        Return(std::make_pair(TransientError(), ReturnType{})));
+    oncall.WillRepeatedly(Return(StatusOr<ReturnType>(TransientError())));
   }
   EXPECT_DEATH_IF_SUPPORTED(tested_operation(client),
                             "exceptions are disabled");
@@ -301,7 +299,7 @@ void PermanentFailureTest(Client& client,
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   // Expect exactly one call before the retry policy is exhausted and an
   // exception is raised.
-  oncall.WillOnce(Return(std::make_pair(PermanentError(), ReturnType{})));
+  oncall.WillOnce(Return(StatusOr<ReturnType>(PermanentError())));
 
   // Verify the right exception type, with the right content, is raised when
   // calling the operation.
@@ -316,7 +314,7 @@ void PermanentFailureTest(Client& client,
   // With EXPECT_DEATH*() the mocking framework cannot detect how many times
   // the operation is called, so we cannot set an exact number of calls to
   // expect.
-  oncall.WillRepeatedly(Return(std::make_pair(PermanentError(), ReturnType{})));
+  oncall.WillRepeatedly(Return(StatusOr<ReturnType>(PermanentError())));
   EXPECT_DEATH_IF_SUPPORTED(tested_operation(client),
                             "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS

--- a/google/cloud/storage/tests/curl_resumable_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/curl_resumable_streambuf_integration_test.cc
@@ -53,15 +53,13 @@ class CurlResumableStreambufIntegrationTest
     ResumableUploadRequest request(bucket_name, object_name);
     request.set_multiple_options(IfGenerationMatch(0));
 
-    Status status;
-    std::unique_ptr<ResumableUploadSession> session;
-    std::tie(status, session) =
+    StatusOr<std::unique_ptr<ResumableUploadSession>> session =
         client.raw_client()->CreateResumableSession(request);
-    ASSERT_TRUE(status.ok());
+    ASSERT_TRUE(session.ok());
 
     ObjectWriteStream writer(
         google::cloud::internal::make_unique<CurlResumableStreambuf>(
-            std::move(session),
+            std::move(session).value(),
             client.raw_client()->client_options().upload_buffer_size(),
             google::cloud::internal::make_unique<NullHashValidator>()));
 


### PR DESCRIPTION
Most of the code was using `std::pair<Status, T>`, but now that we have a
`StatusOr<T>` template class this is a much better representation. There is
no impact to the public API in this PR, as all functions affected are
either in `storage::internal`, or they were private functions.

Sorry for the monster PR, I cannot figure out a way to break this down without
creating a lot of busy work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1723)
<!-- Reviewable:end -->
