### PR TITLE
Use StatusOr to signal errors in a HTTP request.

### DIFF
--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -121,6 +121,27 @@ StatusOr<ReturnType> ParseFromString(StatusOr<HttpResponse> response) {
   return ReturnType::ParseFromString(response->payload);
 }
 
+StatusOr<EmptyResponse> ReturnEmptyResponse(StatusOr<HttpResponse> response) {
+  if (not response.ok()) {
+    return std::move(response).status();
+  }
+  if (response->status_code >= 300) {
+    return AsStatus(*response);
+  }
+  return EmptyResponse{};
+}
+
+template <typename ReturnType>
+StatusOr<ReturnType> ParseFromHttpResponse(StatusOr<HttpResponse> response) {
+  if (not response.ok()) {
+    return std::move(response).status();
+  }
+  if (response->status_code >= 300) {
+    return AsStatus(*response);
+  }
+  return ReturnType::FromHttpResponse(std::move(*response));
+}
+
 }  // namespace
 
 Status CurlClient::SetupBuilderCommon(CurlRequestBuilder& builder,
@@ -292,14 +313,8 @@ StatusOr<ListBucketsResponse> CurlClient::ListBuckets(
     return status;
   }
   builder.AddQueryParameter("project", request.project_id());
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
-  if (not response.ok()) {
-    return std::move(response).status();
-  }
-  if (response->status_code >= 300) {
-    return AsStatus(*response);
-  }
-  return ListBucketsResponse::FromHttpResponse(*std::move(response));
+  return ParseFromHttpResponse<ListBucketsResponse>(
+      builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<BucketMetadata> CurlClient::CreateBucket(
@@ -325,7 +340,8 @@ StatusOr<BucketMetadata> CurlClient::GetBucketMetadata(
   if (not status.ok()) {
     return status;
   }
-  return ParseFromString<BucketMetadata>(builder.BuildRequest().MakeRequest(std::string{}));
+  return ParseFromString<BucketMetadata>(
+      builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteBucket(
@@ -337,14 +353,7 @@ StatusOr<EmptyResponse> CurlClient::DeleteBucket(
   if (not status.ok()) {
     return status;
   }
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
-  if (not response.ok()) {
-    return std::move(response).status();
-  }
-  if (response->status_code >= 300) {
-    return AsStatus(*response);
-  }
-  return internal::EmptyResponse{};
+  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<BucketMetadata> CurlClient::UpdateBucket(
@@ -357,7 +366,8 @@ StatusOr<BucketMetadata> CurlClient::UpdateBucket(
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
-  return ParseFromString<BucketMetadata>(builder.BuildRequest().MakeRequest(request.json_payload()));
+  return ParseFromString<BucketMetadata>(
+      builder.BuildRequest().MakeRequest(request.json_payload()));
 }
 
 StatusOr<BucketMetadata> CurlClient::PatchBucket(
@@ -370,7 +380,8 @@ StatusOr<BucketMetadata> CurlClient::PatchBucket(
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
-  return ParseFromString<BucketMetadata>(builder.BuildRequest().MakeRequest(request.payload()));
+  return ParseFromString<BucketMetadata>(
+      builder.BuildRequest().MakeRequest(request.payload()));
 }
 
 StatusOr<IamPolicy> CurlClient::GetBucketIamPolicy(
@@ -413,8 +424,7 @@ StatusOr<IamPolicy> CurlClient::SetBucketIamPolicy(
 }
 
 StatusOr<TestBucketIamPermissionsResponse> CurlClient::TestBucketIamPermissions(
-    google::cloud::storage::internal::TestBucketIamPermissionsRequest const&
-        request) {
+    TestBucketIamPermissionsRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
                                  "/iam/testPermissions",
                              storage_factory_);
@@ -447,14 +457,7 @@ StatusOr<EmptyResponse> CurlClient::LockBucketRetentionPolicy(
   builder.AddHeader("content-type: application/json");
   builder.AddHeader("content-length: 0");
   builder.AddOption(IfMetagenerationMatch(request.metageneration()));
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
-  if (not response.ok()) {
-    return std::move(response).status();
-  }
-  if (response->status_code >= 300) {
-    return AsStatus(*response);
-  }
-  return EmptyResponse{};
+  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectMetadata> CurlClient::InsertObjectMedia(
@@ -502,7 +505,8 @@ StatusOr<ObjectMetadata> CurlClient::CopyObject(
     json_payload =
         request.GetOption<WithObjectMetadata>().value().JsonPayloadForCopy();
   }
-  return ParseFromString<ObjectMetadata>(builder.BuildRequest().MakeRequest(json_payload));
+  return ParseFromString<ObjectMetadata>(
+      builder.BuildRequest().MakeRequest(json_payload));
 }
 
 StatusOr<ObjectMetadata> CurlClient::GetObjectMetadata(
@@ -514,7 +518,8 @@ StatusOr<ObjectMetadata> CurlClient::GetObjectMetadata(
   if (not status.ok()) {
     return status;
   }
-  return ParseFromString<ObjectMetadata>(builder.BuildRequest().MakeRequest(std::string{}));
+  return ParseFromString<ObjectMetadata>(
+      builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<std::unique_ptr<ObjectReadStreambuf>> CurlClient::ReadObject(
@@ -569,14 +574,8 @@ StatusOr<ListObjectsResponse> CurlClient::ListObjects(
     return status;
   }
   builder.AddQueryParameter("pageToken", request.page_token());
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
-  if (not response.ok()) {
-    return std::move(response).status();
-  }
-  if (response->status_code >= 300) {
-    return AsStatus(*response);
-  }
-  return internal::ListObjectsResponse::FromHttpResponse(*std::move(response));
+  return ParseFromHttpResponse<ListObjectsResponse>(
+  builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteObject(
@@ -589,14 +588,7 @@ StatusOr<EmptyResponse> CurlClient::DeleteObject(
   if (not status.ok()) {
     return status;
   }
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
-  if (not response.ok()) {
-    return std::move(response).status();
-  }
-  if (response->status_code >= 300) {
-    return AsStatus(*response);
-  }
-  return internal::EmptyResponse{};
+  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectMetadata> CurlClient::UpdateObject(
@@ -609,7 +601,8 @@ StatusOr<ObjectMetadata> CurlClient::UpdateObject(
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
-  return ParseFromString<ObjectMetadata>(builder.BuildRequest().MakeRequest(request.json_payload()));
+  return ParseFromString<ObjectMetadata>(
+      builder.BuildRequest().MakeRequest(request.json_payload()));
 }
 
 StatusOr<ObjectMetadata> CurlClient::PatchObject(
@@ -622,7 +615,8 @@ StatusOr<ObjectMetadata> CurlClient::PatchObject(
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
-  return ParseFromString<ObjectMetadata>(builder.BuildRequest().MakeRequest(request.payload()));
+  return ParseFromString<ObjectMetadata>(
+      builder.BuildRequest().MakeRequest(request.payload()));
 }
 
 StatusOr<ObjectMetadata> CurlClient::ComposeObject(
@@ -636,7 +630,8 @@ StatusOr<ObjectMetadata> CurlClient::ComposeObject(
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
-  return ParseFromString<ObjectMetadata>(builder.BuildRequest().MakeRequest(request.JsonPayload()));
+  return ParseFromString<ObjectMetadata>(
+      builder.BuildRequest().MakeRequest(request.JsonPayload()));
 }
 
 StatusOr<RewriteObjectResponse> CurlClient::RewriteObject(
@@ -667,6 +662,8 @@ StatusOr<RewriteObjectResponse> CurlClient::RewriteObject(
   if (response->status_code >= 300) {
     return AsStatus(*response);
   }
+  // This one does not use the common "ParseFromHttpResponse" function because
+  // it takes different arguments.
   return RewriteObjectResponse::FromHttpResponse(*response);
 }
 
@@ -705,7 +702,8 @@ StatusOr<ListBucketAclResponse> CurlClient::ListBucketAcl(
   if (response->status_code >= 300) {
     return AsStatus(*response);
   }
-  return internal::ListBucketAclResponse::FromHttpResponse(*std::move(response));
+  return internal::ListBucketAclResponse::FromHttpResponse(
+      *std::move(response));
 }
 
 StatusOr<BucketAccessControl> CurlClient::GetBucketAcl(
@@ -717,7 +715,8 @@ StatusOr<BucketAccessControl> CurlClient::GetBucketAcl(
   if (not status.ok()) {
     return status;
   }
-  return ParseFromString<BucketAccessControl>(builder.BuildRequest().MakeRequest(std::string{}));
+  return ParseFromString<BucketAccessControl>(
+      builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<BucketAccessControl> CurlClient::CreateBucketAcl(
@@ -733,7 +732,8 @@ StatusOr<BucketAccessControl> CurlClient::CreateBucketAcl(
   nl::json object;
   object["entity"] = request.entity();
   object["role"] = request.role();
-  return ParseFromString<BucketAccessControl>(builder.BuildRequest().MakeRequest(object.dump()));
+  return ParseFromString<BucketAccessControl>(
+      builder.BuildRequest().MakeRequest(object.dump()));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteBucketAcl(
@@ -745,14 +745,7 @@ StatusOr<EmptyResponse> CurlClient::DeleteBucketAcl(
   if (not status.ok()) {
     return status;
   }
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
-  if (not response.ok()) {
-    return std::move(response).status();
-  }
-  if (response->status_code >= 300) {
-    return AsStatus(*response);
-  }
-  return internal::EmptyResponse{};
+  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<BucketAccessControl> CurlClient::UpdateBucketAcl(
@@ -768,7 +761,8 @@ StatusOr<BucketAccessControl> CurlClient::UpdateBucketAcl(
   nl::json patch;
   patch["entity"] = request.entity();
   patch["role"] = request.role();
-  return ParseFromString<BucketAccessControl>(builder.BuildRequest().MakeRequest(patch.dump()));
+  return ParseFromString<BucketAccessControl>(
+      builder.BuildRequest().MakeRequest(patch.dump()));
 }
 
 StatusOr<BucketAccessControl> CurlClient::PatchBucketAcl(
@@ -781,7 +775,8 @@ StatusOr<BucketAccessControl> CurlClient::PatchBucketAcl(
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
-  return ParseFromString<BucketAccessControl>(builder.BuildRequest().MakeRequest(request.payload()));
+  return ParseFromString<BucketAccessControl>(
+      builder.BuildRequest().MakeRequest(request.payload()));
 }
 
 StatusOr<ListObjectAclResponse> CurlClient::ListObjectAcl(
@@ -795,14 +790,8 @@ StatusOr<ListObjectAclResponse> CurlClient::ListObjectAcl(
   if (not status.ok()) {
     return status;
   }
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
-  if (not response.ok()) {
-    return std::move(response).status();
-  }
-  if (response->status_code >= 300) {
-    return AsStatus(*response);
-  }
-  return internal::ListObjectAclResponse::FromHttpResponse(*std::move(response));
+  return ParseFromHttpResponse<ListObjectAclResponse>(
+      builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::CreateObjectAcl(
@@ -819,7 +808,8 @@ StatusOr<ObjectAccessControl> CurlClient::CreateObjectAcl(
   nl::json object;
   object["entity"] = request.entity();
   object["role"] = request.role();
-  return ParseFromString<ObjectAccessControl>(builder.BuildRequest().MakeRequest(object.dump()));
+  return ParseFromString<ObjectAccessControl>(
+      builder.BuildRequest().MakeRequest(object.dump()));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteObjectAcl(
@@ -833,14 +823,7 @@ StatusOr<EmptyResponse> CurlClient::DeleteObjectAcl(
   if (not status.ok()) {
     return status;
   }
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
-  if (not response.ok()) {
-    return std::move(response).status();
-  }
-  if (response->status_code >= 300) {
-    return AsStatus(*response);
-  }
-  return internal::EmptyResponse{};
+  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::GetObjectAcl(
@@ -854,7 +837,8 @@ StatusOr<ObjectAccessControl> CurlClient::GetObjectAcl(
   if (not status.ok()) {
     return status;
   }
-  return ParseFromString<ObjectAccessControl>(builder.BuildRequest().MakeRequest(std::string{}));
+  return ParseFromString<ObjectAccessControl>(
+      builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::UpdateObjectAcl(
@@ -872,7 +856,8 @@ StatusOr<ObjectAccessControl> CurlClient::UpdateObjectAcl(
   nl::json object;
   object["entity"] = request.entity();
   object["role"] = request.role();
-  return ParseFromString<ObjectAccessControl>(builder.BuildRequest().MakeRequest(object.dump()));
+  return ParseFromString<ObjectAccessControl>(
+      builder.BuildRequest().MakeRequest(object.dump()));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::PatchObjectAcl(
@@ -887,7 +872,8 @@ StatusOr<ObjectAccessControl> CurlClient::PatchObjectAcl(
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
-  return ParseFromString<ObjectAccessControl>(builder.BuildRequest().MakeRequest(request.payload()));
+  return ParseFromString<ObjectAccessControl>(
+      builder.BuildRequest().MakeRequest(request.payload()));
 }
 
 StatusOr<ListDefaultObjectAclResponse> CurlClient::ListDefaultObjectAcl(
@@ -900,15 +886,8 @@ StatusOr<ListDefaultObjectAclResponse> CurlClient::ListDefaultObjectAcl(
   if (not status.ok()) {
     return status;
   }
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
-  if (not response.ok()) {
-    return std::move(response).status();
-  }
-  if (response->status_code >= 300) {
-    return AsStatus(*response);
-  }
-  return internal::ListDefaultObjectAclResponse::FromHttpResponse(
-      *std::move(response));
+  return ParseFromHttpResponse<ListDefaultObjectAclResponse>(
+      builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::CreateDefaultObjectAcl(
@@ -924,7 +903,8 @@ StatusOr<ObjectAccessControl> CurlClient::CreateDefaultObjectAcl(
   object["entity"] = request.entity();
   object["role"] = request.role();
   builder.AddHeader("Content-Type: application/json");
-  return ParseFromString<ObjectAccessControl>(builder.BuildRequest().MakeRequest(object.dump()));
+  return ParseFromString<ObjectAccessControl>(
+      builder.BuildRequest().MakeRequest(object.dump()));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteDefaultObjectAcl(
@@ -937,14 +917,7 @@ StatusOr<EmptyResponse> CurlClient::DeleteDefaultObjectAcl(
   if (not status.ok()) {
     return status;
   }
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
-  if (not response.ok()) {
-    return std::move(response).status();
-  }
-  if (response->status_code >= 300) {
-    return AsStatus(*response);
-  }
-  return internal::EmptyResponse{};
+  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::GetDefaultObjectAcl(
@@ -957,7 +930,8 @@ StatusOr<ObjectAccessControl> CurlClient::GetDefaultObjectAcl(
   if (not status.ok()) {
     return status;
   }
-  return ParseFromString<ObjectAccessControl>(builder.BuildRequest().MakeRequest(std::string{}));
+  return ParseFromString<ObjectAccessControl>(
+      builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::UpdateDefaultObjectAcl(
@@ -974,7 +948,8 @@ StatusOr<ObjectAccessControl> CurlClient::UpdateDefaultObjectAcl(
   nl::json object;
   object["entity"] = request.entity();
   object["role"] = request.role();
-  return ParseFromString<ObjectAccessControl>(builder.BuildRequest().MakeRequest(object.dump()));
+  return ParseFromString<ObjectAccessControl>(
+      builder.BuildRequest().MakeRequest(object.dump()));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::PatchDefaultObjectAcl(
@@ -988,7 +963,8 @@ StatusOr<ObjectAccessControl> CurlClient::PatchDefaultObjectAcl(
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
-  return ParseFromString<ObjectAccessControl>(builder.BuildRequest().MakeRequest(request.payload()));
+  return ParseFromString<ObjectAccessControl>(
+      builder.BuildRequest().MakeRequest(request.payload()));
 }
 
 StatusOr<ServiceAccount> CurlClient::GetServiceAccount(
@@ -1000,7 +976,8 @@ StatusOr<ServiceAccount> CurlClient::GetServiceAccount(
   if (not status.ok()) {
     return status;
   }
-  return ParseFromString<ServiceAccount>(builder.BuildRequest().MakeRequest(std::string{}));
+  return ParseFromString<ServiceAccount>(
+      builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<ListNotificationsResponse> CurlClient::ListNotifications(
@@ -1013,15 +990,8 @@ StatusOr<ListNotificationsResponse> CurlClient::ListNotifications(
   if (not status.ok()) {
     return status;
   }
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
-  if (not response.ok()) {
-    return std::move(response).status();
-  }
-  if (response->status_code >= 300) {
-    return AsStatus(*response);
-  }
-  return internal::ListNotificationsResponse::FromHttpResponse(
-      *std::move(response));
+  return ParseFromHttpResponse<ListNotificationsResponse>(
+      builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<NotificationMetadata> CurlClient::CreateNotification(
@@ -1034,7 +1004,8 @@ StatusOr<NotificationMetadata> CurlClient::CreateNotification(
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
-  return ParseFromString<NotificationMetadata>(builder.BuildRequest().MakeRequest(request.json_payload()));
+  return ParseFromString<NotificationMetadata>(
+      builder.BuildRequest().MakeRequest(request.json_payload()));
 }
 
 StatusOr<NotificationMetadata> CurlClient::GetNotification(
@@ -1047,7 +1018,8 @@ StatusOr<NotificationMetadata> CurlClient::GetNotification(
   if (not status.ok()) {
     return status;
   }
-  return ParseFromString<NotificationMetadata>(builder.BuildRequest().MakeRequest(std::string{}));
+  return ParseFromString<NotificationMetadata>(
+      builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteNotification(
@@ -1060,14 +1032,7 @@ StatusOr<EmptyResponse> CurlClient::DeleteNotification(
   if (not status.ok()) {
     return status;
   }
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
-  if (not response.ok()) {
-    return std::move(response).status();
-  }
-  if (response->status_code >= 300) {
-    return AsStatus(*response);
-  }
-  return EmptyResponse{};
+  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 void CurlClient::LockShared() { mu_.lock(); }
@@ -1382,7 +1347,8 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaSimple(
   builder.AddQueryParameter("name", request.object_name());
   builder.AddHeader("Content-Length: " +
                     std::to_string(request.contents().size()));
-  return ParseFromString<ObjectMetadata>(builder.BuildRequest().MakeRequest(request.contents()));
+  return ParseFromString<ObjectMetadata>(
+      builder.BuildRequest().MakeRequest(request.contents()));
 }
 
 StatusOr<std::unique_ptr<ObjectWriteStreambuf>> CurlClient::WriteObjectSimple(

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -575,7 +575,7 @@ StatusOr<ListObjectsResponse> CurlClient::ListObjects(
   }
   builder.AddQueryParameter("pageToken", request.page_token());
   return ParseFromHttpResponse<ListObjectsResponse>(
-  builder.BuildRequest().MakeRequest(std::string{}));
+      builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteObject(

--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -46,13 +46,17 @@ StatusOr<HttpResponse> CurlDownloadRequest::Close() {
 
   // Now remove the handle from the CURLM* interface and wait for the response.
   auto error = curl_multi_remove_handle(multi_.get(), handle_.handle_.get());
-  RaiseOnError(__func__, error);
+  auto status = AsStatus(error, __func__);
+  if (not status.ok()) {
+    return status;
+  }
 
   StatusOr<long> http_code = handle_.GetResponseCode();
   if (not http_code.ok()) {
     return http_code.status();
   }
-  return HttpResponse{http_code.value(), std::string{}, std::move(received_headers_)};
+  return HttpResponse{http_code.value(), std::string{},
+                      std::move(received_headers_)};
 }
 
 StatusOr<HttpResponse> CurlDownloadRequest::GetMore(std::string& buffer) {
@@ -65,7 +69,10 @@ StatusOr<HttpResponse> CurlDownloadRequest::GetMore(std::string& buffer) {
   if (curl_closed_) {
     // Remove the handle from the CURLM* interface and wait for the response.
     auto error = curl_multi_remove_handle(multi_.get(), handle_.handle_.get());
-    RaiseOnError(__func__, error);
+    Status status = AsStatus(error, __func__);
+    if (not status.ok()) {
+      return status;
+    }
 
     buffer_.swap(buffer);
     buffer_.clear();
@@ -76,7 +83,8 @@ StatusOr<HttpResponse> CurlDownloadRequest::GetMore(std::string& buffer) {
     GCP_LOG(DEBUG) << __func__ << "(), size=" << buffer.size()
                    << ", closing=" << closing_ << ", closed=" << curl_closed_
                    << ", code=" << *http_code;
-    return HttpResponse{http_code.value(), std::string{}, std::move(received_headers_)};
+    return HttpResponse{http_code.value(), std::string{},
+                        std::move(received_headers_)};
   }
   buffer_.swap(buffer);
   buffer_.clear();
@@ -91,10 +99,10 @@ StatusOr<HttpResponse> CurlDownloadRequest::GetMore(std::string& buffer) {
   return HttpResponse{100, {}, {}};
 }
 
-void CurlDownloadRequest::SetOptions() {
+Status CurlDownloadRequest::SetOptions() {
   ResetOptions();
   auto error = curl_multi_add_handle(multi_.get(), handle_.handle_.get());
-  RaiseOnError(__func__, error);
+  return AsStatus(error, __func__);
 }
 
 void CurlDownloadRequest::ResetOptions() {
@@ -141,7 +149,7 @@ std::size_t CurlDownloadRequest::WriteCallback(void* ptr, std::size_t size,
   return size * nmemb;
 }
 
-int CurlDownloadRequest::PerformWork() {
+StatusOr<int> CurlDownloadRequest::PerformWork() {
   // Block while there is work to do, apparently newer versions of libcurl do
   // not need this loop and curl_multi_perform() blocks until there is no more
   // work, but is it pretty harmless to keep here.
@@ -152,7 +160,10 @@ int CurlDownloadRequest::PerformWork() {
   } while (result == CURLM_CALL_MULTI_PERFORM);
 
   // Raise an exception if the result is unexpected, otherwise return.
-  RaiseOnError(__func__, result);
+  auto status = AsStatus(result, __func__);
+  if (not status.ok()) {
+    return status;
+  }
   if (running_handles == 0) {
     // The only way we get here is if the handle "completed", and therefore the
     // transfer either failed or was successful. Pull all the messages out of
@@ -168,7 +179,7 @@ int CurlDownloadRequest::PerformWork() {
            << ", msg.msg=[" << msg->msg << "]"
            << ", result=[" << msg->data.result
            << "]=" << curl_easy_strerror(msg->data.result);
-        google::cloud::internal::RaiseRuntimeError(os.str());
+        return Status(StatusCode::UNKNOWN, std::move(os).str());
       }
       GCP_LOG(DEBUG) << __func__ << "(): msg.msg=[" << msg->msg << "], "
                      << " result=[" << msg->data.result
@@ -180,15 +191,15 @@ int CurlDownloadRequest::PerformWork() {
   return running_handles;
 }
 
-void CurlDownloadRequest::WaitForHandles(int& repeats) {
+Status CurlDownloadRequest::WaitForHandles(int& repeats) {
   int const timeout_ms = 1;
   std::chrono::milliseconds const timeout(timeout_ms);
   int numfds = 0;
   CURLMcode result =
       curl_multi_wait(multi_.get(), nullptr, 0, timeout_ms, &numfds);
-  GCP_LOG(DEBUG) << __func__ << "(): numfds=" << numfds
-                 << ", result=" << result << ", repeats=" << repeats;
-  RaiseOnError(__func__, result);
+  GCP_LOG(DEBUG) << __func__ << "(): numfds=" << numfds << ", result=" << result
+                 << ", repeats=" << repeats;
+  return AsStatus(result, __func__);
   // The documentation for curl_multi_wait() recommends sleeping if it returns
   // numfds == 0 more than once in a row :shrug:
   //    https://curl.haxx.se/libcurl/c/curl_multi_wait.html
@@ -199,16 +210,17 @@ void CurlDownloadRequest::WaitForHandles(int& repeats) {
   } else {
     repeats = 0;
   }
+  return Status();
 }
 
-void CurlDownloadRequest::RaiseOnError(char const* where, CURLMcode result) {
+Status CurlDownloadRequest::AsStatus(CURLMcode result, char const *where) {
   if (result == CURLM_OK) {
-    return;
+    return Status();
   }
   std::ostringstream os;
-  os << where << ": unexpected error code in curl_multi_perform, [" << result
+  os << where << "(): unexpected error code in curl_multi_*, [" << result
      << "]=" << curl_multi_strerror(result);
-  google::cloud::internal::RaiseRuntimeError(os.str());
+  return Status(StatusCode::UNKNOWN, std::move(os).str());
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -78,7 +78,7 @@ class CurlDownloadRequest {
   }
 
   bool IsOpen() const { return not curl_closed_; }
-  HttpResponse Close();
+  StatusOr<HttpResponse> Close();
 
   /**
    * Waits for additional data or the end of the transfer.
@@ -90,7 +90,7 @@ class CurlDownloadRequest {
    *     of this parameter are completely replaced with the new data.
    * @returns 100-Continue if the transfer is not yet completed.
    */
-  HttpResponse GetMore(std::string& buffer);
+  StatusOr<HttpResponse> GetMore(std::string& buffer);
 
  private:
   friend class CurlRequestBuilder;

--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -95,7 +95,7 @@ class CurlDownloadRequest {
  private:
   friend class CurlRequestBuilder;
   /// Set the underlying CurlHandle options initially.
-  void SetOptions();
+  Status SetOptions();
 
   /// Reset the underlying CurlHandle options after a move operation.
   void ResetOptions();
@@ -105,7 +105,7 @@ class CurlDownloadRequest {
 
   /// Wait until a condition is met.
   template <typename Predicate>
-  void Wait(Predicate&& predicate) {
+  Status Wait(Predicate&& predicate) {
     int repeats = 0;
     // We can assert that the current thread is the leader, because the
     // predicate is satisfied, and the condition variable exited. Therefore,
@@ -115,25 +115,32 @@ class CurlDownloadRequest {
       GCP_LOG(DEBUG) << __func__ << "() predicate is false"
                      << ", curl.size=" << buffer_.size();
       auto running_handles = PerformWork();
+      if (not running_handles.ok()) {
+        return std::move(running_handles).status();
+      }
       // Only wait if there are CURL handles with pending work *and* the
       // predicate is not satisfied. Note that if the predicate is ill-defined
       // it might continue to be unsatisfied even though the handles have
       // completed their work.
-      if (running_handles == 0 or predicate()) {
-        return;
+      if (*running_handles == 0 or predicate()) {
+        return Status();
       }
-      WaitForHandles(repeats);
+      auto status = WaitForHandles(repeats);
+      if (not status.ok()) {
+        return status;
+      }
     }
+    return Status();
   }
 
   /// Use libcurl to perform at least part of the transfer.
-  int PerformWork();
+  StatusOr<int> PerformWork();
 
   /// Use libcurl to wait until the underlying data can perform work.
-  void WaitForHandles(int& repeats);
+  Status WaitForHandles(int& repeats);
 
   /// Simplify handling of errors in the curl_multi_* API.
-  void RaiseOnError(char const* where, CURLMcode result);
+  Status AsStatus(CURLMcode result, char const* where);
 
   std::string url_;
   CurlHeaders headers_;

--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -145,10 +145,13 @@ void CurlHandle::FlushDebug(char const* where) {
   }
 }
 
-void CurlHandle::RaiseError(CURLcode e, char const* where) {
+Status CurlHandle::AsStatus(CURLcode e, char const* where) {
+  if (e == CURLE_OK) {
+    return Status();
+  }
   std::ostringstream os;
-  os << "Error [" << e << "]=" << curl_easy_strerror(e) << " in " << where;
-  google::cloud::internal::RaiseRuntimeError(os.str());
+  os << where << "() - CURL error [" << e << "]=" << curl_easy_strerror(e);
+  return Status(StatusCode::UNKNOWN, std::move(os).str());
 }
 
 void CurlHandle::RaiseSetOptionError(CURLcode e, CURLoption opt, long param) {

--- a/google/cloud/storage/internal/curl_request.h
+++ b/google/cloud/storage/internal/curl_request.h
@@ -77,7 +77,7 @@ class CurlRequest {
    *
    * @throw std::runtime_error if the request cannot be made at all.
    */
-  HttpResponse MakeRequest(std::string const& payload);
+  StatusOr<HttpResponse> MakeRequest(std::string const& payload);
 
  private:
   friend class CurlRequestBuilder;

--- a/google/cloud/storage/internal/curl_streambuf.cc
+++ b/google/cloud/storage/internal/curl_streambuf.cc
@@ -35,7 +35,7 @@ CurlReadStreambuf::CurlReadStreambuf(
 
 bool CurlReadStreambuf::IsOpen() const { return download_.IsOpen(); }
 
-HttpResponse CurlReadStreambuf::Close() { return download_.Close(); }
+HttpResponse CurlReadStreambuf::Close() { return download_.Close().value(); }
 
 CurlReadStreambuf::int_type CurlReadStreambuf::underflow() {
   if (not IsOpen()) {
@@ -50,11 +50,14 @@ CurlReadStreambuf::int_type CurlReadStreambuf::underflow() {
   }
 
   current_ios_buffer_.reserve(target_buffer_size_);
-  auto response = download_.GetMore(current_ios_buffer_);
-  for (auto const& kv : response.headers) {
+  StatusOr<HttpResponse> response = download_.GetMore(current_ios_buffer_);
+  if (not response.ok()) {
+    return traits_type::eof();
+  }
+  for (auto const& kv : response->headers) {
     hash_validator_->ProcessHeader(kv.first, kv.second);
   }
-  if (response.status_code >= 300) {
+  if (response->status_code >= 300) {
     return traits_type::eof();
   }
 
@@ -126,7 +129,8 @@ HttpResponse CurlWriteStreambuf::DoClose() {
   GCP_LOG(INFO) << __func__ << "()";
   Validate(__func__);
   SwapBuffers();
-  auto response = upload_.Close();
+  // TODO(...) - this can throw an exception,
+  auto response = upload_.Close().value();
   for (auto const& kv : response.headers) {
     hash_validator_->ProcessHeader(kv.first, kv.second);
   }

--- a/google/cloud/storage/internal/curl_streambuf.cc
+++ b/google/cloud/storage/internal/curl_streambuf.cc
@@ -35,7 +35,10 @@ CurlReadStreambuf::CurlReadStreambuf(
 
 bool CurlReadStreambuf::IsOpen() const { return download_.IsOpen(); }
 
-HttpResponse CurlReadStreambuf::Close() { return download_.Close().value(); }
+HttpResponse CurlReadStreambuf::Close() {
+  // TODO(#1736) - return StatusOr<> from here.
+  return download_.Close().value();
+}
 
 CurlReadStreambuf::int_type CurlReadStreambuf::underflow() {
   if (not IsOpen()) {
@@ -129,7 +132,7 @@ HttpResponse CurlWriteStreambuf::DoClose() {
   GCP_LOG(INFO) << __func__ << "()";
   Validate(__func__);
   SwapBuffers();
-  // TODO(...) - this can throw an exception,
+  // TODO(#1735) - return StatusOr<> from here.
   auto response = upload_.Close().value();
   for (auto const& kv : response.headers) {
     hash_validator_->ProcessHeader(kv.first, kv.second);

--- a/google/cloud/storage/internal/curl_upload_request.h
+++ b/google/cloud/storage/internal/curl_upload_request.h
@@ -84,7 +84,7 @@ class CurlUploadRequest {
   void Flush();
 
   /// Closes the transfer and wait for the server's response.
-  HttpResponse Close();
+  StatusOr<HttpResponse> Close();
 
   /**
    * Flushes the current buffer and swap the current buffer with @p next_buffer.
@@ -97,7 +97,7 @@ class CurlUploadRequest {
  private:
   friend class CurlRequestBuilder;
   /// Sets the underlying CurlHandle options initially.
-  void SetOptions();
+  Status SetOptions();
 
   /// Resets the underlying CurlHandle options after a move operation.
   void ResetOptions();
@@ -107,7 +107,7 @@ class CurlUploadRequest {
 
   /// Waits until a condition is met.
   template <typename Predicate>
-  void Wait(Predicate&& predicate) {
+  Status Wait(Predicate&& predicate) {
     int repeats = 0;
     // We can assert that the current thread is the leader, because the
     // predicate is satisfied, and the condition variable exited. Therefore,
@@ -120,25 +120,32 @@ class CurlUploadRequest {
                      << ", curl.end="
                      << std::distance(buffer_.begin(), buffer_.end());
       auto running_handles = PerformWork();
+      if (not running_handles.ok()) {
+        return std::move(running_handles).status();
+      }
       // Only wait if there are CURL handles with pending work *and* the
       // predicate is not satisfied. Note that if the predicate is ill-defined
       // it might continue to be unsatisfied even though the handles have
       // completed their work.
-      if (running_handles == 0 or predicate()) {
-        return;
+      if (*running_handles == 0 or predicate()) {
+        return Status();
       }
-      WaitForHandles(repeats);
+      auto status = WaitForHandles(repeats);
+      if (not status.ok()) {
+        return status;
+      }
     }
+    return Status();
   }
 
   /// Uses libcurl to perform at least part of the transfer.
-  int PerformWork();
+  StatusOr<int> PerformWork();
 
   /// Uses libcurl to wait until the underlying data can perform work.
-  void WaitForHandles(int& repeats);
+  Status WaitForHandles(int& repeats);
 
   /// Simplifies handling of errors in the curl_multi_* API.
-  void RaiseOnError(char const* where, CURLMcode result);
+  Status AsStatus(CURLMcode result, char const* where);
 
   /// Raises an exception if the application tries to use a closed request.
   void ValidateOpen(char const* where);

--- a/google/cloud/storage/oauth2/authorized_user_credentials.h
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.h
@@ -98,17 +98,21 @@ class AuthorizedUserCredentials : public Credentials {
     namespace nl = storage::internal::nl;
 
     auto response = request_.MakeRequest(payload_);
-    if (response.status_code >= 300) {
-      return storage::Status(response.status_code, std::move(response.payload));
+    if (not response.ok()) {
+      return std::move(response).status();
     }
-    nl::json access_token = nl::json::parse(response.payload, nullptr, false);
+    if (response->status_code >= 300) {
+      return storage::Status(response->status_code,
+                             std::move(response->payload));
+    }
+    nl::json access_token = nl::json::parse(response->payload, nullptr, false);
     if (access_token.is_discarded() or
         access_token.count("access_token") == 0U or
         access_token.count("expires_in") == 0U or
         access_token.count("id_token") == 0U or
         access_token.count("token_type") == 0U) {
       return storage::Status(
-          response.status_code, std::move(response.payload),
+          response->status_code, std::move(response->payload),
           "Could not find all required fields in response (access_token,"
           " id_token, expires_in, token_type).");
     }

--- a/google/cloud/storage/testing/mock_http_request.h
+++ b/google/cloud/storage/testing/mock_http_request.h
@@ -36,13 +36,13 @@ class MockHttpRequest {
  public:
   MockHttpRequest() : mock(std::make_shared<Impl>()) {}
 
-  internal::HttpResponse MakeRequest(std::string const& s) {
+  StatusOr<internal::HttpResponse> MakeRequest(std::string const& s) {
     return mock->MakeRequest(s);
   }
 
   struct Impl {
     MOCK_METHOD1(MakeRequest,
-                 storage::internal::HttpResponse(std::string const&));
+                 StatusOr<storage::internal::HttpResponse>(std::string const&));
   };
 
   std::shared_ptr<Impl> mock;

--- a/google/cloud/storage/tests/curl_download_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_download_request_integration_test.cc
@@ -43,7 +43,7 @@ TEST(CurlDownloadRequestTest, SimpleStream) {
 
   auto download = request.BuildDownloadRequest(std::string{});
 
-  HttpResponse response;
+  StatusOr<HttpResponse> response;
   std::string buffer;
   // The type for std::count() is hard to guess, most likely it is
   // std::ptrdiff_t, but could be something else, just use the aliases defined
@@ -51,15 +51,16 @@ TEST(CurlDownloadRequestTest, SimpleStream) {
   std::iterator_traits<std::string::iterator>::difference_type count = 0;
   do {
     response = download.GetMore(buffer);
+    EXPECT_TRUE(response.ok());
     count += std::count(buffer.begin(), buffer.end(), '\n');
-  } while (response.status_code == 100);
+  } while (response->status_code == 100);
 
-  EXPECT_EQ(200, response.status_code)
-      << ", status_code=" << response.status_code
-      << ", payload=" << response.payload << ", headers={" << [&response] {
+  EXPECT_EQ(200, response->status_code)
+      << ", status_code=" << response->status_code
+      << ", payload=" << response->payload << ", headers={" << [&response] {
            std::string result;
            char const* sep = "";
-           for (auto&& kv : response.headers) {
+           for (auto&& kv : response->headers) {
              result += sep;
              result += kv.first;
              result += "=";

--- a/google/cloud/storage/tests/curl_upload_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_upload_request_integration_test.cc
@@ -77,12 +77,13 @@ TEST(CurlUploadRequestTest, UploadPartial) {
   expected_data += current_message;
   upload.NextBuffer(current_message);
   auto response = upload.Close();
-  ASSERT_EQ(200, response.status_code)
-      << ", status_code=" << response.status_code
-      << ", payload=" << response.payload << ", headers={" << [&response] {
+  ASSERT_TRUE(response.ok());
+  ASSERT_EQ(200, response->status_code)
+      << ", status_code=" << response->status_code
+      << ", payload=" << response->payload << ", headers={" << [&response] {
            std::string result;
            char const* sep = "";
-           for (auto&& kv : response.headers) {
+           for (auto&& kv : response->headers) {
              result += sep;
              result += kv.first;
              result += "=";
@@ -93,7 +94,7 @@ TEST(CurlUploadRequestTest, UploadPartial) {
            return result;
          }();
 
-  nl::json parsed = nl::json::parse(response.payload);
+  nl::json parsed = nl::json::parse(response->payload);
   // headers contains the headers that the httpbin server received, use that
   // to verify we configured CURL properly.
   auto headers = parsed["headers"];


### PR DESCRIPTION
This is part of the work to provide a exception-free API to
`google::cloud::storage`. Local errors detected by libcurl were
only reported as exceptions.

There is a lot of refactoring in this change because it became tedious
to see the same code in each function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1733)
<!-- Reviewable:end -->
