### PR TITLE
Fix some targets missing dependency on common_options

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -170,7 +170,8 @@ if (BUILD_TESTING)
                 testing_util/testing_types.h
                 testing_util/testing_types.cc)
     target_link_libraries(google_cloud_cpp_testing
-                          PUBLIC google_cloud_cpp_common GTest::gmock)
+                          PUBLIC google_cloud_cpp_common GTest::gmock
+                          PRIVATE google_cloud_cpp_common_options)
 
     create_bazel_config(google_cloud_cpp_testing)
 

--- a/google/cloud/firestore/CMakeLists.txt
+++ b/google/cloud/firestore/CMakeLists.txt
@@ -58,7 +58,9 @@ export_variables_to_bazel("firestore_client_version.bzl"
 
 # the client library
 add_library(firestore_client field_path.h field_path.cc)
-target_link_libraries(firestore_client PUBLIC google_cloud_cpp_common)
+target_link_libraries(firestore_client
+                      PUBLIC google_cloud_cpp_common
+                      PRIVATE firestore_common_options)
 target_include_directories(firestore_client
                            PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
                                   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
@@ -120,7 +122,7 @@ install(TARGETS
 install(EXPORT firestore-targets
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/firestore_client")
 
-install(TARGETS firestore_client
+install(TARGETS firestore_client firestore_common_options
         EXPORT firestore-targets
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/google/cloud/firestore/field_path.cc
+++ b/google/cloud/firestore/field_path.cc
@@ -102,7 +102,7 @@ bool FieldPath::operator<(FieldPath const& other) const {
   auto const this_size = this->parts_.size();
   auto const other_size = other.size();
   auto const min_length = std::min(this_size, other_size);
-  for (auto i = 0; i < min_length; i++) {
+  for (auto i = 0u; i < min_length; i++) {
     if (this->parts_[i] < other.parts_[i]) {
       return true;
     }


### PR DESCRIPTION
This includes the unsigned fix because including the options enables `Werror` and `Wall`, breaking the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1772)
<!-- Reviewable:end -->
