### PR TITLE
Fixed unitialized member variable.

### DIFF
--- a/google/cloud/storage/internal/object_requests_test.cc
+++ b/google/cloud/storage/internal/object_requests_test.cc
@@ -191,6 +191,7 @@ TEST(ObjectRequestsTest, InsertObjectStreaming) {
 HttpResponse CreateRangeRequestResponse(
     char const* content_range_header_value) {
   HttpResponse response;
+  response.status_code = 200;
   response.headers.emplace(std::string("content-range"),
                            std::string(content_range_header_value));
   response.payload = "some payload";


### PR DESCRIPTION
While this is "only a test", and the variable is not used, it is cleaner
to just do the right thing. This fixes one of the Coverity Scan issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1776)
<!-- Reviewable:end -->
