### PR TITLE
Return StatusOr from Client::*DefaultObjectAcl().

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -1857,9 +1857,6 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This is a read-only operation and is always idempotent.
    *
@@ -1870,11 +1867,15 @@ class Client {
    * https://cloud.google.com/storage/docs/access-control/create-manage-lists#defaultobjects
    */
   template <typename... Options>
-  std::vector<ObjectAccessControl> ListDefaultObjectAcl(
+  StatusOr<std::vector<ObjectAccessControl>> ListDefaultObjectAcl(
       std::string const& bucket_name, Options&&... options) {
     internal::ListDefaultObjectAclRequest request(bucket_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->ListDefaultObjectAcl(request).value().items;
+    auto response = raw_client_->ListDefaultObjectAcl(request);
+    if (not response.ok()) {
+      return std::move(response).status();
+    }
+    return std::move(response.value().items);
   }
 
   /**
@@ -1889,9 +1890,6 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions. There
    * are no pre-conditions for this operation that can make it idempotent.
@@ -1903,13 +1901,12 @@ class Client {
    * https://cloud.google.com/storage/docs/access-control/create-manage-lists#defaultobjects
    */
   template <typename... Options>
-  ObjectAccessControl CreateDefaultObjectAcl(std::string const& bucket_name,
-                                             std::string const& entity,
-                                             std::string const& role,
-                                             Options&&... options) {
+  StatusOr<ObjectAccessControl> CreateDefaultObjectAcl(
+      std::string const& bucket_name, std::string const& entity,
+      std::string const& role, Options&&... options) {
     internal::CreateDefaultObjectAclRequest request(bucket_name, entity, role);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->CreateDefaultObjectAcl(request).value();
+    return raw_client_->CreateDefaultObjectAcl(request);
   }
 
   /**
@@ -1923,9 +1920,6 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions. There
    * are no pre-conditions for this operation that can make it idempotent.
@@ -1937,11 +1931,12 @@ class Client {
    * https://cloud.google.com/storage/docs/access-control/create-manage-lists#defaultobjects
    */
   template <typename... Options>
-  void DeleteDefaultObjectAcl(std::string const& bucket_name,
-                              std::string const& entity, Options&&... options) {
+  StatusOr<void> DeleteDefaultObjectAcl(std::string const& bucket_name,
+                                        std::string const& entity,
+                                        Options&&... options) {
     internal::DeleteDefaultObjectAclRequest request(bucket_name, entity);
     request.set_multiple_options(std::forward<Options>(options)...);
-    raw_client_->DeleteDefaultObjectAcl(request).value();
+    return raw_client_->DeleteDefaultObjectAcl(request).status();
   }
 
   /**
@@ -1955,9 +1950,6 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This is a read-only operation and is always idempotent.
    *
@@ -1968,12 +1960,12 @@ class Client {
    * https://cloud.google.com/storage/docs/access-control/create-manage-lists#defaultobjects
    */
   template <typename... Options>
-  ObjectAccessControl GetDefaultObjectAcl(std::string const& bucket_name,
-                                          std::string const& entity,
-                                          Options&&... options) {
+  StatusOr<ObjectAccessControl> GetDefaultObjectAcl(
+      std::string const& bucket_name, std::string const& entity,
+      Options&&... options) {
     internal::GetDefaultObjectAclRequest request(bucket_name, entity);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->GetDefaultObjectAcl(request).value();
+    return raw_client_->GetDefaultObjectAcl(request);
   }
 
   /**
@@ -1988,9 +1980,6 @@ class Client {
    * @param options a list of optional query parameters and/or request
    *     Valid types for this operation include `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions. There
    * are no pre-conditions for this operation that can make it idempotent.
@@ -2002,13 +1991,13 @@ class Client {
    * https://cloud.google.com/storage/docs/access-control/create-manage-lists#defaultobjects
    */
   template <typename... Options>
-  ObjectAccessControl UpdateDefaultObjectAcl(std::string const& bucket_name,
-                                             ObjectAccessControl const& acl,
-                                             Options&&... options) {
+  StatusOr<ObjectAccessControl> UpdateDefaultObjectAcl(
+      std::string const& bucket_name, ObjectAccessControl const& acl,
+      Options&&... options) {
     internal::UpdateDefaultObjectAclRequest request(bucket_name, acl.entity(),
                                                     acl.role());
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->UpdateDefaultObjectAcl(request).value();
+    return raw_client_->UpdateDefaultObjectAcl(request);
   }
 
   /**
@@ -2035,9 +2024,6 @@ class Client {
    *     as the standard parameters, such as `IfMatchEtag`, and
    *     `IfNoneMatchEtag`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions. There
    * are no pre-conditions for this operation that can make it idempotent.
@@ -2049,14 +2035,14 @@ class Client {
    * https://cloud.google.com/storage/docs/access-control/create-manage-lists#defaultobjects
    */
   template <typename... Options>
-  ObjectAccessControl PatchDefaultObjectAcl(
+  StatusOr<ObjectAccessControl> PatchDefaultObjectAcl(
       std::string const& bucket_name, std::string const& entity,
       ObjectAccessControl const& original_acl,
       ObjectAccessControl const& new_acl, Options&&... options) {
     internal::PatchDefaultObjectAclRequest request(bucket_name, entity,
                                                    original_acl, new_acl);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->PatchDefaultObjectAcl(request).value();
+    return raw_client_->PatchDefaultObjectAcl(request);
   }
 
   /**
@@ -2081,9 +2067,6 @@ class Client {
    *     as the standard parameters, such as `IfMatchEtag`, and
    *     `IfNoneMatchEtag`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions. There
    * are no pre-conditions for this operation that can make it idempotent.
@@ -2096,13 +2079,13 @@ class Client {
    * https://cloud.google.com/storage/docs/access-control/create-manage-lists#defaultobjects
    */
   template <typename... Options>
-  ObjectAccessControl PatchDefaultObjectAcl(
+  StatusOr<ObjectAccessControl> PatchDefaultObjectAcl(
       std::string const& bucket_name, std::string const& entity,
       ObjectAccessControlPatchBuilder const& builder, Options&&... options) {
     internal::PatchDefaultObjectAclRequest request(bucket_name, entity,
                                                    builder);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->PatchDefaultObjectAcl(request).value();
+    return raw_client_->PatchDefaultObjectAcl(request);
   }
   //@}
 

--- a/google/cloud/storage/client_default_object_acl_test.cc
+++ b/google/cloud/storage/client_default_object_acl_test.cc
@@ -231,7 +231,7 @@ TEST_F(DefaultObjectAccessControlsTest, GetDefaultObjectAcl) {
 
   StatusOr<ObjectAccessControl> actual =
       client.GetDefaultObjectAcl("test-bucket", "user-test-user-1");
-  EXPECT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
   EXPECT_EQ(expected, *actual);
 }
 
@@ -281,7 +281,7 @@ TEST_F(DefaultObjectAccessControlsTest, UpdateDefaultObjectAcl) {
       "test-bucket", ObjectAccessControl()
                          .set_entity("user-test-user-1")
                          .set_role(ObjectAccessControl::ROLE_READER()));
-  EXPECT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
   // Compare just a few fields because the values for most of the fields are
   // hard to predict when testing against the production environment.
   EXPECT_EQ(expected.bucket(), actual->bucket());

--- a/google/cloud/storage/client_default_object_acl_test.cc
+++ b/google/cloud/storage/client_default_object_acl_test.cc
@@ -83,7 +83,7 @@ TEST_F(DefaultObjectAccessControlsTest, ListDefaultObjectAcl) {
 
   StatusOr<std::vector<ObjectAccessControl>> actual =
       client.ListDefaultObjectAcl("test-bucket");
-  EXPECT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
   EXPECT_EQ(expected, *actual);
 }
 
@@ -127,7 +127,7 @@ TEST_F(DefaultObjectAccessControlsTest, CreateDefaultObjectAcl) {
 
   StatusOr<ObjectAccessControl> actual = client.CreateDefaultObjectAcl(
       "test-bucket", "user-test-user-1", ObjectAccessControl::ROLE_READER());
-  EXPECT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
   // Compare just a few fields because the values for most of the fields are
   // hard to predict when testing against the production environment.
   EXPECT_EQ(expected.bucket(), actual->bucket());
@@ -178,7 +178,7 @@ TEST_F(DefaultObjectAccessControlsTest, DeleteDefaultObjectAcl) {
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
   auto actual = client.DeleteDefaultObjectAcl("test-bucket", "user-test-user");
-  EXPECT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
 }
 
 TEST_F(DefaultObjectAccessControlsTest, DeleteDefaultObjectAclTooManyFailures) {

--- a/google/cloud/storage/examples/storage_default_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_default_object_acl_samples.cc
@@ -83,18 +83,19 @@ void CreateDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string entity,
      std::string role) {
-    StatusOr<gcs::ObjectAccessControl> result =
+    StatusOr<gcs::ObjectAccessControl> default_object_acl =
         client.CreateDefaultObjectAcl(bucket_name, entity, role);
-    if (not result.ok()) {
+    if (not default_object_acl.ok()) {
       std::cerr << "Failure getting default object ACL for entity " << entity
                 << " in bucket " << bucket_name
-                << ", status=" << result.status() << std::endl;
+                << ", status=" << default_object_acl.status() << std::endl;
       return;
     }
-    std::cout << "Role " << result->role() << " will be granted default to "
-              << result->entity() << " on any new object created on bucket "
-              << result->bucket() << "\n"
-              << "Full attributes: " << *result << std::endl;
+    std::cout << "Role " << default_object_acl->role()
+              << " will be granted default to " << default_object_acl->entity()
+              << " on any new object created on bucket "
+              << default_object_acl->bucket() << "\n"
+              << "Full attributes: " << *default_object_acl << std::endl;
   }
   //! [create default object acl] [END storage_add_default_owner]
   (std::move(client), bucket_name, entity, role);
@@ -164,26 +165,26 @@ void UpdateDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string entity,
      std::string role) {
-    StatusOr<gcs::ObjectAccessControl> current_acl =
+    StatusOr<gcs::ObjectAccessControl> original_acl =
         client.GetDefaultObjectAcl(bucket_name, entity);
-    if (not current_acl.ok()) {
+    if (not original_acl.ok()) {
       std::cerr << "Failure getting default object ACL for entity " << entity
                 << " in bucket " << bucket_name
-                << ", status=" << current_acl.status() << std::endl;
+                << ", status=" << original_acl.status() << std::endl;
       return;
     }
-    current_acl->set_role(role);
-    StatusOr<gcs::ObjectAccessControl> acl =
-        client.UpdateDefaultObjectAcl(bucket_name, *current_acl);
-    if (not acl.ok()) {
+    original_acl->set_role(role);
+    StatusOr<gcs::ObjectAccessControl> updated_acl =
+        client.UpdateDefaultObjectAcl(bucket_name, *original_acl);
+    if (not updated_acl.ok()) {
       std::cerr << "Failure updating default object ACL for entity " << entity
-                << " in bucket " << bucket_name << ", status=" << acl.status()
-                << std::endl;
+                << " in bucket " << bucket_name
+                << ", status=" << updated_acl.status() << std::endl;
       return;
     }
-    std::cout << "Default Object ACL entry for " << acl->entity()
-              << " in bucket " << acl->bucket() << " is now " << *acl
-              << std::endl;
+    std::cout << "Default Object ACL entry for " << updated_acl->entity()
+              << " in bucket " << updated_acl->bucket() << " is now "
+              << *updated_acl << std::endl;
   }
   //! [update default object acl]
   (std::move(client), bucket_name, entity, role);
@@ -243,18 +244,19 @@ void PatchDefaultObjectAclNoRead(google::cloud::storage::Client client,
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string entity,
      std::string role) {
-    StatusOr<gcs::ObjectAccessControl> acl = client.PatchDefaultObjectAcl(
-        bucket_name, entity,
-        gcs::ObjectAccessControlPatchBuilder().set_role(role));
-    if (not acl.ok()) {
+    StatusOr<gcs::ObjectAccessControl> patched_acl =
+        client.PatchDefaultObjectAcl(
+            bucket_name, entity,
+            gcs::ObjectAccessControlPatchBuilder().set_role(role));
+    if (not patched_acl.ok()) {
       std::cerr << "Failure patching default object ACL for entity " << entity
-                << " in bucket " << bucket_name << ", status=" << acl.status()
-                << std::endl;
+                << " in bucket " << bucket_name
+                << ", status=" << patched_acl.status() << std::endl;
       return;
     }
-    std::cout << "Default Object ACL entry for " << acl->entity()
-              << " in bucket " << acl->bucket() << " is now " << *acl
-              << std::endl;
+    std::cout << "Default Object ACL entry for " << patched_acl->entity()
+              << " in bucket " << patched_acl->bucket() << " is now "
+              << *patched_acl << std::endl;
   }
   //! [patch default object acl no-read]
   (std::move(client), bucket_name, entity, role);


### PR DESCRIPTION
This changes all the `Client::*DefaultObjectAcl()` functions to return a
`StatusOr<T>`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1817)
<!-- Reviewable:end -->
