### PR TITLE
Set RPATH for external projects

### DIFF
--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -31,9 +31,6 @@ source "${PROJECT_ROOT}/ci/colors.sh"
 
 (cd "${PROJECT_ROOT}" ; ./ci/check-style.sh)
 
-# TODO (#1797): this is a workaround for the shared library error.
-export LD_LIBRARY_PATH="${PWD}/${BUILD_OUTPUT}/external/lib:${PWD}/${BUILD_OUTPUT}/external/lib64"
-
 CMAKE_COMMAND="cmake"
 if [ "${SCAN_BUILD}" = "yes" ]; then
   CMAKE_COMMAND="scan-build --use-cc=${CC} --use-c++=${CXX} cmake"

--- a/cmake/external/curl.cmake
+++ b/cmake/external/curl.cmake
@@ -34,11 +34,14 @@ if (NOT TARGET curl_project)
         set(PARALLEL "")
     endif ()
 
-    # When CMake passes the configure command to the shell, the semi-colon will
-    # also be interpreted by the shell so it needs to be escaped. Quoting does
-    # not work, so instead we replace the semi-colon with a different separator
-    # and specify that using LIST_SEPARATOR below. This ensures that our RPATH
-    # will contain both directories.
+    # When passing a semi-colon delimited list to ExternalProject_Add, we need
+    # to escape the semi-colon. Quoting does not work and escaping the semi-
+    # colon does not seem to work (see https://reviews.llvm.org/D40257). A
+    # workaround is to use LIST_SEPARATOR to change the delimiter, which will
+    # then be replaced by an escaped semi-colon by CMake. This allows us to use
+    # multiple directories for our RPATH. Normally, it'd make sense to use : as
+    # a delimiter since it is a typical path-list separator, but it is a special
+    # character in CMake.
     set(GOOGLE_CLOUD_CPP_INSTALL_RPATH "<INSTALL_DIR>/lib;<INSTALL_DIR>/lib64")
     string(REPLACE ";"
                    "|"

--- a/cmake/external/curl.cmake
+++ b/cmake/external/curl.cmake
@@ -34,6 +34,17 @@ if (NOT TARGET curl_project)
         set(PARALLEL "")
     endif ()
 
+    # When CMake passes the configure command to the shell, the semi-colon will
+    # also be interpreted by the shell so it needs to be escaped. Quoting does
+    # not work, so instead we replace the semi-colon with a different separator
+    # and specify that using LIST_SEPARATOR below. This ensures that our RPATH
+    # will contain both directories.
+    set(GOOGLE_CLOUD_CPP_INSTALL_RPATH "<INSTALL_DIR>/lib;<INSTALL_DIR>/lib64")
+    string(REPLACE ";"
+                   "|"
+                   GOOGLE_CLOUD_CPP_INSTALL_RPATH
+                   "${GOOGLE_CLOUD_CPP_INSTALL_RPATH}")
+
     create_external_project_library_byproduct_list(curl_byproducts "curl")
 
     include(ExternalProject)
@@ -45,6 +56,7 @@ if (NOT TARGET curl_project)
         INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
         URL ${GOOGLE_CLOUD_CPP_CURL_URL}
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_CURL_SHA256}
+        LIST_SEPARATOR |
         CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
                    # libcurl automatically enables a number of protocols. With
                    # static libraries this is a problem. The indirect
@@ -62,6 +74,7 @@ if (NOT TARGET curl_project)
                    -DCURL_STATICLIB=$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>
                    -DCMAKE_DEBUG_POSTFIX=
                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
         BUILD_COMMAND ${CMAKE_COMMAND}
                       --build
                       <BINARY_DIR>

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -36,11 +36,14 @@ if (NOT TARGET gprc_project)
         set(PARALLEL "")
     endif ()
 
-    # When CMake passes the configure command to the shell, the semi-colon will
-    # also be interpreted by the shell so it needs to be escaped. Quoting does
-    # not work, so instead we replace the semi-colon with a different separator
-    # and specify that using LIST_SEPARATOR below. This ensures that our RPATH
-    # will contain both directories.
+    # When passing a semi-colon delimited list to ExternalProject_Add, we need
+    # to escape the semi-colon. Quoting does not work and escaping the semi-
+    # colon does not seem to work (see https://reviews.llvm.org/D40257). A
+    # workaround is to use LIST_SEPARATOR to change the delimiter, which will
+    # then be replaced by an escaped semi-colon by CMake. This allows us to use
+    # multiple directories for our RPATH. Normally, it'd make sense to use : as
+    # a delimiter since it is a typical path-list separator, but it is a special
+    # character in CMake.
     set(GOOGLE_CLOUD_CPP_INSTALL_RPATH "<INSTALL_DIR>/lib;<INSTALL_DIR>/lib64")
     string(REPLACE ";"
                    "|"

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -36,6 +36,17 @@ if (NOT TARGET gprc_project)
         set(PARALLEL "")
     endif ()
 
+    # When CMake passes the configure command to the shell, the semi-colon will
+    # also be interpreted by the shell so it needs to be escaped. Quoting does
+    # not work, so instead we replace the semi-colon with a different separator
+    # and specify that using LIST_SEPARATOR below. This ensures that our RPATH
+    # will contain both directories.
+    set(GOOGLE_CLOUD_CPP_INSTALL_RPATH "<INSTALL_DIR>/lib;<INSTALL_DIR>/lib64")
+    string(REPLACE ";"
+                   "|"
+                   GOOGLE_CLOUD_CPP_INSTALL_RPATH
+                   "${GOOGLE_CLOUD_CPP_INSTALL_RPATH}")
+
     create_external_project_library_byproduct_list(grpc_byproducts
                                                    "grpc"
                                                    "grpc++"
@@ -50,12 +61,14 @@ if (NOT TARGET gprc_project)
         INSTALL_DIR "external"
         URL ${GOOGLE_CLOUD_CPP_GRPC_URL}
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GRPC_SHA256}
+        LIST_SEPARATOR |
         CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
                    -DCMAKE_BUILD_TYPE=Release
                    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
                    -DgRPC_BUILD_TESTS=OFF
                    -DgRPC_ZLIB_PROVIDER=package
                    -DgRPC_SSL_PROVIDER=package

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -35,6 +35,17 @@ if (NOT TARGET protobuf_project)
         set(PARALLEL "")
     endif ()
 
+    # When CMake passes the configure command to the shell, the semi-colon will
+    # also be interpreted by the shell so it needs to be escaped. Quoting does
+    # not work, so instead we replace the semi-colon with a different separator
+    # and specify that using LIST_SEPARATOR below. This ensures that our RPATH
+    # will contain both directories.
+    set(GOOGLE_CLOUD_CPP_INSTALL_RPATH "<INSTALL_DIR>/lib;<INSTALL_DIR>/lib64")
+    string(REPLACE ";"
+                   "|"
+                   GOOGLE_CLOUD_CPP_INSTALL_RPATH
+                   "${GOOGLE_CLOUD_CPP_INSTALL_RPATH}")
+
     create_external_project_library_byproduct_list(protobuf_byproducts
                                                    "protobuf")
 
@@ -47,24 +58,27 @@ if (NOT TARGET protobuf_project)
         INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
         URL ${GOOGLE_CLOUD_CPP_PROTOBUF_URL}
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_PROTOBUF_SHA256}
-        CONFIGURE_COMMAND ${CMAKE_COMMAND}
-                          -G${CMAKE_GENERATOR}
-                          ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
-                          -DCMAKE_BUILD_TYPE=Debug
-                          -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-                          -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-                          -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-                          -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-                          -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
-                          -Dprotobuf_BUILD_TESTS=OFF
-                          -Dprotobuf_DEBUG_POSTFIX=
-                          -H<SOURCE_DIR>/cmake
-                          -B<BINARY_DIR>
-                          $<$<BOOL:${GOOGLE_CLOUD_CPP_USE_LIBCXX}>:
-                          -DCMAKE_CXX_FLAGS=-stdlib=libc++
-                          # This is needed for protoc
-                          -DCMAKE_EXE_LINKER_FLAGS=-Wl,-lc++abi
-                          -DCMAKE_SHARED_LINKER_FLAGS=-Wl,-lc++abi >
+        LIST_SEPARATOR |
+        CONFIGURE_COMMAND
+            ${CMAKE_COMMAND}
+            -G${CMAKE_GENERATOR}
+            ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+            -DCMAKE_BUILD_TYPE=Debug
+            -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+            -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+            -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+            -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
+            -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+            -Dprotobuf_BUILD_TESTS=OFF
+            -Dprotobuf_DEBUG_POSTFIX=
+            -H<SOURCE_DIR>/cmake
+            -B<BINARY_DIR>
+            $<$<BOOL:${GOOGLE_CLOUD_CPP_USE_LIBCXX}>:
+            -DCMAKE_CXX_FLAGS=-stdlib=libc++
+            # This is needed for protoc
+            -DCMAKE_EXE_LINKER_FLAGS=-Wl,-lc++abi
+            -DCMAKE_SHARED_LINKER_FLAGS=-Wl,-lc++abi >
         BUILD_COMMAND ${CMAKE_COMMAND}
                       --build
                       <BINARY_DIR>

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -35,11 +35,14 @@ if (NOT TARGET protobuf_project)
         set(PARALLEL "")
     endif ()
 
-    # When CMake passes the configure command to the shell, the semi-colon will
-    # also be interpreted by the shell so it needs to be escaped. Quoting does
-    # not work, so instead we replace the semi-colon with a different separator
-    # and specify that using LIST_SEPARATOR below. This ensures that our RPATH
-    # will contain both directories.
+    # When passing a semi-colon delimited list to ExternalProject_Add, we need
+    # to escape the semi-colon. Quoting does not work and escaping the semi-
+    # colon does not seem to work (see https://reviews.llvm.org/D40257). A
+    # workaround is to use LIST_SEPARATOR to change the delimiter, which will
+    # then be replaced by an escaped semi-colon by CMake. This allows us to use
+    # multiple directories for our RPATH. Normally, it'd make sense to use : as
+    # a delimiter since it is a typical path-list separator, but it is a special
+    # character in CMake.
     set(GOOGLE_CLOUD_CPP_INSTALL_RPATH "<INSTALL_DIR>/lib;<INSTALL_DIR>/lib64")
     string(REPLACE ";"
                    "|"


### PR DESCRIPTION
Fixes #1797

The issue as stated earlier was that doing something like `-DCMAKE_INSTALL_RPATH=blah;blah` did not work because the second directory was being ignored. CMake is supposed to split on semi-colons but for some reason, that isn't happening. So this approach specifies a different separator.

More information can be found here: https://public.kitware.com/Bug/view.php?id=16137. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1823)
<!-- Reviewable:end -->
