### PR TITLE
Simplify the TEST_INSTALL builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,7 +141,7 @@ matrix:
         TEST_INSTALL=yes
         CMAKE_FLAGS=-DBUILD_SHARED_LIBS=yes
         BUILD_TYPE=Debug
-        DISTRO=ubuntu
+        DISTRO=ubuntu-install
         DISTRO_VERSION=18.04
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
       compiler: clang
       env:
         TEST_INSTALL=yes
-        DISTRO=ubuntu
+        DISTRO=ubuntu-install
         DISTRO_VERSION=18.04
       if: repo =~ ^GoogleCloudPlatform/ or head_repo =~ ^GoogleCloudPlatform/
     - # Verify that we can compile shared libraries, and verify that the ABI is
@@ -65,7 +65,7 @@ matrix:
         TEST_INSTALL=yes
         CMAKE_FLAGS=-DBUILD_SHARED_LIBS=yes
         BUILD_TYPE=Debug
-        DISTRO=ubuntu
+        DISTRO=ubuntu-install
         DISTRO_VERSION=18.04
       if: repo =~ ^GoogleCloudPlatform/ or head_repo =~ ^GoogleCloudPlatform/
     - # Run clang-tidy, clang-format, and generate the documentation.

--- a/ci/travis/Dockerfile.ubuntu-install
+++ b/ci/travis/Dockerfile.ubuntu-install
@@ -1,0 +1,174 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=18.04
+FROM ubuntu:${DISTRO_VERSION}
+MAINTAINER "Carlos O'Ryan <coryan@google.com>"
+
+RUN apt update && \
+    apt install -y \
+        abi-compliance-checker \
+        abi-dumper \
+        automake \
+        build-essential \
+        ccache \
+        clang \
+        clang-format \
+        cmake \
+        curl \
+        doxygen \
+        gawk \
+        git \
+        gcc \
+        g++ \
+        cmake \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        libtool \
+        lsb-release \
+        make \
+        pkg-config \
+        python-pip \
+        tar \
+        wget \
+        zlib1g-dev
+
+# By default, Ubuntu 18.04 does not install the alternatives for clang-format
+# and clang-tidy, so we need to manually install those.
+RUN if grep -q 18.04 /etc/lsb-release; then \
+      apt update && apt install -y clang-tidy clang-format clang-tools; \
+      update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-6.0 100; \
+      update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-6.0 100; \
+      update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-6.0 100; \
+    fi
+
+# Install the the buildifier tool, which does not compile with the default
+# golang compiler for Ubuntu 16.04 and Ubuntu 18.04.
+RUN wget -q -O /usr/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.17.2/buildifier
+RUN chmod 755 /usr/bin/buildifier
+
+# Install cmake_format to automatically format the CMake list files.
+#     https://github.com/cheshirekow/cmake_format
+# Pin this to an specific version because the formatting changes when the
+# "latest" version is updated, and we do not want the builds to break just
+# because some third party changed something.
+RUN pip install --upgrade pip
+RUN pip install numpy cmake_format==0.4.0
+
+# Install Python packages used in the integration tests.
+RUN pip install flask httpbin gevent gunicorn crc32c
+
+# Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
+# client.  They are used in the integration tests.
+WORKDIR /var/tmp/install/cbt-components
+RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-201.0.0-linux-x86_64.tar.gz
+RUN tar x -C /usr/local -f google-cloud-sdk-201.0.0-linux-x86_64.tar.gz
+RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable
+RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components update || \
+    echo "Ignoring update failure for Google Cloud SDK"
+
+# Parallelize the builds if possible. The default is chosen to work well on
+# Travis, but developers may want to override this value when building on their
+# workstations.
+ARG NCPU=2
+
+# Install Crc32c library.
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/google/crc32c/archive/1.0.6.tar.gz
+RUN tar -xf 1.0.6.tar.gz
+WORKDIR /var/tmp/build/crc32c-1.0.6
+RUN cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=yes \
+      -DCRC32C_BUILD_TESTS=OFF \
+      -DCRC32C_BUILD_BENCHMARKS=OFF \
+      -DCRC32C_USE_GLOG=OFF \
+      -H. -B.build/crc32c
+RUN cmake --build .build/crc32c --target install -- -j ${NCPU}
+RUN ldconfig
+
+# Install protobuf using CMake. Some distributions include protobuf, but gRPC
+# requires 3.4.x or newer, and many of those distribution use older versions.
+# We need to install both the debug and Release version because:
+# - When using pkg-config, only the release version works, the pkg-config
+#   file is hard-coded to search for `libprotobuf.so` (or `.a`)
+# - When using CMake, only the version compiled with the same CMAKE_BUILD_TYPE
+#   as the dependent (gRPC or google-cloud-cpp) works.
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/google/protobuf/archive/v3.6.1.tar.gz
+RUN tar -xf v3.6.1.tar.gz
+WORKDIR /var/tmp/build/protobuf-3.6.1/cmake
+RUN for build_type in "Debug" "Release"; do \
+    cmake \
+        -DCMAKE_BUILD_TYPE="${build_type}" \
+        -DBUILD_SHARED_LIBS=yes \
+        -Dprotobuf_BUILD_TESTS=OFF \
+        -H. -B.build-${build_type}; \
+    cmake --build .build-${build_type} --target install -- -j ${NCPU}; \
+  done
+RUN ldconfig
+
+# Many distributions include c-ares, but they do not include the CMake support
+# files for the library, so manually install it.  c-ares requires two install
+# steps because (1) the CMake-based build does not install pkg-config files,
+# and (2) the Makefile-based build does not install CMake config files.
+WORKDIR /var/tmp/build
+RUN apt-get remove -y libc-ares-dev libc-ares2
+RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
+RUN tar -xf cares-1_14_0.tar.gz
+WORKDIR /var/tmp/build/c-ares-cares-1_14_0
+RUN cmake \
+      -DCMAKE_BUILD_TYPE="Release" \
+      -DBUILD_SHARED_LIBS=yes \
+      -H. -B.build
+RUN cmake --build .build --target install -- -j ${NCPU}
+RUN ./buildconf
+RUN ./configure
+RUN install -m 644 -D -t /usr/local/lib/pkgconfig libcares.pc
+RUN ldconfig
+
+# Install gRPC. Note that we use the system's zlib and ssl libraries.
+# For similar reasons to c-ares (see above), we need two install steps.
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/grpc/grpc/archive/v1.16.1.tar.gz
+RUN tar -xf v1.16.1.tar.gz
+RUN ls -l
+WORKDIR /var/tmp/build/grpc-1.16.1
+RUN ls -l
+RUN cmake \
+      -DCMAKE_BUILD_TYPE="Release" \
+      -DBUILD_SHARED_LIBS=yes \
+      -DgRPC_BUILD_TESTS=OFF \
+      -DgRPC_ZLIB_PROVIDER=package \
+      -DgRPC_SSL_PROVIDER=package \
+      -DgRPC_CARES_PROVIDER=package \
+      -DgRPC_PROTOBUF_PROVIDER=package \
+      -H. -B.build/grpc
+RUN cmake --build .build/grpc --target install -- -j ${NCPU}
+RUN make install-pkg-config_c install-pkg-config_cxx install-certs
+RUN ldconfig
+
+# Install googletest.
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/google/googletest/archive/release-1.8.1.tar.gz
+RUN tar -xf release-1.8.1.tar.gz
+WORKDIR /var/tmp/build/googletest-release-1.8.1
+RUN cmake \
+      -DCMAKE_BUILD_TYPE="Release" \
+      -DBUILD_SHARED_LIBS=yes \
+      -H. -B.build/googletest
+RUN cmake --build .build/googletest --target install -- -j ${NCPU}
+RUN ldconfig
+
+RUN find /usr/local -type d | xargs chmod 777

--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -29,6 +29,7 @@ source "${BINDIR}/../colors.sh"
 # ci/Dockerfile.* build scripts.
 readonly IMAGE="cached-${DISTRO}-${DISTRO_VERSION}"
 readonly BUILD_DIR="build-output/${IMAGE}"
+readonly STAGING_DIR="build-output/${IMAGE}-staging"
 
 CMAKE_COMMAND="cmake"
 if [ "${SCAN_BUILD}" = "yes" ]; then
@@ -36,128 +37,6 @@ if [ "${SCAN_BUILD}" = "yes" ]; then
 fi
 
 ccache_command="$(which ccache)"
-
-function install_crc32c {
-  # Install googletest.
-  echo "${COLOR_YELLOW}Installing Crc32c $(date)${COLOR_RESET}"
-  wget -q https://github.com/google/crc32c/archive/1.0.6.tar.gz
-  tar -xf 1.0.6.tar.gz
-  cd crc32c-1.0.6
-  env CXX="${cached_cxx}" CC="${cached_cc}"  cmake \
-      -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
-      -DCRC32C_BUILD_TESTS=OFF \
-      -DCRC32C_BUILD_BENCHMARKS=OFF \
-      -DCRC32C_USE_GLOG=OFF \
-      ${CMAKE_FLAGS} \
-      -H. -B.build/crc32c
-  cmake --build .build/crc32c --target install -- -j ${NCPU}
-  ldconfig
-}
-
-function install_protobuf {
-  # Install protobuf using CMake. Some distributions include protobuf, but gRPC
-  # requires 3.4.x or newer, and many of those distribution use older versions.
-  # We need to install both the debug and Release version because:
-  # - When using pkg-config, only the release version works, the pkg-config
-  #   file is hard-coded to search for `libprotobuf.so` (or `.a`)
-  # - When using CMake, only the version compiled with the same CMAKE_BUILD_TYPE
-  #   as the dependent (gRPC or google-cloud-cpp) works.
-  echo "${COLOR_YELLOW}Installing protobuf $(date)${COLOR_RESET}"
-  wget -q https://github.com/google/protobuf/archive/v3.6.1.tar.gz
-  tar -xf v3.6.1.tar.gz
-  cd protobuf-3.6.1/cmake
-  for build_type in "Debug" "Release"; do
-    env CXX="${cached_cxx}" CC="${cached_cc}" cmake \
-        -DCMAKE_BUILD_TYPE="${build_type}" \
-        -Dprotobuf_BUILD_TESTS=OFF \
-        ${CMAKE_FLAGS} \
-        -H. -B.build-${build_type}
-    cmake --build .build-${build_type} --target install -- -j ${NCPU}
-  done
-  ldconfig
-}
-
-function install_c_ares {
-  # Many distributions include c-ares, but they do not include the CMake support
-  # files for the library, so manually install it.  c-ares requires two install
-  # steps because (1) the CMake-based build does not install pkg-config files,
-  # and (2) the Makefile-based build does not install CMake config files.
-  echo "${COLOR_YELLOW}Installing c-ares $(date)${COLOR_RESET}"
-  apt-get remove -y libc-ares-dev libc-ares2
-  wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
-  tar -xf cares-1_14_0.tar.gz
-  cd c-ares-cares-1_14_0
-  env CXX="${cached_cxx}" CC="${cached_cc}" cmake \
-      -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
-      ${CMAKE_FLAGS} \
-      -H. -B.build; \
-  cmake --build .build --target install -- -j ${NCPU}
-  ./buildconf
-  ./configure
-  install -m 644 -D -t /usr/local/lib/pkgconfig libcares.pc
-  ldconfig
-}
-
-function install_grpc {
-  # Install gRPC. Note that we use the system's zlib and ssl libraries.
-  # For similar reasons to c-ares (see above), we need two install steps.
-  echo "${COLOR_YELLOW}Installing gRPC $(date)${COLOR_RESET}"
-  wget -q https://github.com/grpc/grpc/archive/v1.16.1.tar.gz
-  tar -xf v1.16.1.tar.gz
-  cd grpc-1.16.1
-  env CXX="${cached_cxx}" CC="${cached_cc}"  cmake \
-      -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
-      -DgRPC_BUILD_TESTS=OFF \
-      -DgRPC_ZLIB_PROVIDER=package \
-      -DgRPC_SSL_PROVIDER=package \
-      -DgRPC_CARES_PROVIDER=package \
-      -DgRPC_PROTOBUF_PROVIDER=package \
-      ${CMAKE_FLAGS} \
-      -H. -B.build/grpc
-  cmake --build .build/grpc --target install -- -j ${NCPU}
-  make install-pkg-config_c install-pkg-config_cxx install-certs
-  ldconfig
-}
-
-function install_googletest {
-  # Install googletest.
-  echo "${COLOR_YELLOW}Installing googletest $(date)${COLOR_RESET}"
-  wget -q https://github.com/google/googletest/archive/release-1.8.1.tar.gz
-  tar -xf release-1.8.1.tar.gz
-  cd googletest-release-1.8.1
-  env CXX="${cached_cxx}" CC="${cached_cc}"  cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      ${CMAKE_FLAGS} \
-      -H. -B.build/googletest
-  cmake --build .build/googletest --target install -- -j ${NCPU}
-  ldconfig
-}
-
-if [ "${TEST_INSTALL:-}" = "yes" -o "${SCAN_BUILD:-}" = "yes" ]; then
-  echo
-  echo "${COLOR_YELLOW}Started dependency install at: $(date)${COLOR_RESET}"
-  echo
-  echo "travis_fold:start:install-dependencies"
-  echo
-  mkdir -p /var/tmp/build-dependencies
-  cached_cxx="${CXX}"
-  cached_cc="${CC}"
-  if [ -n "${ccache_command}" ]; then
-    cached_cxx="${ccache_command} ${CXX}"
-    cached_cc="${ccache_command} ${CC}"
-  fi
-  (cd /var/tmp/build-dependencies; install_crc32c)
-  (cd /var/tmp/build-dependencies; install_protobuf)
-  (cd /var/tmp/build-dependencies; install_c_ares)
-  (cd /var/tmp/build-dependencies; install_grpc)
-  (cd /var/tmp/build-dependencies; install_googletest)
-  "${ccache_command}" --show-stats
-  echo
-  echo "${COLOR_YELLOW}Finished dependency install at: $(date)${COLOR_RESET}"
-  echo
-  echo "travis_fold:end:install-dependencies"
-  echo
-fi
 
 echo "${COLOR_YELLOW}Started CMake config at: $(date)${COLOR_RESET}"
 echo "travis_fold:start:configure-cmake"


### PR DESCRIPTION
Instead of installing all the dependencies during the build script,
install them in the build docker image. This change has almost no effect
on the CI builds, but it makes running those builds locally, in a
developer workstation, far easier (and faster).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1751)
<!-- Reviewable:end -->
