### PR TITLE
Correctly check std::string::find result.

### DIFF
--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -351,12 +351,12 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileNonRegularWarning) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  auto count =
-      std::count_if(backend->log_lines.begin(), backend->log_lines.end(),
-                    [file_name](std::string const& line) {
-                      return line.find(file_name) != std::string::npos and
-                             line.find("not a regular file");
-                    });
+  auto count = std::count_if(
+      backend->log_lines.begin(), backend->log_lines.end(),
+      [file_name](std::string const& line) {
+        return line.find(file_name) != std::string::npos and
+               line.find("not a regular file") != std::string::npos;
+      });
   EXPECT_NE(0U, count);
 
   t.join();


### PR DESCRIPTION
Another little testing bug found by Coverity Scan.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1785)
<!-- Reviewable:end -->
