### PR TITLE
Initialize pointer value to something.

### DIFF
--- a/google/cloud/bigtable/internal/completion_queue_impl.h
+++ b/google/cloud/bigtable/internal/completion_queue_impl.h
@@ -242,7 +242,8 @@ class AsyncUnaryStreamRpcFunctor : public AsyncGrpcOperation {
  public:
   explicit AsyncUnaryStreamRpcFunctor(DataFunctor&& data_functor,
                                       FinishedFunctor&& finished_functor)
-      : state_(CREATING),
+      : tag_(nullptr),
+        state_(CREATING),
         data_functor_(std::forward<DataFunctor>(data_functor)),
         finished_functor_(std::forward<FinishedFunctor>(finished_functor)) {}
 


### PR DESCRIPTION
Coverity Scan is unhappy with a constructor that does not initialize a
field. This is a false positive, the pointer is never written to, and it
is initialized (in Set()) before it is used. Seems worthwhile to clean
this up though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1803)
<!-- Reviewable:end -->
