### PR TITLE
Non throwing object write stream

### DIFF
--- a/ci/test-install/storage_install_test.cc
+++ b/ci/test-install/storage_install_test.cc
@@ -32,17 +32,19 @@ int main(int argc, char* argv[]) try {
   gcs::Client client;
 
   gcs::ObjectWriteStream os = client.WriteObject(bucket_name, object_name);
+  os.exceptions(std::ios_base::badbit | std::ios_base::failbit);
   os << "Hello World" << std::endl;
-  gcs::ObjectMetadata meta = os.Close();
+  os.Close();
+  gcs::ObjectMetadata meta = os.metadata().value();
   std::cout << "Successfully created object, generation=" << meta.generation()
             << std::endl;
 
   gcs::ObjectReadStream stream = client.ReadObject(bucket_name, object_name);
+  stream.exceptions(std::ios_base::badbit | std::ios_base::failbit);
 
   int count = 0;
-  while (not stream.eof()) {
-    std::string line;
-    std::getline(stream, line, '\n');
+  std::string line;
+  while (std::getline(stream, line, '\n')) {
     ++count;
   }
   client.DeleteObject(bucket_name, object_name,

--- a/google/cloud/storage/client_write_object_test.cc
+++ b/google/cloud/storage/client_write_object_test.cc
@@ -59,7 +59,7 @@ class WriteObjectTest : public ::testing::Test {
 class MockStreambuf : public internal::ObjectWriteStreambuf {
  public:
   MOCK_CONST_METHOD0(IsOpen, bool());
-  MOCK_METHOD0(DoClose, internal::HttpResponse());
+  MOCK_METHOD0(DoClose, StatusOr<internal::HttpResponse>());
   MOCK_METHOD1(ValidateHash, void(ObjectMetadata const&));
   MOCK_CONST_METHOD0(received_hash, std::string const&());
   MOCK_CONST_METHOD0(computed_hash, std::string const&());
@@ -88,7 +88,8 @@ TEST_F(WriteObjectTest, WriteObject) {
 
   auto stream = client->WriteObject("test-bucket-name", "test-object-name");
   stream << "Hello World!";
-  ObjectMetadata actual = stream.Close();
+  stream.Close();
+  ObjectMetadata actual = stream.metadata().value();
   EXPECT_EQ(expected, actual);
 }
 

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -477,7 +477,8 @@ void WriteObjectRequesterPays(google::cloud::storage::Client client, int& argc,
       stream << (lineno + 1) << ": I will write better examples\n";
     }
 
-    gcs::ObjectMetadata meta = stream.Close();
+    stream.Close();
+    gcs::ObjectMetadata meta = stream.metadata().value();
     std::cout << "The resulting object size is: " << meta.size() << std::endl;
   }
   //! [write object requester pays]

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -279,7 +279,8 @@ void WriteObject(google::cloud::storage::Client client, int& argc,
       stream << (lineno + 1) << ": " << text << "\n";
     }
 
-    gcs::ObjectMetadata meta = stream.Close();
+    stream.Close();
+    gcs::ObjectMetadata meta = stream.metadata().value();
     std::cout << "The resulting object size is: " << meta.size() << std::endl;
   }
   //! [write object]
@@ -382,7 +383,8 @@ non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 )""";
     }
 
-    gcs::ObjectMetadata metadata = stream.Close();
+    stream.Close();
+    gcs::ObjectMetadata metadata = stream.metadata().value();
     std::cout << "Upload completed, the new object metadata is: " << metadata
               << std::endl;
   }
@@ -754,7 +756,8 @@ void WriteObjectWithKmsKey(google::cloud::storage::Client client, int& argc,
       stream << lineno << ": placeholder text for CMEK example.\n";
     }
 
-    gcs::ObjectMetadata meta = stream.Close();
+    stream.Close();
+    gcs::ObjectMetadata meta = stream.metadata().value();
     std::cout << "The resulting object size is: " << meta.size() << std::endl;
   }
   //! [write object with kms key] [END storage_upload_with_kms_key]

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -282,7 +282,7 @@ StatusOr<ResumableUploadResponse> CurlClient::UploadChunk(
   bool success_with_308 =
       response->status_code == 308 and
       response->headers.find("range") != response->headers.end();
-  if (status.ok() or success_with_308) {
+  if (response->status_code < 300 or success_with_308) {
     return ResumableUploadResponse::FromHttpResponse(*std::move(response));
   }
   return AsStatus(*response);
@@ -305,7 +305,7 @@ StatusOr<ResumableUploadResponse> CurlClient::QueryResumableUpload(
   bool success_with_308 =
       response->status_code == 308 and
       response->headers.find("range") != response->headers.end();
-  if (status.ok() or success_with_308) {
+  if (response->status_code < 300 or success_with_308) {
     return ResumableUploadResponse::FromHttpResponse(*std::move(response));
   }
   return AsStatus(*response);

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -1335,11 +1335,8 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaMultipart(
   writer << crlf << request.contents() << crlf << marker << "--" << crlf;
 
   // 6. Return the results as usual.
-  auto response = writer.CloseRaw();
-  if (response.status_code >= 300) {
-    return Status(response.status_code, std::move(response.payload));
-  }
-  return ObjectMetadata::ParseFromString(response.payload);
+  writer.Close();
+  return std::move(writer).metadata();
 }
 
 std::string CurlClient::PickBoundary(std::string const& text_to_avoid) {

--- a/google/cloud/storage/internal/curl_resumable_streambuf.h
+++ b/google/cloud/storage/internal/curl_resumable_streambuf.h
@@ -57,15 +57,11 @@ class CurlResumableStreambuf : public ObjectWriteStreambuf {
   int sync() override;
   std::streamsize xsputn(char const* s, std::streamsize count) override;
   int_type overflow(int_type ch) override;
-  // TODO(coryan) this is an ugly return type.
-  HttpResponse DoClose() override;
+  StatusOr<HttpResponse> DoClose() override;
 
  private:
-  /// Raise an exception if the stream is closed.
-  void Validate(char const* where) const;
-
   /// Flush the libcurl buffer and swap it with the iostream buffer.
-  HttpResponse Flush(bool final_chunk);
+  StatusOr<HttpResponse> Flush(bool final_chunk);
 
   std::unique_ptr<ResumableUploadSession> upload_session_;
 

--- a/google/cloud/storage/internal/curl_streambuf.h
+++ b/google/cloud/storage/internal/curl_streambuf.h
@@ -95,14 +95,14 @@ class CurlWriteStreambuf : public ObjectWriteStreambuf {
   int sync() override;
   std::streamsize xsputn(char const* s, std::streamsize count) override;
   int_type overflow(int_type ch) override;
-  HttpResponse DoClose() override;
+  StatusOr<HttpResponse> DoClose() override;
 
  private:
   /// Raise an exception if the stream is closed.
-  void Validate(char const* where) const;
+  Status Validate(char const* where) const;
 
   /// Flush the libcurl buffer and swap it with the iostream buffer.
-  void SwapBuffers();
+  Status SwapBuffers();
 
   CurlUploadRequest upload_;
   std::string current_ios_buffer_;

--- a/google/cloud/storage/internal/curl_upload_request.h
+++ b/google/cloud/storage/internal/curl_upload_request.h
@@ -81,7 +81,7 @@ class CurlUploadRequest {
   bool IsOpen() const { return not closing_; }
 
   /// Blocks until the current buffer has been transferred.
-  void Flush();
+  Status Flush();
 
   /// Closes the transfer and wait for the server's response.
   StatusOr<HttpResponse> Close();
@@ -92,7 +92,7 @@ class CurlUploadRequest {
    * Swapping the buffer permits double buffering in users of this class, and
    * avoid copies between the layers of abstraction.
    */
-  void NextBuffer(std::string& next_buffer);
+  Status NextBuffer(std::string& next_buffer);
 
  private:
   friend class CurlRequestBuilder;
@@ -148,7 +148,7 @@ class CurlUploadRequest {
   Status AsStatus(CURLMcode result, char const* where);
 
   /// Raises an exception if the application tries to use a closed request.
-  void ValidateOpen(char const* where);
+  Status ValidateOpen(char const* where);
 
   std::string url_;
   CurlHeaders headers_;

--- a/google/cloud/storage/internal/object_streambuf.cc
+++ b/google/cloud/storage/internal/object_streambuf.cc
@@ -19,7 +19,7 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
-HttpResponse ObjectWriteStreambuf::Close() {
+StatusOr<HttpResponse> ObjectWriteStreambuf::Close() {
   pubsync();
   return DoClose();
 }

--- a/google/cloud/storage/internal/object_streambuf.h
+++ b/google/cloud/storage/internal/object_streambuf.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_OBJECT_STREAMBUF_H_
 
 #include "google/cloud/storage/internal/http_response.h"
-#include "google/cloud/storage/status.h"
+#include "google/cloud/storage/status_or.h"
 #include <iostream>
 
 namespace google {
@@ -67,7 +67,7 @@ class ObjectWriteStreambuf : public std::basic_streambuf<char> {
   ObjectWriteStreambuf(ObjectWriteStreambuf const&) = delete;
   ObjectWriteStreambuf& operator=(ObjectWriteStreambuf const&) = delete;
 
-  HttpResponse Close();
+  StatusOr<HttpResponse> Close();
   virtual bool IsOpen() const = 0;
   virtual void ValidateHash(ObjectMetadata const& meta) = 0;
   virtual std::string const& received_hash() const = 0;
@@ -80,7 +80,7 @@ class ObjectWriteStreambuf : public std::basic_streambuf<char> {
   virtual std::uint64_t next_expected_byte() const = 0;
 
  protected:
-  virtual HttpResponse DoClose() = 0;
+  virtual StatusOr<HttpResponse> DoClose() = 0;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/object_stream.cc
+++ b/google/cloud/storage/object_stream.cc
@@ -94,7 +94,7 @@ void ObjectWriteStream::Close() {
     }
   }
 
-  // TODO() - do not raise here.
+  // TODO(#1747) - do not throw exceptions here.
   buf_->ValidateHash(*metadata_);
 }
 

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -197,9 +197,9 @@ class ObjectWriteStream : public std::basic_ostream<char> {
   /**
    * The received CRC32C checksum and the MD5 hash values as reported by GCS.
    *
-   * Then the upload is finalized (via `Close()`) the GCS server reports the
-   * CRC32C checksum of the uploaded object. Note that in some circumstances the
-   * MD5 hash may not be reported.
+   * When the upload is finalized (via `Close()`) the GCS server reports the
+   * CRC32C checksum and MD5 hash of the uploaded data. Note that in some
+   * circumstances the MD5 hash may not be reported.
    *
    * The values are reported as comma separated `tag=value` pairs, e.g.
    * `crc32c=AAAAAA==,md5=1B2M2Y8AsgTpgAmY7PhCfg==`. The format of this string

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -198,13 +198,17 @@ class ObjectWriteStream : public std::basic_ostream<char> {
    * The received CRC32C checksum and the MD5 hash values as reported by GCS.
    *
    * When the upload is finalized (via `Close()`) the GCS server reports the
-   * CRC32C checksum and MD5 hash of the uploaded data. Note that in some
-   * circumstances the MD5 hash may not be reported.
+   * CRC32C checksum and, if the object is not a composite object, the MDF hash
+   * of the uploaded data. This class compares the reported hashes against
+   * locally computed hash values, and reports an error if they do not match.
    *
    * The values are reported as comma separated `tag=value` pairs, e.g.
    * `crc32c=AAAAAA==,md5=1B2M2Y8AsgTpgAmY7PhCfg==`. The format of this string
    * is subject to change without notice, they are provided for informational
    * purposes only.
+   *
+   * @see https://cloud.google.com/storage/docs/hashes-etags for more
+   *     information on checksums and hashes in GCS.
    */
   std::string const& received_hash() const { return buf_->received_hash(); }
 
@@ -221,6 +225,9 @@ class ObjectWriteStream : public std::basic_ostream<char> {
    * The string has the same format as the value returned by `received_hash()`.
    * Note that the format of this string is also subject to change without
    * notice.
+   *
+   * @see https://cloud.google.com/storage/docs/hashes-etags for more
+   *     information on checksums and hashes in GCS.
    */
   std::string const& computed_hash() const { return buf_->computed_hash(); }
 

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -171,19 +171,16 @@ class ObjectWriteStream : public std::basic_ostream<char> {
    * Close the stream, finalizing the upload.
    *
    * Closing a stream completes an upload and creates the uploaded object. On
-   * failure it calls `setstate(badbit)`.
+   * failure it sets the `badbit` of the stream.
    *
-   * Any success or failure status is accessible via `status()`. The metadata
-   * of the uploaded object, if available, is accessible via `metadata()`. Note
-   * that the metadata may be empty if the application creates a stream with the
-   * `Fields("")` parameter.
+   * The metadata of the uploaded object, or a detailed error status, is
+   * accessible via the `metadata()` member function. Note that the metadata may
+   * be empty if the application creates a stream with the `Fields("")`
+   * parameter, applications cannot assume that all fields in the metadata are
+   * filled on success.
    *
-   * Note that the `failbit` is set if the checksums reported by the server do
-   * not match the locally computed checksums. In this case Google Cloud Storage
-   * may have created an object.
-   *
-   * @throws If the application has enabled exceptions on `badbit` then it
-   *   raises an exception of type `std::ios_base::failure`.
+   * @throws If the application has enabled the exception mask this function may
+   *     throw `std::ios_base::failure`.
    */
   void Close();
 
@@ -197,12 +194,43 @@ class ObjectWriteStream : public std::basic_ostream<char> {
   StatusOr<ObjectMetadata> const& metadata() const& { return metadata_; }
   StatusOr<ObjectMetadata>&& metadata() && { return std::move(metadata_); }
 
+  /**
+   * The received CRC32C checksum and the MD5 hash values as reported by GCS.
+   *
+   * Then the upload is finalized (via `Close()`) the GCS server reports the
+   * CRC32C checksum of the uploaded object. Note that in some circumstances the
+   * MD5 hash may not be reported.
+   *
+   * The values are reported as comma separated `tag=value` pairs, e.g.
+   * `crc32c=AAAAAA==,md5=1B2M2Y8AsgTpgAmY7PhCfg==`. The format of this string
+   * is subject to change without notice, they are provided for informational
+   * purposes only.
+   */
   std::string const& received_hash() const { return buf_->received_hash(); }
+
+  /**
+   * The locally computed checksum and hashes, as a string.
+   *
+   * This object computes the CRC32C checksum and MD5 hash of the uploaded data.
+   * There are several cases where these values may be empty or irrelevant, for
+   * example:
+   *   - When performing resumable uploads the stream may not have had access to
+   *     the full data.
+   *   - The application may disable the CRC32C and/or the MD5 hash computation.
+   *
+   * The string has the same format as the value returned by `received_hash()`.
+   * Note that the format of this string is also subject to change without
+   * notice.
+   */
   std::string const& computed_hash() const { return buf_->computed_hash(); }
 
+  /// The headers returned by the service, for debugging only.
   std::multimap<std::string, std::string> const& headers() const {
     return headers_;
   }
+
+  /// The returned payload as a raw string, for debugging only.
+  std::string const& payload() const { return payload_; }
   //@}
 
   /**
@@ -238,8 +266,6 @@ class ObjectWriteStream : public std::basic_ostream<char> {
    * this function.
    */
   void Suspend() &&;
-
-  std::string const& payload() const { return payload_; }
 
  private:
   std::unique_ptr<internal::ObjectWriteStreambuf> buf_;

--- a/google/cloud/storage/testbench/gcs_bucket.py
+++ b/google/cloud/storage/testbench/gcs_bucket.py
@@ -549,6 +549,10 @@ class GcsBucket(object):
             'request': request,
             'done': False,
         }
+        # Capture the preconditions, including those that are None.
+        for precondition in ['ifGenerationMatch', 'ifGenerationNotMatch',
+                             'ifMetagenerationMatch', 'ifMetagenerationNotMatch']:
+            upload[precondition] = request.args.get(precondition)
         upload_id = base64.b64encode(metadata.get('name'))
         self.resumable_uploads[upload_id] = upload
         location = '%s?uploadType=resumable&upload_id=%s' % (
@@ -622,7 +626,12 @@ class GcsBucket(object):
             original_metadata = upload.pop('metadata', None)
             media = upload.pop('media', None)
             original_request = upload.pop('request', None)
-            blob.check_preconditions(original_request)
+            blob.check_preconditions_by_value(
+                upload.get('ifGenerationMatch'),
+                upload.get('ifGenerationNotMatch'),
+                upload.get('ifMetagenerationMatch'),
+                upload.get('ifMetagenerationNotMatch')
+            )
             revision = blob.insert_resumable(
                 gcs_url, original_request, media,
                 original_metadata)

--- a/google/cloud/storage/tests/curl_resumable_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/curl_resumable_streambuf_integration_test.cc
@@ -65,7 +65,8 @@ class CurlResumableStreambufIntegrationTest
 
     std::ostringstream expected_stream;
     WriteRandomLines(writer, expected_stream, line_count, line_size);
-    auto metadata = writer.Close();
+    writer.Close();
+    ObjectMetadata metadata = writer.metadata().value();
     EXPECT_EQ(object_name, metadata.name());
     EXPECT_EQ(bucket_name, metadata.bucket());
 

--- a/google/cloud/storage/tests/curl_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/curl_streambuf_integration_test.cc
@@ -60,13 +60,14 @@ TEST(CurlStreambufIntegrationTest, WriteManyBytes) {
     writer << random;
     expected += random;
   }
-  auto response = writer.CloseRaw();
-  ASSERT_EQ(200, response.status_code)
-      << ", status_code=" << response.status_code
-      << ", payload=" << response.payload << ", headers={" << [&response] {
+  writer.Close();
+  ASSERT_TRUE(writer.metadata().ok())
+      << ", status=" << writer.metadata().status()
+      << ", payload=" << writer.payload()
+      << ", headers={" << [&writer] {
            std::string result;
            char const* sep = "";
-           for (auto&& kv : response.headers) {
+           for (auto&& kv : writer.headers()) {
              result += sep;
              result += kv.first;
              result += "=";
@@ -77,7 +78,7 @@ TEST(CurlStreambufIntegrationTest, WriteManyBytes) {
            return result;
          }();
 
-  internal::nl::json parsed = internal::nl::json::parse(response.payload);
+  internal::nl::json parsed = internal::nl::json::parse(writer.payload());
 
   // Verify the server received the right data.
   auto actual = parsed.value("data", "");

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -1174,7 +1174,7 @@ TEST_F(ObjectIntegrationTest, StreamingWriteFailure) {
 
   auto os = client.WriteObject(bucket_name, object_name, IfGenerationMatch(0));
   os.exceptions(std::ios_base::badbit | std::ios_base::failbit);
-  os << "Test message\n";
+  os << "Expected failure data:\n" << LoremIpsum();
 
   // This operation should fail because the object already exists.
   testing_util::ExpectException<std::ios::failure>(
@@ -1202,7 +1202,7 @@ TEST_F(ObjectIntegrationTest, StreamingWriteFailureNoex) {
   EXPECT_EQ(bucket_name, meta.bucket());
 
   auto os = client.WriteObject(bucket_name, object_name, IfGenerationMatch(0));
-  os << "Test message\n";
+  os << "Expected failure data:\n" << LoremIpsum();
 
   // This operation should fail because the object already exists.
   os.Close();

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -72,8 +72,10 @@ TEST_F(ObjectMediaIntegrationTest, XmlDownloadFile) {
   // Create an object with the contents to download.
   auto upload =
       client.WriteObject(bucket_name, object_name, IfGenerationMatch(0));
+  upload.exceptions(std::ios_base::failbit);
   WriteRandomLines(upload, expected);
-  ObjectMetadata meta = upload.Close();
+  upload.Close();
+  ObjectMetadata meta = upload.metadata().value();
 
   client.DownloadToFile(bucket_name, object_name, file_name);
   // Create a iostream to read the object back.
@@ -100,7 +102,8 @@ TEST_F(ObjectMediaIntegrationTest, JsonDownloadFile) {
   auto upload =
       client.WriteObject(bucket_name, object_name, IfGenerationMatch(0));
   WriteRandomLines(upload, expected);
-  ObjectMetadata meta = upload.Close();
+  upload.Close();
+  ObjectMetadata meta = upload.metadata().value();
 
   client.DownloadToFile(bucket_name, object_name, file_name,
                         IfMetagenerationNotMatch(0));
@@ -979,13 +982,15 @@ TEST_F(ObjectMediaIntegrationTest, DefaultCrc32cStreamingWriteXML) {
   // Create the object, but only if it does not exist already.
   auto os = client.WriteObject(bucket_name, object_name, IfGenerationMatch(0),
                                Fields(""));
+  os.exceptions(std::ios_base::failbit);
   // We will construct the expected response while streaming the data up.
   std::ostringstream expected;
   WriteRandomLines(os, expected);
 
   auto expected_crc32c = ComputeCrc32cChecksum(expected.str());
 
-  ObjectMetadata meta = os.Close();
+  os.Close();
+  ObjectMetadata meta = os.metadata().value();
   EXPECT_EQ(os.received_hash(), os.computed_hash());
   EXPECT_THAT(os.received_hash(), HasSubstr(expected_crc32c));
 
@@ -1000,13 +1005,15 @@ TEST_F(ObjectMediaIntegrationTest, DefaultCrc32cStreamingWriteJSON) {
 
   // Create the object, but only if it does not exist already.
   auto os = client.WriteObject(bucket_name, object_name, IfGenerationMatch(0));
+  os.exceptions(std::ios_base::failbit);
   // We will construct the expected response while streaming the data up.
   std::ostringstream expected;
   WriteRandomLines(os, expected);
 
   auto expected_crc32c = ComputeCrc32cChecksum(expected.str());
 
-  ObjectMetadata meta = os.Close();
+  os.Close();
+  ObjectMetadata meta = os.metadata().value();
   EXPECT_EQ(os.received_hash(), os.computed_hash());
   EXPECT_THAT(os.received_hash(), HasSubstr(expected_crc32c));
 


### PR DESCRIPTION
Change `ObjectWriteStream` to not throw unless the application explicitly
requests exceptions using the iostream exception mask. By default
`std::ios_base::badbit` is set when an error is detected, and the
`ObjectWriteStream` saves the status with a more detailed error
message.

This change will reduce code coverage because many errors that used to
be propagated as exceptions now require an extra if(), but we do not
have test infrastructure to produce these error conditions on demand.
We should probably fix that in a future PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1749)
<!-- Reviewable:end -->
