### PR TITLE
Fix error handling in curl_multi_wait().

### DIFF
--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -205,7 +205,10 @@ Status CurlDownloadRequest::WaitForHandles(int& repeats) {
       curl_multi_wait(multi_.get(), nullptr, 0, timeout_ms, &numfds);
   GCP_LOG(DEBUG) << __func__ << "(): numfds=" << numfds << ", result=" << result
                  << ", repeats=" << repeats;
-  return AsStatus(result, __func__);
+  Status status = AsStatus(result, __func__);
+  if (not status.ok()) {
+    return status;
+  }
   // The documentation for curl_multi_wait() recommends sleeping if it returns
   // numfds == 0 more than once in a row :shrug:
   //    https://curl.haxx.se/libcurl/c/curl_multi_wait.html
@@ -216,7 +219,7 @@ Status CurlDownloadRequest::WaitForHandles(int& repeats) {
   } else {
     repeats = 0;
   }
-  return Status();
+  return status;
 }
 
 Status CurlDownloadRequest::AsStatus(CURLMcode result, char const *where) {


### PR DESCRIPTION
This was a defect reported by Coverity Scan. Apparently I forgot how
`return` works, and was still thinking "Call this function which will
throw an exception on error." Sigh. In any case, we were lucky (or
unlucky) in that the bug is just a performance issue: the loop would
spin instead of sleeping between calls to curl_multi_wait().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1796)
<!-- Reviewable:end -->
