### PR TITLE
Fix warnings in Coverity Scan.

### DIFF
--- a/google/cloud/bigtable/row_range.cc
+++ b/google/cloud/bigtable/row_range.cc
@@ -197,10 +197,12 @@ bool RowRange::operator==(RowRange const& rhs) const {
       if (row_range_.start_key_closed() != rhs.row_range_.start_key_closed()) {
         return false;
       }
+      break;
     case btproto::RowRange::kStartKeyOpen:
       if (row_range_.start_key_open() != rhs.row_range_.start_key_open()) {
         return false;
       }
+      break;
   }
 
   if (row_range_.end_key_case() != rhs.row_range_.end_key_case()) {
@@ -213,10 +215,12 @@ bool RowRange::operator==(RowRange const& rhs) const {
       if (row_range_.end_key_closed() != rhs.row_range_.end_key_closed()) {
         return false;
       }
+      break;
     case btproto::RowRange::kEndKeyOpen:
       if (row_range_.end_key_open() != rhs.row_range_.end_key_open()) {
         return false;
       }
+      break;
   }
 
   return true;


### PR DESCRIPTION
Coverity Scan warns about missing breaks, that is generally a good idea,
though in this case they happen to be harmless:

If you hit the `case ..kStartKeyClosed` statement then the values returned
in the `case ..kStartKeyOpen` statement are always empty strings, so the
body of that second `if()` does not execute.  I "know" this because the
protos guarantee it (these are `oneof` fields), but Coverity Scan has not way
to know.

Same thing with the `case ...kEndKeyClosed` case statements.

On general principles, fix the warning so we can find the important bugs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1822)
<!-- Reviewable:end -->
