### PR TITLE
Use non-throwing JSON parser for Notifications.

### DIFF
--- a/google/cloud/storage/client_notifications_test.cc
+++ b/google/cloud/storage/client_notifications_test.cc
@@ -62,22 +62,24 @@ TEST_F(NotificationsTest, ListNotifications) {
       NotificationMetadata::ParseFromString(R"""({
           "id": "test-notification-1",
           "topic": "test-topic-1"
-      })"""),
+      })""")
+          .value(),
       NotificationMetadata::ParseFromString(R"""({
           "id": "test-notification-2",
           "topic": "test-topic-2"
-      })"""),
+      })""")
+          .value(),
   };
 
   EXPECT_CALL(*mock_, ListNotifications(_))
-      .WillOnce(Return(StatusOr<internal::ListNotificationsResponse>(TransientError()
-                                      )))
-      .WillOnce(
-          Invoke([&expected](internal::ListNotificationsRequest const& r) {
-            EXPECT_EQ("test-bucket", r.bucket_name());
+      .WillOnce(Return(
+          StatusOr<internal::ListNotificationsResponse>(TransientError())))
+      .WillOnce(Invoke([&expected](
+                           internal::ListNotificationsRequest const& r) {
+        EXPECT_EQ("test-bucket", r.bucket_name());
 
-            return make_status_or(internal::ListNotificationsResponse{expected});
-          }));
+        return make_status_or(internal::ListNotificationsResponse{expected});
+      }));
   Client client{std::shared_ptr<internal::RawClient>(mock_)};
 
   std::vector<NotificationMetadata> actual =
@@ -106,11 +108,11 @@ TEST_F(NotificationsTest, CreateNotification) {
           "payload_format": "JSON_API_V1",
           "object_prefix": "test-object-prefix-",
           "event_type": [ "OBJECT_FINALIZE" ]
-      })""");
+      })""")
+                                      .value();
 
   EXPECT_CALL(*mock_, CreateNotification(_))
-      .WillOnce(
-          Return(StatusOr<NotificationMetadata>(TransientError())))
+      .WillOnce(Return(StatusOr<NotificationMetadata>(TransientError())))
       .WillOnce(
           Invoke([&expected](internal::CreateNotificationRequest const& r) {
             EXPECT_EQ("test-bucket", r.bucket_name());
@@ -160,11 +162,11 @@ TEST_F(NotificationsTest, GetNotification) {
           "payload_format": "JSON_API_V1",
           "object_prefix": "test-object-prefix-",
           "event_type": [ "OBJECT_FINALIZE" ]
-      })""");
+      })""")
+                                      .value();
 
   EXPECT_CALL(*mock_, GetNotification(_))
-      .WillOnce(
-          Return(StatusOr<NotificationMetadata>(TransientError())))
+      .WillOnce(Return(StatusOr<NotificationMetadata>(TransientError())))
       .WillOnce(Invoke([&expected](internal::GetNotificationRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-notification-1", r.notification_id());
@@ -198,8 +200,7 @@ TEST_F(NotificationsTest, GetNotificationPermanentFailure) {
 
 TEST_F(NotificationsTest, DeleteNotification) {
   EXPECT_CALL(*mock_, DeleteNotification(_))
-      .WillOnce(
-          Return(StatusOr<internal::EmptyResponse>(TransientError())))
+      .WillOnce(Return(StatusOr<internal::EmptyResponse>(TransientError())))
       .WillOnce(Invoke([](internal::DeleteNotificationRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-notification-1", r.notification_id());

--- a/google/cloud/storage/internal/notification_requests.h
+++ b/google/cloud/storage/internal/notification_requests.h
@@ -44,7 +44,8 @@ std::ostream& operator<<(std::ostream& os, ListNotificationsRequest const& r);
 
 /// Represents a response to the `Notification: list` API.
 struct ListNotificationsResponse {
-  static ListNotificationsResponse FromHttpResponse(HttpResponse&& response);
+  static StatusOr<ListNotificationsResponse> FromHttpResponse(
+      HttpResponse&& response);
 
   std::vector<NotificationMetadata> items;
 };

--- a/google/cloud/storage/internal/notification_requests_test.cc
+++ b/google/cloud/storage/internal/notification_requests_test.cc
@@ -47,7 +47,8 @@ TEST(NotificationRequestTest, ListResponse) {
       }]})""";
 
   auto actual =
-      ListNotificationsResponse::FromHttpResponse(HttpResponse{200, text, {}});
+      ListNotificationsResponse::FromHttpResponse(HttpResponse{200, text, {}})
+          .value();
   ASSERT_EQ(2UL, actual.items.size());
   EXPECT_EQ("test-notification-id-1", actual.items.at(0).id());
   EXPECT_EQ("test-topic-1", actual.items.at(0).topic());
@@ -61,6 +62,26 @@ TEST(NotificationRequestTest, ListResponse) {
   EXPECT_THAT(str, HasSubstr("id=test-notification-id-2"));
   EXPECT_THAT(str, HasSubstr("ListNotificationResponse={"));
   EXPECT_THAT(str, HasSubstr("NotificationMetadata={"));
+}
+
+TEST(NotificationRequestTest, ListResponseParseFailure) {
+  std::string text = R"""({123)""";
+
+  StatusOr<ListNotificationsResponse> actual =
+      ListNotificationsResponse::FromHttpResponse(HttpResponse{200, text, {}});
+  EXPECT_FALSE(actual.ok());
+}
+
+TEST(NotificationRequestTest, ListResponseParseFailureListElements) {
+  std::string text = R"""({
+      "items": [{
+          "id": "test-notification-id-1",
+          "topic": "test-topic-1"
+      }, "invalid-element"]})""";
+
+  StatusOr<ListNotificationsResponse> actual =
+      ListNotificationsResponse::FromHttpResponse(HttpResponse{200, text, {}});
+  EXPECT_FALSE(actual.ok());
 }
 
 TEST(CreateNotificationRequestTest, Create) {

--- a/google/cloud/storage/notification_metadata.cc
+++ b/google/cloud/storage/notification_metadata.cc
@@ -18,8 +18,11 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-NotificationMetadata NotificationMetadata::ParseFromJson(
+StatusOr<NotificationMetadata> NotificationMetadata::ParseFromJson(
     internal::nl::json const& json) {
+  if (not json.is_object()) {
+    return Status(StatusCode::INVALID_ARGUMENT, __func__);
+  }
   NotificationMetadata result{};
 
   if (json.count("custom_attributes") != 0U) {
@@ -46,9 +49,9 @@ NotificationMetadata NotificationMetadata::ParseFromJson(
   return result;
 }
 
-NotificationMetadata NotificationMetadata::ParseFromString(
+StatusOr<NotificationMetadata> NotificationMetadata::ParseFromString(
     std::string const& payload) {
-  internal::nl::json json = internal::nl::json::parse(payload);
+  internal::nl::json json = internal::nl::json::parse(payload, nullptr, false);
   return ParseFromJson(json);
 }
 

--- a/google/cloud/storage/notification_metadata.h
+++ b/google/cloud/storage/notification_metadata.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_NOTIFICATION_METADATA_H_
 
 #include "google/cloud/storage/internal/nljson.h"
-#include "google/cloud/storage/version.h"
+#include "google/cloud/storage/status_or.h"
 #include <map>
 #include <string>
 
@@ -39,8 +39,10 @@ class NotificationMetadata {
  public:
   NotificationMetadata() = default;
 
-  static NotificationMetadata ParseFromJson(internal::nl::json const& json);
-  static NotificationMetadata ParseFromString(std::string const& payload);
+  static StatusOr<NotificationMetadata> ParseFromJson(
+      internal::nl::json const& json);
+  static StatusOr<NotificationMetadata> ParseFromString(
+      std::string const& payload);
 
   /**
    * Returns the payload for a call to `Notifications: insert`.

--- a/google/cloud/storage/notification_metadata_test.cc
+++ b/google/cloud/storage/notification_metadata_test.cc
@@ -44,7 +44,7 @@ NotificationMetadata CreateNotificationMetadataForTest() {
       "selfLink": "https://www.googleapis.com/storage/v1/b/test-bucket/notificationConfigs/test-id-123",
       "topic": "test-topic"
 })""";
-  return NotificationMetadata::ParseFromString(text);
+  return NotificationMetadata::ParseFromString(text).value();
 }
 
 /// @test Verify that we parse JSON objects into NotificationMetadata objects.
@@ -72,6 +72,12 @@ TEST(NotificationMetadataTest, Parse) {
       "notificationConfigs/test-id-123",
       actual.self_link());
   EXPECT_EQ("test-topic", actual.topic());
+}
+
+/// @test Verify that we parse JSON objects into NotificationMetadata objects.
+TEST(NotificationMetadataTest, ParseFailure) {
+  auto actual = NotificationMetadata::ParseFromString("{123");
+  EXPECT_FALSE(actual.ok());
 }
 
 /// @test Verifies NotificationMetadata iostream operator.


### PR DESCRIPTION
Another in the series of PRs to not throw from nl::json::parse(). Part
of the work for #1685.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1738)
<!-- Reviewable:end -->
