### PR TITLE
Use non-throwing JSON parser for ServiceAccount.

### DIFF
--- a/google/cloud/storage/client_notifications_test.cc
+++ b/google/cloud/storage/client_notifications_test.cc
@@ -70,14 +70,14 @@ TEST_F(NotificationsTest, ListNotifications) {
   };
 
   EXPECT_CALL(*mock_, ListNotifications(_))
-      .WillOnce(Return(StatusOr<internal::ListNotificationsResponse>(TransientError()
-                                      )))
-      .WillOnce(
-          Invoke([&expected](internal::ListNotificationsRequest const& r) {
-            EXPECT_EQ("test-bucket", r.bucket_name());
+      .WillOnce(Return(
+          StatusOr<internal::ListNotificationsResponse>(TransientError())))
+      .WillOnce(Invoke([&expected](
+                           internal::ListNotificationsRequest const& r) {
+        EXPECT_EQ("test-bucket", r.bucket_name());
 
-            return make_status_or(internal::ListNotificationsResponse{expected});
-          }));
+        return make_status_or(internal::ListNotificationsResponse{expected});
+      }));
   Client client{std::shared_ptr<internal::RawClient>(mock_)};
 
   std::vector<NotificationMetadata> actual =
@@ -109,8 +109,7 @@ TEST_F(NotificationsTest, CreateNotification) {
       })""");
 
   EXPECT_CALL(*mock_, CreateNotification(_))
-      .WillOnce(
-          Return(StatusOr<NotificationMetadata>(TransientError())))
+      .WillOnce(Return(StatusOr<NotificationMetadata>(TransientError())))
       .WillOnce(
           Invoke([&expected](internal::CreateNotificationRequest const& r) {
             EXPECT_EQ("test-bucket", r.bucket_name());
@@ -163,8 +162,7 @@ TEST_F(NotificationsTest, GetNotification) {
       })""");
 
   EXPECT_CALL(*mock_, GetNotification(_))
-      .WillOnce(
-          Return(StatusOr<NotificationMetadata>(TransientError())))
+      .WillOnce(Return(StatusOr<NotificationMetadata>(TransientError())))
       .WillOnce(Invoke([&expected](internal::GetNotificationRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-notification-1", r.notification_id());
@@ -198,8 +196,7 @@ TEST_F(NotificationsTest, GetNotificationPermanentFailure) {
 
 TEST_F(NotificationsTest, DeleteNotification) {
   EXPECT_CALL(*mock_, DeleteNotification(_))
-      .WillOnce(
-          Return(StatusOr<internal::EmptyResponse>(TransientError())))
+      .WillOnce(Return(StatusOr<internal::EmptyResponse>(TransientError())))
       .WillOnce(Invoke([](internal::DeleteNotificationRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-notification-1", r.notification_id());

--- a/google/cloud/storage/client_service_account_test.cc
+++ b/google/cloud/storage/client_service_account_test.cc
@@ -55,9 +55,10 @@ class ServiceAccountTest : public ::testing::Test {
 };
 
 TEST_F(ServiceAccountTest, GetProjectServiceAccount) {
-  ServiceAccount expected = ServiceAccount::ParseFromString(R"""({
-          "email_address": "test-service-account@test-domain.com"
-      })""");
+  ServiceAccount expected =
+      ServiceAccount::ParseFromString(
+          R"""({"email_address": "test-service-account@test-domain.com"})""")
+          .value();
 
   EXPECT_CALL(*mock, GetServiceAccount(_))
       .WillOnce(Return(StatusOr<ServiceAccount>(TransientError())))

--- a/google/cloud/storage/service_account.cc
+++ b/google/cloud/storage/service_account.cc
@@ -18,15 +18,20 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-ServiceAccount ServiceAccount::ParseFromJson(internal::nl::json const& json) {
+StatusOr<ServiceAccount> ServiceAccount::ParseFromJson(
+    internal::nl::json const& json) {
+  if (not json.is_object()) {
+    return Status(StatusCode::INVALID_ARGUMENT, __func__);
+  }
   ServiceAccount result{};
   result.kind_ = json.value("kind", "");
   result.email_address_ = json.value("email_address", "");
   return result;
 }
 
-ServiceAccount ServiceAccount::ParseFromString(std::string const& payload) {
-  auto json = internal::nl::json::parse(payload);
+StatusOr<ServiceAccount> ServiceAccount::ParseFromString(
+    std::string const& payload) {
+  auto json = internal::nl::json::parse(payload, nullptr, false);
   return ParseFromJson(json);
 }
 

--- a/google/cloud/storage/service_account.h
+++ b/google/cloud/storage/service_account.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_SERVICE_ACCOUNT_H_
 
 #include "google/cloud/storage/internal/nljson.h"
-#include "google/cloud/storage/version.h"
+#include "google/cloud/storage/status_or.h"
 
 namespace google {
 namespace cloud {
@@ -29,8 +29,8 @@ class ServiceAccount {
  public:
   ServiceAccount() = default;
 
-  static ServiceAccount ParseFromJson(internal::nl::json const& json);
-  static ServiceAccount ParseFromString(std::string const& payload);
+  static StatusOr<ServiceAccount> ParseFromJson(internal::nl::json const& json);
+  static StatusOr<ServiceAccount> ParseFromString(std::string const& payload);
 
   std::string const& email_address() const { return email_address_; }
   std::string const& kind() const { return kind_; }

--- a/google/cloud/storage/service_account_test.cc
+++ b/google/cloud/storage/service_account_test.cc
@@ -26,15 +26,21 @@ ServiceAccount CreateServiceAccountForTest() {
   return ServiceAccount::ParseFromString(R"""({
       "email_address": "service-123@example.com",
       "kind": "storage#serviceAccount"
-})""");
+})""").value();
 }
 
-/// @test Verify that we parse JSON objects into ObjectMetadata objects.
+/// @test Verify that we parse JSON objects into ServiceAccount objects.
 TEST(ServiceAccountTest, Parse) {
   auto actual = CreateServiceAccountForTest();
 
   EXPECT_EQ("service-123@example.com", actual.email_address());
   EXPECT_EQ("storage#serviceAccount", actual.kind());
+}
+
+/// @test Verify that we parse JSON objects into ServiceAccount objects.
+TEST(ServiceAccountTest, ParseFailure) {
+  auto actual = ServiceAccount::ParseFromString("{123");
+  EXPECT_FALSE(actual.ok());
 }
 
 /// @test Verify that the IOStream operator works as expected.


### PR DESCRIPTION
This is another PR in the series to use the non-throwing version of
nl::json::parse(). This is part of the changes to #1685.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1739)
<!-- Reviewable:end -->
