### PR TITLE
Non throwing object read stream

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -786,6 +786,14 @@ class Client {
   /**
    * Reads the contents of an object.
    *
+   * Returns an object derived from `std::istream` which can be used to read the
+   * contents of the GCS blob. The application should check the `badbit` (e.g.
+   * by calling `stream.bad()`) on the returned object to detect if there was
+   * an error reading from the blob. If `badbit` is set, the application can
+   * check the `status()` variable to get details about the failure.
+   * Applications can also set the exception mask on the returned stream, in
+   * which case an exception is thrown if an error is detected.
+   *
    * @param bucket_name the name of the bucket that contains the object.
    * @param object_name the name of the object to be read.
    * @param options a list of optional query parameters and/or request headers.

--- a/google/cloud/storage/internal/curl_streambuf.h
+++ b/google/cloud/storage/internal/curl_streambuf.h
@@ -36,17 +36,25 @@ class CurlReadStreambuf : public ObjectReadStreambuf {
 
   ~CurlReadStreambuf() override = default;
 
-  HttpResponse Close() override;
+  void Close() override;
   bool IsOpen() const override;
+  Status const& status() const override { return status_; }
   std::string const& received_hash() const override {
     return hash_validator_result_.received;
   }
   std::string const& computed_hash() const override {
     return hash_validator_result_.computed;
   }
+  std::multimap<std::string, std::string> const& headers() const override {
+    return headers_;
+  }
 
  protected:
   int_type underflow() override;
+
+  int_type ReportError(Status status);
+
+  void SetEmptyRegion();
 
  private:
   CurlDownloadRequest download_;
@@ -55,6 +63,8 @@ class CurlReadStreambuf : public ObjectReadStreambuf {
 
   std::unique_ptr<HashValidator> hash_validator_;
   HashValidator::Result hash_validator_result_;
+  Status status_;
+  std::multimap<std::string, std::string> headers_;
 };
 
 /**

--- a/google/cloud/storage/internal/object_streambuf.h
+++ b/google/cloud/storage/internal/object_streambuf.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_OBJECT_STREAMBUF_H_
 
 #include "google/cloud/storage/internal/http_response.h"
+#include "google/cloud/storage/status.h"
 #include <iostream>
 
 namespace google {
@@ -41,10 +42,12 @@ class ObjectReadStreambuf : public std::basic_streambuf<char> {
   ObjectReadStreambuf(ObjectReadStreambuf const&) = delete;
   ObjectReadStreambuf& operator=(ObjectReadStreambuf const&) = delete;
 
-  virtual HttpResponse Close() = 0;
+  virtual void Close() = 0;
   virtual bool IsOpen() const = 0;
+  virtual Status const& status() const = 0;
   virtual std::string const& received_hash() const = 0;
   virtual std::string const& computed_hash() const = 0;
+  virtual std::multimap<std::string, std::string> const& headers() const = 0;
 };
 
 /**

--- a/google/cloud/storage/object_stream.cc
+++ b/google/cloud/storage/object_stream.cc
@@ -44,12 +44,14 @@ ObjectReadStream::~ObjectReadStream() {
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
-internal::HttpResponse ObjectReadStream::Close() {
+void ObjectReadStream::Close() {
   if (not IsOpen()) {
-    google::cloud::internal::RaiseRuntimeError(
-        "Attempting to Close() closed ObjectReadStream");
+    return;
   }
-  return buf_->Close();
+  buf_->Close();
+  if (not status().ok()) {
+    setstate(std::ios_base::badbit);
+  }
 }
 
 ObjectWriteStream::~ObjectWriteStream() {

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -72,40 +72,46 @@ class ObjectReadStream : public std::basic_istream<char> {
 
   //@{
   /**
-   * Access the upload results.
+   * Report any download errors.
    *
-   * Note that calling these member functions before `Close()` is undefined
-   * behavior.
+   * Note that errors may go undetected until the download completes.
    */
   Status const& status() const& { return buf_->status(); }
 
   /**
    * The received CRC32C checksum and the MD5 hash values as reported by GCS.
    *
-   * Then the upload is finalized (via `Close()`) the GCS server reports the
-   * CRC32C checksum of the uploaded object. Note that in some circumstances the
-   * MD5 hash may not be reported.
+   * When the download is finalized (via `Close()` or the end of file) the GCS
+   * server reports the CRC32C checksum and, except for composite objects, the
+   * MD5 hash of the data. This class compares the locally computed and received
+   * hashes so applications can detect data download errors.
    *
    * The values are reported as comma separated `tag=value` pairs, e.g.
    * `crc32c=AAAAAA==,md5=1B2M2Y8AsgTpgAmY7PhCfg==`. The format of this string
    * is subject to change without notice, they are provided for informational
    * purposes only.
+   *
+   * @see https://cloud.google.com/storage/docs/hashes-etags for more
+   *     information on checksums and hashes in GCS.
    */
   std::string const& received_hash() const { return buf_->received_hash(); }
 
   /**
    * The locally computed checksum and hashes, as a string.
    *
-   * This object computes the CRC32C checksum and MD5 hash of the uploaded data.
-   * There are several cases where these values may be empty or irrelevant, for
-   * example:
-   *   - When performing resumable uploads the stream may not have had access to
-   *     the full data.
+   * This object computes the CRC32C checksum and MD5 hash of the downloaded
+   * data. Note that there are several cases where these values may be empty or
+   * irrelevant, for example:
+   *   - When reading only a portion of a blob the hash of that portion is
+   *     irrelevant, note that GCS only reports the hashes for the full blob.
    *   - The application may disable the CRC32C and/or the MD5 hash computation.
    *
    * The string has the same format as the value returned by `received_hash()`.
    * Note that the format of this string is also subject to change without
    * notice.
+   *
+   * @see https://cloud.google.com/storage/docs/hashes-etags for more
+   *     information on checksums and hashes in GCS.
    */
   std::string const& computed_hash() const { return buf_->computed_hash(); }
 


### PR DESCRIPTION
When possible, use status() to report errors in ObjectReadStream.
Unfortunately the standard library assumes that exceptions are enabled,
and a `std::basic_istreambuf<>` can only report errors by raising
exceptions. When exceptions are disabled this is, hmmm, difficult, so we
must rely on the application dutifully checking the `status()` flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1750)
<!-- Reviewable:end -->
