### PR TITLE
Use non-throwing JSON parser for ObjectMetadata.

### DIFF
--- a/google/cloud/storage/client_notifications_test.cc
+++ b/google/cloud/storage/client_notifications_test.cc
@@ -178,7 +178,7 @@ TEST_F(NotificationsTest, GetNotification) {
   NotificationMetadata actual =
       client.GetNotification("test-bucket", "test-notification-1");
   EXPECT_EQ(expected, actual);
-}  // namespace
+}
 
 TEST_F(NotificationsTest, GetNotificationTooManyFailures) {
   testing::TooManyFailuresTest<NotificationMetadata>(

--- a/google/cloud/storage/client_notifications_test.cc
+++ b/google/cloud/storage/client_notifications_test.cc
@@ -178,7 +178,7 @@ TEST_F(NotificationsTest, GetNotification) {
   NotificationMetadata actual =
       client.GetNotification("test-bucket", "test-notification-1");
   EXPECT_EQ(expected, actual);
-}
+}  // namespace
 
 TEST_F(NotificationsTest, GetNotificationTooManyFailures) {
   testing::TooManyFailuresTest<NotificationMetadata>(

--- a/google/cloud/storage/client_object_copy_test.cc
+++ b/google/cloud/storage/client_object_copy_test.cc
@@ -63,7 +63,7 @@ TEST_F(ObjectCopyTest, CopyObject) {
   std::string text = R"""({
       "name": "test-bucket-name/test-object-name/1"
 })""";
-  auto expected = storage::ObjectMetadata::ParseFromString(text);
+  auto expected = storage::ObjectMetadata::ParseFromString(text).value();
 
   EXPECT_CALL(*mock, CopyObject(_))
       .WillOnce(Invoke([&expected](internal::CopyObjectRequest const& request) {
@@ -76,9 +76,9 @@ TEST_F(ObjectCopyTest, CopyObject) {
   Client client{std::shared_ptr<internal::RawClient>(mock),
                 LimitedErrorCountRetryPolicy(2)};
 
-  ObjectMetadata actual = client.CopyObject(
-      "source-bucket-name", "source-object-name", "test-bucket-name",
-      "test-object-name");
+  ObjectMetadata actual =
+      client.CopyObject("source-bucket-name", "source-object-name",
+                        "test-bucket-name", "test-object-name");
   EXPECT_EQ(expected, actual);
 }
 
@@ -131,7 +131,7 @@ TEST_F(ObjectCopyTest, ComposeObject) {
       "updated": "2018-05-19T19:31:24Z",
       "componentCount": 2
 })""";
-  auto expected = ObjectMetadata::ParseFromString(response);
+  auto expected = ObjectMetadata::ParseFromString(response).value();
 
   EXPECT_CALL(*mock, ComposeObject(_))
       .WillOnce(Return(StatusOr<ObjectMetadata>(TransientError())))
@@ -149,9 +149,8 @@ TEST_F(ObjectCopyTest, ComposeObject) {
   Client client{std::shared_ptr<internal::RawClient>(mock),
                 LimitedErrorCountRetryPolicy(2)};
 
-  auto actual =
-      client.ComposeObject("test-bucket-name", {{"object1"}, {"object2"}},
-                           "test-object-name");
+  auto actual = client.ComposeObject(
+      "test-bucket-name", {{"object1"}, {"object2"}}, "test-object-name");
   EXPECT_EQ(expected, actual);
 }
 
@@ -181,8 +180,8 @@ TEST_F(ObjectCopyTest, ComposeObjectPermanentFailure) {
 
 TEST_F(ObjectCopyTest, RewriteObject) {
   EXPECT_CALL(*mock, RewriteObject(_))
-      .WillOnce(Return(
-          StatusOr<internal::RewriteObjectResponse>(TransientError())))
+      .WillOnce(
+          Return(StatusOr<internal::RewriteObjectResponse>(TransientError())))
       .WillOnce(Invoke([](internal::RewriteObjectRequest const& r) {
         EXPECT_EQ("test-source-bucket-name", r.source_bucket());
         EXPECT_EQ("test-source-object-name", r.source_object());
@@ -197,8 +196,8 @@ TEST_F(ObjectCopyTest, RewriteObject) {
             "done": false,
             "rewriteToken": "abcd-test-token-0"
         })""";
-        return make_status_or(internal::RewriteObjectResponse::FromHttpResponse(
-                                  internal::HttpResponse{200, response, {}}));
+        return internal::RewriteObjectResponse::FromHttpResponse(
+            internal::HttpResponse{200, response, {}});
       }))
       .WillOnce(Invoke([](internal::RewriteObjectRequest const& r) {
         EXPECT_EQ("test-source-bucket-name", r.source_bucket());
@@ -214,8 +213,8 @@ TEST_F(ObjectCopyTest, RewriteObject) {
             "done": false,
             "rewriteToken": "abcd-test-token-2"
         })""";
-        return make_status_or(internal::RewriteObjectResponse::FromHttpResponse(
-                                  internal::HttpResponse{200, response, {}}));
+        return internal::RewriteObjectResponse::FromHttpResponse(
+            internal::HttpResponse{200, response, {}});
       }))
       .WillOnce(Invoke([](internal::RewriteObjectRequest const& r) {
         EXPECT_EQ("test-source-bucket-name", r.source_bucket());
@@ -235,8 +234,8 @@ TEST_F(ObjectCopyTest, RewriteObject) {
                "name": "test-destination-object-name"
             }
         })""";
-        return make_status_or(internal::RewriteObjectResponse::FromHttpResponse(
-                                  internal::HttpResponse{200, response, {}}));
+        return internal::RewriteObjectResponse::FromHttpResponse(
+            internal::HttpResponse{200, response, {}});
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock),
                 LimitedErrorCountRetryPolicy(2)};
@@ -278,8 +277,7 @@ TEST_F(ObjectCopyTest, RewriteObjectTooManyFailures) {
       [](Client& client) {
         client.RewriteObjectBlocking(
             "test-source-bucket-name", "test-source-object",
-            "test-dest-bucket-name", "test-dest-object",
-            IfGenerationMatch(7));
+            "test-dest-bucket-name", "test-dest-object", IfGenerationMatch(7));
       },
       "RewriteObject");
 }

--- a/google/cloud/storage/client_object_copy_test.cc
+++ b/google/cloud/storage/client_object_copy_test.cc
@@ -60,9 +60,7 @@ class ObjectCopyTest : public ::testing::Test {
 };
 
 TEST_F(ObjectCopyTest, CopyObject) {
-  std::string text = R"""({
-      "name": "test-bucket-name/test-object-name/1"
-})""";
+  std::string text = R"""({"name": "test-bucket-name/test-object-name/1"})""";
   auto expected = storage::ObjectMetadata::ParseFromString(text).value();
 
   EXPECT_CALL(*mock, CopyObject(_))
@@ -130,7 +128,7 @@ TEST_F(ObjectCopyTest, ComposeObject) {
       "timeStorageClassUpdated": "2018-05-19T19:31:34Z",
       "updated": "2018-05-19T19:31:24Z",
       "componentCount": 2
-})""";
+  })""";
   auto expected = ObjectMetadata::ParseFromString(response).value();
 
   EXPECT_CALL(*mock, ComposeObject(_))

--- a/google/cloud/storage/client_write_object_test.cc
+++ b/google/cloud/storage/client_write_object_test.cc
@@ -71,7 +71,7 @@ TEST_F(WriteObjectTest, WriteObject) {
   std::string text = R"""({
       "name": "test-bucket-name/test-object-name/1"
 })""";
-  auto expected = ObjectMetadata::ParseFromString(text);
+  auto expected = ObjectMetadata::ParseFromString(text).value();
 
   EXPECT_CALL(*mock, WriteObject(_))
       .WillOnce(Invoke(

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -215,14 +215,17 @@ CurlClient::CreateResumableSessionGeneric(RequestType const& request) {
   }
   auto response =
       ResumableUploadResponse::FromHttpResponse(*std::move(http_response));
-  if (response.upload_session_url.empty()) {
+  if (not response.ok()) {
+    return std::move(response).status();
+  }
+  if (response->upload_session_url.empty()) {
     std::ostringstream os;
-    os << __func__ << " - invalid server response, parsed to " << response;
+    os << __func__ << " - invalid server response, parsed to " << *response;
     return Status(StatusCode::INTERNAL, std::move(os).str());
   }
   return std::unique_ptr<ResumableUploadSession>(
       google::cloud::internal::make_unique<CurlResumableUploadSession>(
-          shared_from_this(), std::move(response.upload_session_url)));
+          shared_from_this(), std::move(response->upload_session_url)));
 }
 
 CurlClient::CurlClient(ClientOptions options)

--- a/google/cloud/storage/internal/hash_validator_test.cc
+++ b/google/cloud/storage/internal/hash_validator_test.cc
@@ -259,7 +259,7 @@ TEST(CompositeHashValidator, ProcessMetadata) {
   auto object_metadata = ObjectMetadata::ParseFromJson(internal::nl::json{
       {"crc32c", QUICK_FOX_CRC32C_CHECKSUM},
       {"md5Hash", QUICK_FOX_MD5_HASH},
-  });
+  }).value();
   validator.ProcessMetadata(object_metadata);
   auto result = std::move(validator).Finish();
   EXPECT_EQ(

--- a/google/cloud/storage/internal/logging_client_test.cc
+++ b/google/cloud/storage/internal/logging_client_test.cc
@@ -119,7 +119,7 @@ TEST_F(LoggingClientTest, InsertObjectMedia) {
 
   auto mock = std::make_shared<testing::MockClient>();
   EXPECT_CALL(*mock, InsertObjectMedia(_))
-      .WillOnce(Return(ObjectMetadata::ParseFromString(text)));
+      .WillOnce(Return(ObjectMetadata::ParseFromString(text).value()));
 
   // We want to test that the key elements are logged, but do not want a
   // "change detection test", so this is intentionally not exhaustive.
@@ -145,8 +145,10 @@ TEST_F(LoggingClientTest, InsertObjectMedia) {
 
 TEST_F(LoggingClientTest, ListObjects) {
   std::vector<ObjectMetadata> items = {
-      ObjectMetadata::ParseFromString(R""({"name": "response-object-o1"})""),
-      ObjectMetadata::ParseFromString(R""({"name": "response-object-o2"})""),
+      ObjectMetadata::ParseFromString(R""({"name": "response-object-o1"})"")
+          .value(),
+      ObjectMetadata::ParseFromString(R""({"name": "response-object-o2"})"")
+          .value(),
   };
   auto mock = std::make_shared<testing::MockClient>();
   EXPECT_CALL(*mock, ListObjects(_))

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -53,7 +53,8 @@ class ListObjectsRequest
 std::ostream& operator<<(std::ostream& os, ListObjectsRequest const& r);
 
 struct ListObjectsResponse {
-  static ListObjectsResponse FromHttpResponse(HttpResponse&& response);
+  static StatusOr<ListObjectsResponse> FromHttpResponse(
+      HttpResponse&& response);
 
   std::string next_page_token;
   std::vector<ObjectMetadata> items;
@@ -344,7 +345,8 @@ std::ostream& operator<<(std::ostream& os, RewriteObjectRequest const& r);
 
 /// Holds an `Objects: rewrite` response.
 struct RewriteObjectResponse {
-  static RewriteObjectResponse FromHttpResponse(HttpResponse const& response);
+  static StatusOr<RewriteObjectResponse> FromHttpResponse(
+      HttpResponse const& response);
 
   std::uint64_t total_bytes_rewritten;
   std::uint64_t object_size;
@@ -447,7 +449,8 @@ std::ostream& operator<<(std::ostream& os,
                          QueryResumableUploadRequest const& r);
 
 struct ResumableUploadResponse {
-  static ResumableUploadResponse FromHttpResponse(HttpResponse&& response);
+  static StatusOr<ResumableUploadResponse> FromHttpResponse(
+      HttpResponse&& response);
 
   std::string upload_session_url;
   std::uint64_t last_committed_byte;

--- a/google/cloud/storage/list_objects_reader_test.cc
+++ b/google/cloud/storage/list_objects_reader_test.cc
@@ -50,7 +50,7 @@ TEST(ListObjectsReaderTest, Basic) {
         {"selfLink", link},
         {"kind", "storage#object"},
     };
-    expected.emplace_back(ObjectMetadata::ParseFromJson(metadata));
+    expected.emplace_back(ObjectMetadata::ParseFromJson(metadata).value());
   }
 
   auto create_mock = [&expected, page_count](int i) {

--- a/google/cloud/storage/object_metadata.cc
+++ b/google/cloud/storage/object_metadata.cc
@@ -48,16 +48,24 @@ std::ostream& operator<<(std::ostream& os, ComposeSourceObject const& r) {
   return os << "}";
 }
 
-ObjectMetadata ObjectMetadata::ParseFromJson(internal::nl::json const& json) {
+StatusOr<ObjectMetadata> ObjectMetadata::ParseFromJson(
+    internal::nl::json const& json) {
+  if (not json.is_object()) {
+    return Status(StatusCode::INVALID_ARGUMENT, __func__);
+  }
   ObjectMetadata result{};
-  // TODO(#1685) - Return a StatusOr<> from here.
-  CommonMetadata<ObjectMetadata>::ParseFromJson(result, json);
+  auto status = CommonMetadata<ObjectMetadata>::ParseFromJson(result, json);
+  if (not status.ok()) {
+    return status;
+  }
 
   if (json.count("acl") != 0) {
     for (auto const& kv : json["acl"].items()) {
-      // TODO(#1685) - return a StatusOr<> from here.
-      result.acl_.emplace_back(
-          ObjectAccessControl::ParseFromJson(kv.value()).value());
+      auto parsed = ObjectAccessControl::ParseFromJson(kv.value());
+      if (not parsed.ok()) {
+        return std::move(parsed).status();
+      }
+      result.acl_.emplace_back(std::move(*parsed));
     }
   }
 
@@ -96,8 +104,9 @@ ObjectMetadata ObjectMetadata::ParseFromJson(internal::nl::json const& json) {
   return result;
 }
 
-ObjectMetadata ObjectMetadata::ParseFromString(std::string const& payload) {
-  auto json = internal::nl::json::parse(payload);
+StatusOr<ObjectMetadata> ObjectMetadata::ParseFromString(
+    std::string const& payload) {
+  auto json = internal::nl::json::parse(payload, nullptr, false);
   return ParseFromJson(json);
 }
 
@@ -224,10 +233,10 @@ std::ostream& operator<<(std::ostream& os, ObjectMetadata const& rhs) {
        << rhs.customer_encryption().key_sha256;
   }
 
-  os << ", etag=" << rhs.etag()
-     << ", event_based_hold=" << std::boolalpha << rhs.event_based_hold()
-     << ", generation=" << rhs.generation() << ", id=" << rhs.id()
-     << ", kind=" << rhs.kind() << ", kms_key_name=" << rhs.kms_key_name()
+  os << ", etag=" << rhs.etag() << ", event_based_hold=" << std::boolalpha
+     << rhs.event_based_hold() << ", generation=" << rhs.generation()
+     << ", id=" << rhs.id() << ", kind=" << rhs.kind()
+     << ", kms_key_name=" << rhs.kms_key_name()
      << ", md5_hash=" << rhs.md5_hash() << ", media_link=" << rhs.media_link();
   sep = "metadata.";
   for (auto const& kv : rhs.metadata_) {
@@ -359,7 +368,8 @@ ObjectMetadataPatchBuilder& ObjectMetadataPatchBuilder::ResetContentType() {
   return *this;
 }
 
-ObjectMetadataPatchBuilder& ObjectMetadataPatchBuilder::SetEventBasedHold(bool v) {
+ObjectMetadataPatchBuilder& ObjectMetadataPatchBuilder::SetEventBasedHold(
+    bool v) {
   impl_.SetBoolField("eventBasedHold", v);
   return *this;
 }
@@ -389,7 +399,8 @@ ObjectMetadataPatchBuilder& ObjectMetadataPatchBuilder::ResetMetadata() {
   return *this;
 }
 
-ObjectMetadataPatchBuilder& ObjectMetadataPatchBuilder::SetTemporaryHold(bool v) {
+ObjectMetadataPatchBuilder& ObjectMetadataPatchBuilder::SetTemporaryHold(
+    bool v) {
   impl_.SetBoolField("temporaryHold", v);
   return *this;
 }

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/internal/common_metadata.h"
 #include "google/cloud/storage/internal/complex_option.h"
 #include "google/cloud/storage/object_access_control.h"
+#include "google/cloud/storage/status_or.h"
 #include <map>
 
 namespace google {
@@ -81,8 +82,8 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
  public:
   ObjectMetadata() : component_count_(0), generation_(0), size_(0) {}
 
-  static ObjectMetadata ParseFromJson(internal::nl::json const& json);
-  static ObjectMetadata ParseFromString(std::string const& payload);
+  static StatusOr<ObjectMetadata> ParseFromJson(internal::nl::json const& json);
+  static StatusOr<ObjectMetadata> ParseFromString(std::string const& payload);
 
   /**
    * Returns the payload for a call to `Objects: update`.

--- a/google/cloud/storage/object_metadata_test.cc
+++ b/google/cloud/storage/object_metadata_test.cc
@@ -102,7 +102,7 @@ ObjectMetadata CreateObjectMetadataForTest() {
       "timeStorageClassUpdated": "2018-05-19T19:31:34Z",
       "updated": "2018-05-19T19:31:24Z"
 })""";
-  return ObjectMetadata::ParseFromString(text);
+  return ObjectMetadata::ParseFromString(text).value();
 }
 
 /// @test Verify that we parse JSON objects into ObjectMetadata objects.
@@ -161,6 +161,32 @@ TEST(ObjectMetadataTest, Parse) {
   EXPECT_EQ(magic_timestamp + 10, duration_cast<std::chrono::seconds>(
                                       actual.updated().time_since_epoch())
                                       .count());
+}
+
+/// @test Verify that we parse JSON objects into ObjectMetadata objects.
+TEST(ObjectMetadataTest, ParseFailure) {
+  auto actual = ObjectMetadata::ParseFromString("{123");
+  EXPECT_FALSE(actual.ok());
+}
+
+/// @test Verify that we parse JSON objects into ObjectMetadata objects.
+TEST(ObjectMetadataTest, ParseAclListFailure) {
+  std::string text = R"""({
+      "acl": [{
+        "kind": "storage#objectAccessControl",
+        "id": "acl-id-0",
+        "entity": "user-qux"
+      },
+      "not-a-valid-acl"
+      ],
+      "bucket": "foo-bar",
+      "generation": "12345",
+      "id": "foo-bar/baz/12345",
+      "kind": "storage#object",
+      "name": "baz"
+})""";
+  auto actual = ObjectMetadata::ParseFromString(text);
+  EXPECT_FALSE(actual.ok());
 }
 
 /// @test Verify that the IOStream operator works as expected.

--- a/google/cloud/storage/object_stream.cc
+++ b/google/cloud/storage/object_stream.cc
@@ -91,8 +91,9 @@ ObjectMetadata ObjectWriteStream::Close() {
     return ObjectMetadata();
   }
   auto metadata = ObjectMetadata::ParseFromString(response.payload);
-  buf_->ValidateHash(metadata);
-  return metadata;
+  // TODO(#1735) - do not raise here.
+  buf_->ValidateHash(metadata.value());
+  return std::move(metadata).value();
 }
 
 void ObjectWriteStream::Suspend() && {

--- a/google/cloud/storage/object_test.cc
+++ b/google/cloud/storage/object_test.cc
@@ -63,7 +63,7 @@ TEST_F(ObjectTest, InsertObjectMedia) {
   std::string text = R"""({
       "name": "test-bucket-name/test-object-name/1"
 })""";
-  auto expected = storage::ObjectMetadata::ParseFromString(text);
+  auto expected = storage::ObjectMetadata::ParseFromString(text).value();
 
   EXPECT_CALL(*mock, InsertObjectMedia(_))
       .WillOnce(Invoke(
@@ -126,7 +126,7 @@ TEST_F(ObjectTest, GetObjectMetadata) {
       "timeStorageClassUpdated": "2018-05-19T19:31:34Z",
       "updated": "2018-05-19T19:31:24Z"
 })""";
-  auto expected = ObjectMetadata::ParseFromString(text);
+  auto expected = ObjectMetadata::ParseFromString(text).value();
 
   EXPECT_CALL(*mock, GetObjectMetadata(_))
       .WillOnce(Return(StatusOr<ObjectMetadata>(TransientError())))
@@ -224,7 +224,7 @@ TEST_F(ObjectTest, UpdateObject) {
       "timeStorageClassUpdated": "2018-05-19T19:31:34Z",
       "updated": "2018-05-19T19:31:24Z"
 })""";
-  auto expected = ObjectMetadata::ParseFromString(text);
+  auto expected = ObjectMetadata::ParseFromString(text).value();
 
   EXPECT_CALL(*mock, UpdateObject(_))
       .WillOnce(Return(StatusOr<ObjectMetadata>(TransientError())))
@@ -320,7 +320,7 @@ TEST_F(ObjectTest, PatchObject) {
       "timeStorageClassUpdated": "2018-05-19T19:31:34Z",
       "updated": "2018-05-19T19:31:24Z"
 })""";
-  auto expected = ObjectMetadata::ParseFromString(text);
+  auto expected = ObjectMetadata::ParseFromString(text).value();
 
   EXPECT_CALL(*mock, PatchObject(_))
       .WillOnce(Return(StatusOr<ObjectMetadata>(TransientError())))

--- a/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
+++ b/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
@@ -59,7 +59,7 @@ TEST_F(CurlResumableUploadIntegrationTest, Simple) {
 
   ASSERT_TRUE(response.ok());
   EXPECT_FALSE(response->payload.empty());
-  auto metadata = ObjectMetadata::ParseFromString(response->payload);
+  auto metadata = ObjectMetadata::ParseFromString(response->payload).value();
   EXPECT_EQ(object_name, metadata.name());
   EXPECT_EQ(bucket_name, metadata.bucket());
   EXPECT_EQ(contents.size(), metadata.size());
@@ -93,7 +93,7 @@ TEST_F(CurlResumableUploadIntegrationTest, WithReset) {
   ASSERT_TRUE(response.ok()) << response.status();
 
   EXPECT_FALSE(response->payload.empty());
-  auto metadata = ObjectMetadata::ParseFromString(response->payload);
+  auto metadata = ObjectMetadata::ParseFromString(response->payload).value();
   EXPECT_EQ(object_name, metadata.name());
   EXPECT_EQ(bucket_name, metadata.bucket());
   EXPECT_EQ(2 * contents.size(), metadata.size());
@@ -135,7 +135,7 @@ TEST_F(CurlResumableUploadIntegrationTest, Restore) {
   ASSERT_TRUE(response.ok()) << response.status();
 
   EXPECT_FALSE(response->payload.empty());
-  auto metadata = ObjectMetadata::ParseFromString(response->payload);
+  auto metadata = ObjectMetadata::ParseFromString(response->payload).value();
   EXPECT_EQ(object_name, metadata.name());
   EXPECT_EQ(bucket_name, metadata.bucket());
   EXPECT_EQ(3 * contents.size(), metadata.size());


### PR DESCRIPTION
This is the last PR in the series to use the non-throwing version of
nl::json::parse(). It fixes #1685.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1745)
<!-- Reviewable:end -->
