### PR TITLE
Restore support for GCC-4.8.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,14 +27,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 
-    # gcc-4.8 C++11 support has bugs preventing us from using it.
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
+    # gcc-4.8 is the first release that claims C++11 support.
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
         message(
             FATAL_ERROR
                 "GCC version must be at least 4.9. Older versions"
-                " either lack C++11 support or have bugs"
-                " (e.g. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55817)"
-                " that prevent us from using them.")
+                " either lack C++11 support or have bugs that prevent us from"
+                " using them.")
     endif ()
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
         message(
             FATAL_ERROR
-                "GCC version must be at least 4.9. Older versions"
+                "GCC version must be at least 4.8. Older versions"
                 " either lack C++11 support or have bugs that prevent us from"
                 " using them.")
     endif ()

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ against the latest version of the SDK on each commit and PR.
 
 #### CentOS
 
-The default compiler on CentOS doesn't fully support C++11. We need to upgrade
-the compiler and other development tools. In these instructions, we use `g++-7`
-via [Software Collections](https://www.softwarecollections.org/).
+Some of the development tools distributed with CentOS (notably CMake) are quite
+old, In these instructions, we use `cmake3` via
+[Software Collections](https://www.softwarecollections.org/).
 
 ```bash
 # Extra Packages for Enterprise Linux used to install cmake3
@@ -117,7 +117,7 @@ yum install centos-release-scl
 yum-config-manager --enable rhel-server-rhscl-7-rpms
 
 yum makecache
-yum install -y devtoolset-7 cmake3 curl-devel git openssl-devel
+yum install -y cmake3 gcc gcc-c++ git make openssl-devel
 
 # Install cmake3 & ctest3 as cmake & ctest respectively.
 ln -sf /usr/bin/cmake3 /usr/bin/cmake && ln -sf /usr/bin/ctest3 /usr/bin/ctest

--- a/ci/test-readme/Dockerfile.centos
+++ b/ci/test-readme/Dockerfile.centos
@@ -24,11 +24,10 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 RUN yum install -y centos-release-scl
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
 RUN yum makecache
-RUN yum install -y devtoolset-7 cmake3 curl-devel git openssl-devel
+RUN yum install -y cmake3 gcc gcc-c++ git make openssl-devel
 
-# Install cmake3 + ctest3 as cmake + ctest.
-RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake
-RUN ln -sf /usr/bin/ctest3 /usr/bin/ctest
+# Install cmake3 & ctest3 as cmake & ctest respectively.
+RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && ln -sf /usr/bin/ctest3 /usr/bin/ctest
 
 ARG CXX=g++
 ARG CC=gcc
@@ -37,7 +36,7 @@ WORKDIR /var/tmp/
 RUN git clone https://github.com/GoogleCloudPlatform/google-cloud-cpp.git
 WORKDIR /var/tmp/google-cloud-cpp
 RUN git submodule update --init
-RUN scl enable devtoolset-7 -- cmake -H. -Bbuild-output
-RUN scl enable devtoolset-7 -- cmake --build build-output -- -j $(nproc)
+RUN cmake -H. -Bbuild-output
+RUN cmake --build build-output -- -j $(nproc)
 WORKDIR /var/tmp/google-cloud-cpp/build-output
-RUN scl enable devtoolset-7 -- ctest --output-on-failure
+RUN ctest --output-on-failure

--- a/ci/travis/Dockerfile.centos
+++ b/ci/travis/Dockerfile.centos
@@ -24,18 +24,15 @@ RUN yum install -y centos-release-scl
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
 
 RUN yum makecache && yum install -y \
-    devtoolset-7 \
-    c-ares-devel \
     ccache \
     cmake3 \
-    curl \
     curl-devel \
+    gcc \
+    gcc-c++ \
     git \
     openssl-devel \
-    pkgconfig \
     python \
     python-pip \
-    shtool \
     unzip \
     wget \
     which \
@@ -56,3 +53,5 @@ RUN tar x -C /usr/local -f google-cloud-sdk-201.0.0-linux-x86_64.tar.gz
 RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable
 RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components update || \
     echo "Ignoring update failure for Google Cloud SDK"
+
+RUN yum makecache && yum install -y make

--- a/ci/travis/build-linux.sh
+++ b/ci/travis/build-linux.sh
@@ -22,11 +22,6 @@ if [ "${TRAVIS_OS_NAME}" != "linux" ]; then
 fi
 
 readonly IMAGE="cached-${DISTRO}-${DISTRO_VERSION}"
-if [ "${IMAGE}" = "cached-centos-7" ]; then
-  build_script="scl enable devtoolset-7 /v/ci/travis/build-docker.sh";
-else
-  build_script="/v/ci/travis/build-docker.sh";
-fi
 
 # TEST_INSTALL=yes builds work better as root, but other builds should avoid
 # creating root-owned files in the build directory.
@@ -68,4 +63,4 @@ sudo docker run \
      --volume "${PWD}/build-output/ccache":${docker_home}/.ccache \
      --workdir /v \
      "${IMAGE}:tip" \
-     ${build_script}
+     "/v/ci/travis/build-docker.sh"

--- a/ci/travis/install-bazel.sh
+++ b/ci/travis/install-bazel.sh
@@ -17,23 +17,14 @@
 set -eu
 
 sudo apt-get update
-sudo apt-get install -y software-properties-common
-sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-sudo apt-get update
 sudo apt-get install -y \
-     gcc-4.9 \
-     g++-4.9 \
-     libcurl4-openssl-dev \
-     libssl-dev \
+     gcc \
+     g++ \
      unzip \
      wget \
-     zip \
-     zlib1g-dev
+     zip
 
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 100
-sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 100
-
-readonly BAZEL_VERSION=0.12.0
+readonly BAZEL_VERSION=0.20.0
 readonly GITHUB_DL="https://github.com/bazelbuild/bazel/releases/download"
 wget -q "${GITHUB_DL}/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
 chmod +x "bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"

--- a/google/cloud/bigtable/internal/rowreaderiterator.h
+++ b/google/cloud/bigtable/internal/rowreaderiterator.h
@@ -63,12 +63,9 @@ class RowReaderIterator {
 
   Row const& operator*() const& { return *row_; }
   Row& operator*() & { return *row_; }
-#if !defined(__GNUC__) || __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 8)
-  // Exclude this function for gcc-4.8. While we do not support gcc-4.8, we have
-  // made an exception here because the TensorFlow folks need it.
+#if GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   Row const&& operator*() const&& { return *std::move(row_); }
-#endif  // !defined(__GNUC__) || __GNUC__ > 4 || (__GNUC__ == 4 &&
-        // __GNUC_MINOR__ > 8)
+#endif  // GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   Row&& operator*() && { return *std::move(row_); }
   bool operator==(RowReaderIterator const& that) const {
     // All non-end iterators are equal.

--- a/google/cloud/firestore/field_path.cc
+++ b/google/cloud/firestore/field_path.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/firestore/field_path.h"
 #include <array>
 #include <cctype>
+#include <ciso646>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/firestore/field_path.h
+++ b/google/cloud/firestore/field_path.h
@@ -35,7 +35,7 @@ class FieldPath {
    *
    * @param parts A const vector of strings which are field path components.
    */
-  FieldPath(std::vector<std::string> const parts);
+  explicit FieldPath(std::vector<std::string> parts);
 
   /**
    * Construct an invalid FieldPath.

--- a/google/cloud/internal/port_platform.h
+++ b/google/cloud/internal/port_platform.h
@@ -44,6 +44,21 @@
 #  error "Bigtable C++ Client requires C++11, your version of MSVC is too old"
 #endif  // _MSC_VER
 
+// Abort the build if the version of the compiler is too old. With CMake we
+// never start the build, but with Bazel we may start the build only to find
+// that the compiler is too old. This also simplifies some of the testing
+// further down in this file. Because Clang defines both __GNUC__ and __clang__
+// test for the Clang version first (sigh).
+#if defined(__clang__)
+#  if __clang_major__ < 3 || (__clang_major__ == 3 && __clang_minor__ < 8)
+#    error "Only Clang >= 3.8 is supported."
+#  endif  // Clang < 3.8
+#elif defined(__GNUC__)
+#  if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 8)
+#    error "Only GCC >= 4.8 is supported."
+#  endif  // GCC < 4.8
+#endif  // defined(__clang__)
+
 // Discover if exceptions are enabled and define them as needed.
 #ifdef GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 #  error "GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS should not be set directly."
@@ -66,6 +81,28 @@
    // https://isocpp.org/std/standing-documents/sd-6-sg10-feature-test-recommendations
 #  define GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS 1
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+
+// Define a macro to detect if the compiler supports `const&&`-qualified member
+// functions.
+#ifdef GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
+#  error "GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF should not be set directly."
+#elif defined(__clang__)
+   // Of course this is not true of all Clang versions, but older versions are
+   // rejected earlier in this file.
+#  define GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF 1
+#elif defined(_MSC_VER)
+   // Of course this is not true of all MSVC versions, but older versions are
+   // rejected earlier in this file.
+#  define GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF 1
+#elif defined(__GNUC__)
+#  if __GNUC__ == 4 && __GNUC_MINOR__ == 8
+#    define GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF 0
+#  else
+#    define GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF 1
+#  endif  // __GNUC__ == 4 && __GNUC_MINOR__ = 8
+#else
+#    define GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF 1
+#endif  // GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
 // clang-format on
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_PORT_PLATFORM_H_

--- a/google/cloud/optional.h
+++ b/google/cloud/optional.h
@@ -143,9 +143,11 @@ class optional {
   }
   /*constexpr*/ T& operator*() & { return *reinterpret_cast<T*>(&buffer_); }
   // Kind of useless, but the spec requires it.
-  constexpr T const&& operator*() const&& {
+#if GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
+  /*constexpr*/ T const&& operator*() const&& {
     return std::move(*reinterpret_cast<T const*>(&buffer_));
   }
+#endif  // GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   /*constexpr*/ T&& operator*() && {
     return std::move(*reinterpret_cast<T*>(&buffer_));
   }

--- a/google/cloud/storage/list_buckets_reader.h
+++ b/google/cloud/storage/list_buckets_reader.h
@@ -53,7 +53,9 @@ class ListBucketsIterator {
 
   BucketMetadata const& operator*() const& { return *value_; }
   BucketMetadata& operator*() & { return *value_; }
+#if GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   BucketMetadata const&& operator*() const&& { return *std::move(value_); }
+#endif  // GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   BucketMetadata&& operator*() && { return *std::move(value_); }
 
   bool operator==(ListBucketsIterator const& rhs) const {

--- a/google/cloud/storage/list_objects_reader.h
+++ b/google/cloud/storage/list_objects_reader.h
@@ -53,7 +53,9 @@ class ListObjectsIterator {
 
   ObjectMetadata const& operator*() const& { return *value_; }
   ObjectMetadata& operator*() & { return *value_; }
+#if GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   ObjectMetadata const&& operator*() const&& { return *std::move(value_); }
+#endif  // GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   ObjectMetadata&& operator*() && { return *std::move(value_); }
 
   bool operator==(ListObjectsIterator const& rhs) const {

--- a/google/cloud/storage/status_or.h
+++ b/google/cloud/storage/status_or.h
@@ -121,7 +121,9 @@ class StatusOr final {
 
   T&& operator*() && { return std::move(value_); }
 
+#if GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   T const&& operator*() const&& { return std::move(value_); }
+#endif  // GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   //@}
 
   //@{
@@ -164,10 +166,12 @@ class StatusOr final {
     return std::move(value_);
   }
 
+#if GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   T const&& value() const&& {
     CheckHasValue();
     return std::move(value_);
   }
+#endif  // GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   //@}
 
   //@{
@@ -181,8 +185,10 @@ class StatusOr final {
   Status& status() & { return status_; }
   Status const& status() const& { return status_; }
   Status&& status() && { return std::move(status_); }
+#if GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   Status const&& status() const&& { return std::move(status_); }
-  //@}
+#endif  // GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
+        //@}
 
  private:
   void CheckHasValue() const& {
@@ -266,7 +272,9 @@ class StatusOr<void> final {
   void operator*() & {}
   void operator*() const& {}
   void operator*() && {}
+#if GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   void operator*() const&& {}
+#endif  // GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   //@}
 
   //@{
@@ -296,7 +304,9 @@ class StatusOr<void> final {
 
   void value() && { CheckHasValue(); }
 
+#if GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   void value() const&& { CheckHasValue(); }
+#endif  // GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   //@}
 
   //@{
@@ -310,8 +320,10 @@ class StatusOr<void> final {
   Status& status() & { return status_; }
   Status const& status() const& { return status_; }
   Status&& status() && { return std::move(status_); }
+#if GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   Status const&& status() const&& { return std::move(status_); }
-  //@}
+#endif  // GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
+        //@}
 
  private:
   void CheckHasValue() const& {


### PR DESCRIPTION
With the latest version of nlohmann::json we can support GCC-4.8 again.

This fixes #798.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1731)
<!-- Reviewable:end -->
