### PR TITLE
Fix unitialized member variable.

### DIFF
--- a/google/cloud/storage/internal/curl_upload_request.cc
+++ b/google/cloud/storage/internal/curl_upload_request.cc
@@ -29,6 +29,7 @@ namespace internal {
 
 CurlUploadRequest::CurlUploadRequest(std::size_t initial_buffer_size)
     : headers_(nullptr, &curl_slist_free_all),
+      logging_enabled_(false),
       multi_(nullptr, &curl_multi_cleanup),
       closing_(false),
       curl_closed_(false) {


### PR DESCRIPTION
This was a defect reported by Coverity Scan, in practice one of the
fried classes initialized it, but I think it is best to clean up these
errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1781)
<!-- Reviewable:end -->
