### PR TITLE
Do not throw an exception from ~RowReader().

### DIFF
--- a/google/cloud/bigtable/row_reader.cc
+++ b/google/cloud/bigtable/row_reader.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/bigtable/internal/table.h"
 #include "google/cloud/internal/make_unique.h"
 #include "google/cloud/internal/throw_delegate.h"
+#include "google/cloud/log.h"
 #include <thread>
 
 namespace google {
@@ -291,10 +292,11 @@ void RowReader::Cancel() {
 RowReader::~RowReader() {
   // Make sure we don't leave open streams.
   Cancel();
-  if (not raise_on_error_ and not error_retrieved_ and not status_.ok()) {
-    google::cloud::internal::RaiseRuntimeError(
-        "Exception is disabled and error is not retrieved");
-  }
+  GCP_LOG(ERROR)
+      << "Exceptions are disabled, RowReader has an error,"
+      << " and the error status was not retrieved by the application: {"
+      << "status_code=" << status_.error_code()
+      << "error_message=" << status_.error_message();
 }
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/google/cloud/bigtable/row_reader.cc
+++ b/google/cloud/bigtable/row_reader.cc
@@ -292,11 +292,13 @@ void RowReader::Cancel() {
 RowReader::~RowReader() {
   // Make sure we don't leave open streams.
   Cancel();
-  GCP_LOG(ERROR)
-      << "Exceptions are disabled, RowReader has an error,"
-      << " and the error status was not retrieved by the application: {"
-      << "status_code=" << status_.error_code()
-      << "error_message=" << status_.error_message();
+  if (not raise_on_error_ and not error_retrieved_ and not status_.ok()) {
+    GCP_LOG(ERROR)
+        << "Exceptions are disabled, RowReader has an error,"
+        << " and the error status was not retrieved by the application: "
+        << "status_code=" << status_.error_code()
+        << ", error_message=" << status_.error_message();
+  }
 }
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/bigtable/testing/table_test_fixture.h"
 #include "google/cloud/internal/make_unique.h"
 #include "google/cloud/internal/throw_delegate.h"
+#include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include <gmock/gmock.h>
 #include <deque>
 #include <initializer_list>
@@ -787,7 +788,11 @@ TEST_F(RowReaderTest, BeginThrowsAfterImmediateCancelNoExcept) {
   EXPECT_FALSE(status.ok());
 }
 
-TEST_F(RowReaderTest, NoExceptionDestructorWillRaiseIfErrorNotRetrived) {
+TEST_F(RowReaderTest, NoExceptionDestructorWillLogIfErrorNotRetrived) {
+  auto backend =
+      std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
+  auto id = google::cloud::LogSink::Instance().AddBackend(backend);
+
   std::unique_ptr<bigtable::RowReader> reader(new bigtable::RowReader(
       client_, bigtable::TableId(""), bigtable::RowSet(),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
@@ -795,8 +800,18 @@ TEST_F(RowReaderTest, NoExceptionDestructorWillRaiseIfErrorNotRetrived) {
       metadata_update_policy_, std::move(parser_factory_), false));
   reader->Cancel();
   reader->begin();
-  EXPECT_DEATH_IF_SUPPORTED(reader.reset(), "");
-  reader->Finish();
+  reader.reset();
+
+  google::cloud::LogSink::Instance().RemoveBackend(id);
+
+  std::string const expected_message =
+      "RowReader has an error, and the error status was not retrieved";
+  auto count =
+      std::count_if(backend->log_lines.begin(), backend->log_lines.end(),
+                    [&expected_message](std::string const& line) {
+                      return line.find(expected_message) != std::string::npos;
+                    });
+  EXPECT_NE(0U, count);
 }
 
 TEST_F(RowReaderTest, RowReaderConstructorDoesNotCallRpc) {

--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -775,17 +775,37 @@ TEST_F(RowReaderTest, BeginThrowsAfterCancelClosesStreamNoExcept) {
 }
 
 TEST_F(RowReaderTest, BeginThrowsAfterImmediateCancelNoExcept) {
-  bigtable::RowReader reader(
+  auto backend =
+      std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
+  auto id = google::cloud::LogSink::Instance().AddBackend(backend);
+
+  std::unique_ptr<bigtable::RowReader> reader(new bigtable::RowReader(
       client_, bigtable::TableId(""), bigtable::RowSet(),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
       std::move(retry_policy_), std::move(backoff_policy_),
-      metadata_update_policy_, std::move(parser_factory_), false);
+      metadata_update_policy_, std::move(parser_factory_), false));
   // Manually cancel the call before a stream was created.
-  reader.Cancel();
+  reader->Cancel();
+  reader->begin();
 
-  reader.begin();
-  grpc::Status status = reader.Finish();
+  grpc::Status status = reader->Finish();
   EXPECT_FALSE(status.ok());
+
+  // Delete the reader and verify no log is produced because we handled the
+  // error.
+  reader.reset();
+
+  google::cloud::LogSink::Instance().RemoveBackend(id);
+
+  std::string const expected_message =
+      "RowReader has an error, and the error status was not retrieved";
+  auto count =
+      std::count_if(backend->log_lines.begin(), backend->log_lines.end(),
+                    [&expected_message](std::string const& line) {
+                      return line.find(expected_message) != std::string::npos;
+                    });
+  EXPECT_EQ(0U, count) << "Unexpected log captured: "
+                       << backend->log_lines.front();
 }
 
 TEST_F(RowReaderTest, NoExceptionDestructorWillLogIfErrorNotRetrived) {


### PR DESCRIPTION
We were raising an exception from ~RowReader() if the application failed
to retrieve an error after the iteration completed. I never liked this
idea, but we did not have `GCP_LOG()` when we implemented this.

Also Coverity Scan was (rightly) unhappy about this code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1815)
<!-- Reviewable:end -->
