### PR TITLE
Use non-throwing JSON parser.

### DIFF
--- a/google/cloud/storage/bucket_access_control.cc
+++ b/google/cloud/storage/bucket_access_control.cc
@@ -19,16 +19,22 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-BucketAccessControl BucketAccessControl::ParseFromJson(
+StatusOr<BucketAccessControl> BucketAccessControl::ParseFromJson(
     internal::nl::json const& json) {
+  if (not json.is_object()) {
+    return Status(StatusCode::INVALID_ARGUMENT, __func__);
+  }
   BucketAccessControl result{};
-  AccessControlCommon::ParseFromJson(result, json);
+  auto status = AccessControlCommon::ParseFromJson(result, json);
+  if (not status.ok()) {
+    return status;
+  }
   return result;
 }
 
-BucketAccessControl BucketAccessControl::ParseFromString(
+StatusOr<BucketAccessControl> BucketAccessControl::ParseFromString(
     std::string const& payload) {
-  auto json = internal::nl::json::parse(payload);
+  auto json = internal::nl::json::parse(payload, nullptr, false);
   return BucketAccessControl::ParseFromJson(json);
 }
 

--- a/google/cloud/storage/bucket_access_control.h
+++ b/google/cloud/storage/bucket_access_control.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/internal/access_control_common.h"
 #include "google/cloud/storage/internal/patch_builder.h"
+#include "google/cloud/storage/status_or.h"
 
 namespace google {
 namespace cloud {
@@ -36,10 +37,12 @@ class BucketAccessControl : private internal::AccessControlCommon {
  public:
   BucketAccessControl() = default;
 
-  static BucketAccessControl ParseFromJson(internal::nl::json const& json);
+  static StatusOr<BucketAccessControl> ParseFromJson(
+      internal::nl::json const& json);
 
   /// Parse from a string in JSON format.
-  static BucketAccessControl ParseFromString(std::string const& payload);
+  static StatusOr<BucketAccessControl> ParseFromString(
+      std::string const& payload);
 
   using AccessControlCommon::ROLE_OWNER;
   using AccessControlCommon::ROLE_READER;

--- a/google/cloud/storage/bucket_access_control_test.cc
+++ b/google/cloud/storage/bucket_access_control_test.cc
@@ -38,7 +38,7 @@ TEST(BucketAccessControlTest, Parse) {
       },
       "role": "OWNER"
 })""";
-  auto actual = BucketAccessControl::ParseFromString(text);
+  auto actual = BucketAccessControl::ParseFromString(text).value();
 
   EXPECT_EQ("foo-bar", actual.bucket());
   EXPECT_EQ("example.com", actual.domain());
@@ -51,6 +51,12 @@ TEST(BucketAccessControlTest, Parse) {
   EXPECT_EQ("3456789", actual.project_team().project_number);
   EXPECT_EQ("a-team", actual.project_team().team);
   EXPECT_EQ("OWNER", actual.role());
+}
+
+/// @test Verify that we parse JSON objects into BucketAccessControl objects.
+TEST(BucketAccessControlTest, ParseFailure) {
+  auto actual = BucketAccessControl::ParseFromString("{123");
+  EXPECT_FALSE(actual.ok());
 }
 
 /// @test Verify that the IOStream operator works as expected.
@@ -73,7 +79,7 @@ TEST(BucketAccessControlTest, IOStream) {
       "role": "OWNER"
 })""";
 
-  auto meta = BucketAccessControl::ParseFromString(text);
+  auto meta = BucketAccessControl::ParseFromString(text).value();
   std::ostringstream os;
   os << meta;
   auto actual = os.str();
@@ -118,7 +124,7 @@ TEST(BucketAccessControlTest, Compare) {
       },
       "role": "OWNER"
 })""";
-  auto original = BucketAccessControl::ParseFromString(text);
+  auto original = BucketAccessControl::ParseFromString(text).value();
   EXPECT_EQ(original, original);
 
   auto modified = original;

--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -119,7 +119,9 @@ BucketMetadata BucketMetadata::ParseFromJson(internal::nl::json const& json) {
 
   if (json.count("acl") != 0) {
     for (auto const& kv : json["acl"].items()) {
-      result.acl_.emplace_back(BucketAccessControl::ParseFromJson(kv.value()));
+      // TODO(#1685) - return a StatusOr<> from here.
+      result.acl_.emplace_back(
+          BucketAccessControl::ParseFromJson(kv.value()).value());
     }
   }
   if (json.count("billing") != 0) {
@@ -139,8 +141,9 @@ BucketMetadata BucketMetadata::ParseFromJson(internal::nl::json const& json) {
   }
   if (json.count("defaultObjectAcl") != 0) {
     for (auto const& kv : json["defaultObjectAcl"].items()) {
+      // TODO(#1685) - return a StatusOr<> from here.
       result.default_acl_.emplace_back(
-          ObjectAccessControl::ParseFromJson(kv.value()));
+          ObjectAccessControl::ParseFromJson(kv.value()).value());
     }
   }
   if (json.count("encryption") != 0) {

--- a/google/cloud/storage/bucket_metadata_test.cc
+++ b/google/cloud/storage/bucket_metadata_test.cc
@@ -378,8 +378,7 @@ TEST(BucketMetadataTest, ToJsonString) {
   // iam_configuration()
   ASSERT_EQ(1U, actual.count("iamConfiguration"));
   internal::nl::json expected_iam_configuration{
-      {"bucketOnlyPolicy",
-       internal::nl::json{{"enabled", true}}}};
+      {"bucketOnlyPolicy", internal::nl::json{{"enabled", true}}}};
   EXPECT_EQ(expected_iam_configuration, actual["iamConfiguration"]);
 
   // labels()
@@ -597,9 +596,9 @@ TEST(BucketMetadataTest, SetIamConfiguration) {
   copy.set_iam_configuration(new_configuration);
   ASSERT_TRUE(copy.has_iam_configuration());
   EXPECT_EQ(new_configuration, copy.iam_configuration());
-  EXPECT_NE(expected, copy) << "expected = " << expected.iam_configuration()
-                            << "\n  actual=" << copy.iam_configuration()
-                            << "\n";
+  EXPECT_NE(expected, copy)
+      << "expected = " << expected.iam_configuration()
+      << "\n  actual=" << copy.iam_configuration() << "\n";
 }
 
 /// @test Verify we can reset the IAM Configuration in BucketMetadata.
@@ -793,7 +792,8 @@ TEST(BucketMetadataTest, ResetWebsite) {
 TEST(BucketMetadataPatchBuilder, SetAcl) {
   BucketMetadataPatchBuilder builder;
   builder.SetAcl({BucketAccessControl::ParseFromString(
-      R"""({"entity": "user-test-user", "role": "OWNER"})""")});
+                      R"""({"entity": "user-test-user", "role": "OWNER"})""")
+                      .value()});
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);
@@ -892,8 +892,10 @@ TEST(BucketMetadataPatchBuilder, ResetDefaultEventBasedHold) {
 
 TEST(BucketMetadataPatchBuilder, SetDefaultAcl) {
   BucketMetadataPatchBuilder builder;
-  builder.SetDefaultAcl({ObjectAccessControl::ParseFromString(
-      R"""({"entity": "user-test-user", "role": "OWNER"})""")});
+  builder.SetDefaultAcl(
+      {ObjectAccessControl::ParseFromString(
+           R"""({"entity": "user-test-user", "role": "OWNER"})""")
+           .value()});
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);

--- a/google/cloud/storage/client_bucket_acl_test.cc
+++ b/google/cloud/storage/client_bucket_acl_test.cc
@@ -60,12 +60,12 @@ TEST_F(BucketAccessControlsTest, ListBucketAcl) {
           "bucket": "test-bucket",
           "entity": "user-test-user-1",
           "role": "OWNER"
-      })"""),
+      })""").value(),
       BucketAccessControl::ParseFromString(R"""({
           "bucket": "test-bucket",
           "entity": "user-test-user-2",
           "role": "READER"
-      })"""),
+      })""").value(),
   };
 
   EXPECT_CALL(*mock, ListBucketAcl(_))
@@ -101,7 +101,7 @@ TEST_F(BucketAccessControlsTest, CreateBucketAcl) {
           "bucket": "test-bucket",
           "entity": "user-test-user-1",
           "role": "READER"
-      })""");
+      })""").value();
 
   EXPECT_CALL(*mock, CreateBucketAcl(_))
       .WillOnce(Return(StatusOr<BucketAccessControl>(TransientError())))
@@ -188,7 +188,7 @@ TEST_F(BucketAccessControlsTest, GetBucketAcl) {
           "bucket": "test-bucket",
           "entity": "user-test-user-1",
           "role": "OWNER"
-      })""");
+      })""").value();
 
   EXPECT_CALL(*mock, GetBucketAcl(_))
       .WillOnce(Return(StatusOr<BucketAccessControl>(TransientError())))
@@ -228,7 +228,7 @@ TEST_F(BucketAccessControlsTest, UpdateBucketAcl) {
           "bucket": "test-bucket",
           "entity": "user-test-user-1",
           "role": "OWNER"
-      })""");
+      })""").value();
 
   EXPECT_CALL(*mock, UpdateBucketAcl(_))
       .WillOnce(Return(StatusOr<BucketAccessControl>(TransientError())))
@@ -283,7 +283,7 @@ TEST_F(BucketAccessControlsTest, PatchBucketAcl) {
           "bucket": "test-bucket",
           "entity": "user-test-user-1",
           "role": "OWNER"
-      })""");
+      })""").value();
 
   EXPECT_CALL(*mock, PatchBucketAcl(_))
       .WillOnce(Return(StatusOr<BucketAccessControl>(TransientError())))

--- a/google/cloud/storage/client_default_object_acl_test.cc
+++ b/google/cloud/storage/client_default_object_acl_test.cc
@@ -60,23 +60,25 @@ TEST_F(DefaultObjectAccessControlsTest, ListDefaultObjectAcl) {
           "bucket": "test-bucket",
           "entity": "user-test-user-1",
           "role": "OWNER"
-      })"""),
+      })""")
+          .value(),
       ObjectAccessControl::ParseFromString(R"""({
           "bucket": "test-bucket",
           "entity": "user-test-user-2",
           "role": "READER"
-      })"""),
+      })""")
+          .value(),
   };
 
   EXPECT_CALL(*mock, ListDefaultObjectAcl(_))
-      .WillOnce(Return(StatusOr<internal::ListDefaultObjectAclResponse>(
-          TransientError())))
-      .WillOnce(
-          Invoke([&expected](internal::ListDefaultObjectAclRequest const& r) {
-            EXPECT_EQ("test-bucket", r.bucket_name());
+      .WillOnce(Return(
+          StatusOr<internal::ListDefaultObjectAclResponse>(TransientError())))
+      .WillOnce(Invoke([&expected](
+                           internal::ListDefaultObjectAclRequest const& r) {
+        EXPECT_EQ("test-bucket", r.bucket_name());
 
-            return make_status_or(internal::ListDefaultObjectAclResponse{expected});
-          }));
+        return make_status_or(internal::ListDefaultObjectAclResponse{expected});
+      }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
   std::vector<ObjectAccessControl> actual =
@@ -103,7 +105,8 @@ TEST_F(DefaultObjectAccessControlsTest, CreateDefaultObjectAcl) {
           "bucket": "test-bucket",
           "entity": "user-test-user-1",
           "role": "READER"
-      })""");
+      })""")
+                      .value();
 
   EXPECT_CALL(*mock, CreateDefaultObjectAcl(_))
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
@@ -153,8 +156,7 @@ TEST_F(DefaultObjectAccessControlsTest,
 
 TEST_F(DefaultObjectAccessControlsTest, DeleteDefaultObjectAcl) {
   EXPECT_CALL(*mock, DeleteDefaultObjectAcl(_))
-      .WillOnce(
-          Return(StatusOr<internal::EmptyResponse>(TransientError())))
+      .WillOnce(Return(StatusOr<internal::EmptyResponse>(TransientError())))
       .WillOnce(Invoke([](internal::DeleteDefaultObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("user-test-user", r.entity());
@@ -195,7 +197,8 @@ TEST_F(DefaultObjectAccessControlsTest, GetDefaultObjectAcl) {
           "bucket": "test-bucket",
           "entity": "user-test-user-1",
           "role": "OWNER"
-      })""");
+      })""")
+                                     .value();
 
   EXPECT_CALL(*mock, GetDefaultObjectAcl(_))
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
@@ -236,7 +239,8 @@ TEST_F(DefaultObjectAccessControlsTest, UpdateDefaultObjectAcl) {
           "bucket": "test-bucket",
           "entity": "user-test-user-1",
           "role": "READER"
-      })""");
+      })""")
+                      .value();
 
   EXPECT_CALL(*mock, UpdateDefaultObjectAcl(_))
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
@@ -291,7 +295,9 @@ TEST_F(DefaultObjectAccessControlsTest, PatchDefaultObjectAcl) {
           "bucket": "test-bucket",
           "entity": "user-test-user-1",
           "role": "OWNER"
-      })""");
+      })""")
+                    .value();
+
   EXPECT_CALL(*mock, PatchDefaultObjectAcl(_))
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
       .WillOnce(

--- a/google/cloud/storage/client_object_acl_test.cc
+++ b/google/cloud/storage/client_object_acl_test.cc
@@ -60,18 +60,20 @@ TEST_F(ObjectAccessControlsTest, ListObjectAcl) {
           "object": "test-object",
           "entity": "user-test-user-1",
           "role": "OWNER"
-      })"""),
+      })""")
+          .value(),
       ObjectAccessControl::ParseFromString(R"""({
           "bucket": "test-bucket",
           "object": "test-object",
           "entity": "user-test-user-2",
           "role": "READER"
-      })"""),
+      })""")
+          .value(),
   };
 
   EXPECT_CALL(*mock, ListObjectAcl(_))
-      .WillOnce(Return(
-          StatusOr<internal::ListObjectAclResponse>(TransientError())))
+      .WillOnce(
+          Return(StatusOr<internal::ListObjectAclResponse>(TransientError())))
       .WillOnce(Invoke([&expected](internal::ListObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-object", r.object_name());
@@ -109,7 +111,7 @@ TEST_F(ObjectAccessControlsTest, CreateObjectAcl) {
           "object": "test-object",
           "entity": "user-test-user-1",
           "role": "READER"
-      })""");
+      })""").value();
 
   EXPECT_CALL(*mock, CreateObjectAcl(_))
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
@@ -161,8 +163,7 @@ TEST_F(ObjectAccessControlsTest, CreateObjectAclPermanentFailure) {
 
 TEST_F(ObjectAccessControlsTest, DeleteObjectAcl) {
   EXPECT_CALL(*mock, DeleteObjectAcl(_))
-      .WillOnce(
-          Return(StatusOr<internal::EmptyResponse>(TransientError())))
+      .WillOnce(Return(StatusOr<internal::EmptyResponse>(TransientError())))
       .WillOnce(Invoke([](internal::DeleteObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-object", r.object_name());
@@ -206,7 +207,7 @@ TEST_F(ObjectAccessControlsTest, GetObjectAcl) {
           "object": "test-object",
           "entity": "user-test-user-1",
           "role": "READER"
-      })""");
+      })""").value();
 
   EXPECT_CALL(*mock, GetObjectAcl(_))
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
@@ -250,7 +251,7 @@ TEST_F(ObjectAccessControlsTest, UpdateObjectAcl) {
           "object": "test-object",
           "entity": "user-test-user-1",
           "role": "OWNER"
-      })""");
+      })""").value();
   EXPECT_CALL(*mock, UpdateObjectAcl(_))
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
       .WillOnce(Invoke([expected](internal::UpdateObjectAclRequest const& r) {
@@ -299,7 +300,7 @@ TEST_F(ObjectAccessControlsTest, PatchObjectAcl) {
           "object": "test-object",
           "entity": "user-test-user-1",
           "role": "OWNER"
-      })""");
+      })""").value();
   EXPECT_CALL(*mock, PatchObjectAcl(_))
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
       .WillOnce(Invoke([result](internal::PatchObjectAclRequest const& r) {

--- a/google/cloud/storage/internal/access_control_common.cc
+++ b/google/cloud/storage/internal/access_control_common.cc
@@ -20,8 +20,11 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
-void AccessControlCommon::ParseFromJson(AccessControlCommon& result,
+Status AccessControlCommon::ParseFromJson(AccessControlCommon& result,
                                         nl::json const& json) {
+  if (not json.is_object()) {
+    return Status(StatusCode::INVALID_ARGUMENT, __func__);
+  }
   result.bucket_ = json.value("bucket", "");
   result.domain_ = json.value("domain", "");
   result.email_ = json.value("email", "");
@@ -39,6 +42,7 @@ void AccessControlCommon::ParseFromJson(AccessControlCommon& result,
     p.team = tmp.value("team", "");
     result.project_team_ = std::move(p);
   }
+  return Status();
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/access_control_common.h
+++ b/google/cloud/storage/internal/access_control_common.h
@@ -18,6 +18,7 @@
 #include "google/cloud/optional.h"
 #include "google/cloud/storage/internal/common_metadata.h"
 #include "google/cloud/storage/internal/nljson.h"
+#include "google/cloud/storage/status.h"
 #include <utility>
 
 namespace google {
@@ -134,7 +135,8 @@ class AccessControlCommon {
   bool operator!=(AccessControlCommon const& rhs) { return not(*this == rhs); }
 
  protected:
-  static void ParseFromJson(AccessControlCommon& result, nl::json const& json);
+  static Status ParseFromJson(AccessControlCommon& result,
+                              nl::json const& json);
 
  private:
   std::string bucket_;

--- a/google/cloud/storage/internal/bucket_acl_requests.cc
+++ b/google/cloud/storage/internal/bucket_acl_requests.cc
@@ -27,12 +27,19 @@ std::ostream& operator<<(std::ostream& os, ListBucketAclRequest const& r) {
   return os << "}";
 }
 
-ListBucketAclResponse ListBucketAclResponse::FromHttpResponse(
+StatusOr<ListBucketAclResponse> ListBucketAclResponse::FromHttpResponse(
     HttpResponse&& response) {
   ListBucketAclResponse result;
-  auto json = nl::json::parse(response.payload);
+  auto json = nl::json::parse(response.payload, nullptr, false);
+  if (not json.is_object()) {
+    return Status(StatusCode::INVALID_ARGUMENT, __func__);
+  }
   for (auto const& kv : json["items"].items()) {
-    result.items.emplace_back(BucketAccessControl::ParseFromJson(kv.value()));
+    auto parsed = BucketAccessControl::ParseFromJson(kv.value());
+    if (not parsed.ok()) {
+      return std::move(parsed).status();
+    }
+    result.items.emplace_back(std::move(*parsed));
   }
 
   return result;

--- a/google/cloud/storage/internal/bucket_acl_requests.h
+++ b/google/cloud/storage/internal/bucket_acl_requests.h
@@ -44,7 +44,8 @@ std::ostream& operator<<(std::ostream& os, ListBucketAclRequest const& r);
 
 /// Represents a response to the `BucketAccessControl: list` API.
 struct ListBucketAclResponse {
-  static ListBucketAclResponse FromHttpResponse(HttpResponse&& response);
+  static StatusOr<ListBucketAclResponse> FromHttpResponse(
+      HttpResponse&& response);
 
   std::vector<BucketAccessControl> items;
 };

--- a/google/cloud/storage/internal/bucket_acl_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_acl_requests_test.cc
@@ -48,7 +48,8 @@ TEST(BucketAclRequestTest, ListResponse) {
       }]})""";
 
   auto actual =
-      ListBucketAclResponse::FromHttpResponse(HttpResponse{200, text, {}});
+      ListBucketAclResponse::FromHttpResponse(HttpResponse{200, text, {}})
+          .value();
   ASSERT_EQ(2UL, actual.items.size());
   EXPECT_EQ("user-test-user-1", actual.items.at(0).entity());
   EXPECT_EQ("OWNER", actual.items.at(0).role());
@@ -62,6 +63,13 @@ TEST(BucketAclRequestTest, ListResponse) {
   EXPECT_THAT(str, HasSubstr("entity=user-test-user-2"));
   EXPECT_THAT(str, HasSubstr("ListBucketAclResponse={"));
   EXPECT_THAT(str, HasSubstr("BucketAccessControl={"));
+}
+
+TEST(BucketAclRequestTest, ListResponseParseFailure) {
+  std::string text = "{123";
+  StatusOr<ListBucketAclResponse> actual =
+      ListBucketAclResponse::FromHttpResponse(HttpResponse{200, text, {}});
+  EXPECT_FALSE(actual.ok());
 }
 
 TEST(BucketAclRequestTest, Get) {
@@ -140,7 +148,7 @@ BucketAccessControl CreateBucketAccessControlForTest() {
       },
       "role": "OWNER"
 })""";
-  return BucketAccessControl::ParseFromString(text);
+  return BucketAccessControl::ParseFromString(text).value();
 }
 
 TEST(BucketAclRequestTest, PatchDiff) {

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -169,23 +169,22 @@ TEST(PatchBucketRequestTest, DiffSetAcl) {
   BucketMetadata original = CreateBucketMetadataForTest();
   original.set_acl({});
   BucketMetadata updated = original;
-  updated.set_acl({BucketAccessControl::ParseFromString(R"""({
-    "entity": "user-test-user",
-    "role": "OWNER"})""")});
+  updated.set_acl({BucketAccessControl::ParseFromString(
+                       R"""({"entity": "user-test-user", "role": "OWNER"})""")
+                       .value()});
   PatchBucketRequest request("test-bucket", original, updated);
 
   nl::json patch = nl::json::parse(request.payload());
-  nl::json expected = nl::json::parse(R"""({
-      "acl": [{"entity": "user-test-user", "role": "OWNER"}]
-  })""");
+  nl::json expected = nl::json::parse(
+      R"""({"acl": [{"entity": "user-test-user", "role": "OWNER"}]})""");
   EXPECT_EQ(expected, patch);
 }
 
 TEST(PatchBucketRequestTest, DiffResetAcl) {
   BucketMetadata original = CreateBucketMetadataForTest();
-  original.set_acl({BucketAccessControl::ParseFromString(R"""({
-    "entity": "user-test-user",
-    "role": "OWNER"})""")});
+  original.set_acl({BucketAccessControl::ParseFromString(
+                        R"""({"entity": "user-test-user", "role": "OWNER"})""")
+                        .value()});
   BucketMetadata updated = original;
   updated.set_acl({});
   PatchBucketRequest request("test-bucket", original, updated);
@@ -274,9 +273,10 @@ TEST(PatchBucketRequestTest, DiffSetDefaultAcl) {
   BucketMetadata original = CreateBucketMetadataForTest();
   original.set_default_acl({});
   BucketMetadata updated = original;
-  updated.set_default_acl({ObjectAccessControl::ParseFromString(R"""({
-    "entity": "user-test-user",
-    "role": "OWNER"})""")});
+  updated.set_default_acl(
+      {ObjectAccessControl::ParseFromString(
+           R"""({"entity": "user-test-user","role": "OWNER"})""")
+           .value()});
   PatchBucketRequest request("test-bucket", original, updated);
 
   nl::json patch = nl::json::parse(request.payload());
@@ -288,9 +288,9 @@ TEST(PatchBucketRequestTest, DiffSetDefaultAcl) {
 
 TEST(PatchBucketRequestTest, DiffResetDefaultAcl) {
   BucketMetadata original = CreateBucketMetadataForTest();
-  original.set_default_acl({ObjectAccessControl::ParseFromString(R"""({
-    "entity": "user-test-user",
-    "role": "OWNER"})""")});
+  original.set_default_acl({ObjectAccessControl::ParseFromString(
+      R"""({"entity": "user-test-user", "role": "OWNER"})""")
+      .value()});
   BucketMetadata updated = original;
   updated.set_default_acl({});
   PatchBucketRequest request("test-bucket", original, updated);
@@ -643,13 +643,11 @@ TEST(BucketRequestsTest, ParseIamPolicyFromString) {
            // generates them sorted by role. If we ever change that, we will
            // need to change this test, and it will be a bit more difficult to
            // write it.
-           nl::json{
-               {"role", "roles/storage.admin"},
-               {"members", std::vector<std::string>{"test-user-1"}}},
-           nl::json{
-               {"role", "roles/storage.objectViewer"},
-               {"members",
-                std::vector<std::string>{"test-user-2", "test-user-3"}}},
+           nl::json{{"role", "roles/storage.admin"},
+                    {"members", std::vector<std::string>{"test-user-1"}}},
+           nl::json{{"role", "roles/storage.objectViewer"},
+                    {"members",
+                     std::vector<std::string>{"test-user-2", "test-user-3"}}},
        }},
   };
 
@@ -693,10 +691,9 @@ TEST(BucketRequestsTest, ParseIamPolicyFromStringMissingMembers) {
   nl::json expected_payload{
       {"kind", "storage#policy"},
       {"etag", "XYZ="},
-      {"bindings",
-       std::vector<nl::json>{nl::json{
-           {"role", "roles/storage.objectViewer"},
-       }}},
+      {"bindings", std::vector<nl::json>{nl::json{
+                       {"role", "roles/storage.objectViewer"},
+                   }}},
   };
 
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
@@ -718,11 +715,10 @@ TEST(BucketRequestsTest, ParseIamPolicyFromStringInvalidMembers) {
   nl::json expected_payload{
       {"kind", "storage#policy"},
       {"etag", "XYZ="},
-      {"bindings",
-       std::vector<nl::json>{nl::json{
-           {"role", "roles/storage.objectViewer"},
-           {"members", "invalid"},
-       }}},
+      {"bindings", std::vector<nl::json>{nl::json{
+                       {"role", "roles/storage.objectViewer"},
+                       {"members", "invalid"},
+                   }}},
   };
 
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
@@ -782,13 +778,11 @@ TEST(BucketRequestsTest, SetIamPolicy) {
            // generates them sorted by role. If we ever change that, we will
            // need to change this test, and it will be a bit more difficult to
            // write it.
-           nl::json{
-               {"role", "roles/storage.admin"},
-               {"members", std::vector<std::string>{"test-user-1"}}},
-           nl::json{
-               {"role", "roles/storage.objectViewer"},
-               {"members",
-                std::vector<std::string>{"test-user-2", "test-user-3"}}},
+           nl::json{{"role", "roles/storage.admin"},
+                    {"members", std::vector<std::string>{"test-user-1"}}},
+           nl::json{{"role", "roles/storage.objectViewer"},
+                    {"members",
+                     std::vector<std::string>{"test-user-2", "test-user-3"}}},
        }},
   };
   auto actual_payload = nl::json::parse(request.json_payload());

--- a/google/cloud/storage/internal/default_object_acl_requests.h
+++ b/google/cloud/storage/internal/default_object_acl_requests.h
@@ -46,7 +46,8 @@ std::ostream& operator<<(std::ostream& os,
 
 /// Represents a response to the `DefaultObjectAccessControls: list` API.
 struct ListDefaultObjectAclResponse {
-  static ListDefaultObjectAclResponse FromHttpResponse(HttpResponse&& response);
+  static StatusOr<ListDefaultObjectAclResponse> FromHttpResponse(
+      HttpResponse&& response);
 
   std::vector<ObjectAccessControl> items;
 };

--- a/google/cloud/storage/internal/default_object_acl_requests_test.cc
+++ b/google/cloud/storage/internal/default_object_acl_requests_test.cc
@@ -48,7 +48,8 @@ TEST(DefaultObjectAclRequestTest, ListResponse) {
       }]})""";
 
   auto actual = ListDefaultObjectAclResponse::FromHttpResponse(
-      HttpResponse{200, text, {}});
+                    HttpResponse{200, text, {}})
+                    .value();
   ASSERT_EQ(2UL, actual.items.size());
   EXPECT_EQ("user-test-user-1", actual.items.at(0).entity());
   EXPECT_EQ("OWNER", actual.items.at(0).role());
@@ -62,6 +63,15 @@ TEST(DefaultObjectAclRequestTest, ListResponse) {
   EXPECT_THAT(str, HasSubstr("entity=user-test-user-2"));
   EXPECT_THAT(str, HasSubstr("ListDefaultObjectAclResponse={"));
   EXPECT_THAT(str, HasSubstr("ObjectAccessControl={"));
+}
+
+TEST(DefaultObjectAclRequestTest, ListResponseFailure) {
+  std::string text = R"""({123)""";
+
+  StatusOr<ListDefaultObjectAclResponse> actual =
+      ListDefaultObjectAclResponse::FromHttpResponse(
+          HttpResponse{200, text, {}});
+  EXPECT_FALSE(actual.ok());
 }
 
 TEST(DefaultObjectAclRequestTest, Get) {
@@ -141,7 +151,7 @@ ObjectAccessControl CreateDefaultObjectAccessControlForTest() {
       },
       "role": "OWNER"
 })""";
-  return ObjectAccessControl::ParseFromString(text);
+  return ObjectAccessControl::ParseFromString(text).value();
 }
 
 TEST(DefaultObjectAclRequestTest, PatchDiff) {

--- a/google/cloud/storage/internal/object_acl_requests.cc
+++ b/google/cloud/storage/internal/object_acl_requests.cc
@@ -29,12 +29,19 @@ std::ostream& operator<<(std::ostream& os, ListObjectAclRequest const& r) {
   return os << "}";
 }
 
-ListObjectAclResponse ListObjectAclResponse::FromHttpResponse(
+StatusOr<ListObjectAclResponse> ListObjectAclResponse::FromHttpResponse(
     HttpResponse&& response) {
+  auto json = nl::json::parse(response.payload, nullptr, false);
+  if (not json.is_object()) {
+    return Status(StatusCode::INVALID_ARGUMENT, __func__);
+  }
   ListObjectAclResponse result;
-  auto json = nl::json::parse(response.payload);
   for (auto const& kv : json["items"].items()) {
-    result.items.emplace_back(ObjectAccessControl::ParseFromJson(kv.value()));
+    auto parsed = ObjectAccessControl::ParseFromJson(kv.value());
+    if (not parsed.ok()) {
+      return std::move(parsed).status();
+    }
+    result.items.emplace_back(std::move(*parsed));
   }
 
   return result;

--- a/google/cloud/storage/internal/object_acl_requests.h
+++ b/google/cloud/storage/internal/object_acl_requests.h
@@ -41,7 +41,8 @@ std::ostream& operator<<(std::ostream& os, ListObjectAclRequest const& r);
 
 /// Represents a response to the `ObjectAccessControls: list` API.
 struct ListObjectAclResponse {
-  static ListObjectAclResponse FromHttpResponse(HttpResponse&& response);
+  static StatusOr<ListObjectAclResponse> FromHttpResponse(
+      HttpResponse&& response);
 
   std::vector<ObjectAccessControl> items;
 };

--- a/google/cloud/storage/internal/object_acl_requests_test.cc
+++ b/google/cloud/storage/internal/object_acl_requests_test.cc
@@ -54,7 +54,7 @@ TEST(ObjectAclRequestTest, ListResponse) {
       }]})""";
 
   auto actual =
-      ListObjectAclResponse::FromHttpResponse(HttpResponse{200, text, {}});
+      ListObjectAclResponse::FromHttpResponse(HttpResponse{200, text, {}}).value();
   ASSERT_EQ(2UL, actual.items.size());
   EXPECT_EQ("user-qux", actual.items.at(0).entity());
   EXPECT_EQ("OWNER", actual.items.at(0).role());
@@ -69,6 +69,22 @@ TEST(ObjectAclRequestTest, ListResponse) {
   EXPECT_THAT(str, HasSubstr("object=baz"));
   EXPECT_THAT(str, HasSubstr("ListObjectAclResponse={"));
   EXPECT_THAT(str, HasSubstr("ObjectAccessControl={"));
+}
+
+TEST(ObjectAclRequestTest, ListResponseParseFailure) {
+  std::string text = R"""({123)""";
+
+  auto actual =
+      ListObjectAclResponse::FromHttpResponse(HttpResponse{200, text, {}});
+  EXPECT_FALSE(actual.ok());
+}
+
+TEST(ObjectAclRequestTest, ListResponseParseFailureElements) {
+  std::string text = R"""({"items": ["should-be-object"]})""";
+
+  auto actual =
+      ListObjectAclResponse::FromHttpResponse(HttpResponse{200, text, {}});
+  EXPECT_FALSE(actual.ok());
 }
 
 TEST(ObjectAclRequestTest, Get) {
@@ -159,7 +175,7 @@ ObjectAccessControl CreateObjectAccessControlForTest() {
       },
       "role": "OWNER"
 })""";
-  return ObjectAccessControl::ParseFromString(text);
+  return ObjectAccessControl::ParseFromString(text).value();
 }
 
 TEST(ObjectAclRequestTest, PatchDiff) {

--- a/google/cloud/storage/internal/object_requests_test.cc
+++ b/google/cloud/storage/internal/object_requests_test.cc
@@ -614,9 +614,9 @@ TEST(PatchObjectRequestTest, DiffSetAcl) {
   ObjectMetadata original = CreateObjectMetadataForTest();
   original.set_acl({});
   ObjectMetadata updated = original;
-  updated.set_acl({ObjectAccessControl::ParseFromString(R"""({
-    "entity": "user-test-user",
-    "role": "OWNER"})""")});
+  updated.set_acl({ObjectAccessControl::ParseFromString(
+      R"""({"entity": "user-test-user", "role": "OWNER"})""")
+      .value()});
   PatchObjectRequest request("test-bucket", "test-object", original, updated);
 
   nl::json patch = nl::json::parse(request.payload());
@@ -628,9 +628,9 @@ TEST(PatchObjectRequestTest, DiffSetAcl) {
 
 TEST(PatchObjectRequestTest, DiffResetAcl) {
   ObjectMetadata original = CreateObjectMetadataForTest();
-  original.set_acl({ObjectAccessControl::ParseFromString(R"""({
-    "entity": "user-test-user",
-    "role": "OWNER"})""")});
+  original.set_acl({ObjectAccessControl::ParseFromString(
+      R"""({"entity": "user-test-user", "role": "OWNER"})""")
+      .value()});
   ObjectMetadata updated = original;
   updated.set_acl({});
   PatchObjectRequest request("test-bucket", "test-object", original, updated);

--- a/google/cloud/storage/object_access_control.cc
+++ b/google/cloud/storage/object_access_control.cc
@@ -20,18 +20,24 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-ObjectAccessControl ObjectAccessControl::ParseFromJson(
+StatusOr<ObjectAccessControl> ObjectAccessControl::ParseFromJson(
     internal::nl::json const& json) {
+  if (not json.is_object()) {
+    return Status(StatusCode::INVALID_ARGUMENT, __func__);
+  }
   ObjectAccessControl result{};
-  AccessControlCommon::ParseFromJson(result, json);
+  auto status = AccessControlCommon::ParseFromJson(result, json);
+  if (not status.ok()) {
+    return status;
+  }
   result.generation_ = internal::ParseLongField(json, "generation");
   result.object_ = json.value("object", "");
   return result;
 }
 
-ObjectAccessControl ObjectAccessControl::ParseFromString(
+StatusOr<ObjectAccessControl> ObjectAccessControl::ParseFromString(
     std::string const& payload) {
-  auto json = internal::nl::json::parse(payload);
+  auto json = internal::nl::json::parse(payload, nullptr, false);
   return ParseFromJson(json);
 }
 

--- a/google/cloud/storage/object_access_control.h
+++ b/google/cloud/storage/object_access_control.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/internal/common_metadata.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/internal/patch_builder.h"
+#include "google/cloud/storage/status_or.h"
 
 namespace google {
 namespace cloud {
@@ -38,8 +39,10 @@ class ObjectAccessControl : private internal::AccessControlCommon {
  public:
   ObjectAccessControl() : generation_(0) {}
 
-  static ObjectAccessControl ParseFromJson(internal::nl::json const& json);
-  static ObjectAccessControl ParseFromString(std::string const& payload);
+  static StatusOr<ObjectAccessControl> ParseFromJson(
+      internal::nl::json const& json);
+  static StatusOr<ObjectAccessControl> ParseFromString(
+      std::string const& payload);
 
   using AccessControlCommon::ROLE_OWNER;
   using AccessControlCommon::ROLE_READER;

--- a/google/cloud/storage/object_access_control_test.cc
+++ b/google/cloud/storage/object_access_control_test.cc
@@ -40,7 +40,7 @@ TEST(ObjectAccessControlTest, Parse) {
       },
       "role": "OWNER"
 })""";
-  auto actual = ObjectAccessControl::ParseFromString(text);
+  auto actual = ObjectAccessControl::ParseFromString(text).value();
 
   EXPECT_EQ("foo-bar", actual.bucket());
   EXPECT_EQ("example.com", actual.domain());
@@ -79,7 +79,7 @@ TEST(ObjectAccessControlTest, IOStream) {
       "role": "OWNER"
 })""";
 
-  auto meta = ObjectAccessControl::ParseFromString(text);
+  auto meta = ObjectAccessControl::ParseFromString(text).value();
   std::ostringstream os;
   os << meta;
   auto actual = os.str();
@@ -127,7 +127,7 @@ TEST(ObjectAccessControlTest, Compare) {
       },
       "role": "OWNER"
 })""";
-  auto original = ObjectAccessControl::ParseFromString(text);
+  auto original = ObjectAccessControl::ParseFromString(text).value();
   EXPECT_EQ(original, original);
 
   auto modified = original;

--- a/google/cloud/storage/object_metadata.cc
+++ b/google/cloud/storage/object_metadata.cc
@@ -55,7 +55,9 @@ ObjectMetadata ObjectMetadata::ParseFromJson(internal::nl::json const& json) {
 
   if (json.count("acl") != 0) {
     for (auto const& kv : json["acl"].items()) {
-      result.acl_.emplace_back(ObjectAccessControl::ParseFromJson(kv.value()));
+      // TODO(#1685) - return a StatusOr<> from here.
+      result.acl_.emplace_back(
+          ObjectAccessControl::ParseFromJson(kv.value()).value());
     }
   }
 

--- a/google/cloud/storage/object_metadata_test.cc
+++ b/google/cloud/storage/object_metadata_test.cc
@@ -328,7 +328,7 @@ TEST(ObjectMetadataTest, InsertMetadata) {
 TEST(ObjectMetadataPatchBuilder, SetAcl) {
   ObjectMetadataPatchBuilder builder;
   builder.SetAcl({ObjectAccessControl::ParseFromString(
-      R"""({"entity": "user-test-user", "role": "OWNER"})""")});
+      R"""({"entity": "user-test-user", "role": "OWNER"})""").value()});
 
   auto actual = builder.BuildPatch();
   auto actual_as_json = internal::nl::json::parse(actual);


### PR DESCRIPTION
The nlohmann::json parser throws by default. If we ever get an invalid
JSON string from the server that would crash an application with
-fno-exceptions. This change uses the non-throwing version of
nl::json::parse() in the *AccessControl classes, and changes the return
type to StatusOr<>. This is the first of a series of PRs for #1685.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1737)
<!-- Reviewable:end -->
