### PR TITLE
Fix dead code warning in Coverity Scan.

### DIFF
--- a/google/cloud/storage/internal/parse_rfc3339_test.cc
+++ b/google/cloud/storage/internal/parse_rfc3339_test.cc
@@ -64,7 +64,7 @@ TEST(ParseRfc3339Test, ParseFractional) {
   auto actual_seconds = duration_cast<seconds>(timestamp.time_since_epoch());
   EXPECT_EQ(1526654523L, actual_seconds.count());
 
-  bool system_clock_has_nanos = std::ratio_greater_equal<
+  bool const system_clock_has_nanos = std::ratio_greater_equal<
       std::nano, std::chrono::system_clock::duration::period>::value;
   if (system_clock_has_nanos) {
     auto actual_nanoseconds = duration_cast<nanoseconds>(
@@ -85,7 +85,7 @@ TEST(ParseRfc3339Test, ParseFractionalMoreThanNanos) {
   // Use `date -u +%s --date='2018-05-18T14:42:03'` to get the magic value:
   auto actual_seconds = duration_cast<seconds>(timestamp.time_since_epoch());
   EXPECT_EQ(1526654523L, actual_seconds.count());
-  bool system_clock_has_nanos = std::ratio_greater_equal<
+  bool const system_clock_has_nanos = std::ratio_greater_equal<
       std::nano, std::chrono::system_clock::duration::period>::value;
   if (system_clock_has_nanos) {
     auto actual_nanoseconds = duration_cast<nanoseconds>(


### PR DESCRIPTION
Coverity Scan warns about compile-time constants used in flow control,
sensible warning in most cases, but here the "constant" is not constant
across compilers (`if constexpr` would be nice). The recommended way to
suppress this warning is to declare the variable `const`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1794)
<!-- Reviewable:end -->
