### PR TITLE
Separate Docker build output directories.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -172,7 +172,6 @@ cache:
     # Cache the Bazel directories, in builds that do not use Bazel this is
     # empty and trivial to cache.
     - $HOME/.cache/bazel
-    - build-output/cache
     - build-output/ccache
   timeout: 900
 

--- a/ci/travis/build-linux.sh
+++ b/ci/travis/build-linux.sh
@@ -37,7 +37,7 @@ fi
 
 # Use a volume to store the cache files. This exports the cache files from the
 # Docker container, and then we can save them for future Travis builds.
-test -d "${PWD}/${DOCKER_CCACHE_DIR}" || mkdir -p "${PWD}/${DOCKER_CCACHE_DIR}"
+mkdir -p "${PWD}/${DOCKER_CCACHE_DIR}"
 
 sudo docker run \
      --cap-add SYS_PTRACE \

--- a/ci/travis/build-linux.sh
+++ b/ci/travis/build-linux.sh
@@ -37,8 +37,7 @@ fi
 
 # Use a volume to store the cache files. This exports the cache files from the
 # Docker container, and then we can save them for future Travis builds.
-test -d "${PWD}/build-output/cache" || mkdir -p "${PWD}/build-output/cache"
-test -d "${PWD}/build-output/ccache" || mkdir -p "${PWD}/build-output/ccache"
+test -d "${PWD}/${DOCKER_CCACHE_DIR}" || mkdir -p "${PWD}/${DOCKER_CCACHE_DIR}"
 
 sudo docker run \
      --cap-add SYS_PTRACE \
@@ -63,8 +62,7 @@ sudo docker run \
      --env TRAVIS_OS_NAME="${TRAVIS_OS_NAME}" \
      --user "${docker_uid}" \
      --volume "${PWD}":/v \
-     --volume "${PWD}/build-output/cache":${docker_home}/.cache \
-     --volume "${PWD}/build-output/ccache":${docker_home}/.ccache \
+     --volume "${PWD}/${DOCKER_CCACHE_DIR}":${docker_home}/.ccache \
      --workdir /v \
      "${IMAGE}:tip" \
      "/v/ci/travis/build-docker.sh"

--- a/ci/travis/linux-config.sh
+++ b/ci/travis/linux-config.sh
@@ -24,6 +24,38 @@ fi
 if [[ -n "${IMAGE+x}" ]]; then
   echo "IMAGE is already defined."
 else
-  readonly IMAGE="cached-${DISTRO}-${DISTRO_VERSION}"
-  readonly BUILD_OUTPUT="build-output/${IMAGE}"
+  readonly IMAGE="${DISTRO}-${DISTRO_VERSION}"
+  suffix=""
+  if [[ -n "${CC:-}" ]]; then
+    suffix="${suffix}-${CC}"
+  fi
+  if [[ -n "${BUILD_TYPE+x}" ]]; then
+    suffix="${suffix}-${BUILD_TYPE}"
+  else
+    suffix="${suffix}-Release"
+  fi
+  if [[ "${SCAN_BUILD+x}" = "yes" ]]; then
+    suffix="${suffix}-scan"
+  fi
+  if [[ -z "${CMAKE_FLAGS:-}" ]]; then
+      /bin/true
+  elif echo "${CMAKE_FLAGS}" | grep -Eq BUILD_SHARED_LIBS=yes; then
+      suffix="${suffix}-shared"
+  elif echo "${CMAKE_FLAGS}" | grep -Eq GOOGLE_CLOUD_CPP_CLANG_TIDY=yes; then
+      suffix="${suffix}-tidy"
+  elif echo "${CMAKE_FLAGS}" | grep -Eq TEST_INSTALL=yes; then
+      suffix="${suffix}-install"
+  elif echo "${CMAKE_FLAGS}" | grep -Eq SANITIZE_ADDRESS=yes; then
+      suffix="${suffix}-asan"
+  elif echo "${CMAKE_FLAGS}" | grep -Eq SANITIZE_UNDEFINED=yes; then
+      suffix="${suffix}-ubsan"
+  elif echo "${CMAKE_FLAGS}" | grep -Eq SANITIZE_MEMORY=yes; then
+      suffix="${suffix}-msan"
+  elif echo "${CMAKE_FLAGS}" | grep -Eq SANITIZE_THREAD=yes; then
+      suffix="${suffix}-tsan"
+  elif echo "${CMAKE_FLAGS}" | grep -Eq GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS=no; then
+      suffix="${suffix}-noex"
+  fi
+  readonly BUILD_OUTPUT="build-output/${IMAGE}${suffix}"
+  readonly DOCKER_CCACHE_DIR="build-output/ccache/${IMAGE}${suffix}"
 fi

--- a/ci/travis/linux-config.sh
+++ b/ci/travis/linux-config.sh
@@ -29,11 +29,7 @@ else
   if [[ -n "${CC:-}" ]]; then
     suffix="${suffix}-${CC}"
   fi
-  if [[ -n "${BUILD_TYPE+x}" ]]; then
-    suffix="${suffix}-${BUILD_TYPE}"
-  else
-    suffix="${suffix}-Release"
-  fi
+  suffix="${suffix}-${BUILD_TYPE:-Release}"
   if [[ "${SCAN_BUILD+x}" = "yes" ]]; then
     suffix="${suffix}-scan"
   fi


### PR DESCRIPTION
This makes it easier to run multiple different Docker-based builds in a
developer workstation. Each build gets a different output directory
based on the settings for the build. Before this change one had to
clear the output directory for (say) a gcc build before building with clang
for the same distribution.

I also removed the `cached-` prefix from the image names, that made
sense at some point when we actually tried to cache the images, but no
longer does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1774)
<!-- Reviewable:end -->
