### PR TITLE
Initialize member variable.

### DIFF
--- a/google/cloud/bigtable/internal/completion_queue_impl.h
+++ b/google/cloud/bigtable/internal/completion_queue_impl.h
@@ -172,7 +172,7 @@ template <typename Request, typename Response, typename Functor,
 class AsyncUnaryRpcFunctor : public AsyncGrpcOperation {
  public:
   explicit AsyncUnaryRpcFunctor(Functor&& functor)
-      : functor_(std::forward<Functor>(functor)) {}
+      : sync_(false), functor_(std::forward<Functor>(functor)) {}
 
   /// Make the RPC request and prepare the response callback.
   template <typename Client, typename MemberFunction>


### PR DESCRIPTION
This was also reported by Coverity Scan. In this case we are using an
atomic bool to force the right semantics around synchronization, though
we are not interested in the actual value. It is easier to fix the
problem than to explain to Coverity Scan why it is Okay to have an
unitialized variable here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1782)
<!-- Reviewable:end -->
