### PR TITLE
Write function to map GCS HTTP codes to StatusCode.

### DIFF
--- a/google/cloud/storage/internal/http_response.cc
+++ b/google/cloud/storage/internal/http_response.cc
@@ -21,6 +21,108 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
+Status AsStatus(HttpResponse const& http_response) {
+  // The code here is organized by increasing range (or value) of the errors,
+  // just to make it readable. There are probably shorter (and/or more
+  // efficient) ways to write this, but we went for readability.
+
+  if (http_response.status_code < 100) {
+    return Status(StatusCode::kUnknown, http_response.payload);
+  }
+  if (http_response.status_code < 200) {
+    // We treat the 100s (e.g. 100 Continue) as OK results. They normally are
+    // ignored by libcurl, so we do not really expect to see them.
+    return Status(StatusCode::kOk, std::string{});
+  }
+  if (http_response.status_code < 300) {
+    // We treat the 200s as Okay results.
+    return Status(StatusCode::kOk, std::string{});
+  }
+  if (http_response.status_code == 308) {
+    // 308 - Resume Incomplete: is received when performing resumable uploads
+    // and should be treated as an OK.
+    return Status(StatusCode::kOk, std::string{});
+  }
+  if (http_response.status_code < 400) {
+    // The 300s should be handled by libcurl, we should not get them, according
+    // to the Google Cloud Storage documentation these are:
+    // 302 - Found
+    // 303 - See Other
+    // 304 - Not Modified
+    // 307 - Temporary Redirect
+    return Status(StatusCode::kUnknown, http_response.payload);
+  }
+  if (http_response.status_code == 400) {
+    // 400 - Bad Request
+    return Status(StatusCode::kInvalidArgument, http_response.payload);
+  }
+  if (http_response.status_code == 401) {
+    // 401 - Unauthorized
+    return Status(StatusCode::kUnauthenticated, http_response.payload);
+  }
+  if (http_response.status_code == 403) {
+    // 403 - Forbidden
+    return Status(StatusCode::kPermissionDenied, http_response.payload);
+  }
+  if (http_response.status_code == 404) {
+    // 404 - Not Found
+    return Status(StatusCode::kNotFound, http_response.payload);
+  }
+  if (http_response.status_code == 405) {
+    // 405 - Method Not Allowed
+    return Status(StatusCode::kPermissionDenied, http_response.payload);
+  }
+  if (http_response.status_code == 409) {
+    // 409 - Conflict
+    return Status(StatusCode::kAborted, http_response.payload);
+  }
+  if (http_response.status_code == 410) {
+    // 410 - Gone
+    return Status(StatusCode::kNotFound, http_response.payload);
+  }
+  if (http_response.status_code == 411) {
+    // 411 - Length Required
+    return Status(StatusCode::kInvalidArgument, http_response.payload);
+  }
+  if (http_response.status_code == 412) {
+    // 412 - Precondition Failed
+    return Status(StatusCode::kFailedPrecondition, http_response.payload);
+  }
+  if (http_response.status_code == 413) {
+    // 413 - Payload Too Large
+    return Status(StatusCode::kOutOfRange, http_response.payload);
+  }
+  if (http_response.status_code == 416) {
+    // 416 - Request Range Not Satisfiable
+    return Status(StatusCode::kOutOfRange, http_response.payload);
+  }
+  if (http_response.status_code == 429) {
+    // 429 - Too Many Requests
+    return Status(StatusCode::kUnavailable, http_response.payload);
+  }
+  if (http_response.status_code < 500) {
+    // 4XX - A request error.
+    return Status(StatusCode::kInvalidArgument, http_response.payload);
+  }
+  if (http_response.status_code == 500) {
+    // 500 - Internal Server Error
+    return Status(StatusCode::kInternal, http_response.payload);
+  }
+  if (http_response.status_code == 502) {
+    // 502 - Bad Gateway
+    return Status(StatusCode::kInternal, http_response.payload);
+  }
+  if (http_response.status_code == 503) {
+    // 503 - Service Unavailable
+    return Status(StatusCode::kUnavailable, http_response.payload);
+  }
+  if (http_response.status_code < 600) {
+    // 5XX - server errors are mapped to kInternal.
+    return Status(StatusCode::kInternal, http_response.payload);
+  }
+  return Status(StatusCode::kUnknown, http_response.payload);
+}
+
 std::ostream& operator<<(std::ostream& os, HttpResponse const& rhs) {
   os << "status_code=" << rhs.status_code << ", {";
   char const* sep = "";

--- a/google/cloud/storage/internal/http_response.h
+++ b/google/cloud/storage/internal/http_response.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_HTTP_RESPONSE_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_HTTP_RESPONSE_H_
 
+#include "google/cloud/status.h"
 #include "google/cloud/storage/version.h"
 #include <iosfwd>
 #include <map>
@@ -34,6 +35,32 @@ struct HttpResponse {
   std::string payload;
   std::multimap<std::string, std::string> headers;
 };
+
+/**
+ * Maps a HTTP response to a error `Status`.
+ *
+ * HTTP responses have a wide range of status codes (100 to 599), and we have
+ * a much more limited number of `StatusCode` values. This function performs
+ * the mapping between the two.
+ *
+ * The general principles in this mapping are:
+ * - A "code" outside the valid code for HTTP (from 100 to 599 both
+ *   inclusive) is always kUnknown.
+ * - Codes that are not specifically documented in
+ *     https://cloud.google.com/storage/docs/json_api/v1/status-codes
+ *   are mapped by these rules:
+ *     [100,300) -> kOk because they are all success status codes.
+ *     [300,400) -> kUnknown because libcurl should handle the redirects, so
+ *                  getting one is fairly strange.
+ *     [400,500) -> kInvalidArgument because these are generally "the client
+ *                  sent an invalid request" errors.
+ *     [500,600) -> kInternal because these are "server errors".
+ *
+ * @return A status with the code corresponding to @p http_response.status_code,
+ *     the error message in the status is initialized with
+ *     @p http_response.payload.
+ */
+Status AsStatus(HttpResponse const& http_response);
 
 std::ostream& operator<<(std::ostream& os, HttpResponse const& rhs);
 

--- a/google/cloud/storage/internal/http_response.h
+++ b/google/cloud/storage/internal/http_response.h
@@ -37,7 +37,7 @@ struct HttpResponse {
 };
 
 /**
- * Maps a HTTP response to a error `Status`.
+ * Maps a HTTP response to a `Status`.
  *
  * HTTP responses have a wide range of status codes (100 to 599), and we have
  * a much more limited number of `StatusCode` values. This function performs

--- a/google/cloud/storage/internal/http_response_test.cc
+++ b/google/cloud/storage/internal/http_response_test.cc
@@ -34,6 +34,59 @@ TEST(HttpResponseTest, OStream) {
   EXPECT_THAT(actual, HasSubstr("header1: value1"));
   EXPECT_THAT(actual, HasSubstr("header2: value2"));
 }
+
+TEST(HttpResponseTest, AsStatus) {
+  EXPECT_EQ(StatusCode::kUnknown,
+            AsStatus(HttpResponse{-42, "weird"}).status_code());
+  EXPECT_EQ(StatusCode::kUnknown,
+            AsStatus(HttpResponse{99, "still weird"}).status_code());
+  EXPECT_EQ(StatusCode::kOk,
+            AsStatus(HttpResponse{100, "Continue"}).status_code());
+  EXPECT_EQ(StatusCode::kOk,
+            AsStatus(HttpResponse{200, "success"}).status_code());
+  EXPECT_EQ(StatusCode::kOk,
+            AsStatus(HttpResponse{299, "success"}).status_code());
+  EXPECT_EQ(StatusCode::kUnknown,
+            AsStatus(HttpResponse{300, "libcurl should handle this"}).status_code());
+  EXPECT_EQ(StatusCode::kOk,
+            AsStatus(HttpResponse{308, "pending"}).status_code());
+  EXPECT_EQ(StatusCode::kInvalidArgument,
+            AsStatus(HttpResponse{400, "invalid something"}).status_code());
+  EXPECT_EQ(StatusCode::kUnauthenticated,
+            AsStatus(HttpResponse{401, "unauthenticated"}).status_code());
+  EXPECT_EQ(StatusCode::kPermissionDenied,
+            AsStatus(HttpResponse{403, "forbidden"}).status_code());
+  EXPECT_EQ(StatusCode::kNotFound,
+            AsStatus(HttpResponse{404, "not found"}).status_code());
+  EXPECT_EQ(StatusCode::kPermissionDenied,
+            AsStatus(HttpResponse{405, "method not allowed"}).status_code());
+  EXPECT_EQ(StatusCode::kAborted,
+            AsStatus(HttpResponse{409, "conflict"}).status_code());
+  EXPECT_EQ(StatusCode::kNotFound,
+            AsStatus(HttpResponse{410, "gone"}).status_code());
+  EXPECT_EQ(StatusCode::kInvalidArgument,
+            AsStatus(HttpResponse{411, "length required"}).status_code());
+  EXPECT_EQ(StatusCode::kFailedPrecondition,
+            AsStatus(HttpResponse{412, "precondition failed"}).status_code());
+  EXPECT_EQ(StatusCode::kOutOfRange,
+            AsStatus(HttpResponse{413, "payload too large"}).status_code());
+  EXPECT_EQ(StatusCode::kOutOfRange,
+            AsStatus(HttpResponse{416, "request range"}).status_code());
+  EXPECT_EQ(StatusCode::kUnavailable,
+            AsStatus(HttpResponse{429, "too many requests"}).status_code());
+  EXPECT_EQ(StatusCode::kInvalidArgument,
+            AsStatus(HttpResponse{499, "some 4XX error"}).status_code());
+  EXPECT_EQ(StatusCode::kInternal,
+            AsStatus(HttpResponse{500, "internal server error"}).status_code());
+  EXPECT_EQ(StatusCode::kInternal,
+            AsStatus(HttpResponse{502, "bad gateway"}).status_code());
+  EXPECT_EQ(StatusCode::kUnavailable,
+            AsStatus(HttpResponse{503, "service unavailable"}).status_code());
+  EXPECT_EQ(StatusCode::kInternal,
+            AsStatus(HttpResponse{599, "some 5XX error"}).status_code());
+  EXPECT_EQ(StatusCode::kUnknown,
+            AsStatus(HttpResponse{600, "bad"}).status_code());
+}
 }  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS


### PR DESCRIPTION
This is based on the documented status codes for GCS:

https://cloud.google.com/storage/docs/json_api/v1/status-codes#http-status-and-error-codes

And the `StatusCode` semantics from:

https://grpc.io/grpc/cpp/namespacegrpc.html#aff1730578c90160528f6a8d67ef5c43b

(if that link breaks go to the [gRPC docs](https://grpc.io/grpc/cpp/namespacegrpc.html) and search for `StatusCode`).

Note that this is just my best guess at mapping the error codes. This PR is expected to have some large discussion about what are the right semantics for these things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1816)
<!-- Reviewable:end -->
