### PR TITLE
Automatically upload Coverity Scan results [skip ci].

### DIFF
--- a/ci/coverity-scan.sh
+++ b/ci/coverity-scan.sh
@@ -48,6 +48,16 @@ cmake --build .coverity --target skip-scanbuild-targets -- -j $(nproc)
 # Run coverity scan over our code.
 cov-build --dir cov-int cmake --build .coverity -- -j $(nproc)
 
+if [[ -z "${COVERITY_SCAN_TOKEN}" ]]; then
+  echo "COVERITY_SCAN_TOKEN is not defined, skipping upload of results."
+  exit 0
+fi
+
+if [[ -z "${COVERITY_SCAN_EMAIL}" ]]; then
+  echo "COVERITY_SCAN_EMAIL is not defined, skipping upload of results."
+  exit 0
+fi
+
 # Create a tarball with the build results. Print something because this takes
 # a while.
 /bin/echo -n "Creating a tarball with the Coverity Scan results." \
@@ -55,4 +65,9 @@ cov-build --dir cov-int cmake --build .coverity -- -j $(nproc)
 tar caf google-cloud-cpp.tar.xz cov-int
 /bin/echo "DONE"
 
-echo "Manually upload the results to coverity to start a new analysis."
+curl --form "token=${COVERITY_SCAN_TOKEN}" \
+  --form email="${COVERITY_SCAN_EMAIL}" \
+  --form file=@google-cloud-cpp.tar.xz \
+  --form version="master" \
+  --form description="Automatically Compiled Coverity Scan" \
+  https://scan.coverity.com/builds?project=GoogleCloudPlatform%2Fgoogle-cloud-cpp


### PR DESCRIPTION
If `COVERITY_SCAN_TOKEN` and `COVERITY_SCAN_EMAIL` are
defined the `ci/coverity-scan.sh` script automatically prepares and uploads
the result tarball to Coverity Scan for analysis.

I am not sure we will ever use this in Travis, the build takes ~45 minutes
on my laptop, with 8 cores and a local SSD. Travis has a limit of 50 minutes
and only 2 cores. My estimate is that this build is nearly 4 times too slow to
run on Travis. It will (almost certainly) run out of time before finishing.

Having said that, having a single command to run locally is still useful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1793)
<!-- Reviewable:end -->
