### PR TITLE
Convert RewriteObject functions to use StatusOr.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -1176,9 +1176,6 @@ class Client {
    *      `MaxBytesRewrittenPerCall`, `Projection`, `SourceEncryptionKey`,
    *      `SourceGeneration`, `UserProject`, and `WithObjectMetadata`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions, in this
    * case, `IfGenerationMatch`.
@@ -1226,9 +1223,6 @@ class Client {
    *      `IfSourceMetagenerationMatch`, `IfSourceMetagenerationNotMatch`,
    *      `MaxBytesRewrittenPerCall`, `Projection`, `SourceEncryptionKey`,
    *      `SourceGeneration`, `UserProject`, and `WithObjectMetadata`.
-   *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
    *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions, in this
@@ -1280,8 +1274,7 @@ class Client {
    *      `MaxBytesRewrittenPerCall`, `Projection`, `SourceEncryptionKey`,
    *      `SourceGeneration`, `UserProject`, and `WithObjectMetadata`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
+   * @return The metadata of the newly created object.
    *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions, in this
@@ -1298,11 +1291,10 @@ class Client {
    *
    */
   template <typename... Options>
-  ObjectMetadata RewriteObjectBlocking(std::string source_bucket_name,
-                                       std::string source_object_name,
-                                       std::string destination_bucket_name,
-                                       std::string destination_object_name,
-                                       Options&&... options) {
+  StatusOr<ObjectMetadata> RewriteObjectBlocking(
+      std::string source_bucket_name, std::string source_object_name,
+      std::string destination_bucket_name, std::string destination_object_name,
+      Options&&... options) {
     return ResumeRewriteObject(std::move(source_bucket_name),
                                std::move(source_object_name),
                                std::move(destination_bucket_name),


### PR DESCRIPTION
Return a StatusOr in the member functions that might return with an
error. Changed the examples and the tests.

This fixes #1658 #1659 and #1660.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1825)
<!-- Reviewable:end -->
