### PR TITLE
Change *Notification() functions to return StatusOr.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -83,7 +83,7 @@ inline namespace STORAGE_CLIENT_NS {
  * This class uses `StatusOr<T>` to report errors. When an operation fails to
  * perform its work the returned `StatusOr<T>` contains the error details. If
  * the `StatusOr<T>` is `ok()` then it contains the expected result.
- * Applications can also call `.value()` in the returned `StatusOr<T>` to get
+ * Applications can also call `.value()` on the returned `StatusOr<T>` to get
  * the underlying value, this function throws an exception when the
  * `StatusOr<T>` contains an error.
  *

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2301,7 +2301,7 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @returns An error status if there is a permanent failure, or if there were
+   * @return An error status if there is a permanent failure, or if there were
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
@@ -2341,7 +2341,7 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @returns An error status if there is a permanent failure, or if there were
+   * @return An error status if there is a permanent failure, or if there were
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
@@ -2378,7 +2378,7 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @returns An error status if there is a permanent failure, or if there were
+   * @return An error status if there is a permanent failure, or if there were
    *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -82,35 +82,10 @@ inline namespace STORAGE_CLIENT_NS {
  * @par Error Handling
  * This class uses `StatusOr<T>` to report errors. When an operation fails to
  * perform its work the returned `StatusOr<T>` contains the error details. If
- * the `StatusOr<T>` is `ok()` then it contains the expected result.
- * Applications can also call `.value()` on the returned `StatusOr<T>` to get
- * the underlying value, this function throws an exception when the
- * `StatusOr<T>` contains an error.
- *
- * @par Error Handling Example (with exceptions):
- * @code
- * using namespace google::cloud;
- * [](storage::Client client) {
- *   storage::BucketMetadata metadata = client.GetBucketMetadata(
- *       "my-bucket").value(); // throws on error
- *   // use `metadata` here.
- * }
- * @endcode
- *
- * @par Error Handling Example (without exceptions):
- * @code
- * using namespace google::cloud;
- * [](storage::Client client) {
- *   StatusOr<storage::BucketMetadata> metadata = client.GetBucketMetadata(
- *       "my-bucket");
- *   if (not metadata.ok()) {
- *     std::cerr << "Error retrieving metadata for my-bucket: "
- *               << metadata.status() << std::endl;
- *     return;
- *   }
- *   // use `metadata.value()` (or `*metadata`) here.
- * }
- * @endcode
+ * the `ok()` member function in the `StatusOr<T>` returns `true` then it
+ * contains the expected result. Please consult the `StatusOr<T>` documentation
+ * for more details. In addition, the @ref index "main page" contains examples
+ * using `StatusOr<T>` to handle errors.
  *
  * @see https://cloud.google.com/storage/ for an overview of GCS.
  *

--- a/google/cloud/storage/client_notifications_test.cc
+++ b/google/cloud/storage/client_notifications_test.cc
@@ -82,22 +82,27 @@ TEST_F(NotificationsTest, ListNotifications) {
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock_)};
 
-  std::vector<NotificationMetadata> actual =
+  StatusOr<std::vector<NotificationMetadata>> actual =
       client.ListNotifications("test-bucket");
-  EXPECT_EQ(expected, actual);
+  ASSERT_TRUE(actual.ok());
+  EXPECT_EQ(expected, actual.value());
 }
 
 TEST_F(NotificationsTest, ListNotificationsTooManyFailures) {
-  testing::TooManyFailuresTest<internal::ListNotificationsResponse>(
+  testing::TooManyFailuresStatusTest<internal::ListNotificationsResponse>(
       mock_, EXPECT_CALL(*mock_, ListNotifications(_)),
-      [](Client& client) { client.ListNotifications("test-bucket-name"); },
+      [](Client& client) {
+        return client.ListNotifications("test-bucket-name").status();
+      },
       "ListNotifications");
 }
 
 TEST_F(NotificationsTest, ListNotificationsPermanentFailure) {
-  testing::PermanentFailureTest<internal::ListNotificationsResponse>(
+  testing::PermanentFailureStatusTest<internal::ListNotificationsResponse>(
       *client_, EXPECT_CALL(*mock_, ListNotifications(_)),
-      [](Client& client) { client.ListNotifications("test-bucket-name"); },
+      [](Client& client) {
+        return client.ListNotifications("test-bucket-name").status();
+      },
       "ListNotifications");
 }
 
@@ -125,32 +130,33 @@ TEST_F(NotificationsTest, CreateNotification) {
           }));
   Client client{std::shared_ptr<internal::RawClient>(mock_)};
 
-  NotificationMetadata actual = client.CreateNotification(
+  StatusOr<NotificationMetadata> actual = client.CreateNotification(
       "test-bucket", "test-topic-1", payload_format::JsonApiV1(),
       NotificationMetadata()
           .set_object_name_prefix("test-object-prefix-")
           .append_event_type(event_type::ObjectFinalize()));
-  EXPECT_EQ(expected, actual);
+  ASSERT_TRUE(actual.ok());
+  EXPECT_EQ(expected, actual.value());
 }
 
 TEST_F(NotificationsTest, CreateNotificationTooManyFailures) {
-  testing::TooManyFailuresTest<NotificationMetadata>(
+  testing::TooManyFailuresStatusTest<NotificationMetadata>(
       mock_, EXPECT_CALL(*mock_, CreateNotification(_)),
       [](Client& client) {
-        client.CreateNotification("test-bucket-name", "test-topic-1",
-                                  payload_format::JsonApiV1(),
-                                  NotificationMetadata());
+        return client.CreateNotification("test-bucket-name", "test-topic-1",
+                                         payload_format::JsonApiV1(),
+                                         NotificationMetadata()).status();
       },
       "CreateNotification");
 }
 
 TEST_F(NotificationsTest, CreateNotificationPermanentFailure) {
-  testing::PermanentFailureTest<NotificationMetadata>(
+  testing::PermanentFailureStatusTest<NotificationMetadata>(
       *client_, EXPECT_CALL(*mock_, CreateNotification(_)),
       [](Client& client) {
-        client.CreateNotification("test-bucket-name", "test-topic-1",
-                                  payload_format::JsonApiV1(),
-                                  NotificationMetadata());
+        return client.CreateNotification("test-bucket-name", "test-topic-1",
+                                         payload_format::JsonApiV1(),
+                                         NotificationMetadata()).status();
       },
       "CreateNotification");
 }
@@ -175,25 +181,28 @@ TEST_F(NotificationsTest, GetNotification) {
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock_)};
 
-  NotificationMetadata actual =
+  StatusOr<NotificationMetadata> actual =
       client.GetNotification("test-bucket", "test-notification-1");
-  EXPECT_EQ(expected, actual);
+  ASSERT_TRUE(actual.ok());
+  EXPECT_EQ(expected, actual.value());
 }
 
 TEST_F(NotificationsTest, GetNotificationTooManyFailures) {
-  testing::TooManyFailuresTest<NotificationMetadata>(
+  testing::TooManyFailuresStatusTest<NotificationMetadata>(
       mock_, EXPECT_CALL(*mock_, GetNotification(_)),
       [](Client& client) {
-        client.GetNotification("test-bucket-name", "test-notification-1");
+        return client.GetNotification("test-bucket-name",
+                                      "test-notification-1").status();
       },
       "GetNotification");
 }
 
 TEST_F(NotificationsTest, GetNotificationPermanentFailure) {
-  testing::PermanentFailureTest<NotificationMetadata>(
+  testing::PermanentFailureStatusTest<NotificationMetadata>(
       *client_, EXPECT_CALL(*mock_, GetNotification(_)),
       [](Client& client) {
-        client.GetNotification("test-bucket-name", "test-notification-1");
+        return client.GetNotification("test-bucket-name",
+                                      "test-notification-1").status();
       },
       "GetNotification");
 }
@@ -209,23 +218,27 @@ TEST_F(NotificationsTest, DeleteNotification) {
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock_)};
 
-  client.DeleteNotification("test-bucket", "test-notification-1");
+  Status status =
+      client.DeleteNotification("test-bucket", "test-notification-1");
+  ASSERT_TRUE(status.ok());
 }
 
 TEST_F(NotificationsTest, DeleteNotificationTooManyFailures) {
-  testing::TooManyFailuresTest<internal::EmptyResponse>(
+  testing::TooManyFailuresStatusTest<internal::EmptyResponse>(
       mock_, EXPECT_CALL(*mock_, DeleteNotification(_)),
       [](Client& client) {
-        client.DeleteNotification("test-bucket-name", "test-notification-1");
+        return client.DeleteNotification("test-bucket-name",
+                                         "test-notification-1");
       },
       "DeleteNotification");
 }
 
 TEST_F(NotificationsTest, DeleteNotificationPermanentFailure) {
-  testing::PermanentFailureTest<internal::EmptyResponse>(
+  testing::PermanentFailureStatusTest<internal::EmptyResponse>(
       *client_, EXPECT_CALL(*mock_, DeleteNotification(_)),
       [](Client& client) {
-        client.DeleteNotification("test-bucket-name", "test-notification-1");
+        return client.DeleteNotification("test-bucket-name",
+                                         "test-notification-1");
       },
       "DeleteNotification");
 }

--- a/google/cloud/storage/client_notifications_test.cc
+++ b/google/cloud/storage/client_notifications_test.cc
@@ -218,7 +218,7 @@ TEST_F(NotificationsTest, DeleteNotification) {
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock_)};
 
-  Status status =
+  StatusOr<void> status =
       client.DeleteNotification("test-bucket", "test-notification-1");
   ASSERT_TRUE(status.ok());
 }
@@ -228,7 +228,7 @@ TEST_F(NotificationsTest, DeleteNotificationTooManyFailures) {
       mock_, EXPECT_CALL(*mock_, DeleteNotification(_)),
       [](Client& client) {
         return client.DeleteNotification("test-bucket-name",
-                                         "test-notification-1");
+                                         "test-notification-1").status();
       },
       "DeleteNotification");
 }
@@ -238,7 +238,7 @@ TEST_F(NotificationsTest, DeleteNotificationPermanentFailure) {
       *client_, EXPECT_CALL(*mock_, DeleteNotification(_)),
       [](Client& client) {
         return client.DeleteNotification("test-bucket-name",
-                                         "test-notification-1");
+                                         "test-notification-1").status();
       },
       "DeleteNotification");
 }

--- a/google/cloud/storage/doc/storage-main.dox
+++ b/google/cloud/storage/doc/storage-main.dox
@@ -208,9 +208,13 @@ the `StatusOr<T>` object contains an error.
 @code {.cpp}
 using namespace google::cloud;
 [](storage::Client client) {
-  storage::BucketMetadata metadata = client.GetBucketMetadata(
-      "my-bucket").value(); // throws on error
-  // use `metadata` here.
+  try {
+    storage::BucketMetadata metadata = client.GetBucketMetadata(
+        "my-bucket").value(); // throws on error
+    // use `metadata` here.
+  } catch (storage::RuntimeStatusError const& ex) {
+    std::cerr << "Error status: " << ex.what() << std::endl;
+  }
 }
 @endcode
 

--- a/google/cloud/storage/doc/storage-main.dox
+++ b/google/cloud/storage/doc/storage-main.dox
@@ -167,6 +167,53 @@ add_executable(my_program my_program.cc)
 target_link_libraries(my_program storage_client)
 ```
 
+### Error Handling
+
+This library never throws exceptions to signal error. In general, the library
+returns a `StatusOr<T>` if an error is possible. The exception are classes that
+already have an existing error handling mechanism, such as types derived from
+`std::ostream`.
+
+@par Error Handling Example (without exceptions):
+
+Application developers that cannot or prefer not to use exceptions to signal
+errors can check if the `StatusOr<T>` contains an error using `.ok()`. The error
+details are available using the `.status()` member function. If the
+`StatusOr<T>` does not contain an error then the application can use the\
+`StatusOr<T>` as a smart pointer to `T`, that is, `operator->()` and
+`operator*()` work as you would expect. Note that accessing the value of a
+`StatusOr<T>` that contains an error is undefined behavior.
+
+```{.cpp}
+using namespace google::cloud;
+[](storage::Client client) {
+  StatusOr<storage::BucketMetadata> metadata = client.GetBucketMetadata(
+      "my-bucket");
+  if (not metadata.ok()) {
+    std::cerr << "Error retrieving metadata for my-bucket: "
+              << metadata.status() << std::endl;
+    return;
+  }
+  // use `metadata.value()` (use `metadata` as a smart pointer) here.
+}
+```
+
+@par Error Handling Example (with exceptions):
+
+Applications that prefer to use
+exceptions to signal errors can simply call `.value()` on the `StatusOr<T>`
+object. This will return a `T` if there was no error, and throw an exception if
+the `StatusOr<T>` object contains an error.
+
+```{.cpp}
+using namespace google::cloud;
+[](storage::Client client) {
+  storage::BucketMetadata metadata = client.GetBucketMetadata(
+      "my-bucket").value(); // throws on error
+  // use `metadata` here.
+}
+```
+
 ### Next Steps
 
 The documentation for each member function in the [Client] class includes short

--- a/google/cloud/storage/doc/storage-main.dox
+++ b/google/cloud/storage/doc/storage-main.dox
@@ -184,7 +184,7 @@ details are available using the `.status()` member function. If the
 `operator*()` work as you would expect. Note that accessing the value of a
 `StatusOr<T>` that contains an error is undefined behavior.
 
-```{.cpp}
+@code {.cpp}
 using namespace google::cloud;
 [](storage::Client client) {
   StatusOr<storage::BucketMetadata> metadata = client.GetBucketMetadata(
@@ -194,9 +194,9 @@ using namespace google::cloud;
               << metadata.status() << std::endl;
     return;
   }
-  // use `metadata.value()` (use `metadata` as a smart pointer) here.
+  // here, use `metadata` as a smart pointer to `T`, or `metadata.value()`.
 }
-```
+@endcode
 
 @par Error Handling Example (with exceptions):
 
@@ -205,14 +205,14 @@ exceptions to signal errors can simply call `.value()` on the `StatusOr<T>`
 object. This will return a `T` if there was no error, and throw an exception if
 the `StatusOr<T>` object contains an error.
 
-```{.cpp}
+@code {.cpp}
 using namespace google::cloud;
 [](storage::Client client) {
   storage::BucketMetadata metadata = client.GetBucketMetadata(
       "my-bucket").value(); // throws on error
   // use `metadata` here.
 }
-```
+@endcode
 
 ### Next Steps
 

--- a/google/cloud/storage/examples/storage_notification_samples.cc
+++ b/google/cloud/storage/examples/storage_notification_samples.cc
@@ -133,12 +133,12 @@ void DeleteNotification(google::cloud::storage::Client client, int& argc,
   //! [delete notification] [START storage_delete_pubsub_bucket_notification]
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name, std::string notification_id) {
-    gcs::Status status =
+    gcs::StatusOr<void> status =
         client.DeleteNotification(bucket_name, notification_id);
     if (not status.ok()) {
       std::cerr << "Error delete notification id " << notification_id
-                << " on bucket " << bucket_name << ", status=" << status
-                << std::endl;
+                << " on bucket " << bucket_name
+                << ", status=" << status.status() << std::endl;
       return;
     }
     std::cout << "Successfully deleted notification " << notification_id

--- a/google/cloud/storage/examples/storage_notification_samples.cc
+++ b/google/cloud/storage/examples/storage_notification_samples.cc
@@ -54,14 +54,14 @@ void ListNotifications(google::cloud::storage::Client client, int& argc,
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name) {
     std::cout << "Notifications for bucket=" << bucket_name << std::endl;
-    gcs::StatusOr<std::vector<gcs::NotificationMetadata>> status =
+    gcs::StatusOr<std::vector<gcs::NotificationMetadata>> items =
         client.ListNotifications(bucket_name);
-    if (not status.ok()) {
+    if (not items.ok()) {
       std::cerr << "Error reading notification list for " << bucket_name
-                << ", status=" << status.status() << std::endl;
+                << ", status=" << items.status() << std::endl;
       return;
     }
-    for (gcs::NotificationMetadata const& notification : *status) {
+    for (gcs::NotificationMetadata const& notification : *items) {
       std::cout << notification << std::endl;
     }
   }

--- a/google/cloud/storage/examples/storage_notification_samples.cc
+++ b/google/cloud/storage/examples/storage_notification_samples.cc
@@ -54,8 +54,9 @@ void ListNotifications(google::cloud::storage::Client client, int& argc,
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name) {
     std::cout << "Notifications for bucket=" << bucket_name << std::endl;
-    for (gcs::NotificationMetadata const& notification :
-         client.ListNotifications(bucket_name)) {
+    std::vector<gcs::NotificationMetadata> items =
+        client.ListNotifications(bucket_name).value();
+    for (gcs::NotificationMetadata const& notification : items) {
       std::cout << notification << std::endl;
     }
   }
@@ -73,9 +74,12 @@ void CreateNotification(google::cloud::storage::Client client, int& argc,
   //! [create notification] [START storage_create_pubsub_bucket_notification]
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name, std::string topic_name) {
-    gcs::NotificationMetadata notification = client.CreateNotification(
-        bucket_name, topic_name, gcs::payload_format::JsonApiV1(),
-        gcs::NotificationMetadata());
+    gcs::NotificationMetadata notification =
+        client
+            .CreateNotification(bucket_name, topic_name,
+                                gcs::payload_format::JsonApiV1(),
+                                gcs::NotificationMetadata())
+            .value();
     std::cout << "Successfully created notification " << notification.id()
               << " for bucket " << bucket_name
               << "\nfull details=" << notification << std::endl;
@@ -95,7 +99,7 @@ void GetNotification(google::cloud::storage::Client client, int& argc,
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name, std::string notification_id) {
     gcs::NotificationMetadata notification =
-        client.GetNotification(bucket_name, notification_id);
+        client.GetNotification(bucket_name, notification_id).value();
     std::cout << "Notification " << notification.id() << " for bucket "
               << bucket_name << " details=" << notification << std::endl;
   }

--- a/google/cloud/storage/examples/storage_notification_samples.cc
+++ b/google/cloud/storage/examples/storage_notification_samples.cc
@@ -79,18 +79,28 @@ void CreateNotification(google::cloud::storage::Client client, int& argc,
   //! [create notification] [START storage_create_pubsub_bucket_notification]
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name, std::string topic_name) {
-    gcs::StatusOr<gcs::NotificationMetadata> notification = client.CreateNotification(
-        bucket_name, topic_name, gcs::payload_format::JsonApiV1(),
-        gcs::NotificationMetadata());
+    gcs::StatusOr<gcs::NotificationMetadata> notification =
+        client.CreateNotification(bucket_name, topic_name,
+                                  gcs::payload_format::JsonApiV1(),
+                                  gcs::NotificationMetadata());
     if (not notification.ok()) {
       std::cerr << "Error creating notification for " << bucket_name
-                << " on topic " << topic_name << ", status=" << notification.status()
-                << std::endl;
+                << " on topic " << topic_name
+                << ", status=" << notification.status() << std::endl;
       return;
     }
     std::cout << "Successfully created notification " << notification->id()
-              << " for bucket " << bucket_name
-              << "\nfull details=" << *notification << std::endl;
+              << " for bucket " << bucket_name << "\n";
+    if (notification->object_name_prefix().empty()) {
+      std::cout << "This notification will be sent for all objects in the"
+                << " bucket\n";
+    } else {
+      std::cout << "This notification will be set sent only for objects"
+                << " starting with the prefix "
+                << notification->object_name_prefix() << "\n";
+    }
+    std::cout << "Full details for the notification:\n"
+              << *notification << std::endl;
   }
   //! [create notification] [END storage_create_pubsub_bucket_notification]
   (std::move(client), bucket_name, topic_name);
@@ -115,7 +125,15 @@ void GetNotification(google::cloud::storage::Client client, int& argc,
       return;
     }
     std::cout << "Notification " << notification->id() << " for bucket "
-              << bucket_name << " details=" << *notification << std::endl;
+              << bucket_name << "\n";
+    if (notification->object_name_prefix().empty()) {
+      std::cout << "This notification is sent for all objects in the bucket\n";
+    } else {
+      std::cout << "This notification is sent only for objects starting with"
+                << " the prefix " << notification->object_name_prefix() << "\n";
+    }
+    std::cout << "Full details for the notification:\n"
+              << *notification << std::endl;
   }
   //! [get notification] [END storage_print_pubsub_bucket_notification]
   (std::move(client), bucket_name, notification_id);

--- a/google/cloud/storage/examples/storage_notification_samples.cc
+++ b/google/cloud/storage/examples/storage_notification_samples.cc
@@ -79,19 +79,18 @@ void CreateNotification(google::cloud::storage::Client client, int& argc,
   //! [create notification] [START storage_create_pubsub_bucket_notification]
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name, std::string topic_name) {
-    gcs::StatusOr<gcs::NotificationMetadata> status = client.CreateNotification(
+    gcs::StatusOr<gcs::NotificationMetadata> notification = client.CreateNotification(
         bucket_name, topic_name, gcs::payload_format::JsonApiV1(),
         gcs::NotificationMetadata());
-    if (not status.ok()) {
+    if (not notification.ok()) {
       std::cerr << "Error creating notification for " << bucket_name
-                << " on topic " << topic_name << ", status=" << status.status()
+                << " on topic " << topic_name << ", status=" << notification.status()
                 << std::endl;
       return;
     }
-    gcs::NotificationMetadata notification = std::move(*status);
-    std::cout << "Successfully created notification " << notification.id()
+    std::cout << "Successfully created notification " << notification->id()
               << " for bucket " << bucket_name
-              << "\nfull details=" << notification << std::endl;
+              << "\nfull details=" << *notification << std::endl;
   }
   //! [create notification] [END storage_create_pubsub_bucket_notification]
   (std::move(client), bucket_name, topic_name);
@@ -107,17 +106,16 @@ void GetNotification(google::cloud::storage::Client client, int& argc,
   //! [get notification] [START storage_print_pubsub_bucket_notification]
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name, std::string notification_id) {
-    gcs::StatusOr<gcs::NotificationMetadata> status =
+    gcs::StatusOr<gcs::NotificationMetadata> notification =
         client.GetNotification(bucket_name, notification_id);
-    if (not status.ok()) {
+    if (not notification.ok()) {
       std::cerr << "Error getting notification metadata for notification id "
                 << notification_id << " on bucket " << bucket_name
-                << ", status=" << status.status() << std::endl;
+                << ", status=" << notification.status() << std::endl;
       return;
     }
-    gcs::NotificationMetadata notification = std::move(*status);
-    std::cout << "Notification " << notification.id() << " for bucket "
-              << bucket_name << " details=" << notification << std::endl;
+    std::cout << "Notification " << notification->id() << " for bucket "
+              << bucket_name << " details=" << *notification << std::endl;
   }
   //! [get notification] [END storage_print_pubsub_bucket_notification]
   (std::move(client), bucket_name, notification_id);

--- a/google/cloud/storage/testing/retry_tests.h
+++ b/google/cloud/storage/testing/retry_tests.h
@@ -320,6 +320,244 @@ void PermanentFailureTest(Client& client,
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
+/**
+ * Tests the "too many failures" case for a `Client::*` member function.
+ *
+ * We need to verify that each API in the client library handles "too many
+ * errors" correctly. The tests are quite repetitive, and all have the same
+ * structure:
+ *
+ * - Create a `storage::Client` with an easy-to-test retry policy.
+ * - Setup the mock to return the right number of transient failures.
+ * - Call the API.
+ * - Verify an error status is returned, with the right contents.
+ *
+ * This function implements these tests, saving us a lot of repetitive code.
+ *
+ * @tparam ReturnType The low-level RawClient return type (modulo StatusOr).
+ * @tparam F a formal parameter, the googlemock representation of the mocked
+ *     call.
+ *
+ * @param oncall The internal type returned by EXPECT_CALL(...).
+ * @param tested_operation a function wrapping the operation to be tested.
+ * @param api_name the name of the api
+ * @return a function that implements the test.
+ */
+template <typename ReturnType, typename F>
+void TooManyFailuresStatusTest(
+    std::shared_ptr<testing::MockClient> const& mock,
+    ::testing::internal::TypedExpectation<F>& oncall,
+    std::function<Status(Client& client)> const& tested_operation,
+    char const* api_name) {
+  using canonical_errors::TransientError;
+  using ::testing::HasSubstr;
+  using ::testing::Return;
+  // A storage::Client with a simple to test policy.
+  Client client{std::shared_ptr<internal::RawClient>(mock),
+                LimitedErrorCountRetryPolicy(2)};
+
+  // Expect exactly 3 calls before the retry policy is exhausted and an error
+  // status is returned.
+  oncall.WillOnce(Return(StatusOr<ReturnType>(TransientError())))
+      .WillOnce(Return(StatusOr<ReturnType>(TransientError())))
+      .WillOnce(Return(StatusOr<ReturnType>(TransientError())));
+
+  Status status = tested_operation(client);
+  EXPECT_EQ(TransientError().status_code(), status.status_code());
+  EXPECT_THAT(status.error_message(), HasSubstr("Retry policy exhausted"));
+  EXPECT_THAT(status.error_message(), HasSubstr(api_name));
+}
+
+/**
+ * Tests that non-idempotent operations are *not* retried case for a `Client::*`
+ * member function.
+ *
+ * We need to verify that non-idempotent operations are not retied when the
+ * policy says so. The tests are quite repetitive, and all have the same
+ * structure:
+ *
+ * - Create a `storage::Client` with the right idempotency policies.
+ * - Setup the mock to return the right number of transient failures.
+ * - Call the API.
+ * - Verify an error status is returned, with the right contents.
+ *
+ * This function implements these tests, saving us a lot of repetitive code.
+ *
+ * @tparam ReturnType The low-level RawClient return type (modulo StatusOr).
+ * @tparam F a formal parameter, the googlemock representation of the mocked
+ *     call.
+ *
+ * @param oncall The internal type returned by EXPECT_CALL(...).
+ * @param tested_operation a function wrapping the operation to be tested.
+ * @param api_name the name of the api
+ * @param has_will_repeatedly `.WillRepeatedly()` can be called only once
+ *     in @p oncall. If this flag is set, the test will not setup that
+ *     expectation again.
+ * @return a function that implements the test.
+ */
+template <typename ReturnType, typename F>
+void NonIdempotentFailuresStatusTest(
+    std::shared_ptr<testing::MockClient> const& mock,
+    ::testing::internal::TypedExpectation<F>& oncall,
+    std::function<Status(Client& client)> const& tested_operation,
+    char const* api_name, bool has_will_repeatedly = false) {
+  using canonical_errors::TransientError;
+  using ::testing::HasSubstr;
+  using ::testing::Return;
+  // A storage::Client with the strict idempotency policy, but with a generous
+  // retry policy.
+  Client client{std::shared_ptr<internal::RawClient>(mock),
+                StrictIdempotencyPolicy(), LimitedErrorCountRetryPolicy(10)};
+
+  // The first transient error should stop the retries for non-idempotent
+  // operations.
+  oncall.WillOnce(Return(StatusOr<ReturnType>(TransientError())));
+
+  // Verify the right error status, with the right content, is returned when
+  // calling the operation.
+  Status status = tested_operation(client);
+  EXPECT_EQ(status.status_code(), TransientError().status_code());
+  EXPECT_THAT(status.error_message(), HasSubstr("Error in non-idempotent"));
+  EXPECT_THAT(status.error_message(), HasSubstr(api_name));
+}
+
+/**
+ * Tests that non-idempotent operations are *not* retried case for a `Client::*`
+ * member function.
+ *
+ * We need to verify that non-idempotent operations are not retied when the
+ * policy says so. The tests are quite repetitive, and all have the same
+ * structure:
+ *
+ * - Create a `storage::Client` with the right idempotency policies.
+ * - Setup the mock to return the right number of transient failures.
+ * - Call the API.
+ * - Verify an error status is returned, with the right contents.
+ *
+ * This function implements these tests, saving us a lot of repetitive code.
+ *
+ * @tparam ReturnType The low-level RawClient return type (modulo StatusOr).
+ * @tparam F a formal parameter, the googlemock representation of the mocked
+ *     call.
+ *
+ * @param oncall The internal type returned by EXPECT_CALL(...).
+ * @param tested_operation a function wrapping the operation to be tested.
+ * @param api_name the name of the api
+ * @param has_will_repeatedly `.WillRepeatedly()` can be called only once
+ *     in @p oncall. If this flag is set, the test will not setup that
+ *     expectation again.
+ * @return a function that implements the test.
+ */
+template <typename ReturnType, typename F>
+void IdempotentFailuresStatusTest(
+    std::shared_ptr<testing::MockClient> const& mock,
+    ::testing::internal::TypedExpectation<F>& oncall,
+    std::function<Status(Client& client)> const& tested_operation,
+    char const* api_name, bool has_will_repeatedly = true) {
+  using canonical_errors::TransientError;
+  using ::testing::HasSubstr;
+  using ::testing::Return;
+  // A storage::Client with the strict idempotency policy, but with a generous
+  // retry policy.
+  Client client{std::shared_ptr<internal::RawClient>(mock),
+                StrictIdempotencyPolicy(), LimitedErrorCountRetryPolicy(2)};
+
+  // Expect exactly 3 calls before the retry policy is exhausted and an error
+  // status is returned.
+  oncall.WillOnce(Return(StatusOr<ReturnType>(TransientError())))
+      .WillOnce(Return(StatusOr<ReturnType>(TransientError())))
+      .WillOnce(Return(StatusOr<ReturnType>(TransientError())));
+
+  // Verify the right error status, with the right content, is returned when
+  // calling the operation.
+  Status status = tested_operation(client);
+  EXPECT_EQ(TransientError().status_code(), status.status_code());
+  EXPECT_THAT(status.error_message(), HasSubstr("Retry policy exhausted"));
+  EXPECT_THAT(status.error_message(), HasSubstr(api_name));
+}
+
+/**
+ * Test operations that are idempotent or not depending of their parameters.
+ *
+ * Some operations are idempotent when some parameters are set (preconditions),
+ * when the operation is idempotent, we want to verify that they are retried
+ * multiple times, when they are not, we want to retry them only once if the
+ * right policy is set.
+ *
+ * - Create a `storage::Client` with an easy-to-test retry policy.
+ * - Setup the mock to return the right number of transient failures.
+ * - Call the API.
+ * - Verify an error status is returned, with the right contents.
+ *
+ * This function implements these tests, saving us a lot of repetitive code.
+ *
+ * @tparam ReturnType The low-level RawClient return type (modulo StatusOr).
+ * @tparam F a formal parameter, the googlemock representation of the mocked
+ *     call.
+ *
+ * @param oncall The internal type returned by EXPECT_CALL(...).
+ * @param tested_operation a function wrapping the operation to be tested.
+ * @param api_name the name of the api
+ * @return a function that implements the test.
+ */
+template <typename ReturnType, typename F>
+void TooManyFailuresStatusTest(
+    std::shared_ptr<testing::MockClient> const& mock,
+    ::testing::internal::TypedExpectation<F>& oncall,
+    std::function<Status(Client& client)> const& tested_operation,
+    std::function<Status(Client& client)> const& idempotent_operation,
+    char const* api_name) {
+  TooManyFailuresStatusTest<ReturnType>(mock, oncall, tested_operation,
+                                        api_name);
+  IdempotentFailuresStatusTest<ReturnType>(mock, oncall, idempotent_operation,
+                                           api_name, true);
+  NonIdempotentFailuresStatusTest<ReturnType>(mock, oncall, tested_operation,
+                                              api_name, true);
+}
+
+/**
+ * Tests the "permanent failure" case for a `Client::*` member function.
+ *
+ * We need to verify that each API in the client library handles permanent
+ * failures correctly. The tests are quite repetitive, and all have the same
+ * structure:
+ *
+ * - Setup the mock to return a permanent failure.
+ * - Call the API.
+ * - Verify an error status is returned, with the right contents.
+ *
+ * This function implements these tests, saving us a lot of repetitive code.
+ *
+ * @tparam ReturnType The low-level RawClient return type (modulo StatusOr).
+ * @tparam F a formal parameter, the googlemock representation of the mocked
+ *     call.
+ *
+ * @param oncall The internal type returned by EXPECT_CALL(...).
+ * @param tested_operation a function wrapping the operation to be tested.
+ * @param api_name the name of the api
+ * @return a function that implements the test.
+ */
+template <typename ReturnType, typename F>
+void PermanentFailureStatusTest(
+    Client& client, ::testing::internal::TypedExpectation<F>& oncall,
+    std::function<Status(Client& client)> tested_operation,
+    char const* api_name) {
+  using canonical_errors::PermanentError;
+  using ::testing::HasSubstr;
+  using ::testing::Return;
+
+  // Expect exactly one call before the retry policy is exhausted and an error
+  // status is returned.
+  oncall.WillOnce(Return(StatusOr<ReturnType>(PermanentError())));
+
+  // Verify the right exception type, with the right content, is raised when
+  // calling the operation.
+  Status status = tested_operation(client);
+  EXPECT_EQ(PermanentError().status_code(), status.status_code());
+  EXPECT_THAT(status.error_message(), HasSubstr("Permanent error"));
+  EXPECT_THAT(status.error_message(), HasSubstr(api_name));
+}
+
 }  // namespace testing
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/testing/retry_tests.h
+++ b/google/cloud/storage/testing/retry_tests.h
@@ -422,12 +422,11 @@ void NonIdempotentFailuresStatusTest(
 }
 
 /**
- * Tests that non-idempotent operations are *not* retried case for a `Client::*`
- * member function.
+ * Tests that idempotent operations *are* retried for a `Client::*` member
+ * function.
  *
- * We need to verify that non-idempotent operations are not retied when the
- * policy says so. The tests are quite repetitive, and all have the same
- * structure:
+ * We need to verify that idempotent operations are retried when the policy says
+ * so. The tests are quite repetitive, and all have the same structure:
  *
  * - Create a `storage::Client` with the right idempotency policies.
  * - Setup the mock to return the right number of transient failures.
@@ -457,8 +456,8 @@ void IdempotentFailuresStatusTest(
   using canonical_errors::TransientError;
   using ::testing::HasSubstr;
   using ::testing::Return;
-  // A storage::Client with the strict idempotency policy, but with a generous
-  // retry policy.
+  // A storage::Client with the strict idempotency policy, and with an
+  // easy-to-test retry policy.
   Client client{std::shared_ptr<internal::RawClient>(mock),
                 StrictIdempotencyPolicy(), LimitedErrorCountRetryPolicy(2)};
 
@@ -479,8 +478,8 @@ void IdempotentFailuresStatusTest(
 /**
  * Test operations that are idempotent or not depending of their parameters.
  *
- * Some operations are idempotent when some parameters are set (preconditions),
- * when the operation is idempotent, we want to verify that they are retried
+ * Some operations are idempotent when some parameters are set (preconditions).
+ * When the operation is idempotent, we want to verify that they are retried
  * multiple times, when they are not, we want to retry them only once if the
  * right policy is set.
  *

--- a/google/cloud/storage/testing/retry_tests.h
+++ b/google/cloud/storage/testing/retry_tests.h
@@ -47,7 +47,6 @@ namespace testing {
  * @param oncall The internal type returned by EXPECT_CALL(...).
  * @param tested_operation a function wrapping the operation to be tested.
  * @param api_name the name of the api
- * @return a function that implements the test.
  */
 template <typename ReturnType, typename F>
 void TooManyFailuresTest(
@@ -114,7 +113,6 @@ void TooManyFailuresTest(
  * @param has_will_repeatedly `.WillRepeatedly()` can be called only once
  *     in @p oncall. If this flag is set, the test will not setup that
  *     expectation again.
- * @return a function that implements the test.
  */
 template <typename ReturnType, typename F>
 void NonIdempotentFailuresTest(
@@ -182,7 +180,6 @@ void NonIdempotentFailuresTest(
  * @param has_will_repeatedly `.WillRepeatedly()` can be called only once
  *     in @p oncall. If this flag is set, the test will not setup that
  *     expectation again.
- * @return a function that implements the test.
  */
 template <typename ReturnType, typename F>
 void IdempotentFailuresTest(
@@ -249,7 +246,6 @@ void IdempotentFailuresTest(
  * @param oncall The internal type returned by EXPECT_CALL(...).
  * @param tested_operation a function wrapping the operation to be tested.
  * @param api_name the name of the api
- * @return a function that implements the test.
  */
 template <typename ReturnType, typename F>
 void TooManyFailuresTest(
@@ -286,7 +282,6 @@ void TooManyFailuresTest(
  * @param oncall The internal type returned by EXPECT_CALL(...).
  * @param tested_operation a function wrapping the operation to be tested.
  * @param api_name the name of the api
- * @return a function that implements the test.
  */
 template <typename ReturnType, typename F>
 void PermanentFailureTest(Client& client,
@@ -341,7 +336,6 @@ void PermanentFailureTest(Client& client,
  * @param oncall The internal type returned by EXPECT_CALL(...).
  * @param tested_operation a function wrapping the operation to be tested.
  * @param api_name the name of the api
- * @return a function that implements the test.
  */
 template <typename ReturnType, typename F>
 void TooManyFailuresStatusTest(
@@ -390,17 +384,13 @@ void TooManyFailuresStatusTest(
  * @param oncall The internal type returned by EXPECT_CALL(...).
  * @param tested_operation a function wrapping the operation to be tested.
  * @param api_name the name of the api
- * @param has_will_repeatedly `.WillRepeatedly()` can be called only once
- *     in @p oncall. If this flag is set, the test will not setup that
- *     expectation again.
- * @return a function that implements the test.
  */
 template <typename ReturnType, typename F>
 void NonIdempotentFailuresStatusTest(
     std::shared_ptr<testing::MockClient> const& mock,
     ::testing::internal::TypedExpectation<F>& oncall,
     std::function<Status(Client& client)> const& tested_operation,
-    char const* api_name, bool has_will_repeatedly = false) {
+    char const* api_name) {
   using canonical_errors::TransientError;
   using ::testing::HasSubstr;
   using ::testing::Return;
@@ -442,17 +432,13 @@ void NonIdempotentFailuresStatusTest(
  * @param oncall The internal type returned by EXPECT_CALL(...).
  * @param tested_operation a function wrapping the operation to be tested.
  * @param api_name the name of the api
- * @param has_will_repeatedly `.WillRepeatedly()` can be called only once
- *     in @p oncall. If this flag is set, the test will not setup that
- *     expectation again.
- * @return a function that implements the test.
  */
 template <typename ReturnType, typename F>
 void IdempotentFailuresStatusTest(
     std::shared_ptr<testing::MockClient> const& mock,
     ::testing::internal::TypedExpectation<F>& oncall,
     std::function<Status(Client& client)> const& tested_operation,
-    char const* api_name, bool has_will_repeatedly = true) {
+    char const* api_name) {
   using canonical_errors::TransientError;
   using ::testing::HasSubstr;
   using ::testing::Return;
@@ -497,7 +483,6 @@ void IdempotentFailuresStatusTest(
  * @param oncall The internal type returned by EXPECT_CALL(...).
  * @param tested_operation a function wrapping the operation to be tested.
  * @param api_name the name of the api
- * @return a function that implements the test.
  */
 template <typename ReturnType, typename F>
 void TooManyFailuresStatusTest(
@@ -509,9 +494,9 @@ void TooManyFailuresStatusTest(
   TooManyFailuresStatusTest<ReturnType>(mock, oncall, tested_operation,
                                         api_name);
   IdempotentFailuresStatusTest<ReturnType>(mock, oncall, idempotent_operation,
-                                           api_name, true);
+                                           api_name);
   NonIdempotentFailuresStatusTest<ReturnType>(mock, oncall, tested_operation,
-                                              api_name, true);
+                                              api_name);
 }
 
 /**
@@ -534,7 +519,6 @@ void TooManyFailuresStatusTest(
  * @param oncall The internal type returned by EXPECT_CALL(...).
  * @param tested_operation a function wrapping the operation to be tested.
  * @param api_name the name of the api
- * @return a function that implements the test.
  */
 template <typename ReturnType, typename F>
 void PermanentFailureStatusTest(


### PR DESCRIPTION
In this change all the `storage::Client::*Notification()` functions are
changed to return `StatusOr<>`. This change also introduces new helpers
to write unit tests for functions that return `StatusOr<>` instead of
throwing exceptions.

I changed the the examples simply call `.value()`, that keeps them free of
error checking noise, and still produces good error messages if there is
ever an error.

I changed the integration tests to check the if the returned
`StatusOr<>` is `.ok()`, and then we use the `operator*()` and
`operator->()` to use the `StatusOr<T>` as a pointer to `T`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1792)
<!-- Reviewable:end -->
