### PR TITLE
Do not fill up the log with codecov.io noise.

### DIFF
--- a/ci/travis/upload-codecov.sh
+++ b/ci/travis/upload-codecov.sh
@@ -29,10 +29,12 @@ fi
 
 # Upload the results using the script from codecov.io
 # Save the log to a file because it exceeds the 4MB limit in Travis.
+echo -n "Uploading code coverage to codecov.io..."
 readonly CI_ENV=$(bash <(curl -s https://codecov.io/env))
 sudo docker run $CI_ENV \
     --volume $PWD:/v --workdir /v \
     "${IMAGE}:tip" /bin/bash -c \
-    "/bin/bash <(curl -s https://codecov.io/bash) -g './build-output/ccache/*'"
+    "/bin/bash <(curl -s https://codecov.io/bash) -g './build-output/ccache/*' >/v/codecov.log 2>&1"
+echo "DONE"
 
 dump_log codecov.log


### PR DESCRIPTION
The Travis build logs cannot exceed 10,000 lines, the build is aborted if they do. Evidently the code coverage upload logs can use more than that.

Use this trick where we log to a file and then extract the beginning and end of the log to make it easier to troubleshoot things.

This should fix a couple of (currently) broken builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1812)
<!-- Reviewable:end -->
