### PR TITLE
Move CompletionQueue to first argument in Async*().

### DIFF
--- a/google/cloud/bigtable/examples/instance_admin_async_snippets.cc
+++ b/google/cloud/bigtable/examples/instance_admin_async_snippets.cc
@@ -47,7 +47,7 @@ void AsyncGetInstance(cbt::InstanceAdmin instance_admin,
   [](cbt::InstanceAdmin instance_admin, cbt::CompletionQueue cq,
      std::string instance_id) {
     google::cloud::future<google::bigtable::admin::v2::Instance> future =
-        instance_admin.AsyncGetInstance(instance_id, cq);
+        instance_admin.AsyncGetInstance(cq, instance_id);
 
     auto final = future.then(
         [](google::cloud::future<google::bigtable::admin::v2::Instance> f) {
@@ -77,7 +77,7 @@ void AsyncGetCluster(cbt::InstanceAdmin instance_admin, cbt::CompletionQueue cq,
     google::cloud::bigtable::ClusterId cluster_id1(cluster_id);
 
     google::cloud::future<google::bigtable::admin::v2::Cluster> future =
-        instance_admin.AsyncGetCluster(instance_id1, cluster_id1, cq);
+        instance_admin.AsyncGetCluster(cq, instance_id1, cluster_id1);
 
     auto final = future.then(
         [](google::cloud::future<google::bigtable::admin::v2::Cluster> f) {

--- a/google/cloud/bigtable/examples/table_admin_async_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_async_snippets.cc
@@ -45,13 +45,12 @@ void AsyncCreateTable(cbt::TableAdmin admin, cbt::CompletionQueue cq,
   [](cbt::TableAdmin admin, cbt::CompletionQueue cq, std::string table_id) {
     google::cloud::future<google::bigtable::admin::v2::Table> future =
         admin.AsyncCreateTable(
-            table_id,
+            cq, table_id,
             google::cloud::bigtable::TableConfig(
                 {{"fam", google::cloud::bigtable::GcRule::MaxNumVersions(10)},
                  {"foo", google::cloud::bigtable::GcRule::MaxAge(
                              std::chrono::hours(72))}},
-                {}),
-            cq);
+                {}));
 
     auto final = future.then(
         [](google::cloud::future<google::bigtable::admin::v2::Table> f) {
@@ -74,8 +73,8 @@ void AsyncGetTable(cbt::TableAdmin admin, cbt::CompletionQueue cq,
   namespace cbt = google::cloud::bigtable;
   [](cbt::TableAdmin admin, cbt::CompletionQueue cq, std::string table_id) {
     google::cloud::future<google::bigtable::admin::v2::Table> future =
-        admin.AsyncGetTable(table_id, google::bigtable::admin::v2::Table::FULL,
-                            cq);
+        admin.AsyncGetTable(cq, table_id,
+                            google::bigtable::admin::v2::Table::FULL);
 
     auto final = future.then(
         [](google::cloud::future<google::bigtable::admin::v2::Table> f) {
@@ -142,7 +141,8 @@ int main(int argc, char* argv[]) try {
   std::string const command_name = argv[1];
   std::string const project_id = argv[2];
   std::string const instance_id = argv[3];
-  std::transform(argv + 4, argv + argc, std::back_inserter(args), [](char* x) { return std::string(x); });
+  std::transform(argv + 4, argv + argc, std::back_inserter(args),
+                 [](char* x) { return std::string(x); });
 
   auto command = commands.find(command_name);
   if (commands.end() == command) {

--- a/google/cloud/bigtable/instance_admin.cc
+++ b/google/cloud/bigtable/instance_admin.cc
@@ -144,13 +144,14 @@ btadmin::Instance InstanceAdmin::GetInstance(std::string const& instance_id) {
 }
 
 future<btadmin::Instance> InstanceAdmin::AsyncGetInstance(
-    std::string const& instance_id, CompletionQueue& cq) {
+    CompletionQueue& cq, std::string const& instance_id) {
   promise<btadmin::Instance> p;
   auto result = p.get_future();
 
   impl_.AsyncGetInstance(
-      instance_id, cq,
-      internal::MakeAsyncFutureFromCallback(std::move(p), "AsyncGetInstance"));
+      cq,
+      internal::MakeAsyncFutureFromCallback(std::move(p), "AsyncGetInstance"),
+      instance_id);
 
   return result;
 }
@@ -175,14 +176,14 @@ btadmin::Cluster InstanceAdmin::GetCluster(
 }
 
 future<btadmin::Cluster> InstanceAdmin::AsyncGetCluster(
-    bigtable::InstanceId const& instance_id,
-    bigtable::ClusterId const& cluster_id, CompletionQueue& cq) {
+    CompletionQueue& cq, bigtable::InstanceId const& instance_id,
+    bigtable::ClusterId const& cluster_id) {
   promise<btadmin::Cluster> p;
   auto result = p.get_future();
 
   impl_.AsyncGetCluster(
-      instance_id, cluster_id, cq,
-      internal::MakeAsyncFutureFromCallback(std::move(p), "AsyncGetCluster"));
+      cq,
+      internal::MakeAsyncFutureFromCallback(std::move(p), "AsyncGetCluster"), instance_id, cluster_id);
 
   return result;
 }

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -187,7 +187,7 @@ class InstanceAdmin {
    * @snippet instance_admin_async_snippets.cc async get instance
    */
   future<google::bigtable::admin::v2::Instance> AsyncGetInstance(
-      std::string const& instance_id, CompletionQueue& cq);
+      CompletionQueue& cq, std::string const& instance_id);
 
   /**
    * Deletes the instances in the project.
@@ -292,8 +292,8 @@ class InstanceAdmin {
    * @snippet instance_admin_async_snippets.cc async get cluster
    */
   future<google::bigtable::admin::v2::Cluster> AsyncGetCluster(
-      bigtable::InstanceId const& instance_id,
-      bigtable::ClusterId const& cluster_id, CompletionQueue& cq);
+      CompletionQueue& cq, bigtable::InstanceId const& instance_id,
+      bigtable::ClusterId const& cluster_id);
 
   /**
    * Create a new application profile.

--- a/google/cloud/bigtable/internal/async_check_consistency_test.cc
+++ b/google/cloud/bigtable/internal/async_check_consistency_test.cc
@@ -278,7 +278,7 @@ TEST_P(NoexAsyncCheckConsistencyEndToEnd, EndToEnd) {
     user_op_called = true;
     EXPECT_EQ(config.expected, status.error_code());
   };
-  tested.AsyncAwaitConsistency(kTableId, cq, user_callback);
+  tested.AsyncAwaitConsistency(cq, user_callback, kTableId);
 
   EXPECT_FALSE(user_op_called);
   EXPECT_EQ(1U, cq_impl->size());  // AsyncGenerateConsistencyToken
@@ -455,7 +455,7 @@ TEST_P(NoexAsyncCheckConsistencyCancel, Cancellations) {
     user_op_called = true;
     EXPECT_EQ(config.expected, status.error_code());
   };
-  auto op = tested.AsyncAwaitConsistency(kTableId, cq, user_callback);
+  auto op = tested.AsyncAwaitConsistency(cq, user_callback, kTableId);
 
   EXPECT_FALSE(user_op_called);
   EXPECT_EQ(1U, cq_impl->size());  // AsyncGenerateConsistencyToken

--- a/google/cloud/bigtable/internal/instance_admin.h
+++ b/google/cloud/bigtable/internal/instance_admin.h
@@ -184,8 +184,8 @@ class InstanceAdmin {
                                         grpc::Status&>::value,
                                     int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncCreateInstance(
-      bigtable::InstanceConfig instance_config, CompletionQueue& cq,
-      Functor&& callback) {
+      CompletionQueue& cq, Functor&& callback,
+      bigtable::InstanceConfig instance_config) {
     static_assert(internal::ExtractMemberFunctionType<decltype(
                       &InstanceAdminClient::AsyncCreateInstance)>::value,
                   "Cannot extract member function type");
@@ -245,8 +245,8 @@ class InstanceAdmin {
                                         grpc::Status&>::value,
                                     int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncUpdateInstance(
-      InstanceUpdateConfig instance_update_config, CompletionQueue& cq,
-      Functor&& callback) {
+      CompletionQueue& cq, Functor&& callback,
+      InstanceUpdateConfig instance_update_config) {
     static_assert(internal::ExtractMemberFunctionType<decltype(
                       &InstanceAdminClient::AsyncUpdateInstance)>::value,
                   "Cannot extract member function type");
@@ -299,7 +299,7 @@ class InstanceAdmin {
                                         grpc::Status&>::value,
                                     int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncGetInstance(
-      std::string const& instance_id, CompletionQueue& cq, Functor&& callback) {
+      CompletionQueue& cq, Functor&& callback, std::string const& instance_id) {
     google::bigtable::admin::v2::GetInstanceRequest request;
     // Setting instance name.
     request.set_name(project_name_ + "/instances/" + instance_id);
@@ -355,7 +355,7 @@ class InstanceAdmin {
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncDeleteInstance(
-      std::string const& instance_id, CompletionQueue& cq, Functor&& callback) {
+      CompletionQueue& cq, Functor&& callback, std::string const& instance_id) {
     google::bigtable::admin::v2::DeleteInstanceRequest request;
     // Setting instance name.
     request.set_name(InstanceName(instance_id));
@@ -409,7 +409,7 @@ class InstanceAdmin {
                                         grpc::Status&>::value,
                                     int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncListClusters(
-      std::string const& instance_id, CompletionQueue& cq, Functor&& callback) {
+      CompletionQueue& cq, Functor&& callback, std::string const& instance_id) {
     auto op = std::make_shared<internal::AsyncRetryListClusters<Functor>>(
         __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
         metadata_update_policy_, client_, InstanceName(instance_id),
@@ -451,9 +451,9 @@ class InstanceAdmin {
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncDeleteCluster(
+      CompletionQueue& cq, Functor&& callback,
       bigtable::InstanceId const& instance_id,
-      bigtable::ClusterId const& cluster_id, CompletionQueue& cq,
-      Functor&& callback) {
+      bigtable::ClusterId const& cluster_id) {
     google::bigtable::admin::v2::DeleteClusterRequest request;
     // Setting cluster name.
     request.set_name(ClusterName(instance_id, cluster_id));
@@ -512,10 +512,10 @@ class InstanceAdmin {
                                         grpc::Status&>::value,
                                     int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncCreateCluster(
+      CompletionQueue& cq, Functor&& callback,
       bigtable::ClusterConfig cluster_config,
       bigtable::InstanceId const& instance_id,
-      bigtable::ClusterId const& cluster_id, CompletionQueue& cq,
-      Functor&& callback) {
+      bigtable::ClusterId const& cluster_id) {
     static_assert(internal::ExtractMemberFunctionType<decltype(
                       &InstanceAdminClient::AsyncCreateCluster)>::value,
                   "Cannot extract member function type");
@@ -575,7 +575,7 @@ class InstanceAdmin {
                                         grpc::Status&>::value,
                                     int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncUpdateCluster(
-      ClusterConfig cluster_config, CompletionQueue& cq, Functor&& callback) {
+      CompletionQueue& cq, Functor&& callback, ClusterConfig cluster_config) {
     static_assert(internal::ExtractMemberFunctionType<decltype(
                       &InstanceAdminClient::AsyncUpdateCluster)>::value,
                   "Cannot extract member function type");
@@ -631,9 +631,9 @@ class InstanceAdmin {
                                         grpc::Status&>::value,
                                     int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncGetCluster(
+      CompletionQueue& cq, Functor&& callback,
       bigtable::InstanceId const& instance_id,
-      bigtable::ClusterId const& cluster_id, CompletionQueue& cq,
-      Functor&& callback) {
+      bigtable::ClusterId const& cluster_id) {
     google::bigtable::admin::v2::GetClusterRequest request;
     // Setting cluster name.
     request.set_name(ClusterName(instance_id, cluster_id));
@@ -698,9 +698,9 @@ class InstanceAdmin {
               google::bigtable::admin::v2::AppProfile&, grpc::Status&>::value,
           int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncUpdateAppProfile(
+      CompletionQueue& cq, Functor&& callback,
       bigtable::InstanceId const& instance_id,
-      bigtable::AppProfileId profile_id, AppProfileUpdateConfig config,
-      CompletionQueue& cq, Functor&& callback) {
+      bigtable::AppProfileId profile_id, AppProfileUpdateConfig config) {
     static_assert(internal::ExtractMemberFunctionType<decltype(
                       &InstanceAdminClient::AsyncUpdateAppProfile)>::value,
                   "Cannot extract member function type");
@@ -758,8 +758,8 @@ class InstanceAdmin {
               google::bigtable::admin::v2::AppProfile&, grpc::Status&>::value,
           int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncCreateAppProfile(
-      bigtable::InstanceId const& instance_id, AppProfileConfig config,
-      CompletionQueue& cq, Functor&& callback) {
+      CompletionQueue& cq, Functor&& callback,
+      bigtable::InstanceId const& instance_id, AppProfileConfig config) {
     auto request = std::move(config).as_proto();
     request.set_parent(InstanceName(instance_id.get()));
 
@@ -818,9 +818,9 @@ class InstanceAdmin {
               google::bigtable::admin::v2::AppProfile&, grpc::Status&>::value,
           int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncGetAppProfile(
+      CompletionQueue& cq, Functor&& callback,
       bigtable::InstanceId const& instance_id,
-      bigtable::AppProfileId const& profile_id, CompletionQueue& cq,
-      Functor&& callback) {
+      bigtable::AppProfileId const& profile_id) {
     google::bigtable::admin::v2::GetAppProfileRequest request;
     // Setting profile name.
     request.set_name(InstanceName(instance_id.get()) + "/appProfiles/" +
@@ -878,7 +878,7 @@ class InstanceAdmin {
                     grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncListAppProfiles(
-      std::string const& instance_id, CompletionQueue& cq, Functor&& callback) {
+      CompletionQueue& cq, Functor&& callback, std::string const& instance_id) {
     auto op = std::make_shared<internal::AsyncRetryListAppProfiles<Functor>>(
         __func__, rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
         metadata_update_policy_, client_, InstanceName(instance_id),
@@ -920,9 +920,9 @@ class InstanceAdmin {
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncDeleteAppProfile(
+      CompletionQueue& cq, Functor&& callback,
       bigtable::InstanceId const& instance_id,
-      bigtable::AppProfileId const& profile_id, CompletionQueue& cq,
-      Functor&& callback) {
+      bigtable::AppProfileId const& profile_id) {
     google::bigtable::admin::v2::DeleteAppProfileRequest request;
     // Setting profile name.
     request.set_name(InstanceName(instance_id.get()) + "/appProfiles/" +

--- a/google/cloud/bigtable/internal/table.h
+++ b/google/cloud/bigtable/internal/table.h
@@ -165,9 +165,9 @@ class Table {
               Functor, CompletionQueue&,
               google::bigtable::v2::MutateRowResponse&, grpc::Status&>::value,
           int>::type valid_callback_type = 0>
-  std::shared_ptr<AsyncOperation> AsyncApply(SingleRowMutation&& mut,
-                                             CompletionQueue& cq,
-                                             Functor&& callback) {
+  std::shared_ptr<AsyncOperation> AsyncApply(CompletionQueue& cq,
+                                             Functor&& callback,
+                                             SingleRowMutation&& mut) {
     google::bigtable::v2::MutateRowRequest request;
     internal::SetCommonTableOperationRequest<
         google::bigtable::v2::MutateRowRequest>(request, app_profile_id_.get(),
@@ -231,9 +231,9 @@ class Table {
                     Functor, CompletionQueue&, std::vector<FailedMutation>&,
                     grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
-  std::shared_ptr<AsyncOperation> AsyncBulkApply(BulkMutation&& mut,
-                                                 CompletionQueue& cq,
-                                                 Functor&& callback) {
+  std::shared_ptr<AsyncOperation> AsyncBulkApply(CompletionQueue& cq,
+                                                 Functor&& callback,
+                                                 BulkMutation&& mut) {
     auto op =
         std::make_shared<bigtable::internal::AsyncRetryBulkApply<Functor>>(
             rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
@@ -291,9 +291,9 @@ class Table {
                                         grpc::Status const&>::value,
                                     int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncReadRows(
-      RowSet row_set, std::int64_t rows_limit, Filter filter,
       CompletionQueue& cq, ReadRowCallback&& read_row_callback,
-      DoneCallback&& done_callback, bool raise_on_error = false) {
+      DoneCallback&& done_callback, RowSet row_set, std::int64_t rows_limit,
+      Filter filter, bool raise_on_error = false) {
     auto op = std::make_shared<
         internal::AsyncReadRowsOperation<ReadRowCallback, DoneCallback>>(
         rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
@@ -345,9 +345,9 @@ class Table {
                     Functor, CompletionQueue&, bool, grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncCheckAndMutateRow(
-      std::string row_key, Filter filter, std::vector<Mutation> true_mutations,
-      std::vector<Mutation> false_mutations, CompletionQueue& cq,
-      Functor&& callback) {
+      CompletionQueue& cq, Functor&& callback, std::string row_key,
+      Filter filter, std::vector<Mutation> true_mutations,
+      std::vector<Mutation> false_mutations) {
     google::bigtable::v2::CheckAndMutateRowRequest request;
     request.set_row_key(std::move(row_key));
     bigtable::internal::SetCommonTableOperationRequest<

--- a/google/cloud/bigtable/internal/table_admin.h
+++ b/google/cloud/bigtable/internal/table_admin.h
@@ -142,10 +142,10 @@ class TableAdmin {
                     Functor, CompletionQueue&,
                     google::bigtable::admin::v2::Table&, grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
-  std::shared_ptr<AsyncOperation> AsyncCreateTable(std::string table_id,
-                                                   TableConfig config,
-                                                   CompletionQueue& cq,
-                                                   Functor&& callback) {
+  std::shared_ptr<AsyncOperation> AsyncCreateTable(CompletionQueue& cq,
+                                                   Functor&& callback,
+                                                   std::string table_id,
+                                                   TableConfig config) {
     auto request = std::move(config).as_proto();
     request.set_parent(instance_name());
     request.set_table_id(std::move(table_id));
@@ -205,9 +205,8 @@ class TableAdmin {
                     google::bigtable::admin::v2::Table&, grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncGetTable(
-      std::string const& table_id,
-      google::bigtable::admin::v2::Table::View view, CompletionQueue& cq,
-      Functor&& callback) {
+      CompletionQueue& cq, Functor&& callback, std::string const& table_id,
+      google::bigtable::admin::v2::Table::View view) {
     google::bigtable::admin::v2::GetTableRequest request;
     request.set_name(TableName(table_id));
     request.set_view(view);
@@ -260,8 +259,8 @@ class TableAdmin {
                                                       google::protobuf::Empty&,
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
-  void AsyncDeleteTable(std::string const& table_id, TableConfig config,
-                        CompletionQueue& cq, Functor&& callback) {
+  void AsyncDeleteTable(CompletionQueue& cq, Functor&& callback,
+                        std::string const& table_id, TableConfig config) {
     google::bigtable::admin::v2::DeleteTableRequest request;
     request.set_name(TableName(table_id));
 
@@ -348,8 +347,8 @@ class TableAdmin {
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncAwaitConsistency(
-      bigtable::TableId const& table_id, CompletionQueue& cq,
-      Functor&& callback) {
+      CompletionQueue& cq, Functor&& callback,
+      bigtable::TableId const& table_id) {
     auto op = std::make_shared<internal::AsyncAwaitConsistency>(
         __func__, polling_policy_->clone(), rpc_retry_policy_->clone(),
         rpc_backoff_policy_->clone(),
@@ -409,9 +408,8 @@ class TableAdmin {
                     google::bigtable::admin::v2::Table&, grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncModifyColumnFamilies(
-      std::string const& table_id,
-      std::vector<ColumnFamilyModification> modifications, CompletionQueue& cq,
-      Functor&& callback) {
+      CompletionQueue& cq, Functor&& callback, std::string const& table_id,
+      std::vector<ColumnFamilyModification> modifications) {
     google::bigtable::admin::v2::ModifyColumnFamiliesRequest request;
     request.set_name(TableName(table_id));
     for (auto& m : modifications) {
@@ -471,8 +469,8 @@ class TableAdmin {
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncDropRowsByPrefix(
-      std::string const& table_id, std::string row_key_prefix,
-      CompletionQueue& cq, Functor&& callback) {
+      CompletionQueue& cq, Functor&& callback, std::string const& table_id,
+      std::string row_key_prefix) {
     google::bigtable::admin::v2::DropRowRangeRequest request;
     request.set_name(TableName(table_id));
     request.set_row_key_prefix(std::move(row_key_prefix));
@@ -527,9 +525,8 @@ class TableAdmin {
                                                       google::protobuf::Empty&,
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
-  std::shared_ptr<AsyncOperation> AsyncDropAllRows(std::string const& table_id,
-                                                   CompletionQueue& cq,
-                                                   Functor&& callback) {
+  std::shared_ptr<AsyncOperation> AsyncDropAllRows(
+      CompletionQueue& cq, Functor&& callback, std::string const& table_id) {
     google::bigtable::admin::v2::DropRowRangeRequest request;
     request.set_name(TableName(table_id));
     request.set_delete_all_data_from_table(true);
@@ -590,9 +587,9 @@ class TableAdmin {
                                         grpc::Status&>::value,
                                     int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncGetSnapshot(
+      CompletionQueue& cq, Functor&& callback,
       bigtable::ClusterId const& cluster_id,
-      bigtable::SnapshotId const& snapshot_id, CompletionQueue& cq,
-      Functor&& callback) {
+      bigtable::SnapshotId const& snapshot_id) {
     google::bigtable::admin::v2::GetSnapshotRequest request;
     request.set_name(SnapshotName(cluster_id, snapshot_id));
     MetadataUpdatePolicy metadata_update_policy(
@@ -654,9 +651,9 @@ class TableAdmin {
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> AsyncDeleteSnapshot(
+      CompletionQueue& cq, Functor&& callback,
       bigtable::ClusterId const& cluster_id,
-      bigtable::SnapshotId const& snapshot_id, CompletionQueue& cq,
-      Functor&& callback) {
+      bigtable::SnapshotId const& snapshot_id) {
     google::bigtable::admin::v2::DeleteSnapshotRequest request;
     request.set_name(SnapshotName(cluster_id, snapshot_id));
     MetadataUpdatePolicy metadata_update_policy(

--- a/google/cloud/bigtable/internal/table_async_apply_test.cc
+++ b/google/cloud/bigtable/internal/table_async_apply_test.cc
@@ -84,15 +84,15 @@ TEST_F(NoexTableAsyncApplyTest, SuccessAfterOneRetry) {
   bool op_called = false;
   grpc::Status capture_status;
   table_.AsyncApply(
-      bigtable::SingleRowMutation(
-          "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}),
       cq,
       [&op_called, &capture_status](CompletionQueue& cq,
                                     google::bigtable::v2::MutateRowResponse& r,
                                     grpc::Status const& status) {
         op_called = true;
         capture_status = status;
-      });
+      },
+      bigtable::SingleRowMutation(
+          "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}));
 
   // At this point r1 is fired, but neither r2, nor the final callback are
   // called, verify that and simulate the first request completing.
@@ -153,15 +153,15 @@ TEST_F(NoexTableAsyncApplyTest, PermanentFailure) {
   bool op_called = false;
   grpc::Status capture_status;
   table_.AsyncApply(
-      bigtable::SingleRowMutation(
-          "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}),
       cq,
       [&op_called, &capture_status](CompletionQueue& cq,
                                     google::bigtable::v2::MutateRowResponse& r,
                                     grpc::Status const& status) {
         op_called = true;
         capture_status = status;
-      });
+      },
+      bigtable::SingleRowMutation(
+          "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}));
 
   // At this point r1 is fired, but the final callback is not, verify that and
   // simulate the first request completing.
@@ -247,15 +247,15 @@ TEST_F(NoexTableAsyncApplyTest, TooManyTransientFailures) {
   bool op_called = false;
   grpc::Status capture_status;
   tested.AsyncApply(
-      bigtable::SingleRowMutation(
-          "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}),
       cq,
       [&op_called, &capture_status](CompletionQueue& cq,
                                     google::bigtable::v2::MutateRowResponse& r,
                                     grpc::Status const& status) {
         op_called = true;
         capture_status = status;
-      });
+      },
+      bigtable::SingleRowMutation(
+          "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}));
 
   // We expect call -> timer -> call -> timer -> call -> timer -> call[failed],
   // so simulate the cycle 6 times:
@@ -312,15 +312,15 @@ TEST_F(NoexTableAsyncApplyTest, TransientFailureNonIdempotent) {
   bool op_called = false;
   grpc::Status capture_status;
   table_.AsyncApply(
-      bigtable::SingleRowMutation("bar",
-                                  {bigtable::SetCell("fam", "col", "val")}),
       cq,
       [&op_called, &capture_status](CompletionQueue& cq,
                                     google::bigtable::v2::MutateRowResponse& r,
                                     grpc::Status const& status) {
         op_called = true;
         capture_status = status;
-      });
+      },
+      bigtable::SingleRowMutation("bar",
+                                  {bigtable::SetCell("fam", "col", "val")}));
 
   // At this point r1 is fired, but the final callback is not, verify that and
   // simulate the first request completing.
@@ -361,15 +361,15 @@ TEST_F(NoexTableAsyncApplyTest, StopRetryOnOperationCancel) {
   bool op_called = false;
   grpc::Status capture_status;
   tested.AsyncApply(
-      bigtable::SingleRowMutation(
-          "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}),
       cq,
       [&op_called, &capture_status](CompletionQueue& cq,
                                     google::bigtable::v2::MutateRowResponse& r,
                                     grpc::Status const& status) {
         op_called = true;
         capture_status = status;
-      });
+      },
+      bigtable::SingleRowMutation(
+          "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}));
 
   // Cancel the pending operation, this should immediately fail.
   EXPECT_FALSE(op_called);
@@ -408,15 +408,15 @@ TEST_F(NoexTableAsyncApplyTest, BuggyGrpcReturningFalseOnFinish) {
   bool op_called = false;
   grpc::Status capture_status;
   tested.AsyncApply(
-      bigtable::SingleRowMutation(
-          "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}),
       cq,
       [&op_called, &capture_status](CompletionQueue& cq,
                                     google::bigtable::v2::MutateRowResponse& r,
                                     grpc::Status const& status) {
         op_called = true;
         capture_status = status;
-      });
+      },
+      bigtable::SingleRowMutation(
+          "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}));
 
   EXPECT_FALSE(op_called);
   EXPECT_EQ(1U, impl->size());
@@ -453,15 +453,15 @@ TEST_F(NoexTableAsyncApplyTest, StopRetryOnTimerCancel) {
   bool op_called = false;
   grpc::Status capture_status;
   tested.AsyncApply(
-      bigtable::SingleRowMutation(
-          "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}),
       cq,
       [&op_called, &capture_status](CompletionQueue& cq,
                                     google::bigtable::v2::MutateRowResponse& r,
                                     grpc::Status const& status) {
         op_called = true;
         capture_status = status;
-      });
+      },
+      bigtable::SingleRowMutation(
+          "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}));
 
   // Simulate a failure in the pending operation, that should create a timer.
   EXPECT_FALSE(op_called);

--- a/google/cloud/bigtable/internal/table_async_bulk_apply_test.cc
+++ b/google/cloud/bigtable/internal/table_async_bulk_apply_test.cc
@@ -121,7 +121,7 @@ TEST_F(NoexTableAsyncBulkApplyTest, IdempotencyAndRetries) {
   bigtable::CompletionQueue cq(impl);
 
   bool mutator_finished = false;
-  table_.AsyncBulkApply(std::move(mut), cq,
+  table_.AsyncBulkApply(cq,
                         [&mutator_finished](CompletionQueue& cq,
                                             std::vector<FailedMutation>& failed,
                                             grpc::Status& status) {
@@ -129,7 +129,8 @@ TEST_F(NoexTableAsyncBulkApplyTest, IdempotencyAndRetries) {
                           EXPECT_EQ("baz", failed[0].mutation().row_key());
                           EXPECT_TRUE(status.ok());
                           mutator_finished = true;
-                        });
+                        },
+                        std::move(mut));
 
   using bigtable::AsyncOperation;
   impl->SimulateCompletion(cq, true);
@@ -184,7 +185,7 @@ TEST_F(NoexTableAsyncBulkApplyTest, Cancelled) {
   bigtable::CompletionQueue cq(impl);
 
   bool mutator_finished = false;
-  table_.AsyncBulkApply(std::move(mut), cq,
+  table_.AsyncBulkApply(cq,
                         [&mutator_finished](CompletionQueue& cq,
                                             std::vector<FailedMutation>& failed,
                                             grpc::Status& status) {
@@ -192,7 +193,7 @@ TEST_F(NoexTableAsyncBulkApplyTest, Cancelled) {
                           EXPECT_EQ(grpc::StatusCode::CANCELLED,
                                     status.error_code());
                           mutator_finished = true;
-                        });
+                        }, std::move(mut));
 
   using bigtable::AsyncOperation;
   impl->SimulateCompletion(cq, false);
@@ -237,7 +238,7 @@ TEST_F(NoexTableAsyncBulkApplyTest, PermanentError) {
   bigtable::CompletionQueue cq(impl);
 
   bool mutator_finished = false;
-  table_.AsyncBulkApply(std::move(mut), cq,
+  table_.AsyncBulkApply(cq,
                         [&mutator_finished](CompletionQueue& cq,
                                             std::vector<FailedMutation>& failed,
                                             grpc::Status& status) {
@@ -245,7 +246,8 @@ TEST_F(NoexTableAsyncBulkApplyTest, PermanentError) {
                           EXPECT_EQ(grpc::StatusCode::PERMISSION_DENIED,
                                     status.error_code());
                           mutator_finished = true;
-                        });
+                        },
+                        std::move(mut));
 
   using bigtable::AsyncOperation;
   impl->SimulateCompletion(cq, false);
@@ -310,14 +312,15 @@ TEST_F(NoexTableAsyncBulkApplyTest, CancelledInTimer) {
   bigtable::CompletionQueue cq(impl);
 
   bool mutator_finished = false;
-  table_.AsyncBulkApply(std::move(mut), cq,
+  table_.AsyncBulkApply(cq,
                         [&mutator_finished](CompletionQueue& cq,
                                             std::vector<FailedMutation>& failed,
                                             grpc::Status& status) {
                           EXPECT_EQ(grpc::StatusCode::CANCELLED,
                                     status.error_code());
                           mutator_finished = true;
-                        });
+                        },
+                        std::move(mut));
 
   using bigtable::AsyncOperation;
   impl->SimulateCompletion(cq, true);

--- a/google/cloud/bigtable/internal/table_async_check_and_mutate_row_test.cc
+++ b/google/cloud/bigtable/internal/table_async_check_and_mutate_row_test.cc
@@ -67,15 +67,16 @@ TEST_F(NoexTableAsyncCheckAndMutateRowTest, Simple) {
   bool op_called = false;
   grpc::Status capture_status;
   table_.AsyncCheckAndMutateRow(
-      "foo", bt::Filter::PassAllFilter(),
-      {bt::SetCell("fam", "col", 0_ms, "it was true")},
-      {bt::SetCell("fam", "col", 0_ms, "it was false")}, cq,
+      cq,
       [&op_called, &capture_status](CompletionQueue& cq, bool response,
                                     grpc::Status const& status) {
         EXPECT_TRUE(response);
         op_called = true;
         capture_status = status;
-      });
+      },
+      "foo", bt::Filter::PassAllFilter(),
+      {bt::SetCell("fam", "col", 0_ms, "it was true")},
+      {bt::SetCell("fam", "col", 0_ms, "it was false")});
 
   EXPECT_FALSE(op_called);
   EXPECT_EQ(1U, impl->size());
@@ -115,14 +116,15 @@ TEST_F(NoexTableAsyncCheckAndMutateRowTest, Failure) {
   bool op_called = false;
   grpc::Status capture_status;
   table_.AsyncCheckAndMutateRow(
-      "foo", bt::Filter::PassAllFilter(),
-      {bt::SetCell("fam", "col", 0_ms, "it was true")},
-      {bt::SetCell("fam", "col", 0_ms, "it was false")}, cq,
+      cq,
       [&op_called, &capture_status](CompletionQueue& cq, bool response,
                                     grpc::Status const& status) {
         op_called = true;
         capture_status = status;
-      });
+      },
+      "foo", bt::Filter::PassAllFilter(),
+      {bt::SetCell("fam", "col", 0_ms, "it was true")},
+      {bt::SetCell("fam", "col", 0_ms, "it was false")});
 
   EXPECT_FALSE(op_called);
   EXPECT_EQ(1U, impl->size());

--- a/google/cloud/bigtable/internal/table_async_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/table_async_row_reader_test.cc
@@ -78,21 +78,22 @@ TEST_F(NoexTableAsyncReadRowsTest, Simple) {
   bool read_rows_op_called = false;
   bool done_op_called = false;
 
-  table_.AsyncReadRows(bt::RowSet(), bt::RowReader::NO_ROWS_LIMIT,
-                       bt::Filter::PassAllFilter(), cq,
-                       [&read_rows_op_called](CompletionQueue& cq, Row row,
-                                              grpc::Status& status) {
-                         EXPECT_EQ("0001", row.row_key());
-                         EXPECT_TRUE(status.ok());
-                         read_rows_op_called = true;
-                       },
-                       [&done_op_called](CompletionQueue& cq, bool& response,
-                                         grpc::Status const& status) {
-                         EXPECT_TRUE(response);
-                         EXPECT_TRUE(status.ok());
-                         EXPECT_EQ("mocked-status", status.error_message());
-                         done_op_called = true;
-                       });
+  table_.AsyncReadRows(
+      cq,
+      [&read_rows_op_called](CompletionQueue& cq, Row row,
+                             grpc::Status& status) {
+        EXPECT_EQ("0001", row.row_key());
+        EXPECT_TRUE(status.ok());
+        read_rows_op_called = true;
+      },
+      [&done_op_called](CompletionQueue& cq, bool& response,
+                        grpc::Status const& status) {
+        EXPECT_TRUE(response);
+        EXPECT_TRUE(status.ok());
+        EXPECT_EQ("mocked-status", status.error_message());
+        done_op_called = true;
+      },
+      bt::RowSet(), bt::RowReader::NO_ROWS_LIMIT, bt::Filter::PassAllFilter());
 
   using bigtable::AsyncOperation;
   impl->SimulateCompletion(cq, true);
@@ -186,21 +187,22 @@ TEST_F(NoexTableAsyncReadRowsTest, ReadRowsWithRetry) {
   bool read_rows_op_called = false;
   bool done_op_called = false;
 
-  table_.AsyncReadRows(bt::RowSet(bt::RowRange::Range("0000", "0005")),
-                       bt::RowReader::NO_ROWS_LIMIT,
-                       bt::Filter::PassAllFilter(), cq,
-                       [&read_rows_op_called](CompletionQueue& cq, Row row,
-                                              grpc::Status& status) {
-                         EXPECT_TRUE(status.ok());
-                         read_rows_op_called = true;
-                       },
-                       [&done_op_called](CompletionQueue& cq, bool& response,
-                                         grpc::Status const& status) {
-                         EXPECT_TRUE(response);
-                         EXPECT_TRUE(status.ok());
-                         EXPECT_EQ("mocked-status", status.error_message());
-                         done_op_called = true;
-                       });
+  table_.AsyncReadRows(
+      cq,
+      [&read_rows_op_called](CompletionQueue& cq, Row row,
+                             grpc::Status& status) {
+        EXPECT_TRUE(status.ok());
+        read_rows_op_called = true;
+      },
+      [&done_op_called](CompletionQueue& cq, bool& response,
+                        grpc::Status const& status) {
+        EXPECT_TRUE(response);
+        EXPECT_TRUE(status.ok());
+        EXPECT_EQ("mocked-status", status.error_message());
+        done_op_called = true;
+      },
+      bt::RowSet(bt::RowRange::Range("0000", "0005")),
+      bt::RowReader::NO_ROWS_LIMIT, bt::Filter::PassAllFilter());
 
   using bigtable::AsyncOperation;
   impl->SimulateCompletion(cq, true);
@@ -258,19 +260,19 @@ TEST_F(NoexTableAsyncReadRowsTest, Cancelled) {
   bool read_rows_op_called = false;
   bool done_op_called = false;
 
-  table_.AsyncReadRows(bt::RowSet(), bt::RowReader::NO_ROWS_LIMIT,
-                       bt::Filter::PassAllFilter(), cq,
-                       [&read_rows_op_called](CompletionQueue& cq, Row row,
-                                              grpc::Status& status) {
-                         read_rows_op_called = true;
-                       },
-                       [&done_op_called](CompletionQueue& cq, bool& response,
-                                         grpc::Status const& status) {
-                         EXPECT_FALSE(status.ok());
-                         EXPECT_EQ(grpc::StatusCode::CANCELLED,
-                                   status.error_code());
-                         done_op_called = true;
-                       });
+  table_.AsyncReadRows(
+      cq,
+      [&read_rows_op_called](CompletionQueue& cq, Row row,
+                             grpc::Status& status) {
+        read_rows_op_called = true;
+      },
+      [&done_op_called](CompletionQueue& cq, bool& response,
+                        grpc::Status const& status) {
+        EXPECT_FALSE(status.ok());
+        EXPECT_EQ(grpc::StatusCode::CANCELLED, status.error_code());
+        done_op_called = true;
+      },
+      bt::RowSet(), bt::RowReader::NO_ROWS_LIMIT, bt::Filter::PassAllFilter());
 
   using bigtable::AsyncOperation;
   impl->SimulateCompletion(cq, false);
@@ -314,19 +316,19 @@ TEST_F(NoexTableAsyncReadRowsTest, PermanentError) {
   using bigtable::CompletionQueue;
   bigtable::CompletionQueue cq(impl);
 
-  table_.AsyncReadRows(bt::RowSet(), bt::RowReader::NO_ROWS_LIMIT,
-                       bt::Filter::PassAllFilter(), cq,
-                       [&read_rows_op_called](CompletionQueue& cq, Row row,
-                                              grpc::Status& status) {
-                         read_rows_op_called = true;
-                       },
-                       [&done_op_called](CompletionQueue& cq, bool& response,
-                                         grpc::Status const& status) {
-                         EXPECT_FALSE(status.ok());
-                         EXPECT_EQ(grpc::StatusCode::PERMISSION_DENIED,
-                                   status.error_code());
-                         done_op_called = true;
-                       });
+  table_.AsyncReadRows(
+      cq,
+      [&read_rows_op_called](CompletionQueue& cq, Row row,
+                             grpc::Status& status) {
+        read_rows_op_called = true;
+      },
+      [&done_op_called](CompletionQueue& cq, bool& response,
+                        grpc::Status const& status) {
+        EXPECT_FALSE(status.ok());
+        EXPECT_EQ(grpc::StatusCode::PERMISSION_DENIED, status.error_code());
+        done_op_called = true;
+      },
+      bt::RowSet(), bt::RowReader::NO_ROWS_LIMIT, bt::Filter::PassAllFilter());
 
   using bigtable::AsyncOperation;
   impl->SimulateCompletion(cq, false);

--- a/google/cloud/bigtable/table_admin.cc
+++ b/google/cloud/bigtable/table_admin.cc
@@ -45,26 +45,27 @@ btadmin::Table TableAdmin::CreateTable(std::string table_id,
 }
 
 future<google::bigtable::admin::v2::Table> TableAdmin::AsyncCreateTable(
-    std::string table_id, TableConfig config, CompletionQueue& cq) {
+    CompletionQueue& cq, std::string table_id, TableConfig config) {
   promise<google::bigtable::admin::v2::Table> p;
   auto result = p.get_future();
 
   impl_.AsyncCreateTable(
-      std::move(table_id), std::move(config), cq,
-      internal::MakeAsyncFutureFromCallback(std::move(p), "AsyncCreateTable"));
+      cq,
+      internal::MakeAsyncFutureFromCallback(std::move(p), "AsyncCreateTable"),
+      std::move(table_id), std::move(config));
 
   return result;
 }
 
 future<google::bigtable::admin::v2::Table> TableAdmin::AsyncGetTable(
-    std::string const& table_id, btadmin::Table::View view,
-    CompletionQueue& cq) {
+    CompletionQueue& cq, std::string const& table_id,
+    btadmin::Table::View view) {
   promise<google::bigtable::admin::v2::Table> p;
   auto result = p.get_future();
 
   impl_.AsyncGetTable(
-      table_id, view, cq,
-      internal::MakeAsyncFutureFromCallback(std::move(p), "AsyncGetTable"));
+      cq, internal::MakeAsyncFutureFromCallback(std::move(p), "AsyncGetTable"),
+      table_id, view);
 
   return result;
 }

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -137,7 +137,7 @@ class TableAdmin {
    * @snippet table_admin_async_snippets.cc async create table
    */
   future<google::bigtable::admin::v2::Table> AsyncCreateTable(
-      std::string table_id, TableConfig config, CompletionQueue& cq);
+      CompletionQueue& cq, std::string table_id, TableConfig config);
 
   /**
    * Return all the tables in the instance.
@@ -207,8 +207,8 @@ class TableAdmin {
    * @snippet table_admin_async_snippets.cc async get table
    */
   future<google::bigtable::admin::v2::Table> AsyncGetTable(
-      std::string const& table_id,
-      google::bigtable::admin::v2::Table::View view, CompletionQueue& cq);
+      CompletionQueue& cq, std::string const& table_id,
+      google::bigtable::admin::v2::Table::View view);
 
   /**
    * Delete a table.

--- a/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
@@ -80,13 +80,13 @@ TEST_F(AdminAsyncFutureIntegrationTest, CreateListGetDeleteTableTest) {
                            {"a1000", "a2000", "b3000", "m5000"});
 
   future<void> chain =
-      table_admin_->AsyncCreateTable(table_id, table_config, cq)
+      table_admin_->AsyncCreateTable(cq, table_id, table_config)
           .then([&](future<btadmin::Table> fut) {
             btadmin::Table result = fut.get();
             EXPECT_THAT(result.name(), ::testing::HasSubstr(table_id));
 
-            return table_admin_->AsyncGetTable(table_id, btadmin::Table::FULL,
-                                               cq);
+            return table_admin_->AsyncGetTable(cq, table_id,
+                                               btadmin::Table::FULL);
           })
           .then([&](future<btadmin::Table> fut) {
             btadmin::Table get_result = fut.get();
@@ -106,7 +106,7 @@ TEST_F(AdminAsyncFutureIntegrationTest, CreateListGetDeleteTableTest) {
           });
 
   chain.get();
-  SUCCEED(); // we expect that previous operations do not fail.
+  SUCCEED();  // we expect that previous operations do not fail.
   DeleteTable(table_id);
 
   cq.Shutdown();

--- a/google/cloud/bigtable/tests/admin_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_async_integration_test.cc
@@ -80,21 +80,23 @@ TEST_F(AdminAsyncIntegrationTest, CreateListGetDeleteTableTest) {
                            {"a1000", "a2000", "b3000", "m5000"});
   std::promise<btadmin::Table> promise_create_table;
   noex_table_admin_->AsyncCreateTable(
-      table_id, table_config, cq,
+      cq,
       [&promise_create_table](CompletionQueue& cq, btadmin::Table& table,
                               grpc::Status const& status) {
         promise_create_table.set_value(std::move(table));
-      });
+      },
+      table_id, table_config);
 
   auto table = promise_create_table.get_future().get();
 
   std::promise<btadmin::Table> promise_get_table;
   noex_table_admin_->AsyncGetTable(
-      table_id, btadmin::Table::FULL, cq,
+      cq,
       [&promise_get_table](CompletionQueue& cq, btadmin::Table& table,
                            grpc::Status const& status) {
         promise_get_table.set_value(std::move(table));
-      });
+      },
+      table_id, btadmin::Table::FULL);
 
   auto table_result = promise_get_table.get_future().get();
 
@@ -128,11 +130,12 @@ TEST_F(AdminAsyncIntegrationTest, CreateListGetDeleteTableTest) {
   std::promise<btadmin::Table> promise_column_family;
 
   noex_table_admin_->AsyncModifyColumnFamilies(
-      table_id, column_modification_list, cq,
+      cq,
       [&promise_column_family](CompletionQueue& cq, btadmin::Table& table,
                                grpc::Status const& status) {
         promise_column_family.set_value(std::move(table));
-      });
+      },
+      table_id, column_modification_list);
 
   auto table_modified = promise_column_family.get_future().get();
 
@@ -146,12 +149,13 @@ TEST_F(AdminAsyncIntegrationTest, CreateListGetDeleteTableTest) {
   // AsyncDeleteTable
   std::promise<google::protobuf::Empty> promise_delete_table;
   noex_table_admin_->AsyncDeleteTable(
-      table_id, table_config, cq,
+      cq,
       [&promise_delete_table](CompletionQueue& cq,
                               google::protobuf::Empty& response,
                               grpc::Status const& status) {
         promise_delete_table.set_value(std::move(response));
-      });
+      },
+      table_id, table_config);
   auto result = promise_delete_table.get_future().get();
 
   // List to verify it is no longer there
@@ -181,11 +185,12 @@ TEST_F(AdminAsyncIntegrationTest, AsyncDropRowsByPrefixTest) {
 
   std::promise<btadmin::Table> promise_create_table;
   noex_table_admin_->AsyncCreateTable(
-      table_id, table_config, cq,
+      cq,
       [&promise_create_table](CompletionQueue& cq, btadmin::Table& table,
                               grpc::Status const& status) {
         promise_create_table.set_value(std::move(table));
-      });
+      },
+      table_id, table_config);
 
   auto table_created = promise_create_table.get_future().get();
 
@@ -216,12 +221,13 @@ TEST_F(AdminAsyncIntegrationTest, AsyncDropRowsByPrefixTest) {
   // Delete all the records for a row
   std::promise<google::protobuf::Empty> promise_drop_row;
   noex_table_admin_->AsyncDropRowsByPrefix(
-      table_id, row_key1_prefix, cq,
+      cq,
       [&promise_drop_row](CompletionQueue& cq,
                           google::protobuf::Empty& response,
                           grpc::Status const& status) {
         promise_drop_row.set_value(std::move(response));
-      });
+      },
+      table_id, row_key1_prefix);
 
   auto response = promise_drop_row.get_future().get();
   auto actual_cells = ReadRows(table, bigtable::Filter::PassAllFilter());
@@ -249,11 +255,12 @@ TEST_F(AdminAsyncIntegrationTest, AsyncDropAllRowsTest) {
 
   std::promise<btadmin::Table> promise_create_table;
   noex_table_admin_->AsyncCreateTable(
-      table_id, table_config, cq,
+      cq,
       [&promise_create_table](CompletionQueue& cq, btadmin::Table& table,
                               grpc::Status const& status) {
         promise_create_table.set_value(std::move(table));
-      });
+      },
+      table_id, table_config);
 
   auto table_created = promise_create_table.get_future().get();
 
@@ -276,12 +283,13 @@ TEST_F(AdminAsyncIntegrationTest, AsyncDropAllRowsTest) {
   // Delete all the records from a table
   std::promise<google::protobuf::Empty> promise_drop_row;
   noex_table_admin_->AsyncDropAllRows(
-      table_id, cq,
+      cq,
       [&promise_drop_row](CompletionQueue& cq,
                           google::protobuf::Empty& response,
                           grpc::Status const& status) {
         promise_drop_row.set_value(std::move(response));
-      });
+      },
+      table_id);
   auto response = promise_drop_row.get_future().get();
 
   auto actual_cells = ReadRows(table, bigtable::Filter::PassAllFilter());
@@ -367,10 +375,11 @@ TEST_F(AdminAsyncIntegrationTest, CheckConsistencyIntegrationTest) {
 
   std::promise<grpc::Status> consistent_promise;
   noex_table_admin->AsyncAwaitConsistency(
-      table_id, cq,
+      cq,
       [&consistent_promise](CompletionQueue& cq, grpc::Status& status) {
         consistent_promise.set_value(status);
-      });
+      },
+      table_id);
 
   EXPECT_TRUE(consistent_promise.get_future().get().ok());
 

--- a/google/cloud/bigtable/tests/instance_admin_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_async_future_integration_test.cc
@@ -116,7 +116,7 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest,
 
   // Get instance
   google::cloud::future<btadmin::Instance> fut =
-      instance_admin_->AsyncGetInstance(instance_id, cq);
+      instance_admin_->AsyncGetInstance(cq, instance_id);
   auto instance_check = fut.get();
   auto const npos = std::string::npos;
   EXPECT_NE(npos, instance_check.name().find(instance_admin_->project_name()));
@@ -179,7 +179,7 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest,
 
   // Get cluster
   google::cloud::future<btadmin::Cluster> fut =
-      instance_admin_->AsyncGetCluster(instance_id, cluster_id, cq);
+      instance_admin_->AsyncGetCluster(cq, instance_id, cluster_id);
   auto cluster_check = fut.get();
   std::string cluster_name_prefix =
       instance_admin_->project_name() + "/instances/" + id + "/clusters/";

--- a/google/cloud/bigtable/tests/instance_admin_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_async_integration_test.cc
@@ -129,12 +129,13 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteInstanceTest) {
   auto config = IntegrationTestConfig(instance_id);
   std::promise<btadmin::Instance> create_promise;
   admin.AsyncCreateInstance(
-      config, cq,
+      cq,
       [&create_promise](google::cloud::bigtable::CompletionQueue&,
                         btadmin::Instance& response, grpc::Status& status) {
         ASSERT_TRUE(status.ok());
         create_promise.set_value(std::move(response));
-      });
+      },
+      config);
   auto instance = create_promise.get_future().get();
   auto instances_current = instance_admin_->ListInstances();
   EXPECT_TRUE(IsInstancePresent(instances_current, instance.name()));
@@ -142,11 +143,12 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteInstanceTest) {
   // Get instance
   std::promise<btadmin::Instance> done;
   admin.AsyncGetInstance(
-      instance_id, cq,
+      cq,
       [&done](google::cloud::bigtable::CompletionQueue& cq,
               btadmin::Instance& instance, grpc::Status const& status) {
         done.set_value(std::move(instance));
-      });
+      },
+      instance_id);
   auto instance_result = done.get_future().get();
   auto const npos = std::string::npos;
   EXPECT_NE(npos, instance_result.name().find(instance_admin_->project_name()));
@@ -155,12 +157,13 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteInstanceTest) {
   // Delete instance
   std::promise<google::protobuf::Empty> promise_delete_instance;
   admin.AsyncDeleteInstance(
-      instance_id, cq,
+      cq,
       [&promise_delete_instance](google::cloud::bigtable::CompletionQueue& cq,
                                  google::protobuf::Empty& response,
                                  grpc::Status const& status) {
         promise_delete_instance.set_value(std::move(response));
-      });
+      },
+      instance_id);
   auto response = promise_delete_instance.get_future().get();
   auto instances_after_delete = instance_admin_->ListInstances();
   EXPECT_TRUE(IsInstancePresent(instances_current, instance.name()));
@@ -189,26 +192,28 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteClusterTest) {
 
   std::promise<btadmin::Instance> create_instance_promise;
   admin.AsyncCreateInstance(
-      instance_config, cq,
+      cq,
       [&create_instance_promise](google::cloud::bigtable::CompletionQueue&,
                                  btadmin::Instance& response,
                                  grpc::Status& status) {
         ASSERT_TRUE(status.ok());
         create_instance_promise.set_value(std::move(response));
-      });
+      },
+      instance_config);
   auto instance_details = create_instance_promise.get_future().get();
 
   // create cluster
   std::promise<bigtable::ClusterList> clusters_before_promise;
   admin.AsyncListClusters(
-      id, cq,
+      cq,
       [&clusters_before_promise](bigtable::CompletionQueue&,
                                  bigtable::ClusterList& response,
                                  grpc::Status& status) {
         ASSERT_TRUE(status.ok());
         ASSERT_TRUE(response.failed_locations.empty());
         clusters_before_promise.set_value(response);
-      });
+      },
+      id);
   auto clusters_before = clusters_before_promise.get_future().get().clusters;
   ASSERT_FALSE(IsClusterPresent(clusters_before, cluster_id_str))
       << "Cluster (" << cluster_id_str << ") already exists."
@@ -220,23 +225,25 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteClusterTest) {
       bigtable::ClusterConfig(InstanceTestEnvironment::replication_zone(), 3,
                               bigtable::ClusterConfig::HDD);
   admin.AsyncCreateCluster(
-      cluster_config, instance_id, cluster_id, cq,
+      cq,
       [&create_promise](google::cloud::bigtable::CompletionQueue&,
                         btadmin::Cluster& response, grpc::Status& status) {
         ASSERT_TRUE(status.ok());
         create_promise.set_value(std::move(response));
-      });
+      },
+      cluster_config, instance_id, cluster_id);
   auto cluster = create_promise.get_future().get();
   std::promise<bigtable::ClusterList> clusters_after_promise;
   admin.AsyncListClusters(
-      id, cq,
+      cq,
       [&clusters_after_promise](bigtable::CompletionQueue&,
                                 bigtable::ClusterList& response,
                                 grpc::Status& status) {
         ASSERT_TRUE(status.ok());
         ASSERT_TRUE(response.failed_locations.empty());
         clusters_after_promise.set_value(response);
-      });
+      },
+      id);
   auto clusters_after = clusters_after_promise.get_future().get().clusters;
   EXPECT_FALSE(IsClusterPresent(clusters_before, cluster.name()));
   EXPECT_TRUE(IsClusterPresent(clusters_after, cluster.name()));
@@ -244,11 +251,12 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteClusterTest) {
   // Get cluster
   std::promise<btadmin::Cluster> done;
   admin.AsyncGetCluster(
-      instance_id, cluster_id, cq,
+      cq,
       [&done](google::cloud::bigtable::CompletionQueue& cq,
               btadmin::Cluster& cluster, grpc::Status const& status) {
         done.set_value(std::move(cluster));
-      });
+      },
+      instance_id, cluster_id);
   auto cluster_result = done.get_future().get();
   std::string cluster_name_prefix =
       instance_admin_->project_name() + "/instances/" + id + "/clusters/";
@@ -257,12 +265,13 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteClusterTest) {
   // Delete cluster
   std::promise<google::protobuf::Empty> promise_delete_cluster;
   admin.AsyncDeleteCluster(
-      instance_id, cluster_id, cq,
+      cq,
       [&promise_delete_cluster](google::cloud::bigtable::CompletionQueue& cq,
                                 google::protobuf::Empty& response,
                                 grpc::Status const& status) {
         promise_delete_cluster.set_value(std::move(response));
-      });
+      },
+      instance_id, cluster_id);
   auto response = promise_delete_cluster.get_future().get();
   auto clusters_after_delete = instance_admin_->ListClusters(id);
   instance_admin_->DeleteInstance(id);
@@ -301,13 +310,14 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteAppProfile) {
 
   std::promise<std::vector<btadmin::AppProfile>> initial_appprofiles_promise;
   admin.AsyncListAppProfiles(
-      instance_id, cq,
+      cq,
       [&initial_appprofiles_promise](bigtable::CompletionQueue&,
                                      std::vector<btadmin::AppProfile>& response,
                                      grpc::Status& status) {
         ASSERT_TRUE(status.ok());
         initial_appprofiles_promise.set_value(response);
-      });
+      },
+      instance_id);
   auto initial_profiles = initial_appprofiles_promise.get_future().get();
 
   // Simplify writing the rest of the test.
@@ -326,55 +336,57 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteAppProfile) {
   // Create First profile
   std::promise<btadmin::AppProfile> promise_create_first_profile;
   admin.AsyncCreateAppProfile(
-      bigtable::InstanceId(instance_id),
-      bigtable::AppProfileConfig::MultiClusterUseAny(
-          bigtable::AppProfileId(id1)),
       cq,
       [&promise_create_first_profile](
           google::cloud::bigtable::CompletionQueue& cq,
           btadmin::AppProfile& app_profiles, grpc::Status const& status) {
         promise_create_first_profile.set_value(std::move(app_profiles));
-      });
+      },
+      bigtable::InstanceId(instance_id),
+      bigtable::AppProfileConfig::MultiClusterUseAny(
+          bigtable::AppProfileId(id1)));
   auto response_create_first_profile =
       promise_create_first_profile.get_future().get();
 
   // Create second profile
   std::promise<btadmin::AppProfile> promise_create_second_profile;
   admin.AsyncCreateAppProfile(
-      bigtable::InstanceId(instance_id),
-      bigtable::AppProfileConfig::MultiClusterUseAny(
-          bigtable::AppProfileId(id2)),
       cq,
       [&promise_create_second_profile](
           google::cloud::bigtable::CompletionQueue& cq,
           btadmin::AppProfile& app_profiles, grpc::Status const& status) {
         promise_create_second_profile.set_value(std::move(app_profiles));
-      });
+      },
+      bigtable::InstanceId(instance_id),
+      bigtable::AppProfileConfig::MultiClusterUseAny(
+          bigtable::AppProfileId(id2)));
   auto response_create_second_profile =
       promise_create_second_profile.get_future().get();
 
   std::promise<std::vector<btadmin::AppProfile>>
       after_second_appprofiles_promise;
   admin.AsyncListAppProfiles(
-      instance_id, cq,
+      cq,
       [&after_second_appprofiles_promise](
           bigtable::CompletionQueue&,
           std::vector<btadmin::AppProfile>& response, grpc::Status& status) {
         ASSERT_TRUE(status.ok());
         after_second_appprofiles_promise.set_value(response);
-      });
+      },
+      instance_id);
   auto current_profiles = after_second_appprofiles_promise.get_future().get();
   EXPECT_EQ(1U, count_matching_profiles(id1, current_profiles));
   EXPECT_EQ(1U, count_matching_profiles(id2, current_profiles));
 
   std::promise<btadmin::AppProfile> promise_get_profile_1;
   admin.AsyncGetAppProfile(
-      bigtable::InstanceId(instance_id), bigtable::AppProfileId(id1), cq,
+      cq,
       [&promise_get_profile_1](google::cloud::bigtable::CompletionQueue& cq,
                                btadmin::AppProfile& app_profiles,
                                grpc::Status const& status) {
         promise_get_profile_1.set_value(std::move(app_profiles));
-      });
+      },
+      bigtable::InstanceId(instance_id), bigtable::AppProfileId(id1));
   auto detail_1 = promise_get_profile_1.get_future().get();
   EXPECT_EQ(detail_1.name(), response_create_first_profile.name());
   EXPECT_THAT(detail_1.name(), HasSubstr(instance_id));
@@ -382,12 +394,13 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteAppProfile) {
 
   std::promise<btadmin::AppProfile> promise_get_profile_2;
   admin.AsyncGetAppProfile(
-      bigtable::InstanceId(instance_id), bigtable::AppProfileId(id2), cq,
+      cq,
       [&promise_get_profile_2](google::cloud::bigtable::CompletionQueue& cq,
                                btadmin::AppProfile& app_profiles,
                                grpc::Status const& status) {
         promise_get_profile_2.set_value(std::move(app_profiles));
-      });
+      },
+      bigtable::InstanceId(instance_id), bigtable::AppProfileId(id2));
   auto detail_2 = promise_get_profile_2.get_future().get();
   EXPECT_EQ(detail_2.name(), response_create_second_profile.name());
   EXPECT_THAT(detail_2.name(), HasSubstr(instance_id));
@@ -396,23 +409,25 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteAppProfile) {
   // update profile
   std::promise<btadmin::AppProfile> update_promise;
   admin.AsyncUpdateAppProfile(
-      bigtable::InstanceId(instance_id), bigtable::AppProfileId(id2),
-      bigtable::AppProfileUpdateConfig().set_description("new description"), cq,
+      cq,
       [&update_promise](google::cloud::bigtable::CompletionQueue&,
                         btadmin::AppProfile& response, grpc::Status& status) {
         ASSERT_TRUE(status.ok());
         update_promise.set_value(std::move(response));
-      });
+      },
+      bigtable::InstanceId(instance_id), bigtable::AppProfileId(id2),
+      bigtable::AppProfileUpdateConfig().set_description("new description"));
   auto update_2 = update_promise.get_future().get();
 
   std::promise<btadmin::AppProfile> promise_get_profile_after_update;
   admin.AsyncGetAppProfile(
-      bigtable::InstanceId(instance_id), bigtable::AppProfileId(id2), cq,
+      cq,
       [&promise_get_profile_after_update](
           google::cloud::bigtable::CompletionQueue& cq,
           btadmin::AppProfile& app_profiles, grpc::Status const& status) {
         promise_get_profile_after_update.set_value(std::move(app_profiles));
-      });
+      },
+      bigtable::InstanceId(instance_id), bigtable::AppProfileId(id2));
   auto detail_2_after_update =
       promise_get_profile_after_update.get_future().get();
   EXPECT_EQ("new description", update_2.description());
@@ -421,25 +436,27 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteAppProfile) {
   // delete first profile
   std::promise<google::protobuf::Empty> promise_delete_first_profile;
   admin.AsyncDeleteAppProfile(
-      bigtable::InstanceId(instance_id), bigtable::AppProfileId(id1), cq,
+      cq,
       [&promise_delete_first_profile](
           google::cloud::bigtable::CompletionQueue& cq,
           google::protobuf::Empty& response, grpc::Status const& status) {
         promise_delete_first_profile.set_value(std::move(response));
-      });
+      },
+      bigtable::InstanceId(instance_id), bigtable::AppProfileId(id1));
   auto response_delete_first_profile =
       promise_delete_first_profile.get_future().get();
 
   std::promise<std::vector<btadmin::AppProfile>>
       after_delete_appprofiles_promise;
   admin.AsyncListAppProfiles(
-      instance_id, cq,
+      cq,
       [&after_delete_appprofiles_promise](
           bigtable::CompletionQueue&,
           std::vector<btadmin::AppProfile>& response, grpc::Status& status) {
         ASSERT_TRUE(status.ok());
         after_delete_appprofiles_promise.set_value(response);
-      });
+      },
+      instance_id);
   current_profiles = after_delete_appprofiles_promise.get_future().get();
   EXPECT_EQ(0U, count_matching_profiles(id1, current_profiles));
   EXPECT_EQ(1U, count_matching_profiles(id2, current_profiles));
@@ -447,25 +464,27 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteAppProfile) {
   // delete second profile
   std::promise<google::protobuf::Empty> promise_delete_second_profile;
   admin.AsyncDeleteAppProfile(
-      bigtable::InstanceId(instance_id), bigtable::AppProfileId(id2), cq,
+      cq,
       [&promise_delete_second_profile](
           google::cloud::bigtable::CompletionQueue& cq,
           google::protobuf::Empty& response, grpc::Status const& status) {
         promise_delete_second_profile.set_value(std::move(response));
-      });
+      },
+      bigtable::InstanceId(instance_id), bigtable::AppProfileId(id2));
   auto response_delete_second_profile =
       promise_delete_second_profile.get_future().get();
 
   std::promise<std::vector<btadmin::AppProfile>>
       after_delete_second_appprofiles_promise;
   admin.AsyncListAppProfiles(
-      instance_id, cq,
+      cq,
       [&after_delete_second_appprofiles_promise](
           bigtable::CompletionQueue&,
           std::vector<btadmin::AppProfile>& response, grpc::Status& status) {
         ASSERT_TRUE(status.ok());
         after_delete_second_appprofiles_promise.set_value(response);
-      });
+      },
+      instance_id);
   current_profiles = after_delete_second_appprofiles_promise.get_future().get();
   EXPECT_EQ(0U, count_matching_profiles(id1, current_profiles));
   EXPECT_EQ(0U, count_matching_profiles(id2, current_profiles));

--- a/google/cloud/bigtable/tests/snapshot_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/snapshot_async_integration_test.cc
@@ -82,11 +82,12 @@ TEST_F(SnapshotAsyncIntegrationTest, CreateListGetDeleteSnapshot) {
 
   std::promise<btadmin::Table> promise_create_table;
   noex_table_admin_->AsyncCreateTable(
-      table_id.get(), table_config, cq,
+      cq,
       [&promise_create_table](CompletionQueue& cq, btadmin::Table& table,
                               grpc::Status const& status) {
         promise_create_table.set_value(std::move(table));
-      });
+      },
+      table_id.get(), table_config);
 
   auto table_created = promise_create_table.get_future().get();
 
@@ -122,11 +123,12 @@ TEST_F(SnapshotAsyncIntegrationTest, CreateListGetDeleteSnapshot) {
   // get snapshot
   std::promise<btadmin::Snapshot> promise_get_snapshot;
   noex_table_admin_->AsyncGetSnapshot(
-      cluster_id, snapshot_id, cq,
+      cq,
       [&promise_get_snapshot](CompletionQueue& cq, btadmin::Snapshot& snapshot,
                               grpc::Status const& status) {
         promise_get_snapshot.set_value(std::move(snapshot));
-      });
+      },
+      cluster_id, snapshot_id);
 
   auto snapshot_check = promise_get_snapshot.get_future().get();
   auto const npos = std::string::npos;
@@ -134,12 +136,13 @@ TEST_F(SnapshotAsyncIntegrationTest, CreateListGetDeleteSnapshot) {
 
   std::promise<google::protobuf::Empty> promise_delete_snapshot;
   noex_table_admin_->AsyncDeleteSnapshot(
-      cluster_id, snapshot_id, cq,
+      cq,
       [&promise_delete_snapshot](CompletionQueue& cq,
                                  google::protobuf::Empty& response,
                                  grpc::Status const& status) {
         promise_delete_snapshot.set_value(std::move(response));
-      });
+      },
+      cluster_id, snapshot_id);
 
   auto response = promise_delete_snapshot.get_future().get();
 


### PR DESCRIPTION
As described in #1543, it seems better to move the arguments for a
`Async*()` function to be

```C++
AsyncBlah(CompletionQueue& cq, Functor&& callback, Foo)
```

This fixes #1543.