### PR TITLE
Upgrade JSON library to 3.4.0.

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -92,9 +92,9 @@ def google_cloud_cpp_deps():
         http_file(
             name = "com_github_nlohmann_json_single_header",
             urls = [
-                "https://github.com/nlohmann/json/releases/download/v3.1.2/json.hpp",
+                "https://github.com/nlohmann/json/releases/download/v3.4.0/json.hpp",
             ],
-            sha256 = "fbdfec4b4cf63b3b565d09f87e6c3c183bdd45c5be1864d3fcb338f6f02c1733",
+            sha256 = "63da6d1f22b2a7bb9e4ff7d6b255cf691a161ff49532dcc45d398a53e295835f",
         )
 
     # Load google/crc32c, a library to efficiently compute CRC32C checksums.

--- a/cmake/DownloadNlohmannJson.cmake
+++ b/cmake/DownloadNlohmannJson.cmake
@@ -19,9 +19,9 @@
 # downloads, and we get failures.  This is a custom cmake script to download
 # that file.
 set(JSON_URL
-    "https://github.com/nlohmann/json/releases/download/v3.1.2/json.hpp")
+    "https://github.com/nlohmann/json/releases/download/v3.4.0/json.hpp")
 set(
-    JSON_SHA256 fbdfec4b4cf63b3b565d09f87e6c3c183bdd45c5be1864d3fcb338f6f02c1733
+    JSON_SHA256 63da6d1f22b2a7bb9e4ff7d6b255cf691a161ff49532dcc45d398a53e295835f
     )
 message("JSON_URL = ${JSON_URL}")
 message("JSON_SHA256 = ${JSON_SHA256}")

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -14,7 +14,7 @@
 
 #include "google/cloud/storage/internal/bucket_requests.h"
 #include "google/cloud/storage/internal/nljson.h"
-#include <iostream>
+#include <sstream>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/nljson.h
+++ b/google/cloud/storage/internal/nljson.h
@@ -32,7 +32,7 @@
  * @see https://github.com/nlohmann/json.git
  */
 
-#define nlohmann google_cloud_storage_internal_nlohmann_3_1_2
+#define nlohmann google_cloud_storage_internal_nlohmann_3_4_0
 #include "google/cloud/storage/internal/nlohmann_json.hpp"
 
 namespace nlohmann {
@@ -56,7 +56,7 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
-namespace nl = ::google_cloud_storage_internal_nlohmann_3_1_2;
+namespace nl = ::google_cloud_storage_internal_nlohmann_3_4_0;
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/retry_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/retry_resumable_upload_session.h"
+#include <sstream>
 #include <thread>
 
 namespace google {


### PR DESCRIPTION
In addition to the usual bug fixes this version of the library should
support gcc-4.8. That would simplify some of the instructions for CentOS
7 and Ubuntu 14.04.

There is a 3.5.0 version out there, but does not compile for us: they included
support for C++17 features, but I do not think they tested them in the compilers
we support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1727)
<!-- Reviewable:end -->
