### PR TITLE
StatusOr<T> when there is no default constructor.

### DIFF
--- a/google/cloud/storage/status_or_test.cc
+++ b/google/cloud/storage/status_or_test.cc
@@ -219,14 +219,16 @@ TEST(StatusOrVoidTest, StatusConstAccessors) {
   EXPECT_EQ(500, std::move(actual).status().status_code());
 }
 
+using testing_util::NoDefaultConstructor;
+
 TEST(StatusOrNoDefaultConstructor, DefaultConstructed) {
-  StatusOr<testing_util::NoDefaultConstructor> empty;
+  StatusOr<NoDefaultConstructor> empty;
   EXPECT_FALSE(empty.ok());
 }
 
 TEST(StatusOrNoDefaultConstructor, ValueConstructed) {
-  StatusOr<testing_util::NoDefaultConstructor> actual(
-      testing_util::NoDefaultConstructor(std::string("foo")));
+  StatusOr<NoDefaultConstructor> actual(
+      NoDefaultConstructor(std::string("foo")));
   EXPECT_TRUE(actual.ok());
   EXPECT_EQ(actual->str(), "foo");
 }


### PR DESCRIPTION
When `T` lacks a default constructor we need to use some (more or less
standard) tricks to implement the class. I modeled these changes after
optional<T>, where the expectation is that move-assignments and
move-constructors minimize the number of temporaries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1725)
<!-- Reviewable:end -->
