### PR TITLE
Improve code coverage for CurlClient.

### DIFF
--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -16,6 +16,9 @@
 #include "google/cloud/internal/make_unique.h"
 #include "google/cloud/storage/internal/curl_request_builder.h"
 #include "google/cloud/storage/oauth2/credentials.h"
+#include "google/cloud/storage/oauth2/google_credentials.h"
+#include "google/cloud/internal/setenv.h"
+#include "google/cloud/testing_util/environment_variable_restore.h"
 #include <gmock/gmock.h>
 #include <memory>
 #include <utility>
@@ -27,8 +30,8 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
-using ::google::cloud::storage::Status;
 using ::google::cloud::storage::oauth2::Credentials;
+using ::testing::HasSubstr;
 
 long const STATUS_ERROR_CODE = 503;
 std::string const STATUS_ERROR_MSG =
@@ -46,305 +49,357 @@ class FailingCredentials : public Credentials {
   }
 };
 
-class CurlClientTest : public ::testing::Test {
+class CurlClientTest : public ::testing::Test,
+                       public ::testing::WithParamInterface<std::string> {
  protected:
-  static void SetUpTestCase() {
-    client_ = CurlClient::Create(std::make_shared<FailingCredentials>());
+  CurlClientTest() : endpoint_("CLOUD_STORAGE_TESTBENCH_ENDPOINT") {}
+
+  void SetUp() override {
+    std::string const error_type = GetParam();
+    if (error_type == "credentials-failure") {
+      client_ = CurlClient::Create(std::make_shared<FailingCredentials>());
+      expected_status_code_ = STATUS_ERROR_CODE;
+      expected_status_substr_ = STATUS_ERROR_MSG;
+    } else {
+      google::cloud::internal::SetEnv(
+          "CLOUD_STORAGE_TESTBENCH_ENDPOINT", "http://localhost:0");
+      client_ = CurlClient::Create(
+          ClientOptions(oauth2::CreateAnonymousCredentials())
+              .set_endpoint("http://localhost:0"));
+      expected_status_code_ = StatusCode::UNKNOWN;
+      expected_status_substr_ = "CURL error";
+    }
   }
 
-  static void TearDownTestCase() { client_.reset(); }
+  void TearDown() override { client_.reset(); }
 
-  static std::shared_ptr<CurlClient> client_;
+  void TestCorrectFailureStatus(Status const& status) {
+    EXPECT_EQ(expected_status_code_, status.status_code());
+    EXPECT_THAT(status.error_message(), HasSubstr(expected_status_substr_));
+  }
+
+  std::shared_ptr<CurlClient> client_;
+  long expected_status_code_;
+  std::string expected_status_substr_;
+  testing_util::EnvironmentVariableRestore endpoint_;
 };
 
-std::shared_ptr<CurlClient> CurlClientTest::client_;
-
-void TestCorrectFailureStatus(Status const& status) {
-  EXPECT_EQ(status.status_code(), STATUS_ERROR_CODE);
-  EXPECT_EQ(status.error_message(), STATUS_ERROR_MSG);
-}
-
-TEST_F(CurlClientTest, UploadChunk) {
-  auto status_or_foo = client_->UploadChunk(
-      UploadChunkRequest("http://unused.googleapis.com/invalid-session-id", 0U,
-                         std::string{}, 0U));
+TEST_P(CurlClientTest, UploadChunk) {
+  // Use http://localhost:0 to force a libcurl failure
+  auto status_or_foo = client_->UploadChunk(UploadChunkRequest(
+      "http://localhost:0/invalid-session-id", 0U, std::string{}, 0U));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, QueryResumableUpload) {
-  auto status_or_foo =
-      client_->QueryResumableUpload(QueryResumableUploadRequest(
-          "http://unused.googleapis.com/invalid-session-id"));
+TEST_P(CurlClientTest, QueryResumableUpload) {
+  // Use http://localhost:0 to force a libcurl failure
+  auto status_or_foo = client_->QueryResumableUpload(
+      QueryResumableUploadRequest("http://localhost:0/invalid-session-id"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, ListBuckets) {
+TEST_P(CurlClientTest, ListBuckets) {
   auto status_or_foo = client_->ListBuckets(ListBucketsRequest{"project_id"});
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, CreateBucket) {
+TEST_P(CurlClientTest, CreateBucket) {
   auto status_or_foo = client_->CreateBucket(
       CreateBucketRequest("bkt", BucketMetadata().set_name("bkt")));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, GetBucketMetadata) {
+TEST_P(CurlClientTest, GetBucketMetadata) {
   auto status_or_foo =
       client_->GetBucketMetadata(GetBucketMetadataRequest("bkt"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, DeleteBucket) {
+TEST_P(CurlClientTest, DeleteBucket) {
   auto status_or_foo = client_->DeleteBucket(DeleteBucketRequest("bkt"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, UpdateBucket) {
+TEST_P(CurlClientTest, UpdateBucket) {
   auto status_or_foo = client_->UpdateBucket(
       UpdateBucketRequest(BucketMetadata().set_name("bkt")));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, PatchBucket) {
+TEST_P(CurlClientTest, PatchBucket) {
   auto status_or_foo = client_->PatchBucket(
       PatchBucketRequest("bkt", BucketMetadata().set_name("bkt"),
                          BucketMetadata().set_name("bkt")));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, GetBucketIamPolicy) {
+TEST_P(CurlClientTest, GetBucketIamPolicy) {
   auto status_or_foo =
       client_->GetBucketIamPolicy(GetBucketIamPolicyRequest("bkt"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, SetBucketIamPolicy) {
+TEST_P(CurlClientTest, SetBucketIamPolicy) {
   auto status_or_foo = client_->SetBucketIamPolicy(
       SetBucketIamPolicyRequest("bkt", google::cloud::IamPolicy{}));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, TestBucketIamPermissions) {
+TEST_P(CurlClientTest, TestBucketIamPermissions) {
   auto status_or_foo = client_->TestBucketIamPermissions(
       TestBucketIamPermissionsRequest("bkt", {}));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, LockBucketRetentionPolicy) {
+TEST_P(CurlClientTest, LockBucketRetentionPolicy) {
   auto status_or_foo = client_->LockBucketRetentionPolicy(
       LockBucketRetentionPolicyRequest("bkt", 0U));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, InsertObjectMedia) {
+TEST_P(CurlClientTest, InsertObjectMediaSimple) {
+  auto status_or_foo = client_->InsertObjectMedia(
+      InsertObjectMediaRequest("bkt", "obj", "contents")
+          .set_multiple_options(DisableMD5Hash(true),
+                                DisableCrc32cChecksum(true)));
+  TestCorrectFailureStatus(status_or_foo.status());
+}
+
+TEST_P(CurlClientTest, InsertObjectMediaMultipart) {
+  std::string const error_type = GetParam();
+  if (error_type != "credentials-failure") {
+    // TODO(#1735) - enable this test when ObjectWriteStream uses StatusOr.
+    return;
+  }
   auto status_or_foo = client_->InsertObjectMedia(
       InsertObjectMediaRequest("bkt", "obj", "contents"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, GetObjectMetadata) {
+TEST_P(CurlClientTest, InsertObjectMediaXml) {
+  auto status_or_foo = client_->InsertObjectMedia(
+      InsertObjectMediaRequest("bkt", "obj", "contents")
+          .set_multiple_options(Fields("")));
+  TestCorrectFailureStatus(status_or_foo.status());
+}
+
+TEST_P(CurlClientTest, GetObjectMetadata) {
   auto status_or_foo =
       client_->GetObjectMetadata(GetObjectMetadataRequest("bkt", "obj"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, ReadObject) {
+TEST_P(CurlClientTest, ReadObject) {
+  std::string const error_type = GetParam();
+  if (error_type != "credentials-failure") {
+    // TODO(#1736) - enable this test when ObjectReadStream uses StatusOr.
+    return;
+  }
   auto status_or_foo =
       client_->ReadObject(ReadObjectRangeRequest("bkt", "obj"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, WriteObject) {
+TEST_P(CurlClientTest, WriteObject) {
+  std::string const error_type = GetParam();
+  if (error_type != "credentials-failure") {
+    // TODO(#1735) - enable this test when ObjectWriteStream uses StatusOr.
+    return;
+  }
   auto status_or_foo =
       client_->WriteObject(InsertObjectStreamingRequest("bkt", "obj"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, ListObjects) {
+TEST_P(CurlClientTest, ListObjects) {
   auto status_or_foo = client_->ListObjects(ListObjectsRequest("bkt"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, DeleteObject) {
-  auto status_or_foo =
-      client_->DeleteObject(DeleteObjectRequest("bkt", "obj"));
+TEST_P(CurlClientTest, DeleteObject) {
+  auto status_or_foo = client_->DeleteObject(DeleteObjectRequest("bkt", "obj"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, UpdateObject) {
+TEST_P(CurlClientTest, UpdateObject) {
   auto status_or_foo = client_->UpdateObject(
       UpdateObjectRequest("bkt", "obj", ObjectMetadata()));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, PatchObject) {
+TEST_P(CurlClientTest, PatchObject) {
   auto status_or_foo = client_->PatchObject(
       PatchObjectRequest("bkt", "obj", ObjectMetadata(), ObjectMetadata()));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, ComposeObject) {
+TEST_P(CurlClientTest, ComposeObject) {
   auto status_or_foo =
       client_->ComposeObject(ComposeObjectRequest("bkt", {}, "obj"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, ListBucketAcl) {
+TEST_P(CurlClientTest, ListBucketAcl) {
   auto status_or_foo = client_->ListBucketAcl(ListBucketAclRequest("bkt"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, CopyObject) {
+TEST_P(CurlClientTest, CopyObject) {
   auto status_or_foo =
       client_->CopyObject(CopyObjectRequest("bkt", "obj1", "bkt", "obj2"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, CreateBucketAcl) {
+TEST_P(CurlClientTest, CreateBucketAcl) {
   auto status_or_foo =
       client_->CreateBucketAcl(CreateBucketAclRequest("bkt", "entity", "role"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, GetBucketAcl) {
+TEST_P(CurlClientTest, GetBucketAcl) {
   auto status_or_foo =
       client_->GetBucketAcl(GetBucketAclRequest("bkt", "entity"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, DeleteBucketAcl) {
+TEST_P(CurlClientTest, DeleteBucketAcl) {
   auto status_or_foo =
       client_->DeleteBucketAcl(DeleteBucketAclRequest("bkt", "entity"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, UpdateBucketAcl) {
+TEST_P(CurlClientTest, UpdateBucketAcl) {
   auto status_or_foo =
       client_->UpdateBucketAcl(UpdateBucketAclRequest("bkt", "entity", "role"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, PatchBucketAcl) {
+TEST_P(CurlClientTest, PatchBucketAcl) {
   auto status_or_foo = client_->PatchBucketAcl(PatchBucketAclRequest(
       "bkt", "entity", BucketAccessControl(), BucketAccessControl()));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, ListObjectAcl) {
+TEST_P(CurlClientTest, ListObjectAcl) {
   auto status_or_foo =
       client_->ListObjectAcl(ListObjectAclRequest("bkt", "obj"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, CreateObjectAcl) {
+TEST_P(CurlClientTest, CreateObjectAcl) {
   auto status_or_foo = client_->CreateObjectAcl(
       CreateObjectAclRequest("bkt", "obj", "entity", "role"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, DeleteObjectAcl) {
+TEST_P(CurlClientTest, DeleteObjectAcl) {
   auto status_or_foo =
       client_->DeleteObjectAcl(DeleteObjectAclRequest("bkt", "obj", "entity"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, GetObjectAcl) {
+TEST_P(CurlClientTest, GetObjectAcl) {
   auto status_or_foo =
       client_->GetObjectAcl(GetObjectAclRequest("bkt", "obj", "entity"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, UpdateObjectAcl) {
+TEST_P(CurlClientTest, UpdateObjectAcl) {
   auto status_or_foo = client_->UpdateObjectAcl(
       UpdateObjectAclRequest("bkt", "obj", "entity", "role"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, PatchObjectAcl) {
+TEST_P(CurlClientTest, PatchObjectAcl) {
   auto status_or_foo = client_->PatchObjectAcl(PatchObjectAclRequest(
       "bkt", "obj", "entity", ObjectAccessControl(), ObjectAccessControl()));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, RewriteObject) {
+TEST_P(CurlClientTest, RewriteObject) {
   auto status_or_foo = client_->RewriteObject(
       RewriteObjectRequest("bkt", "obj", "bkt2", "obj2", "token"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, CreateResumableSession) {
+TEST_P(CurlClientTest, CreateResumableSession) {
   auto status_or_foo = client_->CreateResumableSession(
       ResumableUploadRequest("test-bucket", "test-object"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, ListDefaultObjectAcl) {
+TEST_P(CurlClientTest, ListDefaultObjectAcl) {
   auto status_or_foo =
       client_->ListDefaultObjectAcl(ListDefaultObjectAclRequest("bkt"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, CreateDefaultObjectAcl) {
+TEST_P(CurlClientTest, CreateDefaultObjectAcl) {
   auto status_or_foo = client_->CreateDefaultObjectAcl(
       CreateDefaultObjectAclRequest("bkt", "entity", "role"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, DeleteDefaultObjectAcl) {
+TEST_P(CurlClientTest, DeleteDefaultObjectAcl) {
   auto status_or_foo = client_->DeleteDefaultObjectAcl(
       DeleteDefaultObjectAclRequest("bkt", "entity"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, GetDefaultObjectAcl) {
+TEST_P(CurlClientTest, GetDefaultObjectAcl) {
   auto status_or_foo =
       client_->GetDefaultObjectAcl(GetDefaultObjectAclRequest("bkt", "entity"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, UpdateDefaultObjectAcl) {
+TEST_P(CurlClientTest, UpdateDefaultObjectAcl) {
   auto status_or_foo = client_->UpdateDefaultObjectAcl(
       UpdateDefaultObjectAclRequest("bkt", "entity", "role"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, PatchDefaultObjectAcl) {
+TEST_P(CurlClientTest, PatchDefaultObjectAcl) {
   auto status_or_foo =
       client_->PatchDefaultObjectAcl(PatchDefaultObjectAclRequest(
           "bkt", "entity", ObjectAccessControl(), ObjectAccessControl()));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, GetServiceAccount) {
+TEST_P(CurlClientTest, GetServiceAccount) {
   auto status_or_foo =
       client_->GetServiceAccount(GetProjectServiceAccountRequest("project_id"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, ListNotifications) {
+TEST_P(CurlClientTest, ListNotifications) {
   auto status_or_foo =
       client_->ListNotifications(ListNotificationsRequest("bkt"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, CreateNotification) {
+TEST_P(CurlClientTest, CreateNotification) {
   auto status_or_foo = client_->CreateNotification(
       CreateNotificationRequest("bkt", NotificationMetadata()));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, GetNotification) {
+TEST_P(CurlClientTest, GetNotification) {
   auto status_or_foo = client_->GetNotification(
       GetNotificationRequest("bkt", "notification_id"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-TEST_F(CurlClientTest, DeleteNotification) {
+TEST_P(CurlClientTest, DeleteNotification) {
   auto status_or_foo = client_->DeleteNotification(
       DeleteNotificationRequest("bkt", "notification_id"));
   TestCorrectFailureStatus(status_or_foo.status());
 }
+
+INSTANTIATE_TEST_CASE_P(CredentialsFailure, CurlClientTest,
+                        ::testing::Values("credentials-failure"));
+
+INSTANTIATE_TEST_CASE_P(LibCurlFailure, CurlClientTest,
+                        ::testing::Values("libcurl-failure"));
 
 }  // namespace
 }  // namespace internal


### PR DESCRIPTION
I thought the existing tests would cover the libcurl failure cases,
obviously I was wrong. This reuses the tests for credential failures,
because otherwise we would need to rewrite basically the same tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1744)
<!-- Reviewable:end -->
