### PR TITLE
Check the return value from mkfifo().

### DIFF
--- a/google/cloud/internal/filesystem_test.cc
+++ b/google/cloud/internal/filesystem_test.cc
@@ -123,7 +123,7 @@ TEST(FilesystemTest, StatusCharacter) {
 TEST(FilesystemTest, StatusFifo) {
 #if GTEST_OS_LINUX
   auto file_name = CreateRandomFileName();
-  mkfifo(file_name.c_str(), 0777);
+  ASSERT_NE(-1, mkfifo(file_name.c_str(), 0777));
   std::error_code ec;
   auto file_status = status(file_name, ec);
   EXPECT_FALSE(static_cast<bool>(ec));

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -334,7 +334,7 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileNonRegularWarning) {
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
 
-  mkfifo(file_name.c_str(), 0777);
+  ASSERT_NE(-1, mkfifo(file_name.c_str(), 0777));
 
   std::string expected = LoremIpsum();
   std::thread t([file_name, expected] {


### PR DESCRIPTION
Another couple of bugs reported by Coverity Scan.