### PR TITLE
Fix ambiguous error when compiling with libc++

### DIFF
--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -743,7 +743,7 @@ BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetRetentionPolicy(
   // fields.
   impl_.AddSubPatch("retentionPolicy",
                     internal::PatchBuilder().SetIntField(
-                        "retentionPeriod", v.retention_period.count()));
+                        "retentionPeriod", static_cast<std::uint64_t>(v.retention_period.count())));
   return *this;
 }
 


### PR DESCRIPTION
Fixes #1761 

Using a cast here to be explicit since Nhjson uses `std::uint64_t`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1765)
<!-- Reviewable:end -->
