### PR TITLE
Use StatusOr in Client::*ObjectAcl.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -1565,9 +1565,6 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `Generation`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This is a read-only operation and is always idempotent.
    *
@@ -1575,12 +1572,16 @@ class Client {
    * @snippet storage_object_acl_samples.cc list object acl
    */
   template <typename... Options>
-  std::vector<ObjectAccessControl> ListObjectAcl(std::string const& bucket_name,
-                                                 std::string const& object_name,
-                                                 Options&&... options) {
+  StatusOr<std::vector<ObjectAccessControl>> ListObjectAcl(
+      std::string const& bucket_name, std::string const& object_name,
+      Options&&... options) {
     internal::ListObjectAclRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->ListObjectAcl(request).value().items;
+    auto result = raw_client_->ListObjectAcl(request);
+    if (not result.ok()) {
+      return std::move(result).status();
+    }
+    return std::move(result.value().items);
   }
 
   /**
@@ -1593,9 +1594,6 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `Generation`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions. There
    * are no pre-conditions for this operation that can make it idempotent.
@@ -1604,15 +1602,15 @@ class Client {
    * @snippet storage_object_acl_samples.cc create object acl
    */
   template <typename... Options>
-  ObjectAccessControl CreateObjectAcl(std::string const& bucket_name,
-                                      std::string const& object_name,
-                                      std::string const& entity,
-                                      std::string const& role,
-                                      Options&&... options) {
+  StatusOr<ObjectAccessControl> CreateObjectAcl(std::string const& bucket_name,
+                                                std::string const& object_name,
+                                                std::string const& entity,
+                                                std::string const& role,
+                                                Options&&... options) {
     internal::CreateObjectAclRequest request(bucket_name, object_name, entity,
                                              role);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->CreateObjectAcl(request).value();
+    return raw_client_->CreateObjectAcl(request);
   }
 
   /**
@@ -1625,9 +1623,6 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `Generation`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions. There
    * are no pre-conditions for this operation that can make it idempotent.
@@ -1636,12 +1631,13 @@ class Client {
    * @snippet storage_object_acl_samples.cc delete object acl
    */
   template <typename... Options>
-  void DeleteObjectAcl(std::string const& bucket_name,
-                       std::string const& object_name,
-                       std::string const& entity, Options&&... options) {
+  StatusOr<void> DeleteObjectAcl(std::string const& bucket_name,
+                                 std::string const& object_name,
+                                 std::string const& entity,
+                                 Options&&... options) {
     internal::DeleteObjectAclRequest request(bucket_name, object_name, entity);
     request.set_multiple_options(std::forward<Options>(options)...);
-    raw_client_->DeleteObjectAcl(request).value();
+    return raw_client_->DeleteObjectAcl(request).status();
   }
 
   /**
@@ -1653,9 +1649,6 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `Generation`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This is a read-only operation and is always idempotent.
    *
@@ -1663,13 +1656,13 @@ class Client {
    * @snippet storage_object_acl_samples.cc get object acl
    */
   template <typename... Options>
-  ObjectAccessControl GetObjectAcl(std::string const& bucket_name,
-                                   std::string const& object_name,
-                                   std::string const& entity,
-                                   Options&&... options) {
+  StatusOr<ObjectAccessControl> GetObjectAcl(std::string const& bucket_name,
+                                             std::string const& object_name,
+                                             std::string const& entity,
+                                             Options&&... options) {
     internal::GetObjectAclRequest request(bucket_name, object_name, entity);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->GetObjectAcl(request).value();
+    return raw_client_->GetObjectAcl(request);
   }
 
   /**
@@ -1682,9 +1675,6 @@ class Client {
    * @param options a list of optional query parameters and/or request
    *     Valid types for this operation include `Generation`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions. There
    * are no pre-conditions for this operation that can make it idempotent.
@@ -1696,14 +1686,14 @@ class Client {
    *     for additional details on what fields are writeable.
    */
   template <typename... Options>
-  ObjectAccessControl UpdateObjectAcl(std::string const& bucket_name,
-                                      std::string const& object_name,
-                                      ObjectAccessControl const& acl,
-                                      Options&&... options) {
+  StatusOr<ObjectAccessControl> UpdateObjectAcl(std::string const& bucket_name,
+                                                std::string const& object_name,
+                                                ObjectAccessControl const& acl,
+                                                Options&&... options) {
     internal::UpdateObjectAclRequest request(bucket_name, object_name,
                                              acl.entity(), acl.role());
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->UpdateObjectAcl(request).value();
+    return raw_client_->UpdateObjectAcl(request);
   }
 
   /**
@@ -1730,9 +1720,6 @@ class Client {
    *     headers. Valid types for this operation include `Generation`,
    *     `UserProject`, `IfMatchEtag`, and `IfNoneMatchEtag`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions. There
    * are no pre-conditions for this operation that can make it idempotent.
@@ -1744,16 +1731,14 @@ class Client {
    *     for additional details on what fields are writeable.
    */
   template <typename... Options>
-  ObjectAccessControl PatchObjectAcl(std::string const& bucket_name,
-                                     std::string const& object_name,
-                                     std::string const& entity,
-                                     ObjectAccessControl const& original_acl,
-                                     ObjectAccessControl const& new_acl,
-                                     Options&&... options) {
+  StatusOr<ObjectAccessControl> PatchObjectAcl(
+      std::string const& bucket_name, std::string const& object_name,
+      std::string const& entity, ObjectAccessControl const& original_acl,
+      ObjectAccessControl const& new_acl, Options&&... options) {
     internal::PatchObjectAclRequest request(bucket_name, object_name, entity,
                                             original_acl, new_acl);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->PatchObjectAcl(request).value();
+    return raw_client_->PatchObjectAcl(request);
   }
 
   /**
@@ -1778,9 +1763,6 @@ class Client {
    *     headers. Valid types for this operation include `Generation`,
    *     `UserProject`, `IfMatchEtag`, and `IfNoneMatchEtag`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions. There
    * are no pre-conditions for this operation that can make it idempotent.
@@ -1792,14 +1774,14 @@ class Client {
    *     for additional details on what fields are writeable.
    */
   template <typename... Options>
-  ObjectAccessControl PatchObjectAcl(
+  StatusOr<ObjectAccessControl> PatchObjectAcl(
       std::string const& bucket_name, std::string const& object_name,
       std::string const& entity, ObjectAccessControlPatchBuilder const& builder,
       Options&&... options) {
     internal::PatchObjectAclRequest request(bucket_name, object_name, entity,
                                             builder);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->PatchObjectAcl(request).value();
+    return raw_client_->PatchObjectAcl(request);
   }
   //@}
 

--- a/google/cloud/storage/examples/storage_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_object_acl_samples.cc
@@ -54,11 +54,19 @@ void ListObjectAcl(gcs::Client client, int& argc, char* argv[]) {
   auto object_name = ConsumeArg(argc, argv);
   //! [list object acl]
   namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
     std::cout << "ACLs for object=" << object_name << " in bucket "
               << bucket_name << std::endl;
-    for (gcs::ObjectAccessControl const& acl :
-         client.ListObjectAcl(bucket_name, object_name)) {
+    StatusOr<std::vector<gcs::ObjectAccessControl>> items =
+        client.ListObjectAcl(bucket_name, object_name);
+    if (not items.ok()) {
+      std::cerr << "Error reading ACL for object " << object_name
+                << " in bucket " << bucket_name
+                << ", status=" << items.status();
+      return;
+    }
+    for (gcs::ObjectAccessControl const& acl : *items) {
       std::cout << acl.role() << ":" << acl.entity() << std::endl;
     }
   }
@@ -77,13 +85,20 @@ void CreateObjectAcl(gcs::Client client, int& argc, char* argv[]) {
   auto role = ConsumeArg(argc, argv);
   //! [create object acl] [START storage_create_file_acl]
   namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string entity, std::string role) {
-    gcs::ObjectAccessControl result =
+    StatusOr<gcs::ObjectAccessControl> object_acl =
         client.CreateObjectAcl(bucket_name, object_name, entity, role);
-    std::cout << "Role " << result.role() << " granted to " << result.entity()
-              << " on " << result.object() << "\n"
-              << "Full attributes: " << result << std::endl;
+    if (not object_acl.ok()) {
+      std::cerr << "Error creating object ACL entry for entity " << entity
+                << " in object " << object_name << " and bucket " << bucket_name
+                << ", status=" << object_acl.status() << std::endl;
+      return;
+    }
+    std::cout << "Role " << object_acl->role() << " granted to "
+              << object_acl->entity() << " on " << object_acl->object()
+              << "\nFull attributes: " << *object_acl << std::endl;
   }
   //! [create object acl] [END storage_create_file_acl]
   (std::move(client), bucket_name, object_name, entity, role);
@@ -98,9 +113,17 @@ void DeleteObjectAcl(gcs::Client client, int& argc, char* argv[]) {
   auto entity = ConsumeArg(argc, argv);
   //! [delete object acl] [START storage_delete_file_acl]
   namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string entity) {
-    client.DeleteObjectAcl(bucket_name, object_name, entity);
+    StatusOr<void> status =
+        client.DeleteObjectAcl(bucket_name, object_name, entity);
+    if (not status.ok()) {
+      std::cerr << "Error deleting object ACL entry for entity " << entity
+                << " in object " << object_name << " and bucket " << bucket_name
+                << ", status=" << status.status() << std::endl;
+      return;
+    }
     std::cout << "Deleted ACL entry for " << entity << " in object "
               << object_name << " in bucket " << bucket_name << std::endl;
   }
@@ -117,12 +140,20 @@ void GetObjectAcl(gcs::Client client, int& argc, char* argv[]) {
   auto entity = ConsumeArg(argc, argv);
   //! [get object acl] [START storage_print_file_acl]
   namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string entity) {
-    gcs::ObjectAccessControl acl =
+    StatusOr<gcs::ObjectAccessControl> acl =
         client.GetObjectAcl(bucket_name, object_name, entity);
-    std::cout << "ACL entry for " << entity << " in object " << object_name
-              << " in bucket " << bucket_name << " is " << acl << std::endl;
+    if (not acl.ok()) {
+      std::cerr << "Error getting object ACL entry for entity " << entity
+                << " in object " << object_name << " and bucket " << bucket_name
+                << ", status=" << acl.status() << std::endl;
+      return;
+    }
+    std::cout << "ACL entry for " << acl->entity() << " in object "
+              << acl->object() << " in bucket " << acl->bucket() << " is "
+              << *acl << std::endl;
   }
   //! [get object acl] [END storage_print_file_acl]
   (std::move(client), bucket_name, object_name, entity);
@@ -139,15 +170,23 @@ void UpdateObjectAcl(gcs::Client client, int& argc, char* argv[]) {
   auto role = ConsumeArg(argc, argv);
   //! [update object acl] [START storage_update_file_acl]
   namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string entity, std::string role) {
-    gcs::ObjectAccessControl current_acl =
+    StatusOr<gcs::ObjectAccessControl> current_acl =
         client.GetObjectAcl(bucket_name, object_name, entity);
-    current_acl.set_role(role);
-    gcs::ObjectAccessControl acl =
-        client.UpdateObjectAcl(bucket_name, object_name, current_acl);
-    std::cout << "ACL entry for " << entity << " in object " << object_name
-              << " in bucket " << bucket_name << " is now " << acl << std::endl;
+    if (not current_acl.ok()) {
+      std::cerr << "Error getting object ACL entry for entity " << entity
+                << " in object " << object_name << " and bucket " << bucket_name
+                << ", status=" << current_acl.status() << std::endl;
+      return;
+    }
+    current_acl->set_role(role);
+    StatusOr<gcs::ObjectAccessControl> updated_acl =
+        client.UpdateObjectAcl(bucket_name, object_name, *current_acl);
+    std::cout << "ACL entry for " << updated_acl->entity() << " in object "
+              << updated_acl->object() << " in bucket " << updated_acl->bucket()
+              << " is now " << *updated_acl << std::endl;
   }
   //! [update object acl] [END storage_update_file_acl]
   (std::move(client), bucket_name, object_name, entity, role);
@@ -163,17 +202,30 @@ void PatchObjectAcl(gcs::Client client, int& argc, char* argv[]) {
   auto role = ConsumeArg(argc, argv);
   //! [patch object acl]
   namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string entity, std::string role) {
-    gcs::ObjectAccessControl original_acl =
+    StatusOr<gcs::ObjectAccessControl> original_acl =
         client.GetObjectAcl(bucket_name, object_name, entity);
-    auto new_acl = original_acl;
+    if (not original_acl.ok()) {
+      std::cerr << "Error getting object ACL entry for entity " << entity
+                << " in object " << object_name << " and bucket " << bucket_name
+                << ", status=" << original_acl.status() << std::endl;
+      return;
+    }
+    auto new_acl = *original_acl;
     new_acl.set_role(role);
-    gcs::ObjectAccessControl updated_acl = client.PatchObjectAcl(
-        bucket_name, object_name, entity, original_acl, new_acl);
-    std::cout << "ACL entry for " << entity << " in object " << object_name
-              << " in bucket " << bucket_name << " is now " << updated_acl
-              << std::endl;
+    StatusOr<gcs::ObjectAccessControl> patched_acl = client.PatchObjectAcl(
+        bucket_name, object_name, entity, *original_acl, new_acl);
+    if (not patched_acl.ok()) {
+      std::cerr << "Error patching object ACL entry for entity " << entity
+                << " in object " << object_name << " and bucket " << bucket_name
+                << ", status=" << patched_acl.status() << std::endl;
+      return;
+    }
+    std::cout << "ACL entry for " << patched_acl->entity() << " in object "
+              << patched_acl->object() << " in bucket " << patched_acl->bucket()
+              << " is now " << *patched_acl << std::endl;
   }
   //! [patch object acl]
   (std::move(client), bucket_name, object_name, entity, role);
@@ -190,13 +242,21 @@ void PatchObjectAclNoRead(gcs::Client client, int& argc, char* argv[]) {
   auto role = ConsumeArg(argc, argv);
   //! [patch object acl no-read]
   namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string entity, std::string role) {
-    gcs::ObjectAccessControl acl = client.PatchObjectAcl(
+    StatusOr<gcs::ObjectAccessControl> patched_acl = client.PatchObjectAcl(
         bucket_name, object_name, entity,
         gcs::ObjectAccessControlPatchBuilder().set_role(role));
-    std::cout << "ACL entry for " << entity << " in object " << object_name
-              << " in bucket " << bucket_name << " is now " << acl << std::endl;
+    if (not patched_acl.ok()) {
+      std::cerr << "Error patching object ACL entry for entity " << entity
+                << " in object " << object_name << " and bucket " << bucket_name
+                << ", status=" << patched_acl.status() << std::endl;
+      return;
+    }
+    std::cout << "ACL entry for " << patched_acl->entity() << " in object "
+              << patched_acl->object() << " in bucket " << patched_acl->bucket()
+              << " is now " << *patched_acl << std::endl;
   }
   //! [patch object acl no-read]
   (std::move(client), bucket_name, object_name, entity, role);
@@ -209,7 +269,7 @@ int main(int argc, char* argv[]) try {
   gcs::Client client;
 
   // Build the list of commands and the usage string from that list.
-  using CommandType = std::function<void(gcs::Client, int&, char*[])>;
+  using CommandType = std::function<void(gcs::Client, int&, char* [])>;
   std::map<std::string, CommandType> commands = {
       {"list-object-acl", &ListObjectAcl},
       {"create-object-acl", &CreateObjectAcl},


### PR DESCRIPTION
Changed all the functions related to Object ACLs to return StatusOr.

This closes #1646, closes #1647, closes #1648, closes #1649, closes #1650, and closes #1651.
