### PR TITLE
Fixed typo: syncing [skip ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ standard [GitHub workflow][workflow-link]:
    branch (likely `master`), if so, we request that you [rebase][about-rebase]
    your branch instead of merging. The reviews can become very confusing if you
    merge during a pull request. You should first ensure that your `master`
-   branch has all the latest commits by sycing your fork (see above), then do
+   branch has all the latest commits by syncing your fork (see above), then do
    the following:
    ```console
    git checkout my-feature-branch


### PR DESCRIPTION
Identified after an earlier PR was merged:
https://github.com/GoogleCloudPlatform/google-cloud-cpp/pull/1773#pullrequestreview-189534577

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1783)
<!-- Reviewable:end -->
