### PR TITLE
Fix handling of 308 responses.

### DIFF
--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -279,10 +279,7 @@ StatusOr<ResumableUploadResponse> CurlClient::UploadChunk(
   if (not response.ok()) {
     return std::move(response).status();
   }
-  bool success_with_308 =
-      response->status_code == 308 and
-      response->headers.find("range") != response->headers.end();
-  if (response->status_code < 300 or success_with_308) {
+  if (response->status_code < 300 or response->status_code == 308) {
     return ResumableUploadResponse::FromHttpResponse(*std::move(response));
   }
   return AsStatus(*response);
@@ -302,10 +299,7 @@ StatusOr<ResumableUploadResponse> CurlClient::QueryResumableUpload(
   if (not response.ok()) {
     return std::move(response).status();
   }
-  bool success_with_308 =
-      response->status_code == 308 and
-      response->headers.find("range") != response->headers.end();
-  if (response->status_code < 300 or success_with_308) {
+  if (response->status_code < 300 or response->status_code == 308) {
     return ResumableUploadResponse::FromHttpResponse(*std::move(response));
   }
   return AsStatus(*response);

--- a/google/cloud/storage/testbench/gcs_bucket.py
+++ b/google/cloud/storage/testbench/gcs_bucket.py
@@ -588,8 +588,9 @@ class GcsBucket(object):
                 # This is just a query to resume an upload, if it is done, return
                 # an empty
                 response = flask.make_response('')
-                response.headers['Range'] = 'bytes=0-%d' % (next_byte - 1)
-                response.status_code = 200
+                if next_byte > 1:
+                    response.headers['Range'] = 'bytes=0-%d' % (next_byte - 1)
+                response.status_code = 308
                 return response
             match = re.match('bytes ([0-9]+)-([0-9]+)/(\*|[0-9]+)', content_range)
             if not match:

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -137,14 +137,14 @@ TEST_F(ObjectResumableWriteIntegrationTest, WriteResume) {
     auto old_os =
         client.WriteObject(bucket_name, object_name, IfGenerationMatch(0),
                            NewResumableUploadSession());
-    old_os.exceptions(std::ios_base::failbit);
+    ASSERT_TRUE(old_os.good()) << "status=" << old_os.metadata().status();
     session_id = old_os.resumable_session_id();
     std::move(old_os).Suspend();
   }
 
   auto os = client.WriteObject(bucket_name, object_name,
                                RestoreResumableUploadSession(session_id));
-  os.exceptions(std::ios_base::failbit);
+  ASSERT_TRUE(os.good()) << "status=" << os.metadata().status();
   EXPECT_EQ(session_id, os.resumable_session_id());
   os << LoremIpsum();
   os.Close();


### PR DESCRIPTION
When resuming an upload that has received no bytes the server can
respond with 308 and exclude the `Range:` header. The client should
interpret that as "oh, you have no committed bytes, cool I will start
from 0 then." We were interpreting that as "The server is broken, you
are supposed to tell me what was the last byte." I guess I just read the
documentation wrong.

I fixed the testbench to behave like the production service does in this
case. That broke one of the integration tests (yay!) and then fixed the
code to handle the response message the "Right Way":tm:

This fixes #1829.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1831)
<!-- Reviewable:end -->
