### PR TITLE
Use StatusOr in Client::CreateBucket.

### DIFF
--- a/google/cloud/storage/benchmarks/storage_latency_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_latency_benchmark.cc
@@ -147,7 +147,7 @@ int main(int argc, char* argv[]) try {
                               .set_location(options.region),
                           gcs::PredefinedAcl("private"),
                           gcs::PredefinedDefaultObjectAcl("projectPrivate"),
-                          gcs::Projection("full"));
+                          gcs::Projection("full")).value();
   std::cout << "# Running test on bucket: " << meta.name() << std::endl;
   std::string notes = google::cloud::storage::version_string() + ";" +
                       google::cloud::internal::compiler() + ";" +

--- a/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
@@ -141,13 +141,15 @@ int main(int argc, char* argv[]) try {
 
   auto bucket_name = MakeRandomBucketName(generator);
   auto meta =
-      client.CreateBucket(bucket_name,
-                          gcs::BucketMetadata()
-                              .set_storage_class(gcs::storage_class::Regional())
-                              .set_location(options.region),
-                          gcs::PredefinedAcl("private"),
-                          gcs::PredefinedDefaultObjectAcl("projectPrivate"),
-                          gcs::Projection("full"));
+      client
+          .CreateBucket(bucket_name,
+                        gcs::BucketMetadata()
+                            .set_storage_class(gcs::storage_class::Regional())
+                            .set_location(options.region),
+                        gcs::PredefinedAcl("private"),
+                        gcs::PredefinedDefaultObjectAcl("projectPrivate"),
+                        gcs::Projection("full"))
+          .value();
   std::cout << "# Running test on bucket: " << meta.name() << std::endl;
   std::string notes = google::cloud::storage::version_string() + ";" +
                       google::cloud::internal::compiler() + ";" +
@@ -268,7 +270,7 @@ TestResult WriteCommon(gcs::Client client, std::string const& bucket_name,
     if (i != 0 and i % kThroughputReportIntervalInChunks == 0) {
       auto elapsed = std::chrono::steady_clock::now() - start;
       result.emplace_back(
-	  IterationResult{op_type, i * data_chunk.size(),
+          IterationResult{op_type, i * data_chunk.size(),
                           std::chrono::duration_cast<milliseconds>(elapsed)});
     }
   }
@@ -276,7 +278,7 @@ TestResult WriteCommon(gcs::Client client, std::string const& bucket_name,
     stream.Close();
     auto elapsed = std::chrono::steady_clock::now() - start;
     result.emplace_back(
-	IterationResult{op_type, options.object_chunk_count * data_chunk.size(),
+        IterationResult{op_type, options.object_chunk_count * data_chunk.size(),
                         std::chrono::duration_cast<milliseconds>(elapsed)});
   } catch (std::exception const& ex) {
     std::cerr << ex.what() << std::endl;
@@ -332,9 +334,8 @@ TestResult ReadOnce(gcs::Client client, std::string const& bucket_name,
     }
   }
   auto elapsed = std::chrono::steady_clock::now() - start;
-  result.emplace_back(
-      IterationResult{OP_READ, total_size,
-                     std::chrono::duration_cast<milliseconds>(elapsed)});
+  result.emplace_back(IterationResult{
+      OP_READ, total_size, std::chrono::duration_cast<milliseconds>(elapsed)});
   return result;
 }
 

--- a/google/cloud/storage/examples/storage_quickstart.cc
+++ b/google/cloud/storage/examples/storage_quickstart.cc
@@ -26,18 +26,21 @@ int main(int argc, char* argv[]) try {
   std::string bucket_name = argv[1];
   std::string project_id = argv[2];
 
-  // Create an alias to make the code easier to read.
+  // Create aliases to make the code easier to read.
   namespace gcs = google::cloud::storage;
 
   // Create a client to communicate with Google Cloud Storage. This client
   // uses the default configuration for authentication and project id.
   gcs::Client client;
 
-  gcs::BucketMetadata metadata = client.CreateBucketForProject(
-      bucket_name, project_id,
-      gcs::BucketMetadata()
-          .set_location("us-east1")
-          .set_storage_class(gcs::storage_class::Regional()));
+  gcs::BucketMetadata metadata =
+      client
+          .CreateBucketForProject(
+              bucket_name, project_id,
+              gcs::BucketMetadata()
+                  .set_location("us-east1")
+                  .set_storage_class(gcs::storage_class::Regional()))
+          .value();
 
   std::cout << "Created bucket " << metadata.name() << std::endl;
 

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -79,14 +79,15 @@ TEST_F(BucketIntegrationTest, BasicCRUD) {
 
   auto insert_meta =
       client.CreateBucketForProject(bucket_name, project_id, BucketMetadata());
-  EXPECT_EQ(bucket_name, insert_meta.name());
+  ASSERT_TRUE(insert_meta.ok()) << "status=" << insert_meta.status();
+  EXPECT_EQ(bucket_name, insert_meta->name());
 
   buckets = client.ListBucketsForProject(project_id);
   std::vector<BucketMetadata> current_buckets(buckets.begin(), buckets.end());
   EXPECT_EQ(1U, name_counter(bucket_name, current_buckets));
 
   BucketMetadata get_meta = client.GetBucketMetadata(bucket_name);
-  EXPECT_EQ(insert_meta, get_meta);
+  EXPECT_EQ(*insert_meta, get_meta);
 
   // Create a request to update the metadata, change the storage class because
   // it is easy. And use either COLDLINE or NEARLINE depending on the existing
@@ -135,23 +136,26 @@ TEST_F(BucketIntegrationTest, FullPatch) {
 
   // We need to have an available bucket for logging ...
   std::string logging_name = MakeRandomBucketName();
-  BucketMetadata const logging_meta = client.CreateBucketForProject(
+  StatusOr<BucketMetadata> const logging_meta = client.CreateBucketForProject(
       logging_name, project_id, BucketMetadata(), PredefinedAcl("private"),
       PredefinedDefaultObjectAcl("projectPrivate"), Projection("noAcl"));
-  EXPECT_EQ(logging_name, logging_meta.name());
+  ASSERT_TRUE(logging_meta.ok()) << "status=" << logging_meta.status();
+
+  EXPECT_EQ(logging_name, logging_meta->name());
 
   // Create a Bucket, use the default settings for most fields, except the
   // storage class and location. Fetch the full attributes of the bucket.
-  BucketMetadata const insert_meta = client.CreateBucketForProject(
+  StatusOr<BucketMetadata> const insert_meta = client.CreateBucketForProject(
       bucket_name, project_id,
       BucketMetadata().set_location("US").set_storage_class(
           storage_class::MultiRegional()),
       PredefinedAcl("private"), PredefinedDefaultObjectAcl("projectPrivate"),
       Projection("full"));
-  EXPECT_EQ(bucket_name, insert_meta.name());
+  ASSERT_TRUE(insert_meta.ok()) << "status=" << insert_meta.status();
+  EXPECT_EQ(bucket_name, insert_meta->name());
 
   // Patch every possible field in the metadata, to verify they work.
-  BucketMetadata desired_state = insert_meta;
+  BucketMetadata desired_state = *insert_meta;
   // acl()
   desired_state.mutable_acl().push_back(BucketAccessControl()
                                             .set_entity("allAuthenticatedUsers")
@@ -218,7 +222,7 @@ TEST_F(BucketIntegrationTest, FullPatch) {
   }
 
   BucketMetadata patched =
-      client.PatchBucket(bucket_name, insert_meta, desired_state);
+      client.PatchBucket(bucket_name, *insert_meta, desired_state);
   // acl() - cannot compare for equality because many fields are updated with
   // unknown values (entity_id, etag, etc)
   EXPECT_EQ(1U, std::count_if(patched.acl().begin(), patched.acl().end(),
@@ -335,6 +339,7 @@ TEST_F(BucketIntegrationTest, AccessControlCRUD) {
   auto meta = client.CreateBucketForProject(
       bucket_name, project_id, BucketMetadata(), PredefinedAcl("private"),
       Projection("full"));
+  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
 
   auto entity_name = MakeEntityName();
 
@@ -346,10 +351,10 @@ TEST_F(BucketIntegrationTest, AccessControlCRUD) {
     };
     return std::count_if(list.begin(), list.end(), name_matcher(name));
   };
-  ASSERT_FALSE(meta.acl().empty())
+  ASSERT_FALSE(meta->acl().empty())
       << "Test aborted. Empty ACL returned from newly created bucket <"
       << bucket_name << "> even though we requested the <full> projection.";
-  ASSERT_EQ(0, name_counter(entity_name, meta.acl()))
+  ASSERT_EQ(0, name_counter(entity_name, meta->acl()))
       << "Test aborted. The bucket <" << bucket_name << "> has <" << entity_name
       << "> in its ACL.  This is unexpected because the bucket was just"
       << " created with a predefine ACL which should preclude this result.";
@@ -414,6 +419,7 @@ TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
   auto meta = client.CreateBucketForProject(
       bucket_name, project_id, BucketMetadata(),
       PredefinedDefaultObjectAcl("projectPrivate"), Projection("full"));
+  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
 
   auto entity_name = MakeEntityName();
 
@@ -425,10 +431,10 @@ TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
     };
     return std::count_if(list.begin(), list.end(), name_matcher(name));
   };
-  ASSERT_FALSE(meta.default_acl().empty())
+  ASSERT_FALSE(meta->default_acl().empty())
       << "Test aborted. Empty ACL returned from newly created bucket <"
       << bucket_name << "> even though we requested the <full> projection.";
-  ASSERT_EQ(0, name_counter(entity_name, meta.default_acl()))
+  ASSERT_EQ(0, name_counter(entity_name, meta->default_acl()))
       << "Test aborted. The bucket <" << bucket_name << "> has <" << entity_name
       << "> in its ACL.  This is unexpected because the bucket was just"
       << " created with a predefine ACL which should preclude this result.";
@@ -485,6 +491,7 @@ TEST_F(BucketIntegrationTest, NotificationsCRUD) {
   // Create a new bucket to run the test.
   auto meta =
       client.CreateBucketForProject(bucket_name, project_id, BucketMetadata());
+  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
 
   auto current_notifications = client.ListNotifications(bucket_name);
   ASSERT_TRUE(current_notifications.ok())
@@ -540,6 +547,7 @@ TEST_F(BucketIntegrationTest, IamCRUD) {
   // Create a new bucket to run the test.
   auto meta =
       client.CreateBucketForProject(bucket_name, project_id, BucketMetadata());
+  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
 
   IamPolicy policy = client.GetBucketIamPolicy(bucket_name);
   auto const& bindings = policy.bindings;
@@ -589,11 +597,12 @@ TEST_F(BucketIntegrationTest, BucketLock) {
   // Create a new bucket to run the test.
   auto meta =
       client.CreateBucketForProject(bucket_name, project_id, BucketMetadata());
+  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
 
   auto after_setting_retention_policy = client.PatchBucket(
       bucket_name,
       BucketMetadataPatchBuilder().SetRetentionPolicy(std::chrono::seconds(30)),
-      IfMetagenerationMatch(meta.metageneration()));
+      IfMetagenerationMatch(meta->metageneration()));
 
   client.LockBucketRetentionPolicy(
       bucket_name, after_setting_retention_policy.metageneration());
@@ -629,10 +638,9 @@ TEST_F(BucketIntegrationTest, CreateFailure) {
   // uppercase letter), the service (or testbench) will reject the request and
   // we should report that error correctly. For good measure, make the project
   // id invalid too.
-  TestPermanentFailure([&client] {
-    client.CreateBucketForProject("Invalid_Bucket_Name", "Invalid-project-id-",
+  StatusOr<BucketMetadata> meta = client.CreateBucketForProject("Invalid_Bucket_Name", "Invalid-project-id-",
                                   BucketMetadata());
-  });
+  ASSERT_FALSE(meta.ok()) << "metadata=" << meta.value();
 }
 
 TEST_F(BucketIntegrationTest, GetFailure) {

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -140,7 +140,6 @@ TEST_F(BucketIntegrationTest, FullPatch) {
       logging_name, project_id, BucketMetadata(), PredefinedAcl("private"),
       PredefinedDefaultObjectAcl("projectPrivate"), Projection("noAcl"));
   ASSERT_TRUE(logging_meta.ok()) << "status=" << logging_meta.status();
-
   EXPECT_EQ(logging_name, logging_meta->name());
 
   // Create a Bucket, use the default settings for most fields, except the

--- a/google/cloud/storage/tests/thread_integration_test.cc
+++ b/google/cloud/storage/tests/thread_integration_test.cc
@@ -111,7 +111,7 @@ TEST_F(ThreadIntegrationTest, Unshared) {
   std::string bucket_name = MakeRandomBucketName();
   Client client;
 
-  auto bucket = client.CreateBucketForProject(
+  StatusOr<BucketMetadata> meta = client.CreateBucketForProject(
       bucket_name, project_id,
       BucketMetadata()
           .set_storage_class(storage_class::Regional())
@@ -119,7 +119,8 @@ TEST_F(ThreadIntegrationTest, Unshared) {
           .disable_versioning(),
       PredefinedAcl("private"), PredefinedDefaultObjectAcl("projectPrivate"),
       Projection("full"));
-  EXPECT_EQ(bucket_name, bucket.name());
+  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  EXPECT_EQ(bucket_name, meta->name());
 
   constexpr int kObjectCount = 2000;
   std::vector<std::string> objects;
@@ -185,7 +186,7 @@ TEST_F(ThreadIntegrationTest, ReuseConnections) {
   std::string bucket_name = MakeRandomBucketName();
 
   auto id = LogSink::Instance().AddBackend(log_backend);
-  auto bucket = client.CreateBucketForProject(
+  StatusOr<BucketMetadata> meta = client.CreateBucketForProject(
       bucket_name, project_id,
       BucketMetadata()
           .set_storage_class(storage_class::Regional())
@@ -193,7 +194,8 @@ TEST_F(ThreadIntegrationTest, ReuseConnections) {
           .disable_versioning(),
       PredefinedAcl("private"), PredefinedDefaultObjectAcl("projectPrivate"),
       Projection("full"));
-  EXPECT_EQ(bucket_name, bucket.name());
+  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  EXPECT_EQ(bucket_name, meta->name());
 
   constexpr int kObjectCount = 100;
   std::vector<std::string> objects;


### PR DESCRIPTION
Return `StatusOr<BucketMetadata>` from `Client::CreateBucket`, change
the examples and tests to use the new return type.

This fixes #1681.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1834)
<!-- Reviewable:end -->
