### PR TITLE
Workaround Travis CI build time problems.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,13 @@ set_property(CACHE GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER
 set(PROJECT_THIRD_PARTY_DIR "${PROJECT_SOURCE_DIR}/third_party")
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
+# There are a number of targets that are pure depedencies, i.e., do not contain
+# our own code. These targets can be skipped when using static analysis tools.
+# Can be built earlier in the CI environment (for example to warm up the cache).
+# And in general can receive special treatment. This custom target collects all
+# these special targets with a single name.
+add_custom_target(google-cloud-cpp-dependencies)
+
 # Add gRPC and protobuf targets as submodules or packages, depending on the
 # configuration.  This should happen before enable_testing(), because we are not
 # interested in compiling and running the gRPC tests.
@@ -150,13 +157,6 @@ include(CTest)
 
 # Each subproject adds dependencies to this target to have their docs generated.
 add_custom_target(doxygen-docs)
-
-# There are a number of targets we cannot, or do not care to compile with the
-# static analyzer enabled. Either because the build times are too long, or
-# because the code is an external dependency, or generated code, or all of
-# above. These targets are added as dependencies of `skip-scanbuild-targets` and
-# compiled with, obviously, scan-build disabled.
-add_custom_target(skip-scanbuild-targets)
 
 # Add subprojects here.
 add_subdirectory(google/cloud)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,7 @@ set_property(CACHE GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER
 set(PROJECT_THIRD_PARTY_DIR "${PROJECT_SOURCE_DIR}/third_party")
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-# There are a number of targets that are pure depedencies, i.e., do not contain
+# There are a number of targets that are pure dependencies, i.e., do not contain
 # our own code. These targets can be skipped when using static analysis tools.
 # Can be built earlier in the CI environment (for example to warm up the cache).
 # And in general can receive special treatment. This custom target collects all

--- a/ci/coverity-scan.sh
+++ b/ci/coverity-scan.sh
@@ -34,16 +34,9 @@ cmake -H. -B.coverity \
     -DCMAKE_BUILD_TYPE=Debug \
     -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=OFF
 
-# The project dependencies should be built without coverity-scan, any errors in
-# them are not actionable.
-cmake --build .coverity --target grpc_project -- -j $(nproc)
-cmake --build .coverity --target curl_project -- -j $(nproc)
-cmake --build .coverity --target crc32c_project -- -j $(nproc)
-cmake --build .coverity --target googletest_project -- -j $(nproc)
-
-# The proto-generated files contain too many errors, and they are not
-# actionable, so they are built without coverity-scan too.
-cmake --build .coverity --target skip-scanbuild-targets -- -j $(nproc)
+# The project dependencies, including the generated protos, should be built
+# without coverity-scan, any errors in them are not actionable.
+cmake --build .coverity --target google-cloud-cpp-dependencies -- -j $(nproc)
 
 # Run coverity scan over our code.
 cov-build --dir cov-int cmake --build .coverity -- -j $(nproc)

--- a/cmake/external/c-ares.cmake
+++ b/cmake/external/c-ares.cmake
@@ -58,6 +58,10 @@ if (NOT TARGET c_ares_project)
                         LOG_BUILD ON
                         LOG_INSTALL ON)
 
+    if (TARGET google-cloud-cpp-dependencies)
+        add_dependencies(google-cloud-cpp-dependencies c_ares_project)
+    endif ()
+
     add_library(c-ares::cares INTERFACE IMPORTED)
     set_library_properties_for_external_project(c-ares::cares cares
                                                 ALWAYS_SHARED)

--- a/cmake/external/crc32c.cmake
+++ b/cmake/external/crc32c.cmake
@@ -64,6 +64,10 @@ if (NOT TARGET crc32c_project)
                         LOG_BUILD ON
                         LOG_INSTALL ON)
 
+    if (TARGET google-cloud-cpp-dependencies)
+        add_dependencies(google-cloud-cpp-dependencies crc32c_project)
+    endif ()
+
     include(ExternalProjectHelper)
     add_library(Crc32c::crc32c INTERFACE IMPORTED)
     add_dependencies(Crc32c::crc32c crc32c_project)

--- a/cmake/external/curl.cmake
+++ b/cmake/external/curl.cmake
@@ -72,6 +72,10 @@ if (NOT TARGET curl_project)
         LOG_BUILD ON
         LOG_INSTALL ON)
 
+    if (TARGET google-cloud-cpp-dependencies)
+        add_dependencies(google-cloud-cpp-dependencies curl_project)
+    endif ()
+
     include(ExternalProjectHelper)
     add_library(CURL::CURL INTERFACE IMPORTED)
     add_dependencies(CURL::CURL curl_project)

--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -65,6 +65,10 @@ if (NOT TARGET googletest_project)
                         LOG_BUILD ON
                         LOG_INSTALL ON)
 
+    if (TARGET google-cloud-cpp-dependencies)
+        add_dependencies(google-cloud-cpp-dependencies googletest_project)
+    endif ()
+
     # On Windows GTest uses library postfixes for debug versions, that is
     # gtest.lib becomes gtestd.lib when compiled with for debugging.  This ugly
     # expression computes that value. Note that it must be a generator

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -77,6 +77,10 @@ if (NOT TARGET gprc_project)
         LOG_BUILD ON
         LOG_INSTALL ON)
 
+    if (TARGET google-cloud-cpp-dependencies)
+        add_dependencies(google-cloud-cpp-dependencies grpc_project)
+    endif ()
+
     add_library(gRPC::address_sorting INTERFACE IMPORTED)
     set_library_properties_for_external_project(gRPC::address_sorting
                                                 address_sorting)

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -76,6 +76,10 @@ if (NOT TARGET protobuf_project)
         LOG_BUILD ON
         LOG_INSTALL ON)
 
+    if (TARGET google-cloud-cpp-dependencies)
+        add_dependencies(google-cloud-cpp-dependencies protobuf_project)
+    endif ()
+
     add_library(protobuf::libprotobuf INTERFACE IMPORTED)
     add_dependencies(protobuf::libprotobuf protobuf_project)
     set_library_properties_for_external_project(protobuf::libprotobuf protobuf)

--- a/cmake/external/zlib.cmake
+++ b/cmake/external/zlib.cmake
@@ -55,6 +55,10 @@ if (NOT TARGET zlib_project)
                         LOG_BUILD ON
                         LOG_INSTALL ON)
 
+    if (TARGET google-cloud-cpp-dependencies)
+        add_dependencies(google-cloud-cpp-dependencies zlib_project)
+    endif ()
+
     include(ExternalProjectHelper)
     add_library(ZLIB::ZLIB INTERFACE IMPORTED)
     add_dependencies(ZLIB::ZLIB zlib_project)

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -119,7 +119,7 @@ add_library(bigtable::protos ALIAS bigtable_protos)
 # Enable unit tests
 include(CTest)
 
-add_dependencies(skip-scanbuild-targets bigtable_protos)
+add_dependencies(google-cloud-cpp-dependencies bigtable_protos)
 
 # Generate the version information from the CMake values.
 configure_file(version_info.h.in version_info.h)


### PR DESCRIPTION
Until we have a better solution in place this enables us to bootstrap
the build cache. Basically when starting with a completely empty cache
the build will stop halfway, which will partially populate the cache and
make the next build go faster.

The majority of this change is to ensure that "halfway" captures enough
things to make for a substantial initial cache.

The algorithm to decide if the cache is "cold" is kind of naive, we
really test for "the cache has 0 bytes". Obviously this will not work
sometimes, for example, if the cache is full of garbage. In that case we
can manually clear the cache in Travis and start over.

I created #1800 to track a real solution, because these hacks are not
awesome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1801)
<!-- Reviewable:end -->
