### PR TITLE
Update release notes [skip ci].

### DIFF
--- a/doc/cutting-a-release.md
+++ b/doc/cutting-a-release.md
@@ -29,7 +29,11 @@ git log upstream/master -- google/cloud/bigtable
 git log upstream/master -- google/cloud/storage
 ```
 
-Do not forget to update `google/cloud/README.md` too.
+Do not forget to update `google/cloud/README.md` too:
+
+```bash
+git log upstream/master -- google/cloud ":(exclude)google/cloud/storage" ":(exclude)google/cloud/bigtable"
+```
 
 It is not recommended that you create the release branch before this PR is
 ready, but in some circumstances it might be needed, for example, if a large

--- a/google/cloud/README.md
+++ b/google/cloud/README.md
@@ -22,7 +22,14 @@ is available [online][doxygen-link].
 
 ## Release Notes
 
-### v0.3.x - TBD
+### v0.3.x - 2019-01
+
+* Support compiling with gcc-4.8.
+* Fix `GCP_LOG()` macro so it works on platforms that define a `DEBUG`
+  pre-processor symbol.
+* Use different PRNG sequences for each backoff instance, previously all the
+  clones of a backoff policy shared the same sequence.
+* Workaround build problems with Xcode 7.3.
 
 ### v0.2.x - 2018-12
 

--- a/google/cloud/bigtable/README.md
+++ b/google/cloud/bigtable/README.md
@@ -21,7 +21,19 @@ is available [online][doxygen-link].
 
 ## Release Notes
 
-### v0.5.x - TBD
+### v0.5.x - 2019-01
+
+* Restore support for gcc-4.8.
+* @remyabel cleaned up some hard-coded zone names in the examples.
+* More experimental asynchronous APIs, including AsyncReadRows. Note that we
+  expect to change all these experimental APIs as described in
+  [#1543](https://github.com/GoogleCloudPlatform/google-cloud-cpp/issues/1543).
+* @remyabel contributed changes to disable the unit and integration tests. This
+  can be useful for package maintainers.
+* New Bigtable filter wrapper that accepts a single column.
+* **Breaking Change**: remove the `as_proto_move()` memnber functions in favor
+  of `as_proto() &&`. With the latter newer compilers will warn if the object
+  is used after the destructive operation.
 
 ### v0.4.x - 2018-12
 

--- a/google/cloud/storage/README.md
+++ b/google/cloud/storage/README.md
@@ -20,7 +20,23 @@ the reference guide includes a quick start guide.
 
 ## Release Notes
 
-### v0.3.x - TBD
+### v0.3.x - 2019-01
+
+* Try to use the exception mask in the IOStream classes
+  (`storage::ObjectReadStream` and `storage::ObjectWriteStream`). This allows
+  applications to check errors locally via `rdstate()`. Note that applications
+  that disable exceptions altogether must check the `status()` member function
+  for these IOStream classes. It is impossible to set the `rdstate()` for all
+  failures when exceptions are disabled.
+* Support reading only a portion of a Blob.
+* Support building with gcc-4.8.
+* Many internal changes to better support applications that disable exceptions.
+  A future release will include APIs that do not raise exceptions for error
+  conditions.
+* @remyabel contributed changes to disable the unit and integration tests. This
+  can be useful for package maintainers.
+* Implement a function to create signed URLs (`Client::CreateV2SignedUrl`).
+* Support resumable uploads in any upload operation.
 
 ### v0.2.x - 2018-12
 


### PR DESCRIPTION
Another month, another release. This is just filling out the release notes,
I expect another update when we actually cut the release in the next
couple of days.

I took the opportunity to update the documentation on how to prepare
these notes in the future.
