### PR TITLE
Use non-throwing JSON parser for BucketMetadata.

### DIFF
--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -487,8 +487,8 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
  public:
   BucketMetadata() : project_number_(0) {}
 
-  static BucketMetadata ParseFromJson(internal::nl::json const& json);
-  static BucketMetadata ParseFromString(std::string const& payload);
+  static StatusOr<BucketMetadata> ParseFromJson(internal::nl::json const& json);
+  static StatusOr<BucketMetadata> ParseFromString(std::string const& payload);
 
   std::string ToJsonString() const;
 

--- a/google/cloud/storage/bucket_metadata_test.cc
+++ b/google/cloud/storage/bucket_metadata_test.cc
@@ -272,6 +272,27 @@ TEST(BucketMetadataTest, ParseFailure) {
   EXPECT_FALSE(actual.ok());
 }
 
+/// @test Verify that we parse JSON objects into BucketMetadata objects.
+TEST(BucketMetadataTest, ParseAclFailure) {
+  auto actual = BucketMetadata::ParseFromString(
+      R"""({"acl: ["invalid-item"]})""");
+  EXPECT_FALSE(actual.ok());
+}
+
+/// @test Verify that we parse JSON objects into BucketMetadata objects.
+TEST(BucketMetadataTest, ParseDefaultObjecAclFailure) {
+  auto actual = BucketMetadata::ParseFromString(
+      R"""({"defaultObjectAcl: ["invalid-item"]})""");
+  EXPECT_FALSE(actual.ok());
+}
+
+/// @test Verify that we parse JSON objects into BucketMetadata objects.
+TEST(BucketMetadataTest, ParseLifecycleFailure) {
+  auto actual = BucketMetadata::ParseFromString(
+      R"""({"lifecycle: {"rule": [ "invalid-item" ]}})""");
+  EXPECT_FALSE(actual.ok());
+}
+
 /// @test Verify that the IOStream operator works as expected.
 TEST(BucketMetadataTest, IOStream) {
   auto meta = CreateBucketMetadataForTest();

--- a/google/cloud/storage/bucket_metadata_test.cc
+++ b/google/cloud/storage/bucket_metadata_test.cc
@@ -155,7 +155,7 @@ BucketMetadata CreateBucketMetadataForTest() {
         "notFoundPage": "404.html"
       }
 })""";
-  return BucketMetadata::ParseFromString(text);
+  return BucketMetadata::ParseFromString(text).value();
 }
 
 /// @test Verify that we parse JSON objects into BucketMetadata objects.
@@ -264,6 +264,12 @@ TEST(BucketMetadataTest, Parse) {
   ASSERT_TRUE(actual.has_website());
   EXPECT_EQ("index.html", actual.website().main_page_suffix);
   EXPECT_EQ("404.html", actual.website().not_found_page);
+}
+
+/// @test Verify that we parse JSON objects into BucketMetadata objects.
+TEST(BucketMetadataTest, ParseFailure) {
+  auto actual = BucketMetadata::ParseFromString("{123");
+  EXPECT_FALSE(actual.ok());
 }
 
 /// @test Verify that the IOStream operator works as expected.
@@ -892,10 +898,8 @@ TEST(BucketMetadataPatchBuilder, ResetDefaultEventBasedHold) {
 
 TEST(BucketMetadataPatchBuilder, SetDefaultAcl) {
   BucketMetadataPatchBuilder builder;
-  builder.SetDefaultAcl(
-      {ObjectAccessControl::ParseFromString(
-           R"""({"entity": "user-test-user", "role": "OWNER"})""")
-           .value()});
+  builder.SetDefaultAcl({ObjectAccessControl::ParseFromString(
+      R"""({"entity": "user-test-user", "role": "OWNER"})""").value()});
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);

--- a/google/cloud/storage/bucket_test.cc
+++ b/google/cloud/storage/bucket_test.cc
@@ -74,7 +74,7 @@ TEST_F(BucketTest, CreateBucket) {
       "storageClass": "STANDARD",
       "etag": "XYZ="
 })""";
-  auto expected = BucketMetadata::ParseFromString(text);
+  auto expected = BucketMetadata::ParseFromString(text).value();
 
   ClientOptions mock_options(oauth2::CreateAnonymousCredentials());
   mock_options.set_project_id("test-project-name");
@@ -132,7 +132,7 @@ TEST_F(BucketTest, GetBucketMetadata) {
       "storageClass": "STANDARD",
       "etag": "XYZ="
 })""";
-  auto expected = BucketMetadata::ParseFromString(text);
+  auto expected = BucketMetadata::ParseFromString(text).value();
 
   EXPECT_CALL(*mock, GetBucketMetadata(_))
       .WillOnce(Return(StatusOr<BucketMetadata>(TransientError())))
@@ -208,7 +208,7 @@ TEST_F(BucketTest, UpdateBucket) {
       "storageClass": "STANDARD",
       "etag": "XYZ="
 })""";
-  auto expected = BucketMetadata::ParseFromString(text);
+  auto expected = BucketMetadata::ParseFromString(text).value();
 
   EXPECT_CALL(*mock, UpdateBucket(_))
       .WillOnce(Return(StatusOr<BucketMetadata>(TransientError())))
@@ -263,7 +263,7 @@ TEST_F(BucketTest, PatchBucket) {
       "storageClass": "STANDARD",
       "etag": "XYZ="
 })""";
-  auto expected = BucketMetadata::ParseFromString(text);
+  auto expected = BucketMetadata::ParseFromString(text).value();
 
   EXPECT_CALL(*mock, PatchBucket(_))
       .WillOnce(Return(StatusOr<BucketMetadata>(TransientError())))

--- a/google/cloud/storage/internal/bucket_requests.h
+++ b/google/cloud/storage/internal/bucket_requests.h
@@ -53,7 +53,8 @@ class ListBucketsRequest
 std::ostream& operator<<(std::ostream& os, ListBucketsRequest const& r);
 
 struct ListBucketsResponse {
-  static ListBucketsResponse FromHttpResponse(HttpResponse&& response);
+  static StatusOr<ListBucketsResponse> FromHttpResponse(
+      HttpResponse&& response);
 
   std::string next_page_token;
   std::vector<BucketMetadata> items;
@@ -199,7 +200,7 @@ class GetBucketIamPolicyRequest
 
 std::ostream& operator<<(std::ostream& os, GetBucketIamPolicyRequest const& r);
 
-IamPolicy ParseIamPolicyFromString(std::string const& payload);
+StatusOr<IamPolicy> ParseIamPolicyFromString(std::string const& payload);
 
 /**
  * Represents a request to the `Buckets: getIamPolicy` API.
@@ -245,7 +246,7 @@ std::ostream& operator<<(std::ostream& os,
                          TestBucketIamPermissionsRequest const& r);
 
 struct TestBucketIamPermissionsResponse {
-  static TestBucketIamPermissionsResponse FromHttpResponse(
+  static StatusOr<TestBucketIamPermissionsResponse> FromHttpResponse(
       HttpResponse const& response);
 
   std::vector<std::string> permissions;

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -111,6 +111,14 @@ TEST(ListBucketsResponseTest, ParseFailure) {
   EXPECT_FALSE(actual.ok());
 }
 
+TEST(ListBucketsResponseTestt, ParseFailureInItems) {
+  std::string text = R"""({"items": [ "invalid-item" ]})""";
+
+  auto actual =
+      ListBucketsResponse::FromHttpResponse(HttpResponse{200, text, {}});
+  EXPECT_FALSE(actual.ok());
+}
+
 TEST(CreateBucketsRequestTest, Basic) {
   CreateBucketRequest request("project-for-new-bucket",
                               BucketMetadata().set_name("test-bucket"));

--- a/google/cloud/storage/internal/common_metadata.h
+++ b/google/cloud/storage/internal/common_metadata.h
@@ -18,6 +18,7 @@
 #include "google/cloud/optional.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include "google/cloud/storage/internal/nljson.h"
+#include "google/cloud/storage/status_or.h"
 #include <chrono>
 #include <map>
 #include <vector>
@@ -72,8 +73,11 @@ class CommonMetadata {
  public:
   CommonMetadata() : metageneration_(0), owner_() {}
 
-  static CommonMetadata<Derived> ParseFromJson(internal::nl::json const& json) {
-    CommonMetadata<Derived> result{};
+  static Status ParseFromJson(CommonMetadata<Derived>& result,
+                              internal::nl::json const& json) {
+    if (not json.is_object()) {
+      return Status(StatusCode::INVALID_ARGUMENT, __func__);
+    }
     result.etag_ = json.value("etag", "");
     result.id_ = json.value("id", "");
     result.kind_ = json.value("kind", "");
@@ -89,9 +93,9 @@ class CommonMetadata {
     result.storage_class_ = json.value("storageClass", "");
     result.time_created_ = ParseTimestampField(json, "timeCreated");
     result.updated_ = ParseTimestampField(json, "updated");
-    return result;
+    return Status();
   }
-  static CommonMetadata ParseFromString(std::string const& payload) {
+  static StatusOr<CommonMetadata> ParseFromString(std::string const& payload) {
     auto json = internal::nl::json::parse(payload);
     return ParseFromJson(json);
   }

--- a/google/cloud/storage/internal/logging_client_test.cc
+++ b/google/cloud/storage/internal/logging_client_test.cc
@@ -14,8 +14,8 @@
 
 #include "google/cloud/storage/internal/logging_client.h"
 #include "google/cloud/log.h"
-#include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
+#include "google/cloud/storage/testing/mock_client.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -24,11 +24,11 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+using google::cloud::storage::testing::canonical_errors::TransientError;
 using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
-using google::cloud::storage::testing::canonical_errors::TransientError;
 
 class MockLogBackend : public google::cloud::LogBackend {
  public:
@@ -67,7 +67,7 @@ TEST_F(LoggingClientTest, GetBucketMetadata) {
 
   auto mock = std::make_shared<testing::MockClient>();
   EXPECT_CALL(*mock, GetBucketMetadata(_))
-      .WillOnce(Return(make_status_or(BucketMetadata::ParseFromString(text))));
+      .WillOnce(Return(BucketMetadata::ParseFromString(text).value()));
 
   // We want to test that the key elements are logged, but do not want a
   // "change detection test", so this is intentionally not exhaustive.
@@ -119,8 +119,7 @@ TEST_F(LoggingClientTest, InsertObjectMedia) {
 
   auto mock = std::make_shared<testing::MockClient>();
   EXPECT_CALL(*mock, InsertObjectMedia(_))
-      .WillOnce(Return(
-          make_status_or(ObjectMetadata::ParseFromString(text))));
+      .WillOnce(Return(ObjectMetadata::ParseFromString(text)));
 
   // We want to test that the key elements are logged, but do not want a
   // "change detection test", so this is intentionally not exhaustive.

--- a/google/cloud/storage/lifecycle_rule.cc
+++ b/google/cloud/storage/lifecycle_rule.cc
@@ -92,7 +92,10 @@ std::ostream& operator<<(std::ostream& os, LifecycleRuleCondition const& rhs) {
   return os << "}";
 }
 
-LifecycleRule LifecycleRule::ParseFromJson(internal::nl::json const& json) {
+StatusOr<LifecycleRule> LifecycleRule::ParseFromJson(internal::nl::json const& json) {
+  if (not json.is_object()) {
+    return Status(StatusCode::INVALID_ARGUMENT, __func__);
+  }
   LifecycleRule result;
   if (json.count("action") != 0) {
     result.action_.type = json["action"].value("type", "");
@@ -126,8 +129,8 @@ LifecycleRule LifecycleRule::ParseFromJson(internal::nl::json const& json) {
   return result;
 }
 
-LifecycleRule LifecycleRule::ParseFromString(std::string const& text) {
-  auto json = internal::nl::json::parse(text);
+StatusOr<LifecycleRule> LifecycleRule::ParseFromString(std::string const& text) {
+  auto json = internal::nl::json::parse(text, nullptr, false);
   return ParseFromJson(json);
 }
 

--- a/google/cloud/storage/lifecycle_rule.h
+++ b/google/cloud/storage/lifecycle_rule.h
@@ -18,6 +18,7 @@
 #include "google/cloud/optional.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/internal/parse_rfc3339.h"
+#include "google/cloud/storage/status_or.h"
 #include "google/cloud/storage/storage_class.h"
 #include <chrono>
 #include <iosfwd>
@@ -129,8 +130,8 @@ class LifecycleRule {
                          LifecycleRuleAction action)
       : action_(std::move(action)), condition_(std::move(condition)) {}
 
-  static LifecycleRule ParseFromJson(internal::nl::json const& json);
-  static LifecycleRule ParseFromString(std::string const& text);
+  static StatusOr<LifecycleRule> ParseFromJson(internal::nl::json const& json);
+  static StatusOr<LifecycleRule> ParseFromString(std::string const& text);
 
   LifecycleRuleAction const& action() const { return action_; }
   LifecycleRuleCondition const& condition() const { return condition_; }

--- a/google/cloud/storage/lifecycle_rule_test.cc
+++ b/google/cloud/storage/lifecycle_rule_test.cc
@@ -35,7 +35,13 @@ LifecycleRule CreateLifecycleRuleForTest() {
         "storageClass": "NEARLINE"
       }
     })""";
-  return LifecycleRule::ParseFromString(text);
+  return LifecycleRule::ParseFromString(text).value();
+}
+
+/// @test Verify that we parse JSON objects into LifecycleRule objects.
+TEST(LifecycleRuleTest, ParseFailure) {
+  auto actual = LifecycleRule::ParseFromString("{123");
+  EXPECT_FALSE(actual.ok());
 }
 
 /// @test Verify that LifecycleRuleAction streaming works as expected.

--- a/google/cloud/storage/list_buckets_reader_test.cc
+++ b/google/cloud/storage/list_buckets_reader_test.cc
@@ -50,7 +50,7 @@ TEST(ListBucketsReaderTest, Basic) {
         {"selfLink", link},
         {"kind", "storage#bucket"},
     };
-    expected.emplace_back(BucketMetadata::ParseFromJson(metadata));
+    expected.emplace_back(BucketMetadata::ParseFromJson(metadata).value());
   }
 
   auto create_mock = [&expected, page_count](int i) {

--- a/google/cloud/storage/object_metadata.cc
+++ b/google/cloud/storage/object_metadata.cc
@@ -50,8 +50,8 @@ std::ostream& operator<<(std::ostream& os, ComposeSourceObject const& r) {
 
 ObjectMetadata ObjectMetadata::ParseFromJson(internal::nl::json const& json) {
   ObjectMetadata result{};
-  static_cast<CommonMetadata<ObjectMetadata>&>(result) =
-      CommonMetadata<ObjectMetadata>::ParseFromJson(json);
+  // TODO(#1685) - Return a StatusOr<> from here.
+  CommonMetadata<ObjectMetadata>::ParseFromJson(result, json);
 
   if (json.count("acl") != 0) {
     for (auto const& kv : json["acl"].items()) {


### PR DESCRIPTION
This is anther PR in the series to use the non-throwing version of
nl::json::parse(). This is part of the changes for #1685.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1741)
<!-- Reviewable:end -->
