### PR TITLE
Use the right protoc compiler.

### DIFF
--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -58,11 +58,11 @@ function (PROTOBUF_GENERATE_CPP SRCS HDRS)
         list(APPEND ${HDRS} ${HDR})
         add_custom_command(
             OUTPUT ${SRC} ${HDR}
-            COMMAND protoc
+            COMMAND $<TARGET_FILE:protobuf::protoc>
                     ARGS
                     --cpp_out ${CMAKE_CURRENT_BINARY_DIR}
                               ${_protobuf_include_path} ${FIL}
-            DEPENDS ${FIL} protoc
+            DEPENDS ${FIL} protobuf::protoc
             COMMENT "Running C++ protocol buffer compiler on ${FIL}"
             VERBATIM)
     endforeach ()
@@ -144,13 +144,13 @@ function (GRPC_GENERATE_CPP_BASE SRCS HDRS MHDRS WITH_MOCK)
         add_custom_command(
             OUTPUT "${SRC}" "${HDR}"
             COMMAND
-                protoc
+                $<TARGET_FILE:protobuf::protoc>
                 ARGS
                 --plugin=protoc-gen-grpc=$<TARGET_FILE:grpc_cpp_plugin>
                 --grpc_out=${GRPC_OUT_EXTRA}${CMAKE_CURRENT_BINARY_DIR}
                 --cpp_out=${CMAKE_CURRENT_BINARY_DIR} ${_protobuf_include_path}
                                                       ${FIL}
-            DEPENDS ${FIL} protoc grpc_cpp_plugin
+            DEPENDS ${FIL} protobuf::protoc grpc_cpp_plugin
             COMMENT "Running gRPC++ protocol buffer compiler on ${FIL}"
             VERBATIM)
     endforeach ()

--- a/cmake/IncludeGrpc.cmake
+++ b/cmake/IncludeGrpc.cmake
@@ -49,10 +49,12 @@ set(GOOGLE_CLOUD_CPP_MSVC_COMPILE_OPTIONS
     /wd4838
     /wd4996)
 
+# gRPC depends on protobuf, so include that too.
+include(IncludeProtobuf)
+
 if ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "external")
     include(external/grpc)
 elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "package")
-    find_package(protobuf REQUIRED protobuf>=3.5.2)
     find_package(gRPC REQUIRED gRPC>=1.9)
 
     if (NOT TARGET protobuf::libprotobuf)
@@ -100,19 +102,6 @@ elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "package")
                               ${GOOGLE_CLOUD_CPP_MSVC_COMPILE_OPTIONS})
     endif (MSVC)
 
-    # Discover the protobuf compiler and the gRPC plugin.
-    find_program(
-        PROTOBUF_PROTOC_EXECUTABLE
-        NAMES protoc
-        DOC "The Google Protocol Buffers Compiler"
-        PATHS
-            ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Release
-            ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Debug)
-    mark_as_advanced(PROTOBUF_PROTOC_EXECUTABLE)
-    add_executable(protoc IMPORTED)
-    set_property(TARGET protoc
-                 PROPERTY IMPORTED_LOCATION ${PROTOBUF_PROTOC_EXECUTABLE})
-
     find_program(
         PROTOC_GRPCPP_PLUGIN_EXECUTABLE
         NAMES grpc_cpp_plugin
@@ -136,18 +125,6 @@ elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "pkg-config")
     # Use pkg-config to find the libraries.
     find_package(PkgConfig REQUIRED)
 
-    # We need a helper function to convert pkg-config(1) output into target
-    # properties.
-    include(${CMAKE_CURRENT_LIST_DIR}/PkgConfigHelper.cmake)
-
-    pkg_check_modules(Protobuf REQUIRED protobuf>=3.5)
-    add_library(protobuf::libprotobuf INTERFACE IMPORTED)
-    set_library_properties_from_pkg_config(protobuf::libprotobuf Protobuf)
-    set_property(TARGET protobuf::libprotobuf
-                 APPEND
-                 PROPERTY INTERFACE_LINK_LIBRARIES Threads::Threads)
-    list(APPEND PROTOBUF_IMPORT_DIRS ${Protobuf_INCLUDE_DIRS})
-
     pkg_check_modules(gRPC REQUIRED grpc>=1.9)
     add_library(gRPC::grpc INTERFACE IMPORTED)
     set_library_properties_from_pkg_config(gRPC::grpc gRPC)
@@ -161,19 +138,6 @@ elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "pkg-config")
     set_property(TARGET gRPC::grpc++
                  APPEND
                  PROPERTY INTERFACE_LINK_LIBRARIES gRPC::grpc)
-
-    # Discover the protobuf compiler and the gRPC plugin.
-    find_program(
-        PROTOBUF_PROTOC_EXECUTABLE
-        NAMES protoc
-        DOC "The Google Protocol Buffers Compiler"
-        PATHS
-            ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Release
-            ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Debug)
-    mark_as_advanced(PROTOBUF_PROTOC_EXECUTABLE)
-    add_executable(protoc IMPORTED)
-    set_property(TARGET protoc
-                 PROPERTY IMPORTED_LOCATION ${PROTOBUF_PROTOC_EXECUTABLE})
 
     find_program(
         PROTOC_GRPCPP_PLUGIN_EXECUTABLE

--- a/cmake/IncludeProtobuf.cmake
+++ b/cmake/IncludeProtobuf.cmake
@@ -1,0 +1,75 @@
+# ~~~
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+# protobuf always requires thread support.
+find_package(Threads REQUIRED)
+
+# Configure the protobuf dependency, this can be found as a external project,
+# package, or  installed with pkg-config support.
+set(GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER ${GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER}
+    CACHE STRING "How to find protobuf libraries and compiler")
+set_property(CACHE GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER
+             PROPERTY STRINGS
+                      "external"
+                      "package"
+                      "pkg-config")
+
+function (define_protobuf_protoc_target)
+    if (NOT TARGET protobuf::protoc)
+        # Discover the protobuf compiler and the gRPC plugin.
+        find_program(
+            PROTOBUF_PROTOC_EXECUTABLE
+            NAMES protoc
+            DOC "The Google Protocol Buffers Compiler"
+            PATHS
+                ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Release
+                ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Debug
+            )
+        mark_as_advanced(PROTOBUF_PROTOC_EXECUTABLE)
+        add_executable(protobuf::protoc IMPORTED)
+        set_property(TARGET protobuf::protoc
+                     PROPERTY IMPORTED_LOCATION ${PROTOBUF_PROTOC_EXECUTABLE})
+    endif ()
+endfunction ()
+
+if ("${GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER}" STREQUAL "external")
+    include(external/protobuf)
+elseif("${GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER}" STREQUAL "package")
+    find_package(protobuf REQUIRED protobuf>=3.5.2)
+
+    # Older versions of CMake (<= 3.9) do not define the protobuf::protoc
+    # target, in this case we define it ourselves to simplify how the rest of
+    # the build scripts are constructed.
+    define_protobuf_protoc_target()
+elseif("${GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER}" STREQUAL "pkg-config")
+    # Use pkg-config to find the libraries.
+    find_package(PkgConfig REQUIRED)
+
+    # We need a helper function to convert pkg-config(1) output into target
+    # properties.
+    include(${CMAKE_CURRENT_LIST_DIR}/PkgConfigHelper.cmake)
+
+    pkg_check_modules(Protobuf REQUIRED protobuf>=3.5)
+    add_library(protobuf::libprotobuf INTERFACE IMPORTED)
+    set_library_properties_from_pkg_config(protobuf::libprotobuf Protobuf)
+    set_property(TARGET protobuf::libprotobuf
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES Threads::Threads)
+    list(APPEND PROTOBUF_IMPORT_DIRS ${Protobuf_INCLUDE_DIRS})
+
+    # Discover the protobuf compiler and the gRPC plugin.
+    define_protobuf_protoc_target()
+endif ()

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -78,4 +78,11 @@ if (NOT TARGET protobuf_project)
                           protobuf::libprotobuf
                           ZLIB::ZLIB
                           Threads::Threads)
+    add_executable(protobuf::protoc IMPORTED)
+    set_property(
+        TARGET protobuf::protoc
+        PROPERTY
+            IMPORTED_LOCATION
+            "${PROJECT_BINARY_DIR}/external/bin/protoc${CMAKE_EXECUTABLE_SUFFIX}"
+        )
 endif ()


### PR DESCRIPTION
The rules in CompileProtos.cmake were picking up whatever protoc binary
happened to be in the path. This is "Not Right"[tm], because the version
in the path may not be compatible with the version of the protobuf
libraries found by CMake.

With this change we use the `protobuf::protoc` target. We define this
target for external projects, and for versions of FindProtobuf that do
not provide the target.

This fixes #1762.