### PR TITLE
Support reading or downloading a GCS object range.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -76,6 +76,7 @@ add_library(storage_client
             client.cc
             client_options.h
             client_options.cc
+            download_options.h
             hashing_options.h
             hashing_options.cc
             idempotency_policy.h

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -792,7 +792,7 @@ class Client {
    *     Valid types for this operation include `DisableCrc32cChecksum`,
    *     `DisableMD5Hash`, `IfGenerationMatch`, `EncryptionKey`, `Generation`,
    *     `IfGenerationMatch`, `IfGenerationNotMatch`, `IfMetagenerationMatch`,
-   *     `IfMetagenerationNotMatch`, and `UserProject`.
+   *     `IfMetagenerationNotMatch`, `ReadRange`, and `UserProject`.
    *
    * @throw std::runtime_error if there is a permanent failure, or if there were
    *     more transient failures than allowed by the current retry policy.
@@ -943,7 +943,7 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *   Valid types for this operation include `IfGenerationMatch`,
    *   `IfGenerationNotMatch`, `IfMetagenerationMatch`,
-   *   `IfMetagenerationNotMatch`, `Generation`, and `UserProject`.
+   *   `IfMetagenerationNotMatch`, `Generation`, `ReadRange`, and `UserProject`.
    *
    * @throw std::runtime_error if there is a permanent failure, or if there were
    *     more transient failures than allowed by the current retry policy.

--- a/google/cloud/storage/download_options.h
+++ b/google/cloud/storage/download_options.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_DOWNLOAD_OPTIONS_H_
 
 #include "google/cloud/storage/internal/complex_option.h"
+#include <cstdint>
 #include <iostream>
 #include <string>
 
@@ -42,7 +43,8 @@ struct ReadRange : public internal::ComplexOption<ReadRange, ReadRangeData> {
 };
 
 inline std::ostream& operator<<(std::ostream& os, ReadRangeData const& rhs) {
-  return os << "ReadRange={begin=" << rhs.begin << ", end=" << rhs.end << "}";
+  return os << "ReadRangeData={begin=" << rhs.begin << ", end=" << rhs.end
+            << "}";
 }
 
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/download_options.h
+++ b/google/cloud/storage/download_options.h
@@ -1,0 +1,53 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_DOWNLOAD_OPTIONS_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_DOWNLOAD_OPTIONS_H_
+
+#include "google/cloud/storage/internal/complex_option.h"
+#include <iostream>
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+struct ReadRangeData {
+  std::int64_t begin;
+  std::int64_t end;
+};
+
+/**
+ * Request only a portion of the GCS object in a ReadObject operation.
+ *
+ * Note that the range is right-open, as it is customary in C++. That is, it
+ * excludes the `end` byte.
+ */
+struct ReadRange : public internal::ComplexOption<ReadRange, ReadRangeData> {
+  ReadRange() : ComplexOption() {}
+  explicit ReadRange(std::int64_t begin, std::int64_t end)
+      : ComplexOption(ReadRangeData{begin, end}) {}
+  static char const* name() { return "read-range"; }
+};
+
+inline std::ostream& operator<<(std::ostream& os, ReadRangeData const& rhs) {
+  return os << "ReadRange={begin=" << rhs.begin << ", end=" << rhs.end << "}";
+}
+
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_DOWNLOAD_OPTIONS_H_

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -95,8 +95,7 @@ std::ostream& operator<<(std::ostream& os, CopyObjectRequest const& r) {
 
 std::ostream& operator<<(std::ostream& os, ReadObjectRangeRequest const& r) {
   os << "ReadObjectRangeRequest={bucket_name=" << r.bucket_name()
-     << ", object_name=" << r.object_name() << ", begin=" << r.begin()
-     << ", end=" << r.end();
+     << ", object_name=" << r.object_name();
   r.DumpOptions(os, ", ");
   return os << "}";
 }

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_OBJECT_REQUESTS_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_OBJECT_REQUESTS_H_
 
+#include "google/cloud/storage/download_options.h"
 #include "google/cloud/storage/hashing_options.h"
 #include "google/cloud/storage/internal/generic_object_request.h"
 #include "google/cloud/storage/internal/http_response.h"
@@ -178,29 +179,10 @@ class ReadObjectRangeRequest
     : public GenericObjectRequest<
           ReadObjectRangeRequest, DisableCrc32cChecksum, DisableMD5Hash,
           EncryptionKey, Generation, IfGenerationMatch, IfGenerationNotMatch,
-          IfMetagenerationMatch, IfMetagenerationNotMatch, UserProject> {
+          IfMetagenerationMatch, IfMetagenerationNotMatch, ReadRange,
+          UserProject> {
  public:
-  ReadObjectRangeRequest() : GenericObjectRequest(), begin_(0), end_(0) {}
-
-  explicit ReadObjectRangeRequest(std::string bucket_name,
-                                  std::string object_name, std::int64_t begin,
-                                  std::int64_t end)
-      : GenericObjectRequest(std::move(bucket_name), std::move(object_name)),
-        begin_(begin),
-        end_(end) {}
-
-  explicit ReadObjectRangeRequest(std::string bucket_name,
-                                  std::string object_name)
-      : GenericObjectRequest(std::move(bucket_name), std::move(object_name)),
-        begin_(0),
-        end_(0) {}
-
-  std::int64_t begin() const { return begin_; }
-  std::int64_t end() const { return end_; }
-
- private:
-  std::int64_t begin_;
-  std::int64_t end_;
+  using GenericObjectRequest::GenericObjectRequest;
 };
 
 std::ostream& operator<<(std::ostream& os, ReadObjectRangeRequest const& r);

--- a/google/cloud/storage/internal/object_requests_test.cc
+++ b/google/cloud/storage/internal/object_requests_test.cc
@@ -198,26 +198,25 @@ HttpResponse CreateRangeRequestResponse(
 }
 
 TEST(ObjectRequestsTest, ReadObjectRange) {
-  ReadObjectRangeRequest request("my-bucket", "my-object", 0, 1024);
+  ReadObjectRangeRequest request("my-bucket", "my-object");
 
   EXPECT_EQ("my-bucket", request.bucket_name());
   EXPECT_EQ("my-object", request.object_name());
-  EXPECT_EQ(0, request.begin());
-  EXPECT_EQ(1024, request.end());
 
   request.set_option(storage::UserProject("my-project"));
   request.set_multiple_options(storage::IfGenerationMatch(7),
-                               storage::UserProject("my-project"));
+                               storage::UserProject("my-project"),
+                               storage::ReadRange(0, 1024));
 
   std::ostringstream os;
   os << request;
   std::string actual = os.str();
   EXPECT_THAT(actual, HasSubstr("my-bucket"));
   EXPECT_THAT(actual, HasSubstr("my-object"));
-  EXPECT_THAT(actual, HasSubstr("begin=0"));
-  EXPECT_THAT(actual, HasSubstr("end=1024"));
   EXPECT_THAT(actual, HasSubstr("ifGenerationMatch=7"));
   EXPECT_THAT(actual, HasSubstr("my-project"));
+  EXPECT_THAT(actual, HasSubstr("begin=0"));
+  EXPECT_THAT(actual, HasSubstr("end=1024"));
 }
 
 TEST(ObjectRequestsTest, RangeResponseParse) {

--- a/google/cloud/storage/storage_client.bzl
+++ b/google/cloud/storage/storage_client.bzl
@@ -21,6 +21,7 @@ storage_client_hdrs = [
     "bucket_metadata.h",
     "client.h",
     "client_options.h",
+    "download_options.h",
     "hashing_options.h",
     "idempotency_policy.h",
     "internal/access_control_common.h",

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -1150,10 +1150,12 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeJSON) {
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
 
-  // This produces a text of around 4 MiB.
+  // This produces a 64 KiB text object, normally applications should download
+  // much larger chunks from GCS, but it is really hard to figure out what is
+  // broken when the error messages are in the MiB ranges.
+  long const chunk = 16 * 1024L;
+  long const lines = 4 * chunk / 128;
   std::string large_text;
-  long const MiB = 1024; // * 1024L;
-  long const lines = 4 * MiB / 128;
   for (long i = 0; i != lines; ++i) {
     auto line = google::cloud::internal::Sample(generator_, 127,
                                                 "abcdefghijklmnopqrstuvwxyz"
@@ -1168,12 +1170,12 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeJSON) {
   EXPECT_EQ(bucket_name, source_meta.bucket());
 
   // Create a iostream to read the object back.
-  auto stream =
-      client.ReadObject(bucket_name, object_name, ReadRange(1 * MiB, 2 * MiB),
-                        IfGenerationNotMatch(0));
+  auto stream = client.ReadObject(bucket_name, object_name,
+                                  ReadRange(1 * chunk, 2 * chunk),
+                                  IfGenerationNotMatch(0));
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
-  EXPECT_EQ(1 * MiB, actual.size());
-  EXPECT_EQ(large_text.substr(1 * MiB, 1 * MiB), actual);
+  EXPECT_EQ(1 * chunk, actual.size());
+  EXPECT_EQ(large_text.substr(1 * chunk, 1 * chunk), actual);
 
   client.DeleteObject(bucket_name, object_name);
 }
@@ -1185,10 +1187,12 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeXml) {
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
 
-  // This produces a text of around 4 MiB.
+  // This produces a 64 KiB text object, normally applications should download
+  // much larger chunks from GCS, but it is really hard to figure out what is
+  // broken when the error messages are in the MiB ranges.
+  long const chunk = 16 * 1024L;
+  long const lines = 4 * chunk / 128;
   std::string large_text;
-  long const MiB = 1024L; // 1024 * 1024L;
-  long const lines = 4 * MiB / 128;
   for (long i = 0; i != lines; ++i) {
     auto line = google::cloud::internal::Sample(generator_, 127,
                                                 "abcdefghijklmnopqrstuvwxyz"
@@ -1203,11 +1207,11 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeXml) {
   EXPECT_EQ(bucket_name, source_meta.bucket());
 
   // Create a iostream to read the object back.
-  auto stream =
-      client.ReadObject(bucket_name, object_name, ReadRange(1 * MiB, 2 * MiB));
+  auto stream = client.ReadObject(bucket_name, object_name,
+                                  ReadRange(1 * chunk, 2 * chunk));
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
-  EXPECT_EQ(1 * MiB, actual.size());
-  EXPECT_EQ(large_text.substr(1 * MiB, 1 * MiB), actual);
+  EXPECT_EQ(1 * chunk, actual.size());
+  EXPECT_EQ(large_text.substr(1 * chunk, 1 * chunk), actual);
 
   client.DeleteObject(bucket_name, object_name);
 }


### PR DESCRIPTION
With this change applications can choose to download a small portion of
an object.

This fixes #1732.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1748)
<!-- Reviewable:end -->
