### PR TITLE
Use StatusOr in several Client::*Bucket operations.

### DIFF
--- a/google/cloud/storage/benchmarks/storage_latency_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_latency_benchmark.cc
@@ -168,7 +168,7 @@ int main(int argc, char* argv[]) try {
   RunTest(client, bucket_name, options, object_names);
   DeleteAllObjects(client, bucket_name, options, object_names);
   std::cout << "# Deleting " << bucket_name << std::endl;
-  client.DeleteBucket(bucket_name);
+  client.DeleteBucket(bucket_name).value();
 
   return 0;
 } catch (std::exception const& ex) {

--- a/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
@@ -172,7 +172,7 @@ int main(int argc, char* argv[]) try {
   DeleteAllObjects(client, bucket_name, options, object_names);
 
   std::cout << "# Deleting " << bucket_name << std::endl;
-  client.DeleteBucket(bucket_name);
+  client.DeleteBucket(bucket_name).value();
 
   return 0;
 } catch (std::exception const& ex) {

--- a/google/cloud/storage/bucket_test.cc
+++ b/google/cloud/storage/bucket_test.cc
@@ -150,20 +150,25 @@ TEST_F(BucketTest, GetBucketMetadata) {
                 LimitedErrorCountRetryPolicy(2)};
 
   auto actual = client.GetBucketMetadata("foo-bar-baz");
-  EXPECT_EQ(expected, actual);
+  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  EXPECT_EQ(expected, *actual);
 }
 
 TEST_F(BucketTest, GetMetadataTooManyFailures) {
-  testing::TooManyFailuresTest<BucketMetadata>(
+  testing::TooManyFailuresStatusTest<BucketMetadata>(
       mock, EXPECT_CALL(*mock, GetBucketMetadata(_)),
-      [](Client& client) { client.GetBucketMetadata("test-bucket-name"); },
+      [](Client& client) {
+        return client.GetBucketMetadata("test-bucket-name").status();
+      },
       "GetBucketMetadata");
 }
 
 TEST_F(BucketTest, GetMetadataPermanentFailure) {
-  testing::PermanentFailureTest<BucketMetadata>(
+  testing::PermanentFailureStatusTest<BucketMetadata>(
       *client, EXPECT_CALL(*mock, GetBucketMetadata(_)),
-      [](Client& client) { client.GetBucketMetadata("test-bucket-name"); },
+      [](Client& client) {
+        return client.GetBucketMetadata("test-bucket-name").status();
+      },
       "GetBucketMetadata");
 }
 
@@ -177,24 +182,30 @@ TEST_F(BucketTest, DeleteBucket) {
   Client client{std::shared_ptr<internal::RawClient>(mock),
                 LimitedErrorCountRetryPolicy(2)};
 
-  client.DeleteBucket("foo-bar-baz");
-  SUCCEED();
+  auto actual = client.DeleteBucket("foo-bar-baz");
+  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
 }
 
 TEST_F(BucketTest, DeleteBucketTooManyFailures) {
-  testing::TooManyFailuresTest<internal::EmptyResponse>(
+  testing::TooManyFailuresStatusTest<internal::EmptyResponse>(
       mock, EXPECT_CALL(*mock, DeleteBucket(_)),
-      [](Client& client) { client.DeleteBucket("test-bucket-name"); },
       [](Client& client) {
-        client.DeleteBucket("test-bucket-name", IfMetagenerationMatch(42));
+        return client.DeleteBucket("test-bucket-name").status();
+      },
+      [](Client& client) {
+        return client
+            .DeleteBucket("test-bucket-name", IfMetagenerationMatch(42))
+            .status();
       },
       "DeleteBucket");
 }
 
 TEST_F(BucketTest, DeleteBucketPermanentFailure) {
-  testing::PermanentFailureTest<internal::EmptyResponse>(
+  testing::PermanentFailureStatusTest<internal::EmptyResponse>(
       *client, EXPECT_CALL(*mock, DeleteBucket(_)),
-      [](Client& client) { client.DeleteBucket("test-bucket-name"); },
+      [](Client& client) {
+        return client.DeleteBucket("test-bucket-name").status();
+      },
       "DeleteBucket");
 }
 
@@ -228,27 +239,32 @@ TEST_F(BucketTest, UpdateBucket) {
   auto actual = client.UpdateBucket(
       "test-bucket-name",
       BucketMetadata().set_location("US").set_storage_class("STANDARD"));
-  EXPECT_EQ(expected, actual);
+  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  EXPECT_EQ(expected, *actual);
 }
 
 TEST_F(BucketTest, UpdateBucketTooManyFailures) {
-  testing::TooManyFailuresTest<BucketMetadata>(
+  testing::TooManyFailuresStatusTest<BucketMetadata>(
       mock, EXPECT_CALL(*mock, UpdateBucket(_)),
       [](Client& client) {
-        client.UpdateBucket("test-bucket-name", BucketMetadata());
+        return client.UpdateBucket("test-bucket-name", BucketMetadata())
+            .status();
       },
       [](Client& client) {
-        client.UpdateBucket("test-bucket-name", BucketMetadata(),
-                            IfMetagenerationMatch(42));
+        return client
+            .UpdateBucket("test-bucket-name", BucketMetadata(),
+                          IfMetagenerationMatch(42))
+            .status();
       },
       "UpdateBucket");
 }
 
 TEST_F(BucketTest, UpdateBucketPermanentFailure) {
-  testing::PermanentFailureTest<BucketMetadata>(
+  testing::PermanentFailureStatusTest<BucketMetadata>(
       *client, EXPECT_CALL(*mock, UpdateBucket(_)),
       [](Client& client) {
-        client.UpdateBucket("test-bucket-name", BucketMetadata());
+        return client.UpdateBucket("test-bucket-name", BucketMetadata())
+            .status();
       },
       "UpdateBucket");
 }
@@ -282,27 +298,34 @@ TEST_F(BucketTest, PatchBucket) {
   auto actual = client.PatchBucket(
       "test-bucket-name",
       BucketMetadataPatchBuilder().SetStorageClass("STANDARD"));
-  EXPECT_EQ(expected, actual);
+  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  EXPECT_EQ(expected, *actual);
 }
 
 TEST_F(BucketTest, PatchBucketTooManyFailures) {
-  testing::TooManyFailuresTest<BucketMetadata>(
+  testing::TooManyFailuresStatusTest<BucketMetadata>(
       mock, EXPECT_CALL(*mock, PatchBucket(_)),
       [](Client& client) {
-        client.PatchBucket("test-bucket-name", BucketMetadataPatchBuilder());
+        return client
+            .PatchBucket("test-bucket-name", BucketMetadataPatchBuilder())
+            .status();
       },
       [](Client& client) {
-        client.PatchBucket("test-bucket-name", BucketMetadataPatchBuilder(),
-                           IfMetagenerationMatch(42));
+        return client
+            .PatchBucket("test-bucket-name", BucketMetadataPatchBuilder(),
+                         IfMetagenerationMatch(42))
+            .status();
       },
       "PatchBucket");
 }
 
 TEST_F(BucketTest, PatchBucketPermanentFailure) {
-  testing::PermanentFailureTest<BucketMetadata>(
+  testing::PermanentFailureStatusTest<BucketMetadata>(
       *client, EXPECT_CALL(*mock, PatchBucket(_)),
       [](Client& client) {
-        client.PatchBucket("test-bucket-name", BucketMetadataPatchBuilder());
+        return client
+            .PatchBucket("test-bucket-name", BucketMetadataPatchBuilder())
+            .status();
       },
       "PatchBucket");
 }

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -292,9 +292,6 @@ class Client {
    *     Valid types for this operation include `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, `UserProject`, and `Projection`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This is a read-only operation and is always idempotent.
    *
@@ -302,11 +299,11 @@ class Client {
    * @snippet storage_bucket_samples.cc get bucket metadata
    */
   template <typename... Options>
-  BucketMetadata GetBucketMetadata(std::string const& bucket_name,
-                                   Options&&... options) {
+  StatusOr<BucketMetadata> GetBucketMetadata(std::string const& bucket_name,
+                                             Options&&... options) {
     internal::GetBucketMetadataRequest request(bucket_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->GetBucketMetadata(request).value();
+    return raw_client_->GetBucketMetadata(request);
   }
 
   /**
@@ -317,9 +314,6 @@ class Client {
    *     Valid types for this operation include `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions, in this
    * case, `IfMetagenerationMatch`.
@@ -328,10 +322,11 @@ class Client {
    * @snippet storage_bucket_samples.cc delete bucket
    */
   template <typename... Options>
-  void DeleteBucket(std::string const& bucket_name, Options&&... options) {
+  StatusOr<void> DeleteBucket(std::string const& bucket_name,
+                              Options&&... options) {
     internal::DeleteBucketRequest request(bucket_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    raw_client_->DeleteBucket(request).value();
+    return raw_client_->DeleteBucket(request).status();
   }
 
   /**
@@ -345,9 +340,6 @@ class Client {
    *     `IfMetagenerationNotMatch`, `PredefinedAcl`,
    *     `PredefinedDefaultObjectAcl`, `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions, in this
    * case,`IfMetagenerationMatch`.
@@ -359,12 +351,13 @@ class Client {
    * @snippet storage_bucket_samples.cc update bucket
    */
   template <typename... Options>
-  BucketMetadata UpdateBucket(std::string bucket_name, BucketMetadata metadata,
-                              Options&&... options) {
+  StatusOr<BucketMetadata> UpdateBucket(std::string bucket_name,
+                                        BucketMetadata metadata,
+                                        Options&&... options) {
     metadata.set_name(std::move(bucket_name));
     internal::UpdateBucketRequest request(std::move(metadata));
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->UpdateBucket(request).value();
+    return raw_client_->UpdateBucket(request);
   }
 
   /**
@@ -383,9 +376,6 @@ class Client {
    *     Valid types for this operation include `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions, in this
    * case, `IfMetagenerationMatch`.
@@ -394,14 +384,14 @@ class Client {
    * @snippet storage_bucket_samples.cc patch bucket storage class
    */
   template <typename... Options>
-  BucketMetadata PatchBucket(std::string bucket_name,
-                             BucketMetadata const& original,
-                             BucketMetadata const& updated,
-                             Options&&... options) {
+  StatusOr<BucketMetadata> PatchBucket(std::string bucket_name,
+                                       BucketMetadata const& original,
+                                       BucketMetadata const& updated,
+                                       Options&&... options) {
     internal::PatchBucketRequest request(std::move(bucket_name), original,
                                          updated);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->PatchBucket(request).value();
+    return raw_client_->PatchBucket(request);
   }
 
   /**
@@ -415,9 +405,6 @@ class Client {
    *     Valid types for this operation include `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions, in this
    * case, `IfMetagenerationMatch`.
@@ -426,12 +413,12 @@ class Client {
    * @snippet storage_bucket_samples.cc patch bucket storage class with builder
    */
   template <typename... Options>
-  BucketMetadata PatchBucket(std::string bucket_name,
-                             BucketMetadataPatchBuilder const& builder,
-                             Options&&... options) {
+  StatusOr<BucketMetadata> PatchBucket(
+      std::string bucket_name, BucketMetadataPatchBuilder const& builder,
+      Options&&... options) {
     internal::PatchBucketRequest request(std::move(bucket_name), builder);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->PatchBucket(request).value();
+    return raw_client_->PatchBucket(request);
   }
 
   /**

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -325,20 +325,19 @@ void GetBucketDefaultKmsKey(google::cloud::storage::Client client, int& argc,
   namespace gcs = google::cloud::storage;
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
-    StatusOr<gcs::BucketMetadata> metadata =
-        client.GetBucketMetadata(bucket_name);
-    if (not metadata.ok()) {
+    StatusOr<gcs::BucketMetadata> meta = client.GetBucketMetadata(bucket_name);
+    if (not meta.ok()) {
       std::cerr << "Error reading the metadata for bucket " << bucket_name
-                << ", status=" << metadata.status() << std::endl;
+                << ", status=" << meta.status() << std::endl;
       return;
     }
-    if (not metadata->has_encryption()) {
-      std::cout << "The bucket " << metadata->name()
+    if (not meta->has_encryption()) {
+      std::cout << "The bucket " << meta->name()
                 << " does not have a default KMS key set." << std::endl;
       return;
     }
-    std::cout << "The default KMS key for bucket " << metadata->name()
-              << " is: " << metadata->encryption().default_kms_key_name
+    std::cout << "The default KMS key for bucket " << meta->name()
+              << " is: " << meta->encryption().default_kms_key_name
               << std::endl;
   }
   //! [get bucket default kms key] [END storage_get_bucket_default_kms_key]
@@ -415,20 +414,20 @@ void GetBucketLabels(google::cloud::storage::Client client, int& argc,
   namespace gcs = google::cloud::storage;
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
-    StatusOr<gcs::BucketMetadata> metadata =
+    StatusOr<gcs::BucketMetadata> meta =
         client.GetBucketMetadata(bucket_name, gcs::Fields("labels"));
-    if (not metadata.ok()) {
+    if (not meta.ok()) {
       std::cerr << "Error reading labels on bucket " << bucket_name
-                << ", status=" << metadata.status() << std::endl;
+                << ", status=" << meta.status() << std::endl;
       return;
     }
-    if (metadata->labels().empty()) {
+    if (meta->labels().empty()) {
       std::cout << "The bucket " << bucket_name << " has no labels set."
                 << std::endl;
       return;
     }
     std::cout << "The labels for bucket " << bucket_name << " are:";
-    for (auto const& kv : metadata->labels()) {
+    for (auto const& kv : meta->labels()) {
       std::cout << "\n  " << kv.first << ": " << kv.second;
     }
     std::cout << std::endl;
@@ -482,27 +481,26 @@ void GetBilling(google::cloud::storage::Client client, int& argc,
   namespace gcs = google::cloud::storage;
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
-    StatusOr<gcs::BucketMetadata> metadata =
-        client.GetBucketMetadata(bucket_name);
-    if (not metadata.ok()) {
+    StatusOr<gcs::BucketMetadata> meta = client.GetBucketMetadata(bucket_name);
+    if (not meta.ok()) {
       std::cerr << "Error reading metadata for bucket " << bucket_name
-                << ", status=" << metadata.status() << std::endl;
+                << ", status=" << meta.status() << std::endl;
       return;
     }
-    if (not metadata->has_billing()) {
+    if (not meta->has_billing()) {
       std::cout
-          << "The bucket " << metadata->name() << " does not have a"
+          << "The bucket " << meta->name() << " does not have a"
           << " billing configuration. The default applies, i.e., the project"
           << " that owns the bucket pays for the requests." << std::endl;
       return;
     }
-    if (metadata->billing().requester_pays) {
+    if (meta->billing().requester_pays) {
       std::cout
-          << "The bucket " << metadata->name()
+          << "The bucket " << meta->name()
           << " is configured to charge the calling project for the requests."
           << std::endl;
     } else {
-      std::cout << "The bucket " << metadata->name()
+      std::cout << "The bucket " << meta->name()
                 << " is configured to charge the project that owns the bucket "
                    "for the requests."
                 << std::endl;
@@ -522,18 +520,18 @@ void EnableRequesterPays(google::cloud::storage::Client client, int& argc,
   namespace gcs = google::cloud::storage;
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
-    StatusOr<gcs::BucketMetadata> metadata = client.PatchBucket(
+    StatusOr<gcs::BucketMetadata> meta = client.PatchBucket(
         bucket_name,
         gcs::BucketMetadataPatchBuilder().SetBilling(gcs::BucketBilling{true}));
-    if (not metadata.ok()) {
+    if (not meta.ok()) {
       std::cerr << "Error setting the billing configuration for bucket "
-                << bucket_name << ", status=" << metadata.status() << std::endl;
+                << bucket_name << ", status=" << meta.status() << std::endl;
     }
-    std::cout << "Billing configuration for bucket " << metadata->name()
+    std::cout << "Billing configuration for bucket " << meta->name()
               << " is updated. The bucket now";
-    if (not metadata->has_billing()) {
+    if (not meta->has_billing()) {
       std::cout << " has no billing configuration." << std::endl;
-    } else if (metadata->billing().requester_pays) {
+    } else if (meta->billing().requester_pays) {
       std::cout << " is configured to charge the caller for requests"
                 << std::endl;
     } else {
@@ -556,20 +554,20 @@ void DisableRequesterPays(google::cloud::storage::Client client, int& argc,
   namespace gcs = google::cloud::storage;
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string project_id) {
-    StatusOr<gcs::BucketMetadata> metadata = client.PatchBucket(
+    StatusOr<gcs::BucketMetadata> meta = client.PatchBucket(
         bucket_name,
         gcs::BucketMetadataPatchBuilder().SetBilling(gcs::BucketBilling{false}),
         gcs::UserProject(project_id));
-    if (not metadata.ok()) {
+    if (not meta.ok()) {
       std::cerr << "Error disabling billing configuration for bucket "
-                << bucket_name << ", status=" << metadata.status() << std::endl;
+                << bucket_name << ", status=" << meta.status() << std::endl;
       return;
     }
     std::cout << "Billing configuration for bucket " << bucket_name
               << " is updated. The bucket now";
-    if (not metadata->has_billing()) {
+    if (not meta->has_billing()) {
       std::cout << " has no billing configuration." << std::endl;
-    } else if (metadata->billing().requester_pays) {
+    } else if (meta->billing().requester_pays) {
       std::cout << " is configured to charge the caller for requests"
                 << std::endl;
     } else {
@@ -689,16 +687,15 @@ void GetDefaultEventBasedHold(google::cloud::storage::Client client, int& argc,
   namespace gcs = google::cloud::storage;
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
-    StatusOr<gcs::BucketMetadata> metadata =
-        client.GetBucketMetadata(bucket_name);
-    if (not metadata.ok()) {
+    StatusOr<gcs::BucketMetadata> meta = client.GetBucketMetadata(bucket_name);
+    if (not meta.ok()) {
       std::cerr << "Error fetching bucket metadata for bucket " << bucket_name
-                << ", status=" << metadata.status() << std::endl;
+                << ", status=" << meta.status() << std::endl;
       return;
     }
     std::cout << "The default event-based hold for objects in bucket "
-              << metadata->name() << " is "
-              << (metadata->default_event_based_hold() ? "enabled" : "disabled")
+              << meta->name() << " is "
+              << (meta->default_event_based_hold() ? "enabled" : "disabled")
               << std::endl;
   }
   // [END storage_get_default_event_based_hold]
@@ -795,21 +792,19 @@ void GetRetentionPolicy(google::cloud::storage::Client client, int& argc,
   namespace gcs = google::cloud::storage;
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
-    StatusOr<gcs::BucketMetadata> metadata =
-        client.GetBucketMetadata(bucket_name);
-    if (not metadata.ok()) {
+    StatusOr<gcs::BucketMetadata> meta = client.GetBucketMetadata(bucket_name);
+    if (not meta.ok()) {
       std::cerr << "Error fetching the metadata for bucket " << bucket_name
-                << ", status=" << metadata.status() << std::endl;
+                << ", status=" << meta.status() << std::endl;
       return;
     }
-    if (not metadata->has_retention_policy()) {
-      std::cout << "The bucket " << metadata->name()
+    if (not meta->has_retention_policy()) {
+      std::cout << "The bucket " << meta->name()
                 << " does not have a retention policy set." << std::endl;
       return;
     }
-    std::cout << "The bucket " << metadata->name()
-              << " retention policy is set to " << metadata->retention_policy()
-              << std::endl;
+    std::cout << "The bucket " << meta->name() << " retention policy is set to "
+              << meta->retention_policy() << std::endl;
   }
   // [END storage_get_retention_policy]
   //! [get retention policy]
@@ -937,7 +932,7 @@ int main(int argc, char* argv[]) try {
   //! [create client]
 
   using CommandType =
-      std::function<void(google::cloud::storage::Client, int&, char*[])>;
+      std::function<void(google::cloud::storage::Client, int&, char* [])>;
   std::map<std::string, CommandType> commands = {
       {"list-buckets", &ListBuckets},
       {"list-buckets-for-project", &ListBucketsForProject},

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -86,24 +86,27 @@ TEST_F(BucketIntegrationTest, BasicCRUD) {
   std::vector<BucketMetadata> current_buckets(buckets.begin(), buckets.end());
   EXPECT_EQ(1U, name_counter(bucket_name, current_buckets));
 
-  BucketMetadata get_meta = client.GetBucketMetadata(bucket_name);
-  EXPECT_EQ(*insert_meta, get_meta);
+  StatusOr<BucketMetadata> get_meta = client.GetBucketMetadata(bucket_name);
+  ASSERT_TRUE(get_meta.ok()) << "status=" << get_meta.status();
+  EXPECT_EQ(insert_meta, *get_meta);
 
   // Create a request to update the metadata, change the storage class because
   // it is easy. And use either COLDLINE or NEARLINE depending on the existing
   // value.
   std::string desired_storage_class = storage_class::Coldline();
-  if (get_meta.storage_class() == storage_class::Coldline()) {
+  if (get_meta->storage_class() == storage_class::Coldline()) {
     desired_storage_class = storage_class::Nearline();
   }
-  BucketMetadata update = get_meta;
+  BucketMetadata update = *get_meta;
   update.set_storage_class(desired_storage_class);
-  BucketMetadata updated_meta = client.UpdateBucket(bucket_name, update);
-  EXPECT_EQ(desired_storage_class, updated_meta.storage_class());
+  StatusOr<BucketMetadata> updated_meta =
+      client.UpdateBucket(bucket_name, update);
+  ASSERT_TRUE(updated_meta.ok()) << "status=" << updated_meta.status();
+  EXPECT_EQ(desired_storage_class, updated_meta->storage_class());
 
   // Patch the metadata to change the storage class, add some lifecycle
   // rules, and the website settings.
-  BucketMetadata desired_state = updated_meta;
+  BucketMetadata desired_state = *updated_meta;
   LifecycleRule rule(LifecycleRule::ConditionConjunction(
                          LifecycleRule::MaxAge(30),
                          LifecycleRule::MatchesStorageClassStandard()),
@@ -112,18 +115,21 @@ TEST_F(BucketIntegrationTest, BasicCRUD) {
       .set_lifecycle(BucketLifecycle{{rule}})
       .set_website(BucketWebsite{"index.html", "404.html"});
 
-  BucketMetadata patched =
-      client.PatchBucket(bucket_name, updated_meta, desired_state);
-  EXPECT_EQ(storage_class::Standard(), patched.storage_class());
-  EXPECT_EQ(1U, patched.lifecycle().rule.size());
+  StatusOr<BucketMetadata> patched =
+      client.PatchBucket(bucket_name, *updated_meta, desired_state);
+  ASSERT_TRUE(patched.ok()) << "status=" << patched.status();
+  EXPECT_EQ(storage_class::Standard(), patched->storage_class());
+  EXPECT_EQ(1U, patched->lifecycle().rule.size());
 
   // Patch the metadata again, this time remove billing and website settings.
   patched = client.PatchBucket(
       bucket_name, BucketMetadataPatchBuilder().ResetWebsite().ResetBilling());
-  EXPECT_FALSE(patched.has_billing());
-  EXPECT_FALSE(patched.has_website());
+  ASSERT_TRUE(patched.ok()) << "status=" << patched.status();
+  EXPECT_FALSE(patched->has_billing());
+  EXPECT_FALSE(patched->has_website());
 
-  client.DeleteBucket(bucket_name);
+  StatusOr<void> status = client.DeleteBucket(bucket_name);
+  ASSERT_TRUE(status.ok()) << "status=" << status.status();
   buckets = client.ListBucketsForProject(project_id);
   current_buckets.assign(buckets.begin(), buckets.end());
   EXPECT_EQ(0U, name_counter(bucket_name, current_buckets));
@@ -220,25 +226,27 @@ TEST_F(BucketIntegrationTest, FullPatch) {
     desired_state.set_website(BucketWebsite{"index.html", "404.html"});
   }
 
-  BucketMetadata patched =
-      client.PatchBucket(bucket_name, *insert_meta, desired_state);
+  StatusOr<BucketMetadata> patched =
+      client.PatchBucket(bucket_name, insert_meta, desired_state);
+  ASSERT_TRUE(patched.ok()) << "status=" << patched.status();
   // acl() - cannot compare for equality because many fields are updated with
   // unknown values (entity_id, etag, etc)
-  EXPECT_EQ(1U, std::count_if(patched.acl().begin(), patched.acl().end(),
+  EXPECT_EQ(1U, std::count_if(patched->acl().begin(), patched->acl().end(),
                               [](BucketAccessControl const& x) {
                                 return x.entity() == "allAuthenticatedUsers";
                               }));
 
   // billing()
-  EXPECT_EQ(desired_state.billing_as_optional(), patched.billing_as_optional());
+  EXPECT_EQ(desired_state.billing_as_optional(),
+            patched->billing_as_optional());
 
   // cors()
-  EXPECT_EQ(desired_state.cors(), patched.cors());
+  EXPECT_EQ(desired_state.cors(), patched->cors());
 
   // default_acl() - cannot compare for equality because many fields are updated
   // with unknown values (entity_id, etag, etc)
-  EXPECT_EQ(1U, std::count_if(patched.default_acl().begin(),
-                              patched.default_acl().end(),
+  EXPECT_EQ(1U, std::count_if(patched->default_acl().begin(),
+                              patched->default_acl().end(),
                               [](ObjectAccessControl const& x) {
                                 return x.entity() == "allAuthenticatedUsers";
                               }));
@@ -247,26 +255,29 @@ TEST_F(BucketIntegrationTest, FullPatch) {
 
   // lifecycle()
   EXPECT_EQ(desired_state.lifecycle_as_optional(),
-            patched.lifecycle_as_optional());
+            patched->lifecycle_as_optional());
 
   // location()
-  EXPECT_EQ(desired_state.location(), patched.location());
+  EXPECT_EQ(desired_state.location(), patched->location());
 
   // logging()
-  EXPECT_EQ(desired_state.logging_as_optional(), patched.logging_as_optional())
-      << patched;
+  EXPECT_EQ(desired_state.logging_as_optional(),
+            patched->logging_as_optional());
 
   // storage_class()
-  EXPECT_EQ(desired_state.storage_class(), patched.storage_class());
+  EXPECT_EQ(desired_state.storage_class(), patched->storage_class());
 
   // versioning()
-  EXPECT_EQ(desired_state.versioning(), patched.versioning());
+  EXPECT_EQ(desired_state.versioning(), patched->versioning());
 
   // website()
-  EXPECT_EQ(desired_state.website_as_optional(), patched.website_as_optional());
+  EXPECT_EQ(desired_state.website_as_optional(),
+            patched->website_as_optional());
 
-  client.DeleteBucket(bucket_name);
-  client.DeleteBucket(logging_name);
+  auto delete_status = client.DeleteBucket(bucket_name);
+  ASSERT_TRUE(delete_status.ok()) << "status=" << delete_status.status();
+  delete_status = client.DeleteBucket(logging_name);
+  ASSERT_TRUE(delete_status.ok()) << "status=" << delete_status.status();
 }
 
 TEST_F(BucketIntegrationTest, GetMetadata) {
@@ -274,9 +285,10 @@ TEST_F(BucketIntegrationTest, GetMetadata) {
   Client client;
 
   auto metadata = client.GetBucketMetadata(bucket_name);
-  EXPECT_EQ(bucket_name, metadata.name());
-  EXPECT_EQ(bucket_name, metadata.id());
-  EXPECT_EQ("storage#bucket", metadata.kind());
+  ASSERT_TRUE(metadata.ok()) << "status=" << metadata.status();
+  EXPECT_EQ(bucket_name, metadata->name());
+  EXPECT_EQ(bucket_name, metadata->id());
+  EXPECT_EQ("storage#bucket", metadata->kind());
 }
 
 TEST_F(BucketIntegrationTest, GetMetadataFields) {
@@ -284,9 +296,10 @@ TEST_F(BucketIntegrationTest, GetMetadataFields) {
   Client client;
 
   auto metadata = client.GetBucketMetadata(bucket_name, Fields("name"));
-  EXPECT_EQ(bucket_name, metadata.name());
-  EXPECT_TRUE(metadata.id().empty());
-  EXPECT_TRUE(metadata.kind().empty());
+  ASSERT_TRUE(metadata.ok()) << "status=" << metadata.status();
+  EXPECT_EQ(bucket_name, metadata->name());
+  EXPECT_TRUE(metadata->id().empty());
+  EXPECT_TRUE(metadata->kind().empty());
 }
 
 TEST_F(BucketIntegrationTest, GetMetadataIfMetagenerationMatch_Success) {
@@ -294,14 +307,16 @@ TEST_F(BucketIntegrationTest, GetMetadataIfMetagenerationMatch_Success) {
   Client client;
 
   auto metadata = client.GetBucketMetadata(bucket_name);
-  EXPECT_EQ(bucket_name, metadata.name());
-  EXPECT_EQ(bucket_name, metadata.id());
-  EXPECT_EQ("storage#bucket", metadata.kind());
+  ASSERT_TRUE(metadata.ok()) << "status=" << metadata.status();
+  EXPECT_EQ(bucket_name, metadata->name());
+  EXPECT_EQ(bucket_name, metadata->id());
+  EXPECT_EQ("storage#bucket", metadata->kind());
 
   auto metadata2 = client.GetBucketMetadata(
       bucket_name, storage::Projection("noAcl"),
-      storage::IfMetagenerationMatch(metadata.metageneration()));
-  EXPECT_EQ(metadata2, metadata);
+      storage::IfMetagenerationMatch(metadata->metageneration()));
+  ASSERT_TRUE(metadata2.ok()) << "status=" << metadata2.status();
+  EXPECT_EQ(*metadata2, *metadata);
 }
 
 TEST_F(BucketIntegrationTest, GetMetadataIfMetagenerationNotMatch_Failure) {
@@ -309,23 +324,15 @@ TEST_F(BucketIntegrationTest, GetMetadataIfMetagenerationNotMatch_Failure) {
   Client client;
 
   auto metadata = client.GetBucketMetadata(bucket_name);
-  EXPECT_EQ(bucket_name, metadata.name());
-  EXPECT_EQ(bucket_name, metadata.id());
-  EXPECT_EQ("storage#bucket", metadata.kind());
+  ASSERT_TRUE(metadata.ok()) << "status=" << metadata.status();
+  EXPECT_EQ(bucket_name, metadata->name());
+  EXPECT_EQ(bucket_name, metadata->id());
+  EXPECT_EQ("storage#bucket", metadata->kind());
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      client.GetBucketMetadata(
-          bucket_name, storage::Projection("noAcl"),
-          storage::IfMetagenerationNotMatch(metadata.metageneration())),
-      std::exception);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(
-      client.GetBucketMetadata(
-          bucket_name, storage::Projection("noAcl"),
-          storage::IfMetagenerationNotMatch(metadata.metageneration())),
-      "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  auto metadata2 = client.GetBucketMetadata(
+      bucket_name, storage::Projection("noAcl"),
+      storage::IfMetagenerationNotMatch(metadata->metageneration()));
+  EXPECT_FALSE(metadata2.ok()) << "metadata=" << *metadata2;
 }
 
 TEST_F(BucketIntegrationTest, AccessControlCRUD) {
@@ -404,7 +411,8 @@ TEST_F(BucketIntegrationTest, AccessControlCRUD) {
   ASSERT_TRUE(current_acl.ok()) << "status=" << current_acl.status();
   EXPECT_EQ(0, name_counter(result->entity(), *current_acl));
 
-  client.DeleteBucket(bucket_name);
+  auto delete_status = client.DeleteBucket(bucket_name);
+  ASSERT_TRUE(delete_status.ok()) << "status=" << delete_status.status();
 }
 
 TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
@@ -479,7 +487,8 @@ TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
   ASSERT_TRUE(current_acl.ok()) << "status=" << current_acl.status();
   EXPECT_EQ(0, name_counter(result->entity(), *current_acl));
 
-  client.DeleteBucket(bucket_name);
+  delete_status = client.DeleteBucket(bucket_name);
+  ASSERT_TRUE(delete_status.ok()) << "status=" << delete_status.status();
 }
 
 TEST_F(BucketIntegrationTest, NotificationsCRUD) {
@@ -535,7 +544,8 @@ TEST_F(BucketIntegrationTest, NotificationsCRUD) {
                         });
   EXPECT_EQ(0U, count) << "create=" << *create;
 
-  client.DeleteBucket(bucket_name);
+  delete_status = client.DeleteBucket(bucket_name);
+  ASSERT_TRUE(delete_status.ok()) << "status=" << delete_status.status();
 }
 
 TEST_F(BucketIntegrationTest, IamCRUD) {
@@ -585,7 +595,8 @@ TEST_F(BucketIntegrationTest, IamCRUD) {
       client.TestBucketIamPermissions(bucket_name, expected_permissions);
   EXPECT_THAT(actual_permissions, ElementsAreArray(expected_permissions));
 
-  client.DeleteBucket(bucket_name);
+  auto delete_status = client.DeleteBucket(bucket_name);
+  ASSERT_TRUE(delete_status.ok()) << "status=" << delete_status.status();
 }
 
 TEST_F(BucketIntegrationTest, BucketLock) {
@@ -601,12 +612,15 @@ TEST_F(BucketIntegrationTest, BucketLock) {
   auto after_setting_retention_policy = client.PatchBucket(
       bucket_name,
       BucketMetadataPatchBuilder().SetRetentionPolicy(std::chrono::seconds(30)),
-      IfMetagenerationMatch(meta->metageneration()));
+      IfMetagenerationMatch(meta.metageneration()));
+  ASSERT_TRUE(after_setting_retention_policy.ok())
+      << "status=" << after_setting_retention_policy.status();
 
   client.LockBucketRetentionPolicy(
-      bucket_name, after_setting_retention_policy.metageneration());
+      bucket_name, after_setting_retention_policy->metageneration());
 
-  client.DeleteBucket(bucket_name);
+  auto status = client.DeleteBucket(bucket_name);
+  ASSERT_TRUE(status.ok()) << "status=" << status.status();
 }
 
 TEST_F(BucketIntegrationTest, BucketLockFailure) {
@@ -648,8 +662,8 @@ TEST_F(BucketIntegrationTest, GetFailure) {
 
   // Try to get information about a bucket that does not exist, or at least
   // it is very unlikely to exist, the name is random.
-  TestPermanentFailure(
-      [&client, bucket_name] { client.GetBucketMetadata(bucket_name); });
+  auto status = client.GetBucketMetadata(bucket_name);
+  ASSERT_FALSE(status.ok()) << "value=" << status.value();
 }
 
 TEST_F(BucketIntegrationTest, DeleteFailure) {
@@ -658,8 +672,8 @@ TEST_F(BucketIntegrationTest, DeleteFailure) {
 
   // Try to delete a bucket that does not exist, or at least it is very unlikely
   // to exist, the name is random.
-  TestPermanentFailure(
-      [&client, bucket_name] { client.DeleteBucket(bucket_name); });
+  auto status = client.DeleteBucket(bucket_name);
+  ASSERT_FALSE(status.ok());
 }
 
 TEST_F(BucketIntegrationTest, UpdateFailure) {
@@ -668,9 +682,8 @@ TEST_F(BucketIntegrationTest, UpdateFailure) {
 
   // Try to update a bucket that does not exist, or at least it is very unlikely
   // to exist, the name is random.
-  TestPermanentFailure([&client, bucket_name] {
-    client.UpdateBucket(bucket_name, BucketMetadata());
-  });
+  auto status = client.UpdateBucket(bucket_name, BucketMetadata());
+  ASSERT_FALSE(status.ok()) << "value=" << status.value();
 }
 
 TEST_F(BucketIntegrationTest, PatchFailure) {
@@ -679,9 +692,8 @@ TEST_F(BucketIntegrationTest, PatchFailure) {
 
   // Try to update a bucket that does not exist, or at least it is very unlikely
   // to exist, the name is random.
-  TestPermanentFailure([&client, bucket_name] {
-    client.PatchBucket(bucket_name, BucketMetadataPatchBuilder());
-  });
+  auto status = client.PatchBucket(bucket_name, BucketMetadataPatchBuilder());
+  ASSERT_FALSE(status.ok()) << "value=" << status.value();
 }
 
 TEST_F(BucketIntegrationTest, GetBucketIamPolicyFailure) {

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -88,7 +88,7 @@ TEST_F(BucketIntegrationTest, BasicCRUD) {
 
   StatusOr<BucketMetadata> get_meta = client.GetBucketMetadata(bucket_name);
   ASSERT_TRUE(get_meta.ok()) << "status=" << get_meta.status();
-  EXPECT_EQ(insert_meta, *get_meta);
+  EXPECT_EQ(*insert_meta, *get_meta);
 
   // Create a request to update the metadata, change the storage class because
   // it is easy. And use either COLDLINE or NEARLINE depending on the existing
@@ -227,7 +227,7 @@ TEST_F(BucketIntegrationTest, FullPatch) {
   }
 
   StatusOr<BucketMetadata> patched =
-      client.PatchBucket(bucket_name, insert_meta, desired_state);
+      client.PatchBucket(bucket_name, *insert_meta, desired_state);
   ASSERT_TRUE(patched.ok()) << "status=" << patched.status();
   // acl() - cannot compare for equality because many fields are updated with
   // unknown values (entity_id, etag, etc)
@@ -612,7 +612,7 @@ TEST_F(BucketIntegrationTest, BucketLock) {
   auto after_setting_retention_policy = client.PatchBucket(
       bucket_name,
       BucketMetadataPatchBuilder().SetRetentionPolicy(std::chrono::seconds(30)),
-      IfMetagenerationMatch(meta.metageneration()));
+      IfMetagenerationMatch(meta->metageneration()));
   ASSERT_TRUE(after_setting_retention_policy.ok())
       << "status=" << after_setting_retention_policy.status();
 

--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -238,10 +238,11 @@ TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclBucketOwnerFullControl) {
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
 
-  BucketMetadata bucket =
+  StatusOr<BucketMetadata> bucket =
       client.GetBucketMetadata(bucket_name, Projection::Full());
-  ASSERT_TRUE(bucket.has_owner());
-  std::string owner = bucket.owner().entity;
+  ASSERT_TRUE(bucket.ok()) << "status=" << bucket.status();
+  ASSERT_TRUE(bucket->has_owner());
+  std::string owner = bucket->owner().entity;
 
   StatusOr<ObjectMetadata> meta = client.InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
@@ -260,10 +261,11 @@ TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclBucketOwnerRead) {
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
 
-  BucketMetadata bucket =
+  StatusOr<BucketMetadata> bucket =
       client.GetBucketMetadata(bucket_name, Projection::Full());
-  ASSERT_TRUE(bucket.has_owner());
-  std::string owner = bucket.owner().entity;
+  ASSERT_TRUE(bucket.ok()) << "status=" << bucket.status();
+  ASSERT_TRUE(bucket->has_owner());
+  std::string owner = bucket->owner().entity;
 
   StatusOr<ObjectMetadata> meta = client.InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
@@ -362,10 +364,11 @@ TEST_F(ObjectInsertIntegrationTest,
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
 
-  BucketMetadata bucket =
+  StatusOr<BucketMetadata> bucket =
       client.GetBucketMetadata(bucket_name, Projection::Full());
-  ASSERT_TRUE(bucket.has_owner());
-  std::string owner = bucket.owner().entity;
+  ASSERT_TRUE(bucket.ok()) << "status=" << bucket.status();
+  ASSERT_TRUE(bucket->has_owner());
+  std::string owner = bucket->owner().entity;
 
   StatusOr<ObjectMetadata> insert = client.InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
@@ -387,10 +390,11 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclBucketOwnerRead) {
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
 
-  BucketMetadata bucket =
+  StatusOr<BucketMetadata> bucket =
       client.GetBucketMetadata(bucket_name, Projection::Full());
-  ASSERT_TRUE(bucket.has_owner());
-  std::string owner = bucket.owner().entity;
+  ASSERT_TRUE(bucket.ok()) << "status=" << bucket.status();
+  ASSERT_TRUE(bucket->has_owner());
+  std::string owner = bucket->owner().entity;
 
   StatusOr<ObjectMetadata> insert = client.InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -240,8 +240,9 @@ TEST_F(ObjectIntegrationTest, ListObjectsVersions) {
   // first to produce a better error message if there is a configuration
   // problem.
   auto bucket_meta = client.GetBucketMetadata(bucket_name);
-  ASSERT_TRUE(bucket_meta.versioning().has_value());
-  ASSERT_TRUE(bucket_meta.versioning().value().enabled);
+  ASSERT_TRUE(bucket_meta.ok()) << "status=" << bucket_meta.status();
+  ASSERT_TRUE(bucket_meta->versioning().has_value());
+  ASSERT_TRUE(bucket_meta->versioning().value().enabled);
 
   auto create_object_with_3_versions = [&client, &bucket_name, this] {
     auto object_name = MakeRandomObjectName();
@@ -605,10 +606,11 @@ TEST_F(ObjectIntegrationTest, CopyPredefinedAclBucketOwnerFullControl) {
   auto object_name = MakeRandomObjectName();
   auto copy_name = MakeRandomObjectName();
 
-  BucketMetadata bucket =
+  StatusOr<BucketMetadata> bucket =
       client.GetBucketMetadata(bucket_name, Projection::Full());
-  ASSERT_TRUE(bucket.has_owner());
-  std::string owner = bucket.owner().entity;
+  ASSERT_TRUE(bucket.ok()) << "status=" << bucket.status();
+  ASSERT_TRUE(bucket->has_owner());
+  std::string owner = bucket->owner().entity;
 
   StatusOr<ObjectMetadata> original = client.InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
@@ -632,10 +634,11 @@ TEST_F(ObjectIntegrationTest, CopyPredefinedAclBucketOwnerRead) {
   auto object_name = MakeRandomObjectName();
   auto copy_name = MakeRandomObjectName();
 
-  BucketMetadata bucket =
+  StatusOr<BucketMetadata> bucket =
       client.GetBucketMetadata(bucket_name, Projection::Full());
-  ASSERT_TRUE(bucket.has_owner());
-  std::string owner = bucket.owner().entity;
+  ASSERT_TRUE(bucket.ok()) << "status=" << bucket.status();
+  ASSERT_TRUE(bucket->has_owner());
+  std::string owner = bucket->owner().entity;
 
   StatusOr<ObjectMetadata> original = client.InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));

--- a/google/cloud/storage/tests/thread_integration_test.cc
+++ b/google/cloud/storage/tests/thread_integration_test.cc
@@ -152,10 +152,10 @@ TEST_F(ThreadIntegrationTest, Unshared) {
     t.get();
   }
 
-  client.DeleteBucket(bucket_name);
+  auto delete_status = client.DeleteBucket(bucket_name);
+  ASSERT_TRUE(delete_status.ok()) << "status=" << delete_status.status();
   // This is basically a smoke test, if the test does not crash it was
   // successful.
-  SUCCEED();
 }
 
 class CaptureSendHeaderBackend : public LogBackend {
@@ -218,7 +218,8 @@ TEST_F(ThreadIntegrationTest, ReuseConnections) {
     delete_elapsed.emplace_back(std::chrono::steady_clock::now() - start);
   }
   LogSink::Instance().RemoveBackend(id);
-  client.DeleteBucket(bucket_name);
+  auto delete_status = client.DeleteBucket(bucket_name);
+  ASSERT_TRUE(delete_status.ok()) << "status=" << delete_status.status();
 
   std::set<std::string> connected;
   std::copy_if(


### PR DESCRIPTION
This change modifies `Client::GetBucketMetadata`, `Client::DeleteBucket`,
`Client::UpdateBucket`, and `Client::PatchBucket` to return a
`StatusOr`.

This closes #1677, closes #1678, closes #1679, and closes #1680.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1836)
<!-- Reviewable:end -->
