### PR TITLE
Tweak coverity scan fixes.

### DIFF
--- a/google/cloud/internal/filesystem_test.cc
+++ b/google/cloud/internal/filesystem_test.cc
@@ -159,10 +159,11 @@ TEST(FilesystemTest, StatusSocket) {
   address.sun_family = AF_UNIX;
   strncpy(address.sun_path, file_name.c_str(), sizeof(address.sun_path) - 1);
   int r = bind(fd, reinterpret_cast<sockaddr*>(&address), sizeof(address));
+  EXPECT_NE(-1, r);
   if (r == -1) {
     (void)close(fd);
+    return;
   }
-  ASSERT_NE(-1, r);
 
   std::error_code ec;
   auto file_status = status(file_name, ec);


### PR DESCRIPTION
Evidently Coverity Scan does not understand ASSERT_NE() and believed
that `close(fd)` was being called twice. I think with the new flow we
both get a test failure if `bind(2)` fails, make the compilers happy, and make
Coverity Scan happy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1798)
<!-- Reviewable:end -->
