### PR TITLE
Changed alternative operator names to symbolic names.

### DIFF
--- a/ci/test-install/bigtable_install_test.cc
+++ b/ci/test-install/bigtable_install_test.cc
@@ -60,7 +60,7 @@ int main(int argc, char* argv[]) try {
   std::cout << "bulk mutation successful" << std::endl;
 
   auto row0 = table.ReadRow("row-key-0", bigtable::Filter::PassAllFilter());
-  if (not row0.first) {
+  if (!row0.first) {
     std::cout << "Cannot find row-key-0" << std::endl;
   } else {
     for (auto const& cell : row0.second.cells()) {
@@ -70,7 +70,7 @@ int main(int argc, char* argv[]) try {
     }
   }
   auto row1 = table.ReadRow("row-key-1", bigtable::Filter::PassAllFilter());
-  if (not row0.first) {
+  if (!row0.first) {
     std::cout << "Cannot find row-key-0" << std::endl;
   } else {
     for (auto const& cell : row1.second.cells()) {

--- a/google/cloud/bigtable/app_profile_config.cc
+++ b/google/cloud/bigtable/app_profile_config.cc
@@ -43,7 +43,7 @@ void AppProfileUpdateConfig::AddPathIfNotPresent(std::string field_name) {
   auto const& paths = proto_.update_mask().paths();
   auto is_present =
       paths.end() != std::find(paths.begin(), paths.end(), field_name);
-  if (not is_present) {
+  if (!is_present) {
     proto_.mutable_update_mask()->add_paths(std::move(field_name));
   }
 }

--- a/google/cloud/bigtable/benchmarks/benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark.cc
@@ -48,11 +48,11 @@ Benchmark::Benchmark(BenchmarkSetup const& setup)
 }
 
 Benchmark::~Benchmark() {
-  if (not server_) {
+  if (!server_) {
     return;
   }
   server_->Shutdown();
-  if (not server_thread_.joinable()) {
+  if (!server_thread_.joinable()) {
     return;
   }
   server_thread_.join();
@@ -209,35 +209,35 @@ void Benchmark::PrintResultCsv(std::ostream& os, std::string const& test_name,
 }
 
 int Benchmark::create_table_count() const {
-  if (not server_) {
+  if (!server_) {
     return 0;
   }
   return server_->create_table_count();
 }
 
 int Benchmark::delete_table_count() const {
-  if (not server_) {
+  if (!server_) {
     return 0;
   }
   return server_->delete_table_count();
 }
 
 int Benchmark::mutate_row_count() const {
-  if (not server_) {
+  if (!server_) {
     return 0;
   }
   return server_->mutate_row_count();
 }
 
 int Benchmark::mutate_rows_count() const {
-  if (not server_) {
+  if (!server_) {
     return 0;
   }
   return server_->mutate_rows_count();
 }
 
 int Benchmark::read_rows_count() const {
-  if (not server_) {
+  if (!server_) {
     return 0;
   }
   return server_->read_rows_count();

--- a/google/cloud/bigtable/bigtable_version_test.cc
+++ b/google/cloud/bigtable/bigtable_version_test.cc
@@ -43,7 +43,7 @@ TEST(StorageVersionTest, Format) {
 
 /// @test Verify the version does not contain build info for release builds.
 TEST(StorageVersionTest, NoBuildInfoInRelease) {
-  if (not google::cloud::internal::is_release()) {
+  if (!google::cloud::internal::is_release()) {
     return;
   }
   EXPECT_THAT(version_string(),

--- a/google/cloud/bigtable/examples/bigtable_hello_app_profile.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_app_profile.cc
@@ -77,7 +77,7 @@ int main(int argc, char* argv[]) try {
 
   auto result =
       read.ReadRow("key-0", cbt::Filter::ColumnRangeClosed("fam", "c0", "c0"));
-  if (not result.first) {
+  if (!result.first) {
     std::cout << "Cannot find row 'key-0' in the table: " << table_id
               << std::endl;
     return 1;

--- a/google/cloud/bigtable/examples/bigtable_hello_world.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_world.cc
@@ -89,7 +89,7 @@ int main(int argc, char* argv[]) try {
   // Read a single row.
   //! [read row] [START getting_a_row]
   auto result = table.ReadRow("key-0", filter);
-  if (not result.first) {
+  if (!result.first) {
     std::cout << "Cannot find row 'key-0' in the table: " << table.table_name()
               << std::endl;
     return 0;

--- a/google/cloud/bigtable/examples/bigtable_quickstart.cc
+++ b/google/cloud/bigtable/examples/bigtable_quickstart.cc
@@ -40,7 +40,7 @@ int main(int argc, char* argv[]) try {
   std::cout << "Getting a single row by row key:" << std::flush;
   auto result = table.ReadRow(
       row_key, google::cloud::bigtable::Filter::FamilyRegex(column_family));
-  if (not result.first) {
+  if (!result.first) {
     std::cout << "Cannot find row " << row_key << " in the table: " << table_id
               << std::endl;
     return 0;

--- a/google/cloud/bigtable/examples/bigtable_samples_instance_admin_ext.cc
+++ b/google/cloud/bigtable/examples/bigtable_samples_instance_admin_ext.cc
@@ -75,7 +75,7 @@ void RunInstanceOperations(std::string project_id, int argc, char* argv[]) {
   // [END bigtable_check_instance_exists]
 
   // Create instance if does not exists
-  if (not instance_exists) {
+  if (!instance_exists) {
     // [START bigtable_create_prod_instance]
     std::cout << "\nCreating a PRODUCTION Instance: ";
     google::cloud::bigtable::DisplayName display_name("Sample Instance");
@@ -149,7 +149,7 @@ void CreateDevInstance(std::string project_id, int argc, char* argv[]) {
             return i.name() == instance_name;
           });
   // Create instance if does not exists
-  if (not instance_exists) {
+  if (!instance_exists) {
     // [START bigtable_create_dev_instance]
     std::cout << "\nCreating a DEVELOPMENT Instance: ";
     google::cloud::bigtable::DisplayName display_name("Put description here");

--- a/google/cloud/bigtable/examples/data_snippets.cc
+++ b/google/cloud/bigtable/examples/data_snippets.cc
@@ -143,7 +143,7 @@ void ReadRow(google::cloud::bigtable::Table table, int argc, char* argv[]) {
     // Read a row, this returns a tuple (bool, row)
     std::pair<bool, google::cloud::bigtable::Row> tuple =
         table.ReadRow(MAGIC_ROW_KEY, std::move(filter));
-    if (not tuple.first) {
+    if (!tuple.first) {
       std::cout << "Row " << MAGIC_ROW_KEY << " not found" << std::endl;
       return;
     }

--- a/google/cloud/bigtable/examples/instance_admin_async_snippets.cc
+++ b/google/cloud/bigtable/examples/instance_admin_async_snippets.cc
@@ -82,7 +82,7 @@ void AsyncListInstances(cbt::InstanceAdmin instance_admin,
           for (const auto& instance : instance_list.instances) {
             std::cout << instance.name() << std::endl;
           }
-          if (not instance_list.failed_locations.empty()) {
+          if (!instance_list.failed_locations.empty()) {
             std::cout << "The Cloud Bigtable service reports that it could not "
                          "retrieve data for the following zones:\n";
             for (const auto& failed_location : instance_list.failed_locations) {

--- a/google/cloud/bigtable/examples/opencensus/bigtable_opencensus.cc
+++ b/google/cloud/bigtable/examples/opencensus/bigtable_opencensus.cc
@@ -129,7 +129,7 @@ int main(int argc, char* argv[]) try {
   auto result = table.ReadRow(
       "key-0",
       google::cloud::bigtable::Filter::ColumnRangeClosed("family", "c0", "c0"));
-  if (not result.first) {
+  if (!result.first) {
     std::cout << "Cannot find row 'key-0' in the table: " << table.table_name()
               << std::endl;
     return 0;

--- a/google/cloud/bigtable/grpc_error.cc
+++ b/google/cloud/bigtable/grpc_error.cc
@@ -55,7 +55,7 @@ std::string GRpcError::CreateWhatString(char const* what,
   os << what << ": " << status.error_message() << " [" << status.error_code()
      << "=";
   int const index = status.error_code();
-  if (0 <= index and index < KNOWN_STATUS_CODES_SIZE) {
+  if (0 <= index && index < KNOWN_STATUS_CODES_SIZE) {
     os << KNOWN_STATUS_CODES[status.error_code()];
   } else {
     os << "(UNKNOWN CODE)";

--- a/google/cloud/bigtable/idempotent_mutation_policy.cc
+++ b/google/cloud/bigtable/idempotent_mutation_policy.cc
@@ -31,7 +31,7 @@ std::unique_ptr<IdempotentMutationPolicy> SafeIdempotentMutationPolicy::clone()
 
 bool SafeIdempotentMutationPolicy::is_idempotent(
     google::bigtable::v2::Mutation const& m) {
-  if (not m.has_set_cell()) {
+  if (!m.has_set_cell()) {
     return true;
   }
   return m.set_cell().timestamp_micros() != ServerSetTimestamp();

--- a/google/cloud/bigtable/instance_admin.cc
+++ b/google/cloud/bigtable/instance_admin.cc
@@ -34,7 +34,7 @@ static_assert(std::is_copy_assignable<bigtable::InstanceAdmin>::value,
 std::vector<btadmin::Instance> InstanceAdmin::ListInstances() {
   grpc::Status status;
   auto result = impl_.ListInstances(status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(status, status.error_message());
   }
   return result;
@@ -85,7 +85,7 @@ google::bigtable::admin::v2::Instance InstanceAdmin::CreateInstanceImpl(
       *impl_.client_, *rpc_policy, *backoff_policy,
       impl_.metadata_update_policy_, &InstanceAdminClient::CreateInstance,
       request, "InstanceAdmin::CreateInstance", status, false);
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(status,
                                       "unrecoverable error in MakeCall()");
   }
@@ -95,7 +95,7 @@ google::bigtable::admin::v2::Instance InstanceAdmin::CreateInstanceImpl(
       impl_.client_, impl_.polling_policy_->clone(),
       impl_.metadata_update_policy_, operation, "InstanceAdmin::CreateInstance",
       status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(
         status, "while polling operation in InstanceAdmin::CreateInstance");
   }
@@ -127,7 +127,7 @@ google::bigtable::admin::v2::Instance InstanceAdmin::UpdateInstanceImpl(
       *impl_.client_, *rpc_policy, *backoff_policy,
       impl_.metadata_update_policy_, &InstanceAdminClient::UpdateInstance,
       request, "InstanceAdmin::UpdateInstance", status, false);
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(status,
                                       "unrecoverable error in MakeCall()");
   }
@@ -137,7 +137,7 @@ google::bigtable::admin::v2::Instance InstanceAdmin::UpdateInstanceImpl(
       impl_.client_, impl_.polling_policy_->clone(),
       impl_.metadata_update_policy_, operation, "InstanceAdmin::UpdateInstance",
       status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(
         status, "while polling operation in InstanceAdmin::UpdateInstance");
   }
@@ -147,7 +147,7 @@ google::bigtable::admin::v2::Instance InstanceAdmin::UpdateInstanceImpl(
 btadmin::Instance InstanceAdmin::GetInstance(std::string const& instance_id) {
   grpc::Status status;
   auto result = impl_.GetInstance(instance_id, status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(status, status.error_message());
   }
   return result;
@@ -169,7 +169,7 @@ future<btadmin::Instance> InstanceAdmin::AsyncGetInstance(
 void InstanceAdmin::DeleteInstance(std::string const& instance_id) {
   grpc::Status status;
   impl_.DeleteInstance(instance_id, status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(status, status.error_message());
   }
 }
@@ -179,7 +179,7 @@ btadmin::Cluster InstanceAdmin::GetCluster(
     bigtable::ClusterId const& cluster_id) {
   grpc::Status status;
   auto result = impl_.GetCluster(instance_id, cluster_id, status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(status, status.error_message());
   }
   return result;
@@ -206,7 +206,7 @@ std::vector<btadmin::Cluster> InstanceAdmin::ListClusters(
     std::string const& instance_id) {
   grpc::Status status;
   auto result = impl_.ListClusters(instance_id, status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(status, status.error_message());
   }
   return result;
@@ -237,7 +237,7 @@ google::bigtable::admin::v2::Cluster InstanceAdmin::UpdateClusterImpl(
       *impl_.client_, *rpc_policy, *backoff_policy,
       impl_.metadata_update_policy_, &InstanceAdminClient::UpdateCluster,
       request, "InstanceAdmin::UpdateCluster", status, false);
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(status,
                                       "unrecoverable error in MakeCall()");
   }
@@ -247,7 +247,7 @@ google::bigtable::admin::v2::Cluster InstanceAdmin::UpdateClusterImpl(
           impl_.client_, impl_.polling_policy_->clone(),
           impl_.metadata_update_policy_, operation,
           "InstanceAdmin::UpdateCluster", status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(
         status, "while polling operation in InstanceAdmin::UpdateCluster");
   }
@@ -257,7 +257,7 @@ void InstanceAdmin::DeleteCluster(bigtable::InstanceId const& instance_id,
                                   bigtable::ClusterId const& cluster_id) {
   grpc::Status status;
   impl_.DeleteCluster(instance_id, cluster_id, status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     internal::ThrowRpcError(status, status.error_message());
   }
 }
@@ -266,7 +266,7 @@ btadmin::AppProfile InstanceAdmin::CreateAppProfile(
     bigtable::InstanceId const& instance_id, AppProfileConfig config) {
   grpc::Status status;
   auto result = impl_.CreateAppProfile(instance_id, std::move(config), status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     internal::ThrowRpcError(status, status.error_message());
   }
   return result;
@@ -277,7 +277,7 @@ btadmin::AppProfile InstanceAdmin::GetAppProfile(
     bigtable::AppProfileId const& profile_id) {
   grpc::Status status;
   auto result = impl_.GetAppProfile(instance_id, profile_id, status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     internal::ThrowRpcError(status, status.error_message());
   }
   return result;
@@ -295,7 +295,7 @@ std::vector<btadmin::AppProfile> InstanceAdmin::ListAppProfiles(
     std::string const& instance_id) {
   grpc::Status status;
   auto result = impl_.ListAppProfiles(instance_id, status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     internal::ThrowRpcError(status, status.error_message());
   }
   return result;
@@ -306,7 +306,7 @@ void InstanceAdmin::DeleteAppProfile(bigtable::InstanceId const& instance_id,
                                      bool ignore_warnings) {
   grpc::Status status;
   impl_.DeleteAppProfile(instance_id, profile_id, ignore_warnings, status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     internal::ThrowRpcError(status, status.error_message());
   }
 }
@@ -336,7 +336,7 @@ google::bigtable::admin::v2::Cluster InstanceAdmin::CreateClusterImpl(
       *impl_.client_, *rpc_policy, *backoff_policy,
       impl_.metadata_update_policy_, &InstanceAdminClient::CreateCluster,
       request, "InstanceAdmin::CreateCluster", status, false);
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(status,
                                       "unrecoverable error in MakeCall()");
   }
@@ -346,7 +346,7 @@ google::bigtable::admin::v2::Cluster InstanceAdmin::CreateClusterImpl(
           impl_.client_, impl_.polling_policy_->clone(),
           impl_.metadata_update_policy_, operation,
           "InstanceAdmin::CreateCluster", status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(
         status, "while polling operation in InstanceAdmin::CreateCluster");
   }
@@ -359,7 +359,7 @@ btadmin::AppProfile InstanceAdmin::UpdateAppProfileImpl(
   grpc::Status status;
   auto operation = impl_.UpdateAppProfile(
       std::move(instance_id), std::move(profile_id), std::move(config), status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     internal::ThrowRpcError(status, status.error_message());
   }
 
@@ -368,7 +368,7 @@ btadmin::AppProfile InstanceAdmin::UpdateAppProfileImpl(
       impl_.client_, impl_.polling_policy_->clone(),
       impl_.metadata_update_policy_, operation,
       "InstanceAdmin::UpdateAppProfileImpl", status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     internal::ThrowRpcError(status, status.error_message());
   }
   return result;
@@ -379,7 +379,7 @@ google::cloud::IamPolicy InstanceAdmin::GetIamPolicy(
   grpc::Status status;
   auto result = impl_.GetIamPolicy(instance_id, status);
 
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(status, status.error_message());
   }
   return result;
@@ -391,7 +391,7 @@ google::cloud::IamPolicy InstanceAdmin::SetIamPolicy(
   grpc::Status status;
   auto result = impl_.SetIamPolicy(instance_id, iam_bindings, etag, status);
 
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(status, status.error_message());
   }
   return result;
@@ -403,7 +403,7 @@ std::vector<std::string> InstanceAdmin::TestIamPermissions(
   grpc::Status status;
   auto result = impl_.TestIamPermissions(instance_id, permissions, status);
 
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(status, status.error_message());
   }
 

--- a/google/cloud/bigtable/instance_update_config.h
+++ b/google/cloud/bigtable/instance_update_config.h
@@ -113,7 +113,7 @@ class InstanceUpdateConfig {
     auto is_present = proto_.update_mask().paths().end() !=
                       std::find(proto_.update_mask().paths().begin(),
                                 proto_.update_mask().paths().end(), field_name);
-    if (not is_present) {
+    if (!is_present) {
       proto_.mutable_update_mask()->add_paths(field_name);
     }
   }

--- a/google/cloud/bigtable/internal/async_check_consistency.h
+++ b/google/cloud/bigtable/internal/async_check_consistency.h
@@ -234,7 +234,7 @@ class AsyncAwaitConsistency
                     grpc::Status const& status) {
       std::unique_lock<std::mutex> lk(parent_->mu_);
       parent_->current_op_.reset();
-      if (status.ok() && not response) {
+      if (status.ok() && !response) {
         // I don't think it could happen, TBH.
         grpc::Status res_status(grpc::StatusCode::UNKNOWN,
                                 "The state is not consistent and for some "
@@ -285,7 +285,7 @@ class AsyncAwaitConsistency
         callback_(cq, res_status);
         return;
       }
-      if (not status.ok()) {
+      if (!status.ok()) {
         lk.unlock();
         grpc::Status res_status(status);
         callback_(cq, res_status);

--- a/google/cloud/bigtable/internal/async_future_from_callback.h
+++ b/google/cloud/bigtable/internal/async_future_from_callback.h
@@ -46,7 +46,7 @@ class AsyncFutureFromCallback {
       : promise_(std::move(p)), where_(w) {}
 
   void operator()(CompletionQueue& cq, R& result, grpc::Status& status) {
-    if (not status.ok()) {
+    if (!status.ok()) {
       promise_.set_exception(
           std::make_exception_ptr(GRpcError(where_, status)));
       return;
@@ -75,7 +75,7 @@ class AsyncFutureFromCallback<void> {
 
   void operator()(CompletionQueue& cq, google::protobuf::Empty& result,
                   grpc::Status& status) {
-    if (not status.ok()) {
+    if (!status.ok()) {
       promise_.set_exception(
           std::make_exception_ptr(GRpcError(where_, status)));
       return;

--- a/google/cloud/bigtable/internal/async_longrunning_op.h
+++ b/google/cloud/bigtable/internal/async_longrunning_op.h
@@ -112,12 +112,12 @@ class AsyncLongrunningOp {
         [this, callback](CompletionQueue& cq,
                          google::longrunning::Operation& operation,
                          grpc::Status& status) {
-          if (not status.ok()) {
+          if (!status.ok()) {
             callback(cq, false, status);
             return;
           }
           operation_.Swap(&operation);
-          if (not operation_.done()) {
+          if (!operation_.done()) {
             callback(cq, false, status);
             return;
           }

--- a/google/cloud/bigtable/internal/async_longrunning_op_test.cc
+++ b/google/cloud/bigtable/internal/async_longrunning_op_test.cc
@@ -125,7 +125,7 @@ TEST_P(NoexAsyncLongrunningImmediatelyFinished, ImmeditalyFinished) {
   google::longrunning::Operation longrunning_op;
   longrunning_op.set_name("qwerty");
   longrunning_op.set_done(true);
-  if (not has_error) {
+  if (!has_error) {
     // This might be confusing, but we're using a GetOperationRequest as
     // response. This could have been any other message for the purpose of
     // this test, but this is simple, so it's handy.
@@ -150,7 +150,7 @@ TEST_P(NoexAsyncLongrunningImmediatelyFinished, ImmeditalyFinished) {
                            CompletionQueue& cq,
                            google::longrunning::GetOperationRequest& response,
                            grpc::Status const& status) {
-    EXPECT_EQ(status.ok(), not has_error);
+    EXPECT_EQ(status.ok(), !has_error);
     if (has_error) {
       EXPECT_EQ(grpc::StatusCode::FAILED_PRECONDITION, status.error_code());
     } else {

--- a/google/cloud/bigtable/internal/async_loop_op.h
+++ b/google/cloud/bigtable/internal/async_loop_op.h
@@ -210,7 +210,7 @@ class AsyncLoopOp : public std::enable_shared_from_this<AsyncLoopOp<Operation>>,
   void OnTimer(CompletionQueue& cq, bool cancelled) {
     std::unique_lock<std::mutex> lk(mu_);
     current_op_.reset();
-    if (cancelled or cancelled_) {
+    if (cancelled || cancelled_) {
       // Cancelled, no more action to take.
       // The operation couldn't have noticed this cancellation, because it came
       // while we were waiting.

--- a/google/cloud/bigtable/internal/async_poll_op.h
+++ b/google/cloud/bigtable/internal/async_poll_op.h
@@ -167,7 +167,7 @@ class PollableLoopAdapter {
     // that a call to OnFailure() always preceeds a call to WaitPeriod(). That
     // way the policy can react differently to successful requests.
     bool const allowed_to_retry = polling_policy_->OnFailure(status);
-    if (not status.ok() and not allowed_to_retry) {
+    if (!status.ok() && !allowed_to_retry) {
       std::string full_message =
           FullErrorMessageUnlocked(polling_policy_->IsPermanentError(status)
                                        ? "permanent error"

--- a/google/cloud/bigtable/internal/async_poll_op_test.cc
+++ b/google/cloud/bigtable/internal/async_poll_op_test.cc
@@ -766,7 +766,7 @@ TEST_P(NoexTableAsyncPollOpCancelInTimerTest, TestCancelInTimer) {
   EXPECT_EQ(1U, cq_impl->size());
 
   // Sometime the timer might return timeout despite having been cancelled.
-  cq_impl->SimulateCompletion(cq, not notice_cancel);
+  cq_impl->SimulateCompletion(cq, !notice_cancel);
 
   EXPECT_TRUE(cq_impl->empty());
   EXPECT_TRUE(user_op_completed);

--- a/google/cloud/bigtable/internal/async_read_row_operation.h
+++ b/google/cloud/bigtable/internal/async_read_row_operation.h
@@ -123,7 +123,7 @@ class ReadRowCallbackAdapter {
 
   const void operator()(CompletionQueue& cq, bool& response,
                         grpc::Status const& status) const {
-    if (not status.ok()) {
+    if (!status.ok()) {
       callback_(cq, std::make_pair(false, Row("", {})), status);
       return;
     }

--- a/google/cloud/bigtable/internal/async_retry_multi_page.h
+++ b/google/cloud/bigtable/internal/async_retry_multi_page.h
@@ -126,7 +126,7 @@ class MultipageRetriableAdapter {
       // failure happens, we start from small wait periods.
       rpc_backoff_policy_ = rpc_backoff_policy_prototype_->clone();
     }
-    if (not rpc_retry_policy_->OnFailure(status)) {
+    if (!rpc_retry_policy_->OnFailure(status)) {
       std::string full_message =
           FullErrorMessageUnlocked(RPCRetryPolicy::IsPermanentFailure(status)
                                        ? "permanent error"

--- a/google/cloud/bigtable/internal/async_retry_multi_page_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_multi_page_test.cc
@@ -191,7 +191,7 @@ class MultipageRetriableAdapterTest
     local_copy(cq_, finished, status);
   }
 
-  bool AttemptWasMade() { return not not attempt_cb_; }
+  bool AttemptWasMade() { return !!attempt_cb_; }
 
   void OnUserCompleted(CompletionQueue&, int res, grpc::Status& status) {
     user_op_called_ = true;

--- a/google/cloud/bigtable/internal/async_retry_op.h
+++ b/google/cloud/bigtable/internal/async_retry_op.h
@@ -171,7 +171,7 @@ class RetriableLoopAdapter {
       attempt_completed_callback(cq, true);
       return;
     }
-    if (not idempotent_policy_.is_idempotent()) {
+    if (!idempotent_policy_.is_idempotent()) {
       grpc::Status res_status(
           status.error_code(),
           FullErrorMessageUnlocked("non-idempotent operation failed", status),
@@ -181,7 +181,7 @@ class RetriableLoopAdapter {
       attempt_completed_callback(cq, true);
       return;
     }
-    if (not rpc_retry_policy_->OnFailure(status)) {
+    if (!rpc_retry_policy_->OnFailure(status)) {
       std::string full_message =
           FullErrorMessageUnlocked(RPCRetryPolicy::IsPermanentFailure(status)
                                        ? "permanent error"

--- a/google/cloud/bigtable/internal/async_retry_op_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_op_test.cc
@@ -399,7 +399,7 @@ TEST_P(NoexTableAsyncRetryOpCancelInTimerTest, TestCancelInTimer) {
   EXPECT_EQ(1U, cq_impl->size());
 
   // Sometime the timer might return timeout despite having been cancelled.
-  cq_impl->SimulateCompletion(cq, not notice_cancel);
+  cq_impl->SimulateCompletion(cq, !notice_cancel);
 
   EXPECT_TRUE(cq_impl->empty());
   EXPECT_TRUE(user_op_completed);

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll.h
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll.h
@@ -149,7 +149,7 @@ class AsyncRetryAndPollUnaryRpc
       callback_(cq, response, res_status);
       return;
     }
-    if (not status.ok()) {
+    if (!status.ok()) {
       lk.unlock();
       grpc::Status res_status(status);
       Response response;

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
@@ -99,7 +99,7 @@ TEST_P(AsyncRetryUnaryRpcAndPollResEndToEnd, EndToEnd) {
     EXPECT_CALL(*get_operation_reader, Finish(_, _, _))
         .WillOnce(Invoke([config](longrunning::Operation* response,
                                   grpc::Status* status, void*) {
-          if (not config.polling_finished) {
+          if (!config.polling_finished) {
             *status = grpc::Status(config.polling_error_code, "mocked-status");
             return;
           }

--- a/google/cloud/bigtable/internal/async_row_reader.h
+++ b/google/cloud/bigtable/internal/async_row_reader.h
@@ -86,7 +86,7 @@ class AsyncRowReader {
       parser_->HandleChunk(
           std::move(*(response.mutable_chunks(processed_chunks_count_))),
           status_);
-      if (not status_.ok()) {
+      if (!status_.ok()) {
         // An error must result in a retry, so we return without calling the
         // callback function and check for status before finishing the call
         return;
@@ -95,7 +95,7 @@ class AsyncRowReader {
       if (parser_->HasNext()) {
         // We have a complete row in the parser.
         Row parsed_row = parser_->Next(status_);
-        if (not status_.ok()) {
+        if (!status_.ok()) {
           return;
         }
         ++rows_count_;
@@ -118,7 +118,7 @@ class AsyncRowReader {
     request.set_app_profile_id(app_profile_id_.get());
     request.set_table_name(table_name_.get());
 
-    if (not last_read_row_key_.empty()) {
+    if (!last_read_row_key_.empty()) {
       // We've returned some rows and need to make sure we don't
       // request them again.
       row_set_ = row_set_.Intersect(RowRange::Open(last_read_row_key_, ""));
@@ -162,7 +162,7 @@ class AsyncRowReader {
         parent_.parser_->HandleEndOfStream(status);
       }
 
-      if (not parent_.status_.ok() && status.ok()) {
+      if (!parent_.status_.ok() && status.ok()) {
         status = grpc::Status(grpc::StatusCode::UNAVAILABLE,
                               "Some rows were not returned");
       }

--- a/google/cloud/bigtable/internal/async_sample_row_keys.h
+++ b/google/cloud/bigtable/internal/async_sample_row_keys.h
@@ -99,7 +99,7 @@ class AsyncSampleRowKeys {
 
     void operator()(CompletionQueue& cq, grpc::ClientContext& context,
                     grpc::Status& status) {
-      if (not status.ok()) {
+      if (!status.ok()) {
         // The sample must be a consistent sample of the rows in the table. On
         // failure we must forget the previous responses and accumulate only
         // new values.

--- a/google/cloud/bigtable/internal/bulk_mutator.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator.cc
@@ -85,7 +85,7 @@ void BulkMutator::ProcessResponse(
     google::bigtable::v2::MutateRowsResponse& response) {
   for (auto& entry : *response.mutable_entries()) {
     auto index = entry.index();
-    if (index < 0 or annotations_.size() <= std::size_t(index)) {
+    if (index < 0 || annotations_.size() <= std::size_t(index)) {
       // TODO(#72) - decide how this is logged.
       continue;
     }
@@ -101,7 +101,7 @@ void BulkMutator::ProcessResponse(
     }
     auto& original = *mutations_.mutable_entries(index);
     // Failed responses are handled according to the current policies.
-    if (SafeGrpcRetry::IsTransientFailure(code) and annotation.is_idempotent) {
+    if (SafeGrpcRetry::IsTransientFailure(code) && annotation.is_idempotent) {
       // Retryable requests are saved in the pending mutations, along with the
       // mapping from their index in pending_mutations_ to the original
       // vector and other miscellanea.

--- a/google/cloud/bigtable/internal/common_client.cc
+++ b/google/cloud/bigtable/internal/common_client.cc
@@ -24,7 +24,7 @@ std::vector<std::shared_ptr<grpc::Channel>> CreateChannelPool(
   std::vector<std::shared_ptr<grpc::Channel>> result;
   for (std::size_t i = 0; i != options.connection_pool_size(); ++i) {
     auto args = options.channel_arguments();
-    if (not options.connection_pool_name().empty()) {
+    if (!options.connection_pool_name().empty()) {
       args.SetString("cbt-c++/connection-pool-name",
                      options.connection_pool_name());
     }

--- a/google/cloud/bigtable/internal/common_client.h
+++ b/google/cloud/bigtable/internal/common_client.h
@@ -86,7 +86,7 @@ class CommonClient {
  private:
   /// Make sure the connections exit, and create them if needed.
   void CheckConnections(std::unique_lock<std::mutex>& lk) {
-    if (not stubs_.empty()) {
+    if (!stubs_.empty()) {
       return;
     }
     // Release the lock while making remote calls.  gRPC uses the current

--- a/google/cloud/bigtable/internal/completion_queue_impl.cc
+++ b/google/cloud/bigtable/internal/completion_queue_impl.cc
@@ -27,7 +27,7 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
 void CompletionQueueImpl::Run(CompletionQueue& cq) {
-  while (not shutdown_.load()) {
+  while (!shutdown_.load()) {
     void* tag;
     bool ok;
     auto deadline = std::chrono::system_clock::now() + LOOP_TIMEOUT;

--- a/google/cloud/bigtable/internal/completion_queue_impl.h
+++ b/google/cloud/bigtable/internal/completion_queue_impl.h
@@ -113,7 +113,7 @@ class AsyncTimerFunctor : public AsyncGrpcOperation {
   bool Notify(CompletionQueue& cq, bool ok) override {
     std::unique_lock<std::mutex> lk(mu_);
     alarm_.reset();
-    timer_.cancelled = not ok;
+    timer_.cancelled = !ok;
     lk.unlock();
     // At this point timer_ is not going to be used by any other thread, so we
     // might use it without a lock.
@@ -196,7 +196,7 @@ class AsyncUnaryRpcFunctor : public AsyncGrpcOperation {
   bool Notify(CompletionQueue& cq, bool ok) override {
     // Make sure members are visible.
     static_cast<void>(sync_.load(std::memory_order_acquire));
-    if (not ok) {
+    if (!ok) {
       // This would mean a bug in grpc. Documentation states that Finish()
       // always returns true.
       status_ =

--- a/google/cloud/bigtable/internal/instance_admin.cc
+++ b/google/cloud/bigtable/internal/instance_admin.cc
@@ -47,7 +47,7 @@ std::vector<btadmin::Instance> InstanceAdmin::ListInstances(
         *client_, *rpc_policy, *backoff_policy, metadata_update_policy_,
         &InstanceAdminClient::ListInstances, request,
         "InstanceAdmin::ListInstances", status, true);
-    if (not status.ok()) {
+    if (!status.ok()) {
       return result;
     }
 
@@ -55,7 +55,7 @@ std::vector<btadmin::Instance> InstanceAdmin::ListInstances(
       result.emplace_back(std::move(x));
     }
     page_token = std::move(*response.mutable_next_page_token());
-  } while (not page_token.empty());
+  } while (!page_token.empty());
   return result;
 }
 
@@ -121,7 +121,7 @@ std::vector<btadmin::Cluster> InstanceAdmin::ListClusters(
         *client_, *rpc_policy, *backoff_policy, metadata_update_policy_,
         &InstanceAdminClient::ListClusters, request,
         "InstanceAdmin::ListClusters", status, true);
-    if (not status.ok()) {
+    if (!status.ok()) {
       return result;
     }
 
@@ -129,7 +129,7 @@ std::vector<btadmin::Cluster> InstanceAdmin::ListClusters(
       result.emplace_back(std::move(x));
     }
     page_token = std::move(*response.mutable_next_page_token());
-  } while (not page_token.empty());
+  } while (!page_token.empty());
   return result;
 }
 
@@ -207,7 +207,7 @@ std::vector<btadmin::AppProfile> InstanceAdmin::ListAppProfiles(
         *client_, *rpc_policy, *backoff_policy, metadata_update_policy_,
         &InstanceAdminClient::ListAppProfiles, request,
         "InstanceAdmin::ListAppProfiles", status, true);
-    if (not status.ok()) {
+    if (!status.ok()) {
       return result;
     }
 
@@ -215,7 +215,7 @@ std::vector<btadmin::AppProfile> InstanceAdmin::ListAppProfiles(
       result.emplace_back(std::move(x));
     }
     page_token = std::move(*response.mutable_next_page_token());
-  } while (not page_token.empty());
+  } while (!page_token.empty());
   return result;
 }
 

--- a/google/cloud/bigtable/internal/poll_longrunning_operation.h
+++ b/google/cloud/bigtable/internal/poll_longrunning_operation.h
@@ -40,7 +40,7 @@ ResultType PollLongRunningOperation(
     if (operation.done()) {
       if (operation.has_response()) {
         auto const& any = operation.response();
-        if (not any.Is<ResultType>()) {
+        if (!any.Is<ResultType>()) {
           std::ostringstream os;
           os << error_message << "(" << metadata_update_policy.value() << ") - "
              << "invalid result type in operation=" << operation.name();
@@ -67,10 +67,10 @@ ResultType PollLongRunningOperation(
     op.set_name(operation.name());
     grpc::ClientContext context;
     status = client->GetOperation(&context, op, &operation);
-    if (not status.ok() and not polling_policy->OnFailure(status)) {
+    if (!status.ok() && !polling_policy->OnFailure(status)) {
       return ResultType{};
     }
-  } while (not polling_policy->Exhausted());
+  } while (!polling_policy->Exhausted());
   std::ostringstream os;
   os << error_message << "(" << metadata_update_policy.value() << ") - "
      << "polling policy exhausted in operation=" << operation.name();

--- a/google/cloud/bigtable/internal/readrowsparser.cc
+++ b/google/cloud/bigtable/internal/readrowsparser.cc
@@ -35,7 +35,7 @@ void ReadRowsParser::HandleChunk(ReadRowsResponse_CellChunk chunk,
     return;
   }
 
-  if (not chunk.row_key().empty()) {
+  if (!chunk.row_key().empty()) {
     if (last_seen_row_key_.compare(chunk.row_key()) >= 0) {
       status = grpc::Status(grpc::StatusCode::INTERNAL,
                             "Row keys are expected in increasing order");
@@ -45,7 +45,7 @@ void ReadRowsParser::HandleChunk(ReadRowsResponse_CellChunk chunk,
   }
 
   if (chunk.has_family_name()) {
-    if (not chunk.has_qualifier()) {
+    if (!chunk.has_qualifier()) {
       status = grpc::Status(grpc::StatusCode::INTERNAL,
                             "New column family must specify qualifier");
       return;
@@ -101,13 +101,13 @@ void ReadRowsParser::HandleChunk(ReadRowsResponse_CellChunk chunk,
   if (chunk.reset_row()) {
     cells_.clear();
     cell_ = {};
-    if (not cell_first_chunk_) {
+    if (!cell_first_chunk_) {
       status = grpc::Status(grpc::StatusCode::INTERNAL,
                             "Reset row with an unfinished cell");
       return;
     }
   } else if (chunk.commit_row()) {
-    if (not cell_first_chunk_) {
+    if (!cell_first_chunk_) {
       status = grpc::Status(grpc::StatusCode::INTERNAL,
                             "Commit row with an unfinished cell");
       return;
@@ -131,13 +131,13 @@ void ReadRowsParser::HandleEndOfStream(grpc::Status& status) {
   }
   end_of_stream_ = true;
 
-  if (not cell_first_chunk_) {
+  if (!cell_first_chunk_) {
     status = grpc::Status(grpc::StatusCode::INTERNAL,
                           "end of stream with unfinished cell");
     return;
   }
 
-  if (cells_.begin() != cells_.end() and not row_ready_) {
+  if (cells_.begin() != cells_.end() && !row_ready_) {
     status = grpc::Status(grpc::StatusCode::INTERNAL,
                           "end of stream with unfinished row");
     return;
@@ -147,7 +147,7 @@ void ReadRowsParser::HandleEndOfStream(grpc::Status& status) {
 bool ReadRowsParser::HasNext() const { return row_ready_; }
 
 Row ReadRowsParser::Next(grpc::Status& status) {
-  if (not row_ready_) {
+  if (!row_ready_) {
     status =
         grpc::Status(grpc::StatusCode::INTERNAL, "Next with row not ready");
     return Row("", {});

--- a/google/cloud/bigtable/internal/readrowsparser_test.cc
+++ b/google/cloud/bigtable/internal/readrowsparser_test.cc
@@ -213,7 +213,7 @@ class AcceptanceTest : public ::testing::Test {
     std::vector<ReadRowsResponse_CellChunk> chunks;
     for (std::string const& chunk_string : chunk_strings) {
       ReadRowsResponse_CellChunk chunk;
-      if (not TextFormat::ParseFromString(chunk_string, &chunk)) {
+      if (!TextFormat::ParseFromString(chunk_string, &chunk)) {
         return {};
       }
       chunks.emplace_back(std::move(chunk));
@@ -226,18 +226,18 @@ class AcceptanceTest : public ::testing::Test {
     grpc::Status status;
     for (auto const& chunk : chunks) {
       parser_.HandleChunk(chunk, status);
-      if (not status.ok()) {
+      if (!status.ok()) {
         google::cloud::internal::ThrowRuntimeError(status.error_message());
       }
       if (parser_.HasNext()) {
         rows_.emplace_back(parser_.Next(status));
-        if (not status.ok()) {
+        if (!status.ok()) {
           google::cloud::internal::ThrowRuntimeError(status.error_message());
         }
       }
     }
     parser_.HandleEndOfStream(status);
-    if (not status.ok()) {
+    if (!status.ok()) {
       google::cloud::internal::ThrowRuntimeError(status.error_message());
     }
   }

--- a/google/cloud/bigtable/internal/rowreaderiterator.h
+++ b/google/cloud/bigtable/internal/rowreaderiterator.h
@@ -69,7 +69,7 @@ class RowReaderIterator {
   Row&& operator*() && { return *std::move(row_); }
   bool operator==(RowReaderIterator const& that) const {
     // All non-end iterators are equal.
-    return owner_ == that.owner_ and row_.has_value() == that.row_.has_value();
+    return owner_ == that.owner_ && row_.has_value() == that.row_.has_value();
   }
 
   bool operator!=(RowReaderIterator const& that) const {

--- a/google/cloud/bigtable/internal/table.cc
+++ b/google/cloud/bigtable/internal/table.cc
@@ -67,7 +67,7 @@ std::vector<FailedMutation> Table::Apply(SingleRowMutation&& mut) {
     }
     // It is up to the policy to terminate this loop, it could run
     // forever, but that would be a bad policy (pun intended).
-    if (not rpc_policy->OnFailure(status) or not is_idempotent) {
+    if (!rpc_policy->OnFailure(status) || !is_idempotent) {
       google::rpc::Status rpc_status;
       rpc_status.set_code(status.error_code());
       rpc_status.set_message(status.error_message());
@@ -105,17 +105,17 @@ std::vector<FailedMutation> Table::BulkApply(BulkMutation&& mut,
     retry_policy->Setup(client_context);
     metadata_update_policy_.Setup(client_context);
     status = mutator.MakeOneRequest(*client_, client_context);
-    if (not status.ok() and not retry_policy->OnFailure(status)) {
+    if (!status.ok() && !retry_policy->OnFailure(status)) {
       break;
     }
     auto delay = backoff_policy->OnCompletion(status);
     std::this_thread::sleep_for(delay);
   }
   auto failures = mutator.ExtractFinalFailures();
-  if (not status.ok()) {
+  if (!status.ok()) {
     return failures;
   }
-  if (not failures.empty()) {
+  if (!failures.empty()) {
     status = grpc::Status(
         grpc::StatusCode::INTERNAL,
         "Permanent (or too many transient) errors in Table::BulkApply()");
@@ -196,7 +196,7 @@ Row Table::CallReadModifyWriteRowRequest(
       *client_, rpc_retry_policy_->clone(), metadata_update_policy_,
       &DataClient::ReadModifyWriteRow, request, "ReadModifyWriteRowRequest",
       status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     return Row("", {});
   }
 
@@ -257,7 +257,7 @@ void Table::SampleRowsImpl(
     if (status.ok()) {
       break;
     }
-    if (not retry_policy->OnFailure(status)) {
+    if (!retry_policy->OnFailure(status)) {
       status = grpc::Status(grpc::StatusCode::INTERNAL,
                             "No more retries allowed as per policy.");
       return;

--- a/google/cloud/bigtable/internal/table_admin.cc
+++ b/google/cloud/bigtable/internal/table_admin.cc
@@ -62,7 +62,7 @@ std::vector<btadmin::Table> TableAdmin::ListTables(btadmin::Table::View view,
     auto response = ClientUtils::MakeCall(
         *client_, *rpc_policy, *backoff_policy, metadata_update_policy_,
         &AdminClient::ListTables, request, "TableAdmin", status, true);
-    if (not status.ok()) {
+    if (!status.ok()) {
       return result;
     }
 
@@ -70,7 +70,7 @@ std::vector<btadmin::Table> TableAdmin::ListTables(btadmin::Table::View view,
       result.emplace_back(std::move(x));
     }
     page_token = std::move(*response.mutable_next_page_token());
-  } while (not page_token.empty());
+  } while (!page_token.empty());
   return result;
 }
 
@@ -215,7 +215,7 @@ bool TableAdmin::WaitForConsistencyCheckHelper(
     } else if (polling_policy->IsPermanentError(status)) {
       return false;
     }
-  } while (not polling_policy->Exhausted());
+  } while (!polling_policy->Exhausted());
 
   return false;
 }
@@ -255,7 +255,7 @@ void TableAdmin::ListSnapshotsImpl(
         *client_, *rpc_policy, *backoff_policy, metadata_update_policy,
         &AdminClient::ListSnapshots, request, "ListSnapshotsImpl", status,
         true);
-    if (not status.ok()) {
+    if (!status.ok()) {
       break;
     }
 
@@ -263,7 +263,7 @@ void TableAdmin::ListSnapshotsImpl(
       inserter(x);
     }
     page_token = std::move(*response.mutable_next_page_token());
-  } while (not page_token.empty());
+  } while (!page_token.empty());
 }
 
 }  // namespace noex

--- a/google/cloud/bigtable/internal/unary_client_utils.h
+++ b/google/cloud/bigtable/internal/unary_client_utils.h
@@ -180,7 +180,7 @@ struct UnaryClientUtils {
       if (status.ok()) {
         break;
       }
-      if (not rpc_policy.OnFailure(status)) {
+      if (!rpc_policy.OnFailure(status)) {
         std::string full_message = error_message;
         full_message += "(" + metadata_update_policy.value() + ") ";
         full_message += status.error_message();
@@ -237,7 +237,7 @@ struct UnaryClientUtils {
     // Call the pointer to member function.
     status = (client.*function)(&client_context, request, &response);
 
-    if (not status.ok()) {
+    if (!status.ok()) {
       std::string full_message = error_message;
       full_message += "(" + metadata_update_policy.value() + ") ";
       full_message += status.error_message();

--- a/google/cloud/bigtable/mutations.cc
+++ b/google/cloud/bigtable/mutations.cc
@@ -64,7 +64,7 @@ Mutation DeleteFromRow() {
 
 grpc::Status FailedMutation::ToGrpcStatus(google::rpc::Status const& status) {
   std::string details;
-  if (not google::protobuf::TextFormat::PrintToString(status, &details)) {
+  if (!google::protobuf::TextFormat::PrintToString(status, &details)) {
     details = "error [could not print details as string]";
   }
   return grpc::Status(static_cast<grpc::StatusCode>(status.code()),

--- a/google/cloud/bigtable/polling_policy.h
+++ b/google/cloud/bigtable/polling_policy.h
@@ -89,7 +89,7 @@ class GenericPollingPolicy : public PollingPolicy {
     return rpc_retry_policy_.OnFailure(status);
   }
 
-  bool Exhausted() override { return not OnFailure(grpc::Status::OK); }
+  bool Exhausted() override { return !OnFailure(grpc::Status::OK); }
 
   std::chrono::milliseconds WaitPeriod() override {
     return rpc_backoff_policy_.OnCompletion(grpc::Status::OK);

--- a/google/cloud/bigtable/row_range.cc
+++ b/google/cloud/bigtable/row_range.cc
@@ -72,20 +72,20 @@ bool RowRange::IsEmpty() const {
   }
 
   // Special case of an open interval of two consecutive strings.
-  if (start_open and end_open and Consecutive(*start, *end)) {
+  if (start_open && end_open && Consecutive(*start, *end)) {
     return true;
   }
 
   // Compare the strings as byte vectors (careful with unsigned chars).
   int cmp = start->compare(*end);
   if (cmp == 0) {
-    return start_open or end_open;
+    return start_open || end_open;
   }
   return cmp > 0;
 }
 
 bool RowRange::Contains(std::string const& key) const {
-  return not BelowStart(key) and not AboveEnd(key);
+  return !BelowStart(key) && !AboveEnd(key);
 }
 
 bool RowRange::BelowStart(std::string const& key) const {
@@ -183,7 +183,7 @@ std::pair<bool, RowRange> RowRange::Intersect(RowRange const& range) const {
   }
 
   bool is_empty = intersection.IsEmpty();
-  return std::make_pair(not is_empty, std::move(intersection));
+  return std::make_pair(!is_empty, std::move(intersection));
 }
 
 bool RowRange::operator==(RowRange const& rhs) const {

--- a/google/cloud/bigtable/row_range.h
+++ b/google/cloud/bigtable/row_range.h
@@ -86,7 +86,7 @@ class RowRange {
   static RowRange RightOpen(std::string begin, std::string end) {
     RowRange result;
     result.row_range_.set_start_key_closed(std::move(begin));
-    if (not end.empty()) {
+    if (!end.empty()) {
       result.row_range_.set_end_key_open(std::move(end));
     }
     return result;
@@ -96,7 +96,7 @@ class RowRange {
   static RowRange LeftOpen(std::string begin, std::string end) {
     RowRange result;
     result.row_range_.set_start_key_open(std::move(begin));
-    if (not end.empty()) {
+    if (!end.empty()) {
       result.row_range_.set_end_key_closed(std::move(end));
     }
     return result;
@@ -106,7 +106,7 @@ class RowRange {
   static RowRange Open(std::string begin, std::string end) {
     RowRange result;
     result.row_range_.set_start_key_open(std::move(begin));
-    if (not end.empty()) {
+    if (!end.empty()) {
       result.row_range_.set_end_key_open(std::move(end));
     }
     return result;
@@ -116,7 +116,7 @@ class RowRange {
   static RowRange Closed(std::string begin, std::string end) {
     RowRange result;
     result.row_range_.set_start_key_closed(std::move(begin));
-    if (not end.empty()) {
+    if (!end.empty()) {
       result.row_range_.set_end_key_closed(std::move(end));
     }
     return result;

--- a/google/cloud/bigtable/row_reader.cc
+++ b/google/cloud/bigtable/row_reader.cc
@@ -136,7 +136,7 @@ RowReader::iterator RowReader::begin() {
       return internal::RowReaderIterator(this, true);
     }
   }
-  if (not stream_) {
+  if (!stream_) {
     MakeRequest();
   }
   // Increment the iterator to read a row.
@@ -183,7 +183,7 @@ bool RowReader::NextChunk() {
   while (processed_chunks_count_ >= response_.chunks_size()) {
     processed_chunks_count_ = 0;
     bool response_is_valid = stream_->Read(&response_);
-    if (not response_is_valid) {
+    if (!response_is_valid) {
       response_ = {};
       return false;
     }
@@ -203,11 +203,11 @@ void RowReader::Advance(internal::OptionalRow& row) {
     // number of rows and still receive an error (the parser can throw
     // an error at end of stream for example), there is no need to
     // retry and we have no good value for rows_limit anyway.
-    if (rows_limit_ != NO_ROWS_LIMIT and rows_limit_ <= rows_count_) {
+    if (rows_limit_ != NO_ROWS_LIMIT && rows_limit_ <= rows_count_) {
       return;
     }
 
-    if (not last_read_row_key_.empty()) {
+    if (!last_read_row_key_.empty()) {
       // We've returned some rows and need to make sure we don't
       // request them again.
       row_set_ = row_set_.Intersect(RowRange::Open(last_read_row_key_, ""));
@@ -218,7 +218,7 @@ void RowReader::Advance(internal::OptionalRow& row) {
       return;
     }
 
-    if (not status.ok() and not retry_policy_->OnFailure(status)) {
+    if (!status.ok() && !retry_policy_->OnFailure(status)) {
       if (raise_on_error_) {
         google::cloud::internal::ThrowRuntimeError("Unretriable error: " +
                                                    status.error_message());
@@ -238,12 +238,12 @@ void RowReader::Advance(internal::OptionalRow& row) {
 grpc::Status RowReader::AdvanceOrFail(internal::OptionalRow& row) {
   grpc::Status status;
   row.reset();
-  while (not parser_->HasNext()) {
+  while (!parser_->HasNext()) {
     if (NextChunk()) {
       parser_->HandleChunk(
           std::move(*(response_.mutable_chunks(processed_chunks_count_))),
           status);
-      if (not status.ok()) {
+      if (!status.ok()) {
         return status;
       }
       continue;
@@ -254,7 +254,7 @@ grpc::Status RowReader::AdvanceOrFail(internal::OptionalRow& row) {
     // fails during cleanup.
     stream_is_open_ = false;
     status = stream_->Finish();
-    if (not status.ok()) {
+    if (!status.ok()) {
       return status;
     }
     parser_->HandleEndOfStream(status);
@@ -263,7 +263,7 @@ grpc::Status RowReader::AdvanceOrFail(internal::OptionalRow& row) {
 
   // We have a complete row in the parser.
   Row parsed_row = parser_->Next(status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   row.emplace(std::move(parsed_row));
@@ -275,7 +275,7 @@ grpc::Status RowReader::AdvanceOrFail(internal::OptionalRow& row) {
 
 void RowReader::Cancel() {
   operation_cancelled_ = true;
-  if (not stream_is_open_) {
+  if (!stream_is_open_) {
     return;
   }
   context_->TryCancel();
@@ -292,7 +292,7 @@ void RowReader::Cancel() {
 RowReader::~RowReader() {
   // Make sure we don't leave open streams.
   Cancel();
-  if (not raise_on_error_ and not error_retrieved_ and not status_.ok()) {
+  if (!raise_on_error_ && !error_retrieved_ && !status_.ok()) {
     GCP_LOG(ERROR)
         << "Exceptions are disabled, RowReader has an error,"
         << " and the error status was not retrieved by the application: "

--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -56,7 +56,7 @@ class ReadRowsParserMock : public bigtable::internal::ReadRowsParser {
     HandleEndOfStreamHook(status);
   }
 
-  bool HasNext() const override { return not rows_.empty(); }
+  bool HasNext() const override { return !rows_.empty(); }
 
   Row Next(grpc::Status& status) override {
     Row row = rows_.front();

--- a/google/cloud/bigtable/row_set.cc
+++ b/google/cloud/bigtable/row_set.cc
@@ -20,7 +20,7 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 RowSet RowSet::Intersect(bigtable::RowRange const& range) const {
   // Special case: "all rows", return the argument range.
-  if (row_set_.row_keys().empty() and row_set_.row_ranges().empty()) {
+  if (row_set_.row_keys().empty() && row_set_.row_ranges().empty()) {
     return RowSet(range);
   }
   // Normal case: find the intersection with
@@ -39,7 +39,7 @@ RowSet RowSet::Intersect(bigtable::RowRange const& range) const {
   }
   // Another special case: a RowSet() with no entries
   // means "all rows", but we want "no rows".
-  if (result.row_set_.row_keys().empty() and
+  if (result.row_set_.row_keys().empty() &&
       result.row_set_.row_ranges().empty()) {
     return RowSet(bigtable::RowRange::Empty());
   }
@@ -51,7 +51,7 @@ bool RowSet::IsEmpty() const {
     return false;
   }
   for (auto const& r : row_set_.row_ranges()) {
-    if (not RowRange(r).IsEmpty()) {
+    if (!RowRange(r).IsEmpty()) {
       return false;
     }
   }

--- a/google/cloud/bigtable/rpc_retry_policy.h
+++ b/google/cloud/bigtable/rpc_retry_policy.h
@@ -31,8 +31,8 @@ struct SafeGrpcRetry {
   // Sometimes we need to use google::protobuf::rpc::Status, in which case this
   // is a easier function
   static inline bool IsTransientFailure(grpc::StatusCode code) {
-    return code == grpc::StatusCode::ABORTED or
-           code == grpc::StatusCode::UNAVAILABLE or
+    return code == grpc::StatusCode::ABORTED ||
+           code == grpc::StatusCode::UNAVAILABLE ||
            code == grpc::StatusCode::DEADLINE_EXCEEDED;
   }
 
@@ -41,7 +41,7 @@ struct SafeGrpcRetry {
     return IsTransientFailure(status.error_code());
   }
   static inline bool IsPermanentFailure(grpc::Status const& status) {
-    return not IsOk(status) and not IsTransientFailure(status);
+    return !IsOk(status) && !IsTransientFailure(status);
   }
 };
 

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -50,7 +50,7 @@ static_assert(std::is_copy_assignable<bigtable::Table>::value,
 
 void Table::Apply(SingleRowMutation&& mut) {
   std::vector<FailedMutation> failures = impl_.Apply(std::move(mut));
-  if (not failures.empty()) {
+  if (!failures.empty()) {
     grpc::Status status = failures.front().status();
     ReportPermanentFailures(status.error_message().c_str(), status, failures);
   }
@@ -60,7 +60,7 @@ void Table::BulkApply(BulkMutation&& mut) {
   grpc::Status status;
   std::vector<FailedMutation> failures =
       impl_.BulkApply(std::move(mut), status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     ReportPermanentFailures(status.error_message().c_str(), status, failures);
   }
 }
@@ -78,7 +78,7 @@ RowReader Table::ReadRows(RowSet row_set, std::int64_t rows_limit,
 std::pair<bool, Row> Table::ReadRow(std::string row_key, Filter filter) {
   grpc::Status status;
   auto result = impl_.ReadRow(std::move(row_key), std::move(filter), status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     google::cloud::internal::ThrowRuntimeError(status.error_message());
   }
   return result;
@@ -91,7 +91,7 @@ bool Table::CheckAndMutateRow(std::string row_key, Filter filter,
   bool value = impl_.CheckAndMutateRow(std::move(row_key), std::move(filter),
                                        std::move(true_mutations),
                                        std::move(false_mutations), status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(status, status.error_message());
   }
   return value;

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -307,7 +307,7 @@ class Table {
   Collection<bigtable::RowKeySample> SampleRows() {
     grpc::Status status;
     auto result = impl_.SampleRows<Collection>(status);
-    if (not status.ok()) {
+    if (!status.ok()) {
       bigtable::internal::ThrowRpcError(status, status.error_message());
     }
 
@@ -339,7 +339,7 @@ class Table {
     Row row =
         impl_.ReadModifyWriteRow(std::move(row_key), status, std::move(rule),
                                  std::forward<Args>(rules)...);
-    if (not status.ok()) {
+    if (!status.ok()) {
       internal::ThrowRpcError(status, status.error_message());
     }
     return row;

--- a/google/cloud/bigtable/table_admin.cc
+++ b/google/cloud/bigtable/table_admin.cc
@@ -38,7 +38,7 @@ btadmin::Table TableAdmin::CreateTable(std::string table_id,
   grpc::Status status;
   auto result =
       impl_.CreateTable(std::move(table_id), std::move(config), status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     internal::ThrowRpcError(status, status.error_message());
   }
   return result;
@@ -73,7 +73,7 @@ future<google::bigtable::admin::v2::Table> TableAdmin::AsyncGetTable(
 std::vector<btadmin::Table> TableAdmin::ListTables(btadmin::Table::View view) {
   grpc::Status status;
   auto result = impl_.ListTables(view, status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     internal::ThrowRpcError(status, status.error_message());
   }
   return result;
@@ -83,7 +83,7 @@ btadmin::Table TableAdmin::GetTable(std::string const& table_id,
                                     btadmin::Table::View view) {
   grpc::Status status;
   auto result = impl_.GetTable(table_id, status, view);
-  if (not status.ok()) {
+  if (!status.ok()) {
     internal::ThrowRpcError(status, status.error_message());
   }
   return result;
@@ -92,7 +92,7 @@ btadmin::Table TableAdmin::GetTable(std::string const& table_id,
 void TableAdmin::DeleteTable(std::string const& table_id) {
   grpc::Status status;
   impl_.DeleteTable(table_id, status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     internal::ThrowRpcError(status, status.error_message());
   }
 }
@@ -103,7 +103,7 @@ btadmin::Table TableAdmin::ModifyColumnFamilies(
   grpc::Status status;
   auto result =
       impl_.ModifyColumnFamilies(table_id, std::move(modifications), status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     internal::ThrowRpcError(status, status.error_message());
   }
   return result;
@@ -113,7 +113,7 @@ void TableAdmin::DropRowsByPrefix(std::string const& table_id,
                                   std::string row_key_prefix) {
   grpc::Status status;
   impl_.DropRowsByPrefix(table_id, std::move(row_key_prefix), status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     internal::ThrowRpcError(status, status.error_message());
   }
 }
@@ -121,7 +121,7 @@ void TableAdmin::DropRowsByPrefix(std::string const& table_id,
 void TableAdmin::DropAllRows(std::string const& table_id) {
   grpc::Status status;
   impl_.DropAllRows(table_id, status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     internal::ThrowRpcError(status, status.error_message());
   }
 }
@@ -155,7 +155,7 @@ btadmin::Snapshot TableAdmin::SnapshotTableImpl(
       impl_.rpc_backoff_policy_->clone(), metadata_update_policy,
       &AdminClient::SnapshotTable, request, "SnapshotTable", status, true);
 
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(status,
                                       "unrecoverable error in MakeCall()");
   }
@@ -165,7 +165,7 @@ btadmin::Snapshot TableAdmin::SnapshotTableImpl(
           impl_.client_, impl_.polling_policy_->clone(),
           impl_.metadata_update_policy_, operation, "TableAdmin::SnapshotTable",
           status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(
         status, "while polling operation in TableAdmin::SnapshotTable");
   }
@@ -178,7 +178,7 @@ btadmin::Snapshot TableAdmin::GetSnapshot(
     bigtable::SnapshotId const& snapshot_id) {
   grpc::Status status;
   auto result = impl_.GetSnapshot(cluster_id, snapshot_id, status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     internal::ThrowRpcError(status, status.error_message());
   }
   return result;
@@ -187,7 +187,7 @@ btadmin::Snapshot TableAdmin::GetSnapshot(
 std::string TableAdmin::GenerateConsistencyToken(std::string const& table_id) {
   grpc::Status status;
   std::string token = impl_.GenerateConsistencyToken(table_id, status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     internal::ThrowRpcError(status, status.error_message());
   }
   return token;
@@ -198,7 +198,7 @@ bool TableAdmin::CheckConsistency(
     bigtable::ConsistencyToken const& consistency_token) {
   grpc::Status status;
   bool consistent = impl_.CheckConsistency(table_id, consistency_token, status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     internal::ThrowRpcError(status, status.error_message());
   }
   return consistent;
@@ -210,7 +210,7 @@ bool TableAdmin::WaitForConsistencyCheckImpl(
   grpc::Status status;
   bool consistent =
       impl_.WaitForConsistencyCheckHelper(table_id, consistency_token, status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     internal::ThrowRpcError(status, status.error_message());
   }
   return consistent;
@@ -220,7 +220,7 @@ void TableAdmin::DeleteSnapshot(bigtable::ClusterId const& cluster_id,
                                 bigtable::SnapshotId const& snapshot_id) {
   grpc::Status status;
   impl_.DeleteSnapshot(cluster_id, snapshot_id, status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     internal::ThrowRpcError(status, status.error_message());
   }
 }
@@ -253,7 +253,7 @@ btadmin::Table TableAdmin::CreateTableFromSnapshotImpl(
       *impl_.client_, *rpc_policy, *backoff_policy,
       impl_.metadata_update_policy_, &AdminClient::CreateTableFromSnapshot,
       request, "TableAdmin", status, true);
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(status,
                                       "unrecoverable error in MakeCall()");
   }
@@ -262,7 +262,7 @@ btadmin::Table TableAdmin::CreateTableFromSnapshotImpl(
       impl_.client_, impl_.polling_policy_->clone(),
       impl_.metadata_update_policy_, operation,
       "TableAdmin::CreateTableFromSnapshot", status);
-  if (not status.ok()) {
+  if (!status.ok()) {
     bigtable::internal::ThrowRpcError(
         status,
         "while polling operation in TableAdmin::CreateTableFromSnapshot");

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -434,7 +434,7 @@ class TableAdmin {
       bigtable::ClusterId cluster_id = bigtable::ClusterId("-")) {
     grpc::Status status;
     auto result = impl_.ListSnapshots<Collection>(status, cluster_id);
-    if (not status.ok()) {
+    if (!status.ok()) {
       bigtable::internal::ThrowRpcError(status, status.error_message());
     }
     return result;

--- a/google/cloud/bigtable/tests/instance_admin_emulator.cc
+++ b/google/cloud/bigtable/tests/instance_admin_emulator.cc
@@ -131,7 +131,7 @@ class InstanceAdminEmulator final
     for (int index = 0; index != request->update_mask().paths_size(); ++index) {
       if ("display_name" == request->update_mask().paths(index)) {
         auto size = request->instance().display_name().size();
-        if (size < 4 or size > 30) {
+        if (size < 4 || size > 30) {
           return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
                               "display name size must be in range [4,30]");
         }

--- a/google/cloud/bigtable/version.cc
+++ b/google/cloud/bigtable/version.cc
@@ -26,7 +26,7 @@ std::string version_string() {
     std::ostringstream os;
     os << "v" << version_major() << "." << version_minor() << "."
        << version_patch();
-    if (not google::cloud::internal::is_release()) {
+    if (!google::cloud::internal::is_release()) {
       os << "+" << google::cloud::internal::gitrev();
     }
     return os.str();

--- a/google/cloud/examples/gcs2cbt.cc
+++ b/google/cloud/examples/gcs2cbt.cc
@@ -47,8 +47,8 @@ class GenericCircularBuffer {
 
   bool Pop(T& next) {
     std::unique_lock<std::mutex> lk(mu_);
-    cv_.wait(lk, [this]() { return not Empty() or is_shutdown_; });
-    if (not Empty()) {
+    cv_.wait(lk, [this]() { return !Empty() || is_shutdown_; });
+    if (!Empty()) {
       next = std::move(buffer_[head_]);
       ++head_;
       if (head_ >= buffer_.size()) {
@@ -59,12 +59,12 @@ class GenericCircularBuffer {
       cv_.notify_all();
       return true;
     }
-    return not is_shutdown_;
+    return !is_shutdown_;
   }
 
   void Push(T data) {
     std::unique_lock<std::mutex> lk(mu_);
-    cv_.wait(lk, [this]() { return not Full(); });
+    cv_.wait(lk, [this]() { return !Full(); });
     buffer_[tail_] = std::move(data);
     ++tail_;
     if (tail_ >= buffer_.size()) {
@@ -76,8 +76,8 @@ class GenericCircularBuffer {
   }
 
  private:
-  bool Empty() { return head_ == tail_ and empty_; }
-  bool Full() { return head_ == tail_ and not empty_; }
+  bool Empty() { return head_ == tail_ && empty_; }
+  bool Full() { return head_ == tail_ && !empty_; }
 
  private:
   std::mutex mu_;
@@ -242,7 +242,7 @@ int main(int argc, char* argv[]) try {
   auto bulk_apply_size = static_cast<int>(100000 / headers.size());
   cbt::BulkMutation bulk;
   int count = 0;
-  while (not is.eof()) {
+  while (!is.eof()) {
     ++lineno;
     std::getline(is, line, '\n');
     if (line.empty()) {
@@ -328,7 +328,7 @@ std::vector<std::string> ParseLine(long lineno, std::string const& line,
 
   // Extract the fields one at a time using a std::istringstream.
   std::istringstream tokens(line);
-  while (not tokens.eof()) {
+  while (!tokens.eof()) {
     std::string tk;
     std::getline(tokens, tk, separator);
     result.emplace_back(std::move(tk));

--- a/google/cloud/firestore/field_path.cc
+++ b/google/cloud/firestore/field_path.cc
@@ -66,11 +66,11 @@ std::string FieldPath::ToApiRepr() const {
     if (part.empty()) {
       return false;
     }
-    if (part[0] != '_' and std::isalpha(part[0]) == 0) {
+    if (part[0] != '_' && std::isalpha(part[0]) == 0) {
       return false;
     }
     return std::all_of(part.begin(), part.end(), [](char c) {
-      return c == '_' or std::isalnum(c) != 0;
+      return c == '_' || std::isalnum(c) != 0;
     });
   };
   std::string s;

--- a/google/cloud/future_generic.h
+++ b/google/cloud/future_generic.h
@@ -179,7 +179,7 @@ class promise final : private internal::promise_base<T> {
    *   a shared state.
    */
   void set_value(T&& value) {
-    if (not this->shared_state_) {
+    if (!this->shared_state_) {
       internal::ThrowFutureError(std::future_errc::no_state, __func__);
     }
     this->shared_state_->set_value(std::forward<T>(value));

--- a/google/cloud/future_void.h
+++ b/google/cloud/future_void.h
@@ -175,7 +175,7 @@ class promise<void> final : private internal::promise_base<void> {
    *   a shared state.
    */
   void set_value() {
-    if (not shared_state_) {
+    if (!shared_state_) {
       internal::ThrowFutureError(std::future_errc::no_state, __func__);
     }
     shared_state_->set_value();

--- a/google/cloud/internal/backoff_policy.cc
+++ b/google/cloud/internal/backoff_policy.cc
@@ -41,7 +41,7 @@ std::chrono::milliseconds ExponentialBackoffPolicy::OnCompletion() {
   //
   // So we delay the initialization of the PRNG until the first call that needs
   // to, that is here:
-  if (not generator_) {
+  if (!generator_) {
     generator_ = google::cloud::internal::MakeDefaultPRNG();
   }
   using namespace std::chrono;

--- a/google/cloud/internal/filesystem.h
+++ b/google/cloud/internal/filesystem.h
@@ -156,12 +156,11 @@ inline bool is_symlink(file_status s) noexcept {
 }
 
 inline bool exists(file_status s) noexcept {
-  return status_known(s) and s.type() != file_type::not_found;
+  return status_known(s) && s.type() != file_type::not_found;
 }
 
 inline bool is_other(file_status s) noexcept {
-  return exists(s) and not is_regular(s) and not is_directory(s) and
-         not is_symlink(s);
+  return exists(s) && !is_regular(s) && !is_directory(s) && !is_symlink(s);
 }
 
 std::uintmax_t file_size(std::string const& path);

--- a/google/cloud/internal/filesystem_test.cc
+++ b/google/cloud/internal/filesystem_test.cc
@@ -88,7 +88,7 @@ TEST(FilesystemTest, StatusBlock) {
   std::error_code ec;
   auto file_status = status("/dev/loop0", ec);
   EXPECT_FALSE(static_cast<bool>(ec));
-  if (not exists(file_status)) {
+  if (!exists(file_status)) {
     // In some CI builds there is no /dev/loop0, and no other well-known
     // block device comes to mind, simply stop the test when that happens.
     return;

--- a/google/cloud/internal/future_base.h
+++ b/google/cloud/internal/future_base.h
@@ -133,7 +133,7 @@ class future_base {
 
   /// Throws an exception if the shared state is not valid.
   void check_valid() const {
-    if (not shared_state_) {
+    if (!shared_state_) {
       ThrowFutureError(std::future_errc::no_state, __func__);
     }
   }
@@ -169,7 +169,7 @@ class promise_base {
    *   a shared state.
    */
   void set_exception(std::exception_ptr ex) {
-    if (not shared_state_) {
+    if (!shared_state_) {
       ThrowFutureError(std::future_errc::no_state, __func__);
     }
     shared_state_->set_exception(std::move(ex));

--- a/google/cloud/internal/future_impl.h
+++ b/google/cloud/internal/future_impl.h
@@ -137,7 +137,7 @@ class future_shared_state_base {
   template <typename Clock>
   std::future_status wait_until(std::chrono::time_point<Clock> deadline) {
     std::unique_lock<std::mutex> lk(mu_);
-    if (not lk.owns_lock()) {
+    if (!lk.owns_lock()) {
       return std::future_status::timeout;
     }
     bool result =
@@ -239,7 +239,7 @@ class future_shared_state_base {
    * @throws std::future_error if the operation fails.
    */
   static void mark_retrieved(future_shared_state_base* sh) {
-    if (not sh) {
+    if (!sh) {
       ThrowFutureError(std::future_errc::no_state, __func__);
     }
     if (sh->retrieved_.test_and_set()) {
@@ -643,7 +643,7 @@ struct continuation : public continuation_base {
 
   void execute() override {
     auto tmp = input.lock();
-    if (not tmp) {
+    if (!tmp) {
       output->set_exception(std::make_exception_ptr(
           std::future_error(std::future_errc::no_state)));
       return;
@@ -694,7 +694,7 @@ struct unwrapping_continuation : public continuation_base {
 
   void execute() override {
     auto tmp = input.lock();
-    if (not tmp) {
+    if (!tmp) {
       output->set_exception(std::make_exception_ptr(
           std::future_error(std::future_errc::no_state)));
       return;
@@ -712,7 +712,7 @@ struct unwrapping_continuation : public continuation_base {
     intermediate = functor(std::move(tmp));
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 
-    if (not intermediate) {
+    if (!intermediate) {
       output->set_exception(std::make_exception_ptr(
           std::future_error(std::future_errc::broken_promise)));
       return;

--- a/google/cloud/internal/invoke_result_test.cc
+++ b/google/cloud/internal/invoke_result_test.cc
@@ -71,10 +71,10 @@ TEST(ResultOfTest, Function) {
   static_assert(is_invocable<F, int, std::string&>::value,
                 "expected `is_invocable<F, int, std::string&>` to be true");
 
-  static_assert(not is_invocable<F, std::string>::value,
+  static_assert(!is_invocable<F, std::string>::value,
                 "expected `is_invocable<F, std::string>` to be false");
 
-  static_assert(not is_invocable<F>::value,
+  static_assert(!is_invocable<F>::value,
                 "expected `is_invocable<F>` to be false");
 
   // Some compilers create warnings/errors if the function is not used, even
@@ -101,13 +101,13 @@ TEST(ResultOfTest, TestMemberFn) {
                 "expected `is_invocable<DoSomethingTemplatedType, TestStruct&, "
                 "std::string const&, int>` to be true");
   using DoSomethingType = decltype(&TestStruct::DoSomething);
-  static_assert(not is_invocable<DoSomethingType, TestStruct&, int, int>::value,
+  static_assert(!is_invocable<DoSomethingType, TestStruct&, int, int>::value,
                 "expected `is_invocable<DoSomethingType, TestStruct&, "
                 "std::string const&, int>` to be true");
   using DoSomethingTemplatedType =
       decltype(&TestStruct::DoSomethingTemplated<std::string>);
-  static_assert(not is_invocable<DoSomethingTemplatedType, TestStruct&, int,
-                                 std::string&&>::value,
+  static_assert(!is_invocable<DoSomethingTemplatedType, TestStruct&, int,
+                              std::string&&>::value,
                 "expected `is_invocable<DoSomethingTemplatedType, TestStruct&, "
                 "std::string const&, int>` to be true");
 }

--- a/google/cloud/internal/retry_policy.h
+++ b/google/cloud/internal/retry_policy.h
@@ -42,7 +42,7 @@ class RetryPolicy {
       return false;
     }
     OnFailureImpl();
-    return not IsExhausted();
+    return !IsExhausted();
   }
   virtual bool IsExhausted() const = 0;
 

--- a/google/cloud/internal/retry_policy_test.cc
+++ b/google/cloud/internal/retry_policy_test.cc
@@ -23,7 +23,7 @@ struct Status {
 };
 struct IsRetryablePolicy {
   static bool IsPermanentFailure(Status const& s) {
-    return s.is_ok or not s.is_retryable;
+    return s.is_ok || !s.is_retryable;
   }
 };
 

--- a/google/cloud/internal/setenv.cc
+++ b/google/cloud/internal/setenv.cc
@@ -47,7 +47,7 @@ void SetEnv(char const* variable, char const* value) {
 }
 
 void SetEnv(char const* variable, optional<std::string> value) {
-  if (not value.has_value()) {
+  if (!value.has_value()) {
     UnsetEnv(variable);
     return;
   }

--- a/google/cloud/log.h
+++ b/google/cloud/log.h
@@ -349,14 +349,14 @@ class Logger {
         function_(function),
         filename_(filename),
         lineno_(lineno) {
-    enabled_ = not sink.empty() and sink.is_enabled(severity);
+    enabled_ = !sink.empty() && sink.is_enabled(severity);
   }
 
   bool enabled() const { return enabled_; }
 
   /// Send the log record captured by this object to @p sink.
   void LogTo(LogSink& sink) {
-    if (not stream_ or not enabled_) {
+    if (!stream_ || !enabled_) {
       return;
     }
     enabled_ = false;
@@ -372,7 +372,7 @@ class Logger {
 
   /// Return the iostream that captures the log message.
   std::ostream& Stream() {
-    if (not stream_) {
+    if (!stream_) {
       stream_.reset(new std::ostringstream);
     }
     return *stream_;

--- a/google/cloud/optional.h
+++ b/google/cloud/optional.h
@@ -75,15 +75,15 @@ class optional {
     // There may be shorter ways to express this, but this is fairly readable,
     // and should be reasonably efficient. Note that we must avoid destructing
     // the destination and/or default initializing it unless really needed.
-    if (not has_value_) {
-      if (not rhs.has_value_) {
+    if (!has_value_) {
+      if (!rhs.has_value_) {
         return *this;
       }
       new (reinterpret_cast<T*>(&buffer_)) T(*rhs);
       has_value_ = true;
       return *this;
     }
-    if (not rhs.has_value_) {
+    if (!rhs.has_value_) {
       reset();
       return *this;
     }
@@ -96,15 +96,15 @@ class optional {
     // There may be shorter ways to express this, but this is fairly readable,
     // and should be reasonably efficient. Note that we must avoid destructing
     // the destination and/or default initializing it unless really needed.
-    if (not has_value_) {
-      if (not rhs.has_value_) {
+    if (!has_value_) {
+      if (!rhs.has_value_) {
         return *this;
       }
       new (reinterpret_cast<T*>(&buffer_)) T(std::move(*rhs));
       has_value_ = true;
       return *this;
     }
-    if (not rhs.has_value_) {
+    if (!rhs.has_value_) {
       reset();
       return *this;
     }
@@ -124,7 +124,7 @@ class optional {
     // There may be shorter ways to express this, but this is fairly readable,
     // and should be reasonably efficient. Note that we must avoid destructing
     // the destination and/or default initializing it unless really needed.
-    if (not has_value_) {
+    if (!has_value_) {
       new (reinterpret_cast<T*>(&buffer_)) T(std::forward<U>(rhs));
       has_value_ = true;
       return *this;
@@ -202,7 +202,7 @@ class optional {
     if (has_value() != rhs.has_value()) {
       return false;
     }
-    if (not has_value()) {
+    if (!has_value()) {
       return true;
     }
     return **this == *rhs;
@@ -214,7 +214,7 @@ class optional {
 
   bool operator<(optional const& rhs) const {
     if (has_value()) {
-      if (not rhs.has_value()) {
+      if (!rhs.has_value()) {
         return false;
       }
       // Both have a value, compare them

--- a/google/cloud/status.h
+++ b/google/cloud/status.h
@@ -71,9 +71,9 @@ class Status {
   bool ok() const { return code_ == StatusCode::kOk; }
 
   bool operator==(Status const& rhs) const {
-    return code() == rhs.code() and message() == rhs.message();
+    return code() == rhs.code() && message() == rhs.message();
   }
-  bool operator!=(Status const& rhs) const { return not(*this == rhs); }
+  bool operator!=(Status const& rhs) const { return !(*this == rhs); }
 
   StatusCode code() const { return code_; }
   std::string const& message() const { return message_; }

--- a/google/cloud/status_or.h
+++ b/google/cloud/status_or.h
@@ -38,7 +38,7 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
  * void AppCode(gcs::noex::Client client) {
  *   gcs::StatusOr<gcs::BucketMetadata> meta_err = client.GetBucketMetadata(
  *       "my-bucket-name");
- *   if (not meta_err) {
+ *   if (!meta_err) {
  *       std::cerr << "Error in GetBucketMetadata: " << meta_err.status()
  *                 << std::endl;
  *       return;
@@ -97,8 +97,8 @@ class StatusOr final {
     // There may be shorter ways to express this, but this is fairly readable,
     // and should be reasonably efficient. Note that we must avoid destructing
     // the destination and/or default initializing it unless really needed.
-    if (not ok()) {
-      if (not rhs.ok()) {
+    if (!ok()) {
+      if (!rhs.ok()) {
         status_ = std::move(rhs.status_);
         return *this;
       }
@@ -106,7 +106,7 @@ class StatusOr final {
       status_ = Status();
       return *this;
     }
-    if (not rhs.ok()) {
+    if (!rhs.ok()) {
       value_.~T();
       status_ = std::move(rhs.status_);
       return *this;
@@ -126,8 +126,8 @@ class StatusOr final {
     // There may be shorter ways to express this, but this is fairly readable,
     // and should be reasonably efficient. Note that we must avoid destructing
     // the destination and/or default initializing it unless really needed.
-    if (not ok()) {
-      if (not rhs.ok()) {
+    if (!ok()) {
+      if (!rhs.ok()) {
         status_ = rhs.status_;
         return *this;
       }
@@ -135,7 +135,7 @@ class StatusOr final {
       status_ = rhs.status_;
       return *this;
     }
-    if (not rhs.ok()) {
+    if (!rhs.ok()) {
       value_.~T();
       status_ = rhs.status_;
       return *this;
@@ -165,7 +165,7 @@ class StatusOr final {
     // There may be shorter ways to express this, but this is fairly readable,
     // and should be reasonably efficient. Note that we must avoid destructing
     // the destination and/or default initializing it unless really needed.
-    if (not ok()) {
+    if (!ok()) {
       new (&value_) T(std::forward<U>(rhs));
       status_ = Status();
       return *this;
@@ -281,14 +281,14 @@ class StatusOr final {
 
  private:
   void CheckHasValue() const& {
-    if (not ok()) {
+    if (!ok()) {
       internal::ThrowStatus(status_);
     }
   }
 
   // When possible, do not copy the status.
   void CheckHasValue() && {
-    if (not ok()) {
+    if (!ok()) {
       internal::ThrowStatus(std::move(status_));
     }
   }
@@ -313,7 +313,7 @@ class StatusOr final {
  * namespace gcs = google::cloud::storage;
  * void AppCode(gcs::noex::Client client) {
  *   gcs::StatusOr<void> delete_err = client.DeleteBucket("my-bucket-name");
- *   if (not delete_err.ok()) {
+ *   if (!delete_err.ok()) {
  *       std::cerr << "Error in DeleteBucket: " << meta_err.status()
  *                 << std::endl;
  *       return;
@@ -416,14 +416,14 @@ class StatusOr<void> final {
 
  private:
   void CheckHasValue() const& {
-    if (not ok()) {
+    if (!ok()) {
       internal::ThrowStatus(Status(status_));
     }
   }
 
   // When possible, do not copy the status.
   void CheckHasValue() && {
-    if (not ok()) {
+    if (!ok()) {
       internal::ThrowStatus(std::move(status_));
     }
   }

--- a/google/cloud/status_or_test.cc
+++ b/google/cloud/status_or_test.cc
@@ -27,13 +27,13 @@ TEST(StatusOrTest, DefaultConstructor) {
   StatusOr<int> actual;
   EXPECT_FALSE(actual.ok());
   EXPECT_FALSE(actual.status().ok());
-  EXPECT_TRUE(not actual);
+  EXPECT_FALSE(actual);
 }
 
 TEST(StatusOrTest, StatusConstructorNormal) {
   StatusOr<int> actual(Status(StatusCode::kNotFound, "NOT FOUND"));
   EXPECT_FALSE(actual.ok());
-  EXPECT_TRUE(not actual);
+  EXPECT_FALSE(actual);
   EXPECT_EQ(StatusCode::kNotFound, actual.status().code());
   EXPECT_EQ("NOT FOUND", actual.status().message());
 }
@@ -51,7 +51,7 @@ TEST(StatusOrTest, StatusConstructorInvalid) {
 TEST(StatusOrTest, ValueConstructor) {
   StatusOr<int> actual(42);
   EXPECT_TRUE(actual.ok());
-  EXPECT_FALSE(not actual);
+  EXPECT_TRUE(actual);
   EXPECT_EQ(42, actual.value());
   EXPECT_EQ(42, std::move(actual).value());
 }

--- a/google/cloud/storage/benchmarks/storage_latency_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_latency_benchmark.cc
@@ -124,14 +124,14 @@ int main(int argc, char* argv[]) try {
   Options options;
   options.ParseArgs(argc, argv);
 
-  if (not google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").has_value()) {
+  if (!google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").has_value()) {
     std::cerr << "GOOGLE_CLOUD_PROJECT environment variable must be set"
               << std::endl;
     return 1;
   }
 
   gcs::ClientOptions client_options;
-  if (not options.enable_connection_pool) {
+  if (!options.enable_connection_pool) {
     client_options.set_connection_pool_size(0);
   }
   gcs::Client client(client_options);
@@ -294,7 +294,7 @@ IterationResult ReadOnce(gcs::Client client, std::string const& bucket_name,
                                gcs::IfGenerationNotMatch(0));
   }
   std::size_t total_size = 0;
-  while (not stream.eof()) {
+  while (!stream.eof()) {
     char buf[4096];
     stream.read(buf, sizeof(buf));
     total_size += stream.gcount();
@@ -351,7 +351,7 @@ std::vector<std::string> CreateAllObjects(
       group = {};  // after a move, must assign to guarantee it is valid.
     }
   }
-  if (not group.empty()) {
+  if (!group.empty()) {
     tasks.emplace_back(std::async(std::launch::async, &CreateGroup, client,
                                   bucket_name, options, std::move(group)));
     group = {};  // after a move, must assign to guarantee it is valid.
@@ -447,7 +447,7 @@ void DeleteAllObjects(gcs::Client client, std::string const& bucket_name,
       group = {};  // after a move, must assign to guarantee it is valid.
     }
   }
-  if (not group.empty()) {
+  if (!group.empty()) {
     tasks.emplace_back(
         std::async(std::launch::async, &DeleteGroup, client, std::move(group)));
   }

--- a/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
@@ -124,14 +124,14 @@ int main(int argc, char* argv[]) try {
   Options options;
   options.ParseArgs(argc, argv);
 
-  if (not google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").has_value()) {
+  if (!google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").has_value()) {
     std::cerr << "GOOGLE_CLOUD_PROJECT environment variable must be set"
               << std::endl;
     return 1;
   }
 
   gcs::ClientOptions client_options;
-  if (not options.enable_connection_pool) {
+  if (!options.enable_connection_pool) {
     client_options.set_connection_pool_size(0);
   }
   gcs::Client client(client_options);
@@ -267,7 +267,7 @@ TestResult WriteCommon(gcs::Client client, std::string const& bucket_name,
   }
   for (int i = 0; i < options.object_chunk_count; ++i) {
     stream.write(data_chunk.data(), data_chunk.size());
-    if (i != 0 and i % kThroughputReportIntervalInChunks == 0) {
+    if (i != 0 && i % kThroughputReportIntervalInChunks == 0) {
       auto elapsed = std::chrono::steady_clock::now() - start;
       result.emplace_back(
           IterationResult{op_type, i * data_chunk.size(),
@@ -319,14 +319,14 @@ TestResult ReadOnce(gcs::Client client, std::string const& bucket_name,
   }
   std::size_t total_size = 0;
   constexpr auto report = kThroughputReportIntervalInChunks * kChunkSize;
-  while (not stream.eof()) {
+  while (!stream.eof()) {
     char buf[4096];
     stream.read(buf, sizeof(buf));
     if (stream.gcount() == 0) {
       continue;
     }
     total_size += stream.gcount();
-    if (total_size != 0 and total_size % report == 0) {
+    if (total_size != 0 && total_size % report == 0) {
       auto elapsed = std::chrono::steady_clock::now() - start;
       result.emplace_back(
           IterationResult{OP_READ, total_size,
@@ -385,7 +385,7 @@ std::vector<std::string> CreateAllObjects(
       group = {};  // after a move, must assign to guarantee it is valid.
     }
   }
-  if (not group.empty()) {
+  if (!group.empty()) {
     tasks.emplace_back(std::async(std::launch::async, &CreateGroup, client,
                                   bucket_name, options, std::move(group)));
     group = {};  // after a move, must assign to guarantee it is valid.
@@ -480,7 +480,7 @@ void DeleteAllObjects(gcs::Client client, std::string const& bucket_name,
       group = {};  // after a move, must assign to guarantee it is valid.
     }
   }
-  if (not group.empty()) {
+  if (!group.empty()) {
     tasks.emplace_back(
         std::async(std::launch::async, &DeleteGroup, client, std::move(group)));
   }

--- a/google/cloud/storage/bucket_access_control.cc
+++ b/google/cloud/storage/bucket_access_control.cc
@@ -21,12 +21,12 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 StatusOr<BucketAccessControl> BucketAccessControl::ParseFromJson(
     internal::nl::json const& json) {
-  if (not json.is_object()) {
+  if (!json.is_object()) {
     return Status(StatusCode::kInvalidArgument, __func__);
   }
   BucketAccessControl result{};
   auto status = AccessControlCommon::ParseFromJson(result, json);
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   return result;

--- a/google/cloud/storage/bucket_access_control.h
+++ b/google/cloud/storage/bucket_access_control.h
@@ -77,7 +77,7 @@ class BucketAccessControl : private internal::AccessControlCommon {
 
   bool operator==(BucketAccessControl const& rhs) const;
   bool operator!=(BucketAccessControl const& rhs) const {
-    return not(*this == rhs);
+    return !(*this == rhs);
   }
 };
 

--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -114,19 +114,19 @@ std::ostream& operator<<(std::ostream& os, BucketRetentionPolicy const& rhs) {
 
 StatusOr<BucketMetadata> BucketMetadata::ParseFromJson(
     internal::nl::json const& json) {
-  if (not json.is_object()) {
+  if (!json.is_object()) {
     return Status(StatusCode::kInvalidArgument, __func__);
   }
   BucketMetadata result{};
   auto status = CommonMetadata<BucketMetadata>::ParseFromJson(result, json);
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
 
   if (json.count("acl") != 0) {
     for (auto const& kv : json["acl"].items()) {
       auto parsed = BucketAccessControl::ParseFromJson(kv.value());
-      if (not parsed.ok()) {
+      if (!parsed.ok()) {
         return std::move(parsed).status();
       }
       result.acl_.emplace_back(std::move(*parsed));
@@ -150,7 +150,7 @@ StatusOr<BucketMetadata> BucketMetadata::ParseFromJson(
   if (json.count("defaultObjectAcl") != 0) {
     for (auto const& kv : json["defaultObjectAcl"].items()) {
       auto parsed = ObjectAccessControl::ParseFromJson(kv.value());
-      if (not parsed.ok()) {
+      if (!parsed.ok()) {
         return std::move(parsed).status();
       }
       result.default_acl_.emplace_back(std::move(*parsed));
@@ -177,7 +177,7 @@ StatusOr<BucketMetadata> BucketMetadata::ParseFromJson(
     if (lifecycle.count("rule") != 0) {
       for (auto const& kv : lifecycle["rule"].items()) {
         auto parsed = LifecycleRule::ParseFromJson(kv.value());
-        if (not parsed.ok()) {
+        if (!parsed.ok()) {
           return std::move(parsed).status();
         }
         value.rule.emplace_back(std::move(*parsed));
@@ -240,7 +240,7 @@ StatusOr<BucketMetadata> BucketMetadata::ParseFromString(
 std::string BucketMetadata::ToJsonString() const {
   using internal::nl::json;
   json metadata_as_json;
-  if (not acl().empty()) {
+  if (!acl().empty()) {
     for (BucketAccessControl const& a : acl()) {
       json entry;
       SetIfNotEmpty(entry, "entity", a.entity());
@@ -249,19 +249,19 @@ std::string BucketMetadata::ToJsonString() const {
     }
   }
 
-  if (not cors().empty()) {
+  if (!cors().empty()) {
     for (CorsEntry const& v : cors()) {
       json cors_as_json;
       if (v.max_age_seconds.has_value()) {
         cors_as_json["maxAgeSeconds"] = *v.max_age_seconds;
       }
-      if (not v.method.empty()) {
+      if (!v.method.empty()) {
         cors_as_json["method"] = v.method;
       }
-      if (not v.origin.empty()) {
+      if (!v.origin.empty()) {
         cors_as_json["origin"] = v.origin;
       }
-      if (not v.response_header.empty()) {
+      if (!v.response_header.empty()) {
         cors_as_json["responseHeader"] = v.response_header;
       }
       metadata_as_json["cors"].emplace_back(std::move(cors_as_json));
@@ -277,7 +277,7 @@ std::string BucketMetadata::ToJsonString() const {
 
   metadata_as_json["defaultEventBasedHold"] = default_event_based_hold();
 
-  if (not default_acl().empty()) {
+  if (!default_acl().empty()) {
     for (ObjectAccessControl const& a : default_acl()) {
       json entry;
       SetIfNotEmpty(entry, "entity", a.entity());
@@ -304,7 +304,7 @@ std::string BucketMetadata::ToJsonString() const {
     metadata_as_json["iamConfiguration"] = std::move(c);
   }
 
-  if (not labels_.empty()) {
+  if (!labels_.empty()) {
     json labels_as_json;
     for (auto const& kv : labels_) {
       labels_as_json[kv.first] = kv.second;
@@ -333,7 +333,7 @@ std::string BucketMetadata::ToJsonString() const {
         condition["numNewerVersions"] = *c.num_newer_versions;
       }
       json action{{"type", v.action().type}};
-      if (not v.action().storage_class.empty()) {
+      if (!v.action().storage_class.empty()) {
         action["storageClass"] = v.action().storage_class;
       }
       rule.emplace_back(json{{"condition", std::move(condition)},
@@ -377,16 +377,15 @@ std::string BucketMetadata::ToJsonString() const {
 bool BucketMetadata::operator==(BucketMetadata const& rhs) const {
   return static_cast<internal::CommonMetadata<BucketMetadata> const&>(*this) ==
              rhs and
-         acl_ == rhs.acl_ and billing_ == rhs.billing_ and
-         cors_ == rhs.cors_ and
-         default_event_based_hold_ == rhs.default_event_based_hold_ and
-         default_acl_ == rhs.default_acl_ and encryption_ == rhs.encryption_ and
-         iam_configuration_ == rhs.iam_configuration_ and
-         project_number_ == rhs.project_number_ and
-         lifecycle_ == rhs.lifecycle_ and location_ == rhs.location_ and
-         logging_ == rhs.logging_ and labels_ == rhs.labels_ and
-         retention_policy_ == rhs.retention_policy_ and
-         versioning_ == rhs.versioning_ and website_ == rhs.website_;
+         acl_ == rhs.acl_ && billing_ == rhs.billing_ && cors_ == rhs.cors_ &&
+         default_event_based_hold_ == rhs.default_event_based_hold_ &&
+         default_acl_ == rhs.default_acl_ && encryption_ == rhs.encryption_ &&
+         iam_configuration_ == rhs.iam_configuration_ &&
+         project_number_ == rhs.project_number_ &&
+         lifecycle_ == rhs.lifecycle_ && location_ == rhs.location_ &&
+         logging_ == rhs.logging_ && labels_ == rhs.labels_ &&
+         retention_policy_ == rhs.retention_policy_ &&
+         versioning_ == rhs.versioning_ && website_ == rhs.website_;
 }
 
 std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs) {
@@ -555,13 +554,13 @@ BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetCors(
     if (a.max_age_seconds.has_value()) {
       entry["maxAgeSeconds"] = *a.max_age_seconds;
     }
-    if (not a.method.empty()) {
+    if (!a.method.empty()) {
       entry["method"] = a.method;
     }
-    if (not a.origin.empty()) {
+    if (!a.origin.empty()) {
       entry["origin"] = a.origin;
     }
-    if (not a.response_header.empty()) {
+    if (!a.response_header.empty()) {
       entry["responseHeader"] = a.response_header;
     }
     array.emplace_back(std::move(entry));
@@ -689,10 +688,10 @@ BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetLifecycle(
       condition["numNewerVersions"] = *c.num_newer_versions;
     }
     internal::nl::json action;
-    if (not a.action().type.empty()) {
+    if (!a.action().type.empty()) {
       action["type"] = a.action().type;
     }
-    if (not a.action().storage_class.empty()) {
+    if (!a.action().storage_class.empty()) {
       action["storageClass"] = a.action().storage_class;
     }
     array.emplace_back(internal::nl::json{

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -673,7 +673,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   /// Insert or update the label entry.
   BucketMetadata& upsert_label(std::string key, std::string value) {
     auto i = labels_.lower_bound(key);
-    if (i == labels_.end() or i->first != key) {
+    if (i == labels_.end() || i->first != key) {
       labels_.emplace_hint(i, std::move(key), std::move(value));
     } else {
       i->second = std::move(value);
@@ -828,7 +828,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   //@}
 
   bool operator==(BucketMetadata const& rhs) const;
-  bool operator!=(BucketMetadata const& rhs) const { return not(*this == rhs); }
+  bool operator!=(BucketMetadata const& rhs) const { return !(*this == rhs); }
 
  private:
   friend std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs);

--- a/google/cloud/storage/bucket_metadata_test.cc
+++ b/google/cloud/storage/bucket_metadata_test.cc
@@ -534,7 +534,7 @@ TEST(BucketMetadataTest, SetBilling) {
   auto expected = CreateBucketMetadataForTest();
   auto copy = expected;
   auto billing = copy.billing();
-  billing.requester_pays = not billing.requester_pays;
+  billing.requester_pays = !billing.requester_pays;
   copy.set_billing(billing);
   EXPECT_NE(expected, copy);
 }
@@ -579,7 +579,7 @@ TEST(BucketMetadataTest, SetDefaultEventBasedHold) {
   auto expected = CreateBucketMetadataForTest();
   auto copy = expected;
   EXPECT_TRUE(copy.default_event_based_hold());
-  copy.set_default_event_based_hold(not copy.default_event_based_hold());
+  copy.set_default_event_based_hold(!copy.default_event_based_hold());
   EXPECT_NE(expected, copy);
   std::ostringstream os;
   os << copy;

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -39,7 +39,7 @@ std::shared_ptr<internal::RawClient> Client::CreateDefaultClient(
 
 bool Client::UseSimpleUpload(std::string const& file_name) const {
   auto status = google::cloud::internal::status(file_name);
-  if (not is_regular(status)) {
+  if (!is_regular(status)) {
     return false;
   }
   auto size = google::cloud::internal::file_size(file_name);
@@ -49,7 +49,7 @@ bool Client::UseSimpleUpload(std::string const& file_name) const {
 StatusOr<ObjectMetadata> Client::UploadFileSimple(
     std::string const& file_name, internal::InsertObjectMediaRequest request) {
   std::ifstream is(file_name);
-  if (not is.is_open()) {
+  if (!is.is_open()) {
     std::string msg = __func__;
     msg += ": cannot open source file ";
     msg += file_name;
@@ -66,7 +66,7 @@ StatusOr<ObjectMetadata> Client::UploadFileResumable(
     std::string const& file_name,
     google::cloud::storage::internal::ResumableUploadRequest const& request) {
   auto status = google::cloud::internal::status(file_name);
-  if (not is_regular(status)) {
+  if (!is_regular(status)) {
     GCP_LOG(WARNING) << "Trying to upload " << file_name
                      << R"""( which is not a regular file.
 This is often a problem because:
@@ -82,7 +82,7 @@ integrity checks using the DisableMD5Hash() and DisableCrc32cChecksum() options.
   }
 
   std::ifstream source(file_name);
-  if (not source.is_open()) {
+  if (!source.is_open()) {
     std::string msg = __func__;
     msg += ": cannot open source file ";
     msg += file_name;
@@ -100,7 +100,7 @@ StatusOr<ObjectMetadata> Client::UploadStreamResumable(
     internal::ResumableUploadRequest const& request) {
   StatusOr<std::unique_ptr<internal::ResumableUploadSession>> session_status =
       raw_client()->CreateResumableSession(request);
-  if (not session_status.ok()) {
+  if (!session_status.ok()) {
     return std::move(session_status).status();
   }
 
@@ -114,7 +114,7 @@ StatusOr<ObjectMetadata> Client::UploadStreamResumable(
       internal::ResumableUploadResponse{});
   // We iterate while `source` is good and the retry policy has not been
   // exhausted.
-  while (not source.eof() and upload_response.ok() and
+  while (!source.eof() && upload_response.ok() &&
          upload_response->payload.empty()) {
     // Read a chunk of data from the source file.
     std::string buffer(chunk_size, '\0');
@@ -127,7 +127,7 @@ StatusOr<ObjectMetadata> Client::UploadStreamResumable(
 
     auto expected = session->next_expected_byte() + gcount - 1;
     upload_response = session->UploadChunk(buffer, source_size);
-    if (not upload_response.ok()) {
+    if (!upload_response.ok()) {
       return std::move(upload_response).status();
     }
     if (session->next_expected_byte() != expected) {
@@ -138,7 +138,7 @@ StatusOr<ObjectMetadata> Client::UploadStreamResumable(
     }
   }
 
-  if (not upload_response.ok()) {
+  if (!upload_response.ok()) {
     return std::move(upload_response).status();
   }
 
@@ -160,13 +160,13 @@ StatusOr<void> Client::DownloadFileImpl(
         << " - status.message=" << stream.status().message();
     return Status(stream.status().code(), std::move(msg).str());
   };
-  if (not stream.status().ok()) {
+  if (!stream.status().ok()) {
     return report_error(__func__, "cannot open destination file");
   }
 
   // Open the destination file, and immediate raise an exception on failure.
   std::ofstream os(file_name);
-  if (not os.is_open()) {
+  if (!os.is_open()) {
     std::ostringstream msg;
     msg << __func__ << "(" << request << ", " << file_name << "): "
         << "cannot open destination file";
@@ -178,15 +178,15 @@ StatusOr<void> Client::DownloadFileImpl(
   do {
     stream.read(&buffer[0], buffer.size());
     os.write(buffer.data(), stream.gcount());
-  } while (os.good() and stream.good());
+  } while (os.good() && stream.good());
   os.close();
-  if (not os.good()) {
+  if (!os.good()) {
     std::ostringstream msg;
     msg << __func__ << "(" << request << ", " << file_name << "): "
         << "cannot close destination file";
     return Status(StatusCode::kUnknown, std::move(msg).str());
   }
-  if (not stream.status().ok()) {
+  if (!stream.status().ok()) {
     return report_error(__func__, "error in download stream");
   }
   return Status();
@@ -207,7 +207,7 @@ https://cloud.google.com/storage/docs/authentication
   }
 
   auto result = credentials->SignString(request.StringToSign());
-  if (not result.first.ok()) {
+  if (!result.first.ok()) {
     return result.first;
   }
 
@@ -216,7 +216,7 @@ https://cloud.google.com/storage/docs/authentication
 
   std::ostringstream os;
   os << "https://storage.googleapis.com/" << request.bucket_name();
-  if (not request.object_name().empty()) {
+  if (!request.object_name().empty()) {
     os << '/' << curl.MakeEscapedString(request.object_name()).get();
   }
   os << "?GoogleAccessId=" << credentials->client_id()

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -545,7 +545,7 @@ class Client {
                                                       std::move(permissions));
     request.set_multiple_options(std::forward<Options>(options)...);
     auto result = raw_client_->TestBucketIamPermissions(request);
-    if (not result.ok()) {
+    if (!result.ok()) {
       return std::move(result).status();
     }
     return std::move(result.value().permissions);
@@ -1298,7 +1298,7 @@ class Client {
     internal::ListBucketAclRequest request(bucket_name);
     request.set_multiple_options(std::forward<Options>(options)...);
     auto items = raw_client_->ListBucketAcl(request);
-    if (not items.ok()) {
+    if (!items.ok()) {
       return std::move(items).status();
     }
     return std::move(items.value().items);
@@ -1533,7 +1533,7 @@ class Client {
     internal::ListObjectAclRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
     auto result = raw_client_->ListObjectAcl(request);
-    if (not result.ok()) {
+    if (!result.ok()) {
       return std::move(result).status();
     }
     return std::move(result.value().items);
@@ -1777,7 +1777,7 @@ class Client {
     internal::ListDefaultObjectAclRequest request(bucket_name);
     request.set_multiple_options(std::forward<Options>(options)...);
     auto response = raw_client_->ListDefaultObjectAcl(request);
-    if (not response.ok()) {
+    if (!response.ok()) {
       return std::move(response).status();
     }
     return std::move(response.value().items);
@@ -2161,7 +2161,7 @@ class Client {
     internal::ListNotificationsRequest request(bucket_name);
     request.set_multiple_options(std::forward<Options>(options)...);
     auto result = raw_client_->ListNotifications(request);
-    if (not result.ok()) {
+    if (!result.ok()) {
       return std::move(result).status();
     }
     return std::move(result).value().items;

--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -96,7 +96,7 @@ void ClientOptions::SetupFromEnvironment() {
   if (tracing.has_value()) {
     std::set<std::string> enabled;
     std::istringstream is{*tracing};
-    while (not is.eof()) {
+    while (!is.eof()) {
       std::string token;
       std::getline(is, token, ',');
       enabled.emplace(std::move(token));

--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -97,7 +97,7 @@ class ClientOptions {
   std::string const& user_agent_prefix() const { return user_agent_prefix_; }
   ClientOptions& add_user_agent_prefx(std::string const& v) {
     std::string prefix = v;
-    if (not user_agent_prefix_.empty()) {
+    if (!user_agent_prefix_.empty()) {
       prefix += '/';
       prefix += user_agent_prefix_;
     }

--- a/google/cloud/storage/doc/storage-main.dox
+++ b/google/cloud/storage/doc/storage-main.dox
@@ -189,7 +189,7 @@ using namespace google::cloud;
 [](storage::Client client) {
   StatusOr<storage::BucketMetadata> metadata = client.GetBucketMetadata(
       "my-bucket");
-  if (not metadata.ok()) {
+  if (!metadata.ok()) {
     std::cerr << "Error retrieving metadata for my-bucket: "
               << metadata.status() << std::endl;
     return;

--- a/google/cloud/storage/examples/storage_bucket_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_acl_samples.cc
@@ -56,7 +56,7 @@ void ListBucketAcl(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<std::vector<gcs::BucketAccessControl>> items =
         client.ListBucketAcl(bucket_name);
-    if (not items.ok()) {
+    if (!items.ok()) {
       std::cerr << "Error getting ACL entries for bucket " << bucket_name
                 << ", status=" << items.status() << std::endl;
       return;
@@ -85,7 +85,7 @@ void CreateBucketAcl(google::cloud::storage::Client client, int& argc,
      std::string role) {
     StatusOr<gcs::BucketAccessControl> bucket_acl =
         client.CreateBucketAcl(bucket_name, entity, role);
-    if (not bucket_acl.ok()) {
+    if (!bucket_acl.ok()) {
       std::cerr << "Failure getting bucket ACL for entity " << entity
                 << " in bucket " << bucket_name
                 << ", status=" << bucket_acl.status() << std::endl;
@@ -112,7 +112,7 @@ void DeleteBucketAcl(google::cloud::storage::Client client, int& argc,
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string entity) {
     StatusOr<void> status = client.DeleteBucketAcl(bucket_name, entity);
-    if (not status.ok()) {
+    if (!status.ok()) {
       std::cerr << "Failure deleting ACL for entity " << entity << " in bucket "
                 << bucket_name << ", status=" << status.status() << std::endl;
       return;
@@ -137,7 +137,7 @@ void GetBucketAcl(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name, std::string entity) {
     StatusOr<gcs::BucketAccessControl> acl =
         client.GetBucketAcl(bucket_name, entity);
-    if (not acl.ok()) {
+    if (!acl.ok()) {
       std::cerr << "Failure getting ACL for entity " << entity << " in bucket "
                 << bucket_name << ", status=" << acl.status() << std::endl;
       return;
@@ -166,7 +166,7 @@ void UpdateBucketAcl(google::cloud::storage::Client client, int& argc,
         gcs::BucketAccessControl().set_entity(entity).set_role(role);
     StatusOr<gcs::BucketAccessControl> updated_acl =
         client.UpdateBucketAcl(bucket_name, desired_acl);
-    if (not updated_acl.ok()) {
+    if (!updated_acl.ok()) {
       std::cerr << "Error updating ACL for entity " << entity << " in bucket "
                 << bucket_name << ", status=" << updated_acl.status()
                 << std::endl;
@@ -195,7 +195,7 @@ void PatchBucketAcl(google::cloud::storage::Client client, int& argc,
      std::string role) {
     StatusOr<gcs::BucketAccessControl> original_acl =
         client.GetBucketAcl(bucket_name, entity);
-    if (not original_acl.ok()) {
+    if (!original_acl.ok()) {
       std::cerr << "Failure getting ACL for entity " << entity << " in bucket "
                 << bucket_name << ", status=" << original_acl.status()
                 << std::endl;
@@ -205,7 +205,7 @@ void PatchBucketAcl(google::cloud::storage::Client client, int& argc,
     new_acl.set_role(role);
     StatusOr<gcs::BucketAccessControl> patched_acl =
         client.PatchBucketAcl(bucket_name, entity, *original_acl, new_acl);
-    if (not patched_acl.ok()) {
+    if (!patched_acl.ok()) {
       std::cerr << "Failure patching ACL for entity " << entity << " in bucket "
                 << bucket_name << ", status=" << patched_acl.status()
                 << std::endl;
@@ -235,7 +235,7 @@ void PatchBucketAclNoRead(google::cloud::storage::Client client, int& argc,
     StatusOr<gcs::BucketAccessControl> patched_acl = client.PatchBucketAcl(
         bucket_name, entity,
         gcs::BucketAccessControlPatchBuilder().set_role(role));
-    if (not patched_acl.ok()) {
+    if (!patched_acl.ok()) {
       std::cerr << "Failure patching ACL for entity " << entity << " in bucket "
                 << bucket_name << ", status=" << patched_acl.status()
                 << std::endl;

--- a/google/cloud/storage/examples/storage_bucket_iam_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_iam_samples.cc
@@ -56,7 +56,7 @@ void GetBucketIamPolicy(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<google::cloud::IamPolicy> policy =
         client.GetBucketIamPolicy(bucket_name);
-    if (not policy.ok()) {
+    if (!policy.ok()) {
       std::cerr << "Error getting IAM policy for bucket " << bucket_name
                 << ", status=" << policy.status() << std::endl;
       return;
@@ -83,7 +83,7 @@ void AddBucketIamMember(google::cloud::storage::Client client, int& argc,
      std::string member) {
     StatusOr<google::cloud::IamPolicy> policy =
         client.GetBucketIamPolicy(bucket_name);
-    if (not policy.ok()) {
+    if (!policy.ok()) {
       std::cerr << "Error getting current IAM policy for bucket " << bucket_name
                 << ", status=" << policy.status() << std::endl;
       return;
@@ -91,7 +91,7 @@ void AddBucketIamMember(google::cloud::storage::Client client, int& argc,
     policy->bindings.AddMember(role, member);
     StatusOr<google::cloud::IamPolicy> updated_policy =
         client.SetBucketIamPolicy(bucket_name, *policy);
-    if (not updated_policy.ok()) {
+    if (!updated_policy.ok()) {
       std::cerr << "Error setting IAM policy for bucket " << bucket_name
                 << ", status=" << updated_policy.status() << std::endl;
       return;
@@ -117,7 +117,7 @@ void RemoveBucketIamMember(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name, std::string role,
      std::string member) {
     StatusOr<google::cloud::IamPolicy> policy = client.GetBucketIamPolicy(bucket_name);
-    if (not policy.ok()) {
+    if (!policy.ok()) {
       std::cerr << "Error getting current IAM policy for bucket " << bucket_name
                 << ", status=" << policy.status() << std::endl;
       return;
@@ -125,7 +125,7 @@ void RemoveBucketIamMember(google::cloud::storage::Client client, int& argc,
     policy->bindings.RemoveMember(role, member);
     StatusOr<google::cloud::IamPolicy> updated_policy =
         client.SetBucketIamPolicy(bucket_name, *policy);
-    if (not updated_policy.ok()) {
+    if (!updated_policy.ok()) {
       std::cerr << "Error setting IAM policy for bucket " << bucket_name
                 << ", status=" << updated_policy.status() << std::endl;
       return;
@@ -156,7 +156,7 @@ void TestBucketIamPermissions(google::cloud::storage::Client client, int& argc,
      std::vector<std::string> permissions) {
     StatusOr<std::vector<std::string>> actual_permissions =
         client.TestBucketIamPermissions(bucket_name, permissions);
-    if (not actual_permissions.ok()) {
+    if (!actual_permissions.ok()) {
       std::cerr << "Error checking IAM permissions for bucket " << bucket_name
                 << ", status=" << actual_permissions.status() << std::endl;
       return;

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -54,7 +54,7 @@ void ListBuckets(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client) {
     int count = 0;
     for (auto&& meta : client.ListBuckets()) {
-      if (not meta.ok()) {
+      if (!meta.ok()) {
         std::cerr << "Error reading bucket list for default project"
                   << ", status=" << meta.status() << std::endl;
         return;
@@ -81,7 +81,7 @@ void ListBucketsForProject(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string project_id) {
     int count = 0;
     for (auto&& meta : client.ListBucketsForProject(project_id)) {
-      if (not meta.ok()) {
+      if (!meta.ok()) {
         std::cerr << "Error reading bucket list for project " << project_id
                   << ", status=" << meta.status() << std::endl;
         return;
@@ -109,7 +109,7 @@ void CreateBucket(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> meta =
         client.CreateBucket(bucket_name, gcs::BucketMetadata());
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Could not create bucket " << bucket_name << std::endl;
       return;
     }
@@ -133,7 +133,7 @@ void CreateBucketForProject(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name, std::string project_id) {
     StatusOr<gcs::BucketMetadata> meta = client.CreateBucketForProject(
         bucket_name, project_id, gcs::BucketMetadata());
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Could not create bucket " << bucket_name << " in project "
                 << project_id << std::endl;
       return;
@@ -157,7 +157,7 @@ void GetBucketMetadata(google::cloud::storage::Client client, int& argc,
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> meta = client.GetBucketMetadata(bucket_name);
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Error while getting metadata for bucket " << bucket_name
                 << ", status=" << meta.status() << std::endl;
       return;
@@ -180,7 +180,7 @@ void DeleteBucket(google::cloud::storage::Client client, int& argc,
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<void> status = client.DeleteBucket(bucket_name);
-    if (not status.ok()) {
+    if (!status.ok()) {
       std::cerr << "Error while deleting bucket " << bucket_name
                 << ", status=" << status.status() << std::endl;
       return;
@@ -204,7 +204,7 @@ void ChangeDefaultStorageClass(google::cloud::storage::Client client, int& argc,
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string storage_class) {
     StatusOr<gcs::BucketMetadata> meta = client.GetBucketMetadata(bucket_name);
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Error while getting metadata for bucket " << bucket_name
                 << ", status=" << meta.status() << std::endl;
       return;
@@ -212,7 +212,7 @@ void ChangeDefaultStorageClass(google::cloud::storage::Client client, int& argc,
     meta->set_storage_class(storage_class);
     StatusOr<gcs::BucketMetadata> updated_meta =
         client.UpdateBucket(bucket_name, *meta);
-    if (not updated_meta.ok()) {
+    if (!updated_meta.ok()) {
       std::cerr << "Error updating the metadata for bucket " << meta->name()
                 << ", status=" << meta.status() << std::endl;
       return;
@@ -238,7 +238,7 @@ void PatchBucketStorageClass(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name, std::string storage_class) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
-    if (not original.ok()) {
+    if (!original.ok()) {
       std::cerr << "Error while getting metadata for bucket " << bucket_name
                 << ", status=" << original.status() << std::endl;
       return;
@@ -247,7 +247,7 @@ void PatchBucketStorageClass(google::cloud::storage::Client client, int& argc,
     desired.set_storage_class(storage_class);
     StatusOr<gcs::BucketMetadata> patched =
         client.PatchBucket(bucket_name, *original, desired);
-    if (not patched.ok()) {
+    if (!patched.ok()) {
       std::cerr << "Error patching the metadata for bucket " << original->name()
                 << ", status=" << patched.status() << std::endl;
       return;
@@ -275,7 +275,7 @@ void PatchBucketStorageClassWithBuilder(google::cloud::storage::Client client,
     StatusOr<gcs::BucketMetadata> patched = client.PatchBucket(
         bucket_name,
         gcs::BucketMetadataPatchBuilder().SetStorageClass(storage_class));
-    if (not patched.ok()) {
+    if (!patched.ok()) {
       std::cerr << "Error patching the metadata for bucket " << bucket_name
                 << ", status=" << patched.status() << std::endl;
       return;
@@ -302,12 +302,12 @@ void AddBucketDefaultKmsKey(google::cloud::storage::Client client, int& argc,
     StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
         bucket_name, gcs::BucketMetadataPatchBuilder().SetEncryption(
                          gcs::BucketEncryption{key_name}));
-    if (not updated_metadata.ok()) {
+    if (!updated_metadata.ok()) {
       std::cerr << "Error updating the metadata for bucket " << bucket_name
                 << ", status=" << updated_metadata.status() << std::endl;
       return;
     }
-    if (not updated_metadata->has_encryption()) {
+    if (!updated_metadata->has_encryption()) {
       std::cerr << "The change to set the encryption attribute on bucket "
                 << updated_metadata->name()
                 << " was sucessful, but the encryption is not set."
@@ -335,12 +335,12 @@ void GetBucketDefaultKmsKey(google::cloud::storage::Client client, int& argc,
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> meta = client.GetBucketMetadata(bucket_name);
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Error reading the metadata for bucket " << bucket_name
                 << ", status=" << meta.status() << std::endl;
       return;
     }
-    if (not meta->has_encryption()) {
+    if (!meta->has_encryption()) {
       std::cout << "The bucket " << meta->name()
                 << " does not have a default KMS key set." << std::endl;
       return;
@@ -366,7 +366,7 @@ void RemoveBucketDefaultKmsKey(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
         bucket_name, gcs::BucketMetadataPatchBuilder().ResetEncryption());
-    if (not updated_metadata.ok()) {
+    if (!updated_metadata.ok()) {
       std::cerr << "Error resetting the default encryption key for bucket "
                 << bucket_name << ", status=" << updated_metadata.status()
                 << std::endl;
@@ -396,7 +396,7 @@ void AddBucketLabel(google::cloud::storage::Client client, int& argc,
     StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
         bucket_name,
         gcs::BucketMetadataPatchBuilder().SetLabel(label_key, label_value));
-    if (not updated_metadata.ok()) {
+    if (!updated_metadata.ok()) {
       std::cerr << "Error setting a label on bucket " << bucket_name
                 << ", status=" << updated_metadata.status() << std::endl;
       return;
@@ -425,7 +425,7 @@ void GetBucketLabels(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> meta =
         client.GetBucketMetadata(bucket_name, gcs::Fields("labels"));
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Error reading labels on bucket " << bucket_name
                 << ", status=" << meta.status() << std::endl;
       return;
@@ -458,7 +458,7 @@ void RemoveBucketLabel(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name, std::string label_key) {
     StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
         bucket_name, gcs::BucketMetadataPatchBuilder().ResetLabel(label_key));
-    if (not updated_metadata.ok()) {
+    if (!updated_metadata.ok()) {
       std::cerr << "Error resetting label " << label_key << " on bucket "
                 << bucket_name << ", status=" << updated_metadata.status()
                 << std::endl;
@@ -491,12 +491,12 @@ void GetBilling(google::cloud::storage::Client client, int& argc,
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> meta = client.GetBucketMetadata(bucket_name);
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Error reading metadata for bucket " << bucket_name
                 << ", status=" << meta.status() << std::endl;
       return;
     }
-    if (not meta->has_billing()) {
+    if (!meta->has_billing()) {
       std::cout
           << "The bucket " << meta->name() << " does not have a"
           << " billing configuration. The default applies, i.e., the project"
@@ -532,13 +532,13 @@ void EnableRequesterPays(google::cloud::storage::Client client, int& argc,
     StatusOr<gcs::BucketMetadata> meta = client.PatchBucket(
         bucket_name,
         gcs::BucketMetadataPatchBuilder().SetBilling(gcs::BucketBilling{true}));
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Error setting the billing configuration for bucket "
                 << bucket_name << ", status=" << meta.status() << std::endl;
     }
     std::cout << "Billing configuration for bucket " << meta->name()
               << " is updated. The bucket now";
-    if (not meta->has_billing()) {
+    if (!meta->has_billing()) {
       std::cout << " has no billing configuration." << std::endl;
     } else if (meta->billing().requester_pays) {
       std::cout << " is configured to charge the caller for requests"
@@ -567,14 +567,14 @@ void DisableRequesterPays(google::cloud::storage::Client client, int& argc,
         bucket_name,
         gcs::BucketMetadataPatchBuilder().SetBilling(gcs::BucketBilling{false}),
         gcs::UserProject(project_id));
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Error disabling billing configuration for bucket "
                 << bucket_name << ", status=" << meta.status() << std::endl;
       return;
     }
     std::cout << "Billing configuration for bucket " << bucket_name
               << " is updated. The bucket now";
-    if (not meta->has_billing()) {
+    if (!meta->has_billing()) {
       std::cout << " has no billing configuration." << std::endl;
     } else if (meta->billing().requester_pays) {
       std::cout << " is configured to charge the caller for requests"
@@ -637,7 +637,7 @@ void ReadObjectRequesterPays(google::cloud::storage::Client client, int& argc,
      std::string billed_project) {
     gcs::ObjectReadStream stream = client.ReadObject(
         bucket_name, object_name, gcs::UserProject(billed_project));
-    while (not stream.eof()) {
+    while (!stream.eof()) {
       std::string line;
       std::getline(stream, line, '\n');
       if (stream.good()) {
@@ -660,7 +660,7 @@ void GetServiceAccount(google::cloud::storage::Client client, int& argc,
   using google::cloud::StatusOr;
   [](gcs::Client client) {
     StatusOr<gcs::ServiceAccount> details = client.GetServiceAccount();
-    if (not details.ok()) {
+    if (!details.ok()) {
       std::cerr << "Error getting service account details, status="
                 << details.status() << std::endl;
       return;
@@ -684,7 +684,7 @@ void GetServiceAccountForProject(google::cloud::storage::Client client,
   [](gcs::Client client, std::string project_id) {
     StatusOr<gcs::ServiceAccount> details =
         client.GetServiceAccountForProject(project_id);
-    if (not details.ok()) {
+    if (!details.ok()) {
       std::cerr << "Error getting service account details, status="
                 << details.status() << std::endl;
       return;
@@ -709,7 +709,7 @@ void GetDefaultEventBasedHold(google::cloud::storage::Client client, int& argc,
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> meta = client.GetBucketMetadata(bucket_name);
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Error fetching bucket metadata for bucket " << bucket_name
                 << ", status=" << meta.status() << std::endl;
       return;
@@ -737,7 +737,7 @@ void EnableDefaultEventBasedHold(google::cloud::storage::Client client,
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
-    if (not original.ok()) {
+    if (!original.ok()) {
       std::cerr << "Error fetching bucket metadata for bucket " << bucket_name
                 << ", status=" << original.status() << std::endl;
       return;
@@ -746,7 +746,7 @@ void EnableDefaultEventBasedHold(google::cloud::storage::Client client,
         bucket_name,
         gcs::BucketMetadataPatchBuilder().SetDefaultEventBasedHold(true),
         gcs::IfMetagenerationMatch(original->metageneration()));
-    if (not patched_metadata.ok()) {
+    if (!patched_metadata.ok()) {
       std::cerr << "Error setting default event based hold in bucket "
                 << original->name() << ", status=" << original.status()
                 << std::endl;
@@ -776,7 +776,7 @@ void DisableDefaultEventBasedHold(google::cloud::storage::Client client,
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
-    if (not original.ok()) {
+    if (!original.ok()) {
       std::cerr << "Error fetching bucket metadata for bucket " << bucket_name
                 << ", status=" << original.status() << std::endl;
       return;
@@ -785,7 +785,7 @@ void DisableDefaultEventBasedHold(google::cloud::storage::Client client,
         bucket_name,
         gcs::BucketMetadataPatchBuilder().SetDefaultEventBasedHold(false),
         gcs::IfMetagenerationMatch(original->metageneration()));
-    if (not patched_metadata.ok()) {
+    if (!patched_metadata.ok()) {
       std::cerr << "Error disabling default event based hold in bucket "
                 << original->name() << ", status=" << original.status()
                 << std::endl;
@@ -814,12 +814,12 @@ void GetRetentionPolicy(google::cloud::storage::Client client, int& argc,
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> meta = client.GetBucketMetadata(bucket_name);
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Error fetching the metadata for bucket " << bucket_name
                 << ", status=" << meta.status() << std::endl;
       return;
     }
-    if (not meta->has_retention_policy()) {
+    if (!meta->has_retention_policy()) {
       std::cout << "The bucket " << meta->name()
                 << " does not have a retention policy set." << std::endl;
       return;
@@ -846,7 +846,7 @@ void SetRetentionPolicy(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name, std::chrono::seconds period) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
-    if (not original.ok()) {
+    if (!original.ok()) {
       std::cerr << "Error fetching the metadata for bucket " << bucket_name
                 << ", status=" << original.status() << std::endl;
       return;
@@ -855,13 +855,13 @@ void SetRetentionPolicy(google::cloud::storage::Client client, int& argc,
         bucket_name,
         gcs::BucketMetadataPatchBuilder().SetRetentionPolicy(period),
         gcs::IfMetagenerationMatch(original->metageneration()));
-    if (not patched_metadata.ok()) {
+    if (!patched_metadata.ok()) {
       std::cerr << "Error setting the retention policy on bucket "
                 << original->name() << ", status=" << patched_metadata.status()
                 << std::endl;
       return;
     }
-    if (not patched_metadata->has_retention_policy()) {
+    if (!patched_metadata->has_retention_policy()) {
       std::cout << "The bucket " << patched_metadata->name()
                 << " does not have a retention policy set." << std::endl;
       return;
@@ -888,7 +888,7 @@ void RemoveRetentionPolicy(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
-    if (not original.ok()) {
+    if (!original.ok()) {
       std::cerr << "Error fetching the metadata for bucket " << bucket_name
                 << ", status=" << original.status() << std::endl;
       return;
@@ -896,13 +896,13 @@ void RemoveRetentionPolicy(google::cloud::storage::Client client, int& argc,
     StatusOr<gcs::BucketMetadata> patched_metadata = client.PatchBucket(
         bucket_name, gcs::BucketMetadataPatchBuilder().ResetRetentionPolicy(),
         gcs::IfMetagenerationMatch(original->metageneration()));
-    if (not patched_metadata.ok()) {
+    if (!patched_metadata.ok()) {
       std::cerr << "Error removing the retention policy on bucket "
                 << original->name() << ", status=" << patched_metadata.status()
                 << std::endl;
       return;
     }
-    if (not patched_metadata->has_retention_policy()) {
+    if (!patched_metadata->has_retention_policy()) {
       std::cout << "The bucket " << patched_metadata->name()
                 << " does not have a retention policy set." << std::endl;
       return;
@@ -931,14 +931,14 @@ void LockRetentionPolicy(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
-    if (not original.ok()) {
+    if (!original.ok()) {
       std::cerr << "Error fetching the metadata for bucket " << bucket_name
                 << ", status=" << original.status() << std::endl;
       return;
     }
     StatusOr<void> status = client.LockBucketRetentionPolicy(
         bucket_name, original->metageneration());
-    if (not status.ok()) {
+    if (!status.ok()) {
       std::cerr << "Error locking bucket retention policy for bucket "
                 << bucket_name << ", status=" << status.status() << std::endl;
     }

--- a/google/cloud/storage/examples/storage_default_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_default_object_acl_samples.cc
@@ -56,7 +56,7 @@ void ListDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<std::vector<gcs::ObjectAccessControl>> items =
         client.ListDefaultObjectAcl(bucket_name);
-    if (not items.ok()) {
+    if (!items.ok()) {
       std::cerr << "Error getting default object ACL entries for bucket "
                 << bucket_name << ", status=" << items.status() << std::endl;
       return;
@@ -85,7 +85,7 @@ void CreateDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
      std::string role) {
     StatusOr<gcs::ObjectAccessControl> default_object_acl =
         client.CreateDefaultObjectAcl(bucket_name, entity, role);
-    if (not default_object_acl.ok()) {
+    if (!default_object_acl.ok()) {
       std::cerr << "Failure getting default object ACL for entity " << entity
                 << " in bucket " << bucket_name
                 << ", status=" << default_object_acl.status() << std::endl;
@@ -113,7 +113,7 @@ void DeleteDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string entity) {
     StatusOr<void> status = client.DeleteDefaultObjectAcl(bucket_name, entity);
-    if (not status.ok()) {
+    if (!status.ok()) {
       std::cerr << "Failure deleting default object ACL for entity " << entity
                 << " in bucket " << bucket_name
                 << ", status=" << status.status() << std::endl;
@@ -139,7 +139,7 @@ void GetDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name, std::string entity) {
     StatusOr<gcs::ObjectAccessControl> acl =
         client.GetDefaultObjectAcl(bucket_name, entity);
-    if (not acl.ok()) {
+    if (!acl.ok()) {
       std::cerr << "Failure getting default object ACL for entity " << entity
                 << " in bucket " << bucket_name << ", status=" << acl.status()
                 << std::endl;
@@ -167,7 +167,7 @@ void UpdateDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
      std::string role) {
     StatusOr<gcs::ObjectAccessControl> original_acl =
         client.GetDefaultObjectAcl(bucket_name, entity);
-    if (not original_acl.ok()) {
+    if (!original_acl.ok()) {
       std::cerr << "Failure getting default object ACL for entity " << entity
                 << " in bucket " << bucket_name
                 << ", status=" << original_acl.status() << std::endl;
@@ -176,7 +176,7 @@ void UpdateDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
     original_acl->set_role(role);
     StatusOr<gcs::ObjectAccessControl> updated_acl =
         client.UpdateDefaultObjectAcl(bucket_name, *original_acl);
-    if (not updated_acl.ok()) {
+    if (!updated_acl.ok()) {
       std::cerr << "Failure updating default object ACL for entity " << entity
                 << " in bucket " << bucket_name
                 << ", status=" << updated_acl.status() << std::endl;
@@ -205,7 +205,7 @@ void PatchDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
      std::string role) {
     StatusOr<gcs::ObjectAccessControl> original_acl =
         client.GetDefaultObjectAcl(bucket_name, entity);
-    if (not original_acl.ok()) {
+    if (!original_acl.ok()) {
       std::cerr << "Failure getting default object ACL for entity " << entity
                 << " in bucket " << bucket_name
                 << ", status=" << original_acl.status() << std::endl;
@@ -216,7 +216,7 @@ void PatchDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
     StatusOr<gcs::ObjectAccessControl> patched_acl =
         client.PatchDefaultObjectAcl(bucket_name, entity, *original_acl,
                                      new_acl);
-    if (not patched_acl.ok()) {
+    if (!patched_acl.ok()) {
       std::cerr << "Failure patching default object ACL for entity " << entity
                 << " in bucket " << bucket_name
                 << ", status=" << patched_acl.status() << std::endl;
@@ -248,7 +248,7 @@ void PatchDefaultObjectAclNoRead(google::cloud::storage::Client client,
         client.PatchDefaultObjectAcl(
             bucket_name, entity,
             gcs::ObjectAccessControlPatchBuilder().set_role(role));
-    if (not patched_acl.ok()) {
+    if (!patched_acl.ok()) {
       std::cerr << "Failure patching default object ACL for entity " << entity
                 << " in bucket " << bucket_name
                 << ", status=" << patched_acl.status() << std::endl;

--- a/google/cloud/storage/examples/storage_notification_samples.cc
+++ b/google/cloud/storage/examples/storage_notification_samples.cc
@@ -57,7 +57,7 @@ void ListNotifications(google::cloud::storage::Client client, int& argc,
     std::cout << "Notifications for bucket=" << bucket_name << std::endl;
     StatusOr<std::vector<gcs::NotificationMetadata>> items =
         client.ListNotifications(bucket_name);
-    if (not items.ok()) {
+    if (!items.ok()) {
       std::cerr << "Error reading notification list for " << bucket_name
                 << ", status=" << items.status() << std::endl;
       return;
@@ -85,7 +85,7 @@ void CreateNotification(google::cloud::storage::Client client, int& argc,
         client.CreateNotification(bucket_name, topic_name,
                                   gcs::payload_format::JsonApiV1(),
                                   gcs::NotificationMetadata());
-    if (not notification.ok()) {
+    if (!notification.ok()) {
       std::cerr << "Error creating notification for " << bucket_name
                 << " on topic " << topic_name
                 << ", status=" << notification.status() << std::endl;
@@ -121,7 +121,7 @@ void GetNotification(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name, std::string notification_id) {
     StatusOr<gcs::NotificationMetadata> notification =
         client.GetNotification(bucket_name, notification_id);
-    if (not notification.ok()) {
+    if (!notification.ok()) {
       std::cerr << "Error getting notification metadata for notification id "
                 << notification_id << " on bucket " << bucket_name
                 << ", status=" << notification.status() << std::endl;
@@ -155,7 +155,7 @@ void DeleteNotification(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name, std::string notification_id) {
     StatusOr<void> status =
         client.DeleteNotification(bucket_name, notification_id);
-    if (not status.ok()) {
+    if (!status.ok()) {
       std::cerr << "Error delete notification id " << notification_id
                 << " on bucket " << bucket_name
                 << ", status=" << status.status() << std::endl;

--- a/google/cloud/storage/examples/storage_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_object_acl_samples.cc
@@ -60,7 +60,7 @@ void ListObjectAcl(gcs::Client client, int& argc, char* argv[]) {
               << bucket_name << std::endl;
     StatusOr<std::vector<gcs::ObjectAccessControl>> items =
         client.ListObjectAcl(bucket_name, object_name);
-    if (not items.ok()) {
+    if (!items.ok()) {
       std::cerr << "Error reading ACL for object " << object_name
                 << " in bucket " << bucket_name
                 << ", status=" << items.status() << std::endl;
@@ -90,7 +90,7 @@ void CreateObjectAcl(gcs::Client client, int& argc, char* argv[]) {
      std::string entity, std::string role) {
     StatusOr<gcs::ObjectAccessControl> object_acl =
         client.CreateObjectAcl(bucket_name, object_name, entity, role);
-    if (not object_acl.ok()) {
+    if (!object_acl.ok()) {
       std::cerr << "Error creating object ACL entry for entity " << entity
                 << " in object " << object_name << " and bucket " << bucket_name
                 << ", status=" << object_acl.status() << std::endl;
@@ -118,7 +118,7 @@ void DeleteObjectAcl(gcs::Client client, int& argc, char* argv[]) {
      std::string entity) {
     StatusOr<void> status =
         client.DeleteObjectAcl(bucket_name, object_name, entity);
-    if (not status.ok()) {
+    if (!status.ok()) {
       std::cerr << "Error deleting object ACL entry for entity " << entity
                 << " in object " << object_name << " and bucket " << bucket_name
                 << ", status=" << status.status() << std::endl;
@@ -145,7 +145,7 @@ void GetObjectAcl(gcs::Client client, int& argc, char* argv[]) {
      std::string entity) {
     StatusOr<gcs::ObjectAccessControl> acl =
         client.GetObjectAcl(bucket_name, object_name, entity);
-    if (not acl.ok()) {
+    if (!acl.ok()) {
       std::cerr << "Error getting object ACL entry for entity " << entity
                 << " in object " << object_name << " and bucket " << bucket_name
                 << ", status=" << acl.status() << std::endl;
@@ -175,7 +175,7 @@ void UpdateObjectAcl(gcs::Client client, int& argc, char* argv[]) {
      std::string entity, std::string role) {
     StatusOr<gcs::ObjectAccessControl> current_acl =
         client.GetObjectAcl(bucket_name, object_name, entity);
-    if (not current_acl.ok()) {
+    if (!current_acl.ok()) {
       std::cerr << "Error getting object ACL entry for entity " << entity
                 << " in object " << object_name << " and bucket " << bucket_name
                 << ", status=" << current_acl.status() << std::endl;
@@ -207,7 +207,7 @@ void PatchObjectAcl(gcs::Client client, int& argc, char* argv[]) {
      std::string entity, std::string role) {
     StatusOr<gcs::ObjectAccessControl> original_acl =
         client.GetObjectAcl(bucket_name, object_name, entity);
-    if (not original_acl.ok()) {
+    if (!original_acl.ok()) {
       std::cerr << "Error getting object ACL entry for entity " << entity
                 << " in object " << object_name << " and bucket " << bucket_name
                 << ", status=" << original_acl.status() << std::endl;
@@ -217,7 +217,7 @@ void PatchObjectAcl(gcs::Client client, int& argc, char* argv[]) {
     new_acl.set_role(role);
     StatusOr<gcs::ObjectAccessControl> patched_acl = client.PatchObjectAcl(
         bucket_name, object_name, entity, *original_acl, new_acl);
-    if (not patched_acl.ok()) {
+    if (!patched_acl.ok()) {
       std::cerr << "Error patching object ACL entry for entity " << entity
                 << " in object " << object_name << " and bucket " << bucket_name
                 << ", status=" << patched_acl.status() << std::endl;
@@ -248,7 +248,7 @@ void PatchObjectAclNoRead(gcs::Client client, int& argc, char* argv[]) {
     StatusOr<gcs::ObjectAccessControl> patched_acl = client.PatchObjectAcl(
         bucket_name, object_name, entity,
         gcs::ObjectAccessControlPatchBuilder().set_role(role));
-    if (not patched_acl.ok()) {
+    if (!patched_acl.ok()) {
       std::cerr << "Error patching object ACL entry for entity " << entity
                 << " in object " << object_name << " and bucket " << bucket_name
                 << ", status=" << patched_acl.status() << std::endl;

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -57,7 +57,7 @@ void ListObjects(google::cloud::storage::Client client, int& argc,
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name) {
     for (auto&& object_metadata : client.ListObjects(bucket_name)) {
-      if (not object_metadata.ok()) {
+      if (!object_metadata.ok()) {
         std::cerr << "Error reading object list for " << bucket_name
                   << ", status=" << object_metadata.status();
         return;
@@ -86,7 +86,7 @@ void InsertObject(google::cloud::storage::Client client, int& argc,
      std::string contents) {
     StatusOr<gcs::ObjectMetadata> meta =
         client.InsertObject(bucket_name, object_name, std::move(contents));
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Error inserting object " << object_name << " in bucket "
                 << bucket_name << ", status=" << meta.status() << std::endl;
       return;
@@ -118,7 +118,7 @@ void InsertObjectStrictIdempotency(google::cloud::storage::Client unused,
     StatusOr<gcs::ObjectMetadata> meta =
         client.InsertObject(bucket_name, object_name, std::move(contents),
                             gcs::IfGenerationMatch(0));
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Error inserting object " << object_name << " in bucket "
                 << bucket_name << ", status=" << meta.status() << std::endl;
       return;
@@ -151,7 +151,7 @@ void InsertObjectModifiedRetry(google::cloud::storage::Client unused, int& argc,
     StatusOr<gcs::ObjectMetadata> meta =
         client.InsertObject(bucket_name, object_name, std::move(contents),
                             gcs::IfGenerationMatch(0));
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Error inserting object " << object_name << " in bucket "
                 << bucket_name << ", status=" << meta.status() << std::endl;
       return;
@@ -183,7 +183,7 @@ void CopyObject(google::cloud::storage::Client client, int& argc,
     StatusOr<gcs::ObjectMetadata> new_copy_meta =
         client.CopyObject(source_bucket_name, source_object_name,
                           destination_bucket_name, destination_object_name);
-    if (not new_copy_meta.ok()) {
+    if (!new_copy_meta.ok()) {
       std::cerr << "Error copying object " << source_bucket_name
                 << " in bucket " << source_bucket_name << " to bucket "
                 << destination_bucket_name << " with name "
@@ -224,7 +224,7 @@ void CopyEncryptedObject(google::cloud::storage::Client client, int& argc,
     StatusOr<gcs::ObjectMetadata> new_copy_meta = client.CopyObject(
         source_bucket_name, source_object_name, destination_bucket_name,
         destination_object_name, gcs::EncryptionKey::FromBase64Key(key_base64));
-    if (not new_copy_meta.ok()) {
+    if (!new_copy_meta.ok()) {
       std::cerr << "Error copying object " << source_bucket_name
                 << " in bucket " << source_bucket_name << " to bucket "
                 << destination_bucket_name << " with name "
@@ -256,7 +256,7 @@ void GetObjectMetadata(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
     StatusOr<gcs::ObjectMetadata> meta =
         client.GetObjectMetadata(bucket_name, object_name);
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Error getting object metadata for object " << object_name
                 << " in bucket " << bucket_name << ", status=" << meta.status()
                 << std::endl;
@@ -281,7 +281,7 @@ void ReadObject(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
     gcs::ObjectReadStream stream = client.ReadObject(bucket_name, object_name);
     int count = 0;
-    while (not stream.eof()) {
+    while (!stream.eof()) {
       std::string line;
       std::getline(stream, line, '\n');
       ++count;
@@ -304,7 +304,7 @@ void DeleteObject(google::cloud::storage::Client client, int& argc,
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
     StatusOr<void> status = client.DeleteObject(bucket_name, object_name);
-    if (not status.ok()) {
+    if (!status.ok()) {
       std::cerr << "Error deleting object " << object_name << " in bucket "
                 << bucket_name << ", status=" << status.status() << std::endl;
       return;
@@ -471,7 +471,7 @@ void UploadFile(google::cloud::storage::Client client, int& argc,
     // client-side to verify data integrity during transmission.
     StatusOr<gcs::ObjectMetadata> meta = client.UploadFile(
         file_name, bucket_name, object_name, gcs::IfGenerationMatch(0));
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Error uploading file " << file_name << " to bucket "
                 << bucket_name << " as object " << object_name
                 << ", status=" << meta.status() << std::endl;
@@ -505,7 +505,7 @@ void UploadFileResumable(google::cloud::storage::Client client, int& argc,
     StatusOr<gcs::ObjectMetadata> meta = client.UploadFile(
         file_name, bucket_name, object_name, gcs::IfGenerationMatch(0),
         gcs::NewResumableUploadSession());
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Error uploading file " << file_name << " to bucket "
                 << bucket_name << " as object " << object_name
                 << ", status=" << meta.status() << std::endl;
@@ -535,7 +535,7 @@ void DownloadFile(google::cloud::storage::Client client, int& argc,
      std::string file_name) {
     StatusOr<void> status =
         client.DownloadToFile(bucket_name, object_name, file_name);
-    if (not status.ok()) {
+    if (!status.ok()) {
       std::cerr << "Error downloading object " << object_name << " in bucket "
                 << bucket_name << " to file " << file_name
                 << ", status=" << status.status() << std::endl;
@@ -565,7 +565,7 @@ void UpdateObjectMetadata(google::cloud::storage::Client client, int& argc,
      std::string key, std::string value) {
     StatusOr<gcs::ObjectMetadata> meta =
         client.GetObjectMetadata(bucket_name, object_name);
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Error getting object metadata for object " << object_name
                 << " in bucket " << bucket_name << ", status=" << meta.status()
                 << std::endl;
@@ -575,7 +575,7 @@ void UpdateObjectMetadata(google::cloud::storage::Client client, int& argc,
     desired.mutable_metadata().emplace(key, value);
     StatusOr<gcs::ObjectMetadata> updated = client.UpdateObject(
         bucket_name, object_name, desired, gcs::Generation(meta->generation()));
-    if (not updated.ok()) {
+    if (!updated.ok()) {
       std::cerr << "Error updating object metadata for object " << meta->name()
                 << " in bucket " << meta->bucket()
                 << ", status=" << updated.status() << std::endl;
@@ -603,7 +603,7 @@ void PatchObjectDeleteMetadata(google::cloud::storage::Client client, int& argc,
      std::string key) {
     StatusOr<gcs::ObjectMetadata> original =
         client.GetObjectMetadata(bucket_name, object_name);
-    if (not original.ok()) {
+    if (!original.ok()) {
       std::cerr << "Error getting object metadata for object " << object_name
                 << " in bucket " << bucket_name
                 << ", status=" << original.status() << std::endl;
@@ -613,7 +613,7 @@ void PatchObjectDeleteMetadata(google::cloud::storage::Client client, int& argc,
     desired.mutable_metadata().erase(key);
     StatusOr<gcs::ObjectMetadata> updated =
         client.PatchObject(bucket_name, object_name, *original, desired);
-    if (not updated.ok()) {
+    if (!updated.ok()) {
       std::cerr << "Error updating object metadata for object "
                 << original->name() << " in bucket " << original->bucket()
                 << ", status=" << updated.status() << std::endl;
@@ -643,7 +643,7 @@ void PatchObjectContentType(google::cloud::storage::Client client, int& argc,
     StatusOr<gcs::ObjectMetadata> updated = client.PatchObject(
         bucket_name, object_name,
         gcs::ObjectMetadataPatchBuilder().SetContentType(content_type));
-    if (not updated.ok()) {
+    if (!updated.ok()) {
       std::cerr << "Error patching object metadata for object " << object_name
                 << " in bucket " << bucket_name
                 << ", status=" << updated.status() << std::endl;
@@ -670,7 +670,7 @@ void MakeObjectPublic(google::cloud::storage::Client client, int& argc,
     StatusOr<gcs::ObjectMetadata> updated = client.PatchObject(
         bucket_name, object_name, gcs::ObjectMetadataPatchBuilder(),
         gcs::PredefinedAcl::PublicRead());
-    if (not updated.ok()) {
+    if (!updated.ok()) {
       std::cerr << "Error patching object metadata for object " << object_name
                 << " in bucket " << bucket_name
                 << ", status=" << updated.status() << std::endl;
@@ -698,7 +698,7 @@ void ReadObjectUnauthenticated(google::cloud::storage::Client client, int& argc,
     // Read an object, the object must have been made public.
     gcs::ObjectReadStream stream = client.ReadObject(bucket_name, object_name);
     int count = 0;
-    while (not stream.eof()) {
+    while (!stream.eof()) {
       std::string line;
       std::getline(stream, line, '\n');
       ++count;
@@ -772,7 +772,7 @@ void WriteEncryptedObject(google::cloud::storage::Client client, int& argc,
     StatusOr<gcs::ObjectMetadata> meta = client.InsertObject(
         bucket_name, object_name, "top secret",
         gcs::EncryptionKey::FromBase64Key(base64_aes256_key));
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Error inserting object " << object_name << " in bucket "
                 << bucket_name << ", status=" << meta.status() << std::endl;
       return;
@@ -829,7 +829,7 @@ void ComposeObject(google::cloud::storage::Client client, int& argc,
      std::vector<gcs::ComposeSourceObject> compose_objects) {
     StatusOr<gcs::ObjectMetadata> composed_object = client.ComposeObject(
         bucket_name, compose_objects, destination_object_name);
-    if (not composed_object.ok()) {
+    if (!composed_object.ok()) {
       std::cerr << "Error composing objects in bucket " << bucket_name
                 << ", status=" << composed_object.status() << std::endl;
       return;
@@ -867,7 +867,7 @@ void ComposeObjectFromEncryptedObjects(google::cloud::storage::Client client,
     StatusOr<gcs::ObjectMetadata> composed_object = client.ComposeObject(
         bucket_name, compose_objects, destination_object_name,
         gcs::EncryptionKey::FromBase64Key(base64_aes256_key));
-    if (not composed_object.ok()) {
+    if (!composed_object.ok()) {
       std::cerr << "Error composing objects in bucket " << bucket_name
                 << ", status=" << composed_object.status() << std::endl;
       return;
@@ -962,7 +962,7 @@ void RewriteObjectNonBlocking(google::cloud::storage::Client client, int& argc,
                              destination_bucket_name, destination_object_name);
     StatusOr<gcs::ObjectMetadata> meta = rewriter.ResultWithProgressCallback(
         [](StatusOr<gcs::RewriteProgress> const& progress) {
-          if (not progress.ok()) {
+          if (!progress.ok()) {
             std::cerr << "Error during rewrite: " << progress.status()
                       << std::endl;
             return;
@@ -1000,7 +1000,7 @@ void RewriteObjectToken(google::cloud::storage::Client client, int& argc,
         source_bucket_name, source_object_name, destination_bucket_name,
         destination_object_name, gcs::MaxBytesRewrittenPerCall(1024 * 1024));
     StatusOr<gcs::RewriteProgress> progress = rewriter.Iterate();
-    if (not progress.ok()) {
+    if (!progress.ok()) {
       std::cerr << "Error during rewrite: " << progress.status() << std::endl;
       return;
     }
@@ -1041,7 +1041,7 @@ void RewriteObjectResume(google::cloud::storage::Client client, int& argc,
         gcs::MaxBytesRewrittenPerCall(1024 * 1024));
     StatusOr<gcs::ObjectMetadata> meta = rewriter.ResultWithProgressCallback(
         [](StatusOr<gcs::RewriteProgress> const& progress) {
-          if (not progress.ok()) {
+          if (!progress.ok()) {
             std::cerr << "Error during rewrite: " << progress.status()
                       << std::endl;
             return;
@@ -1078,7 +1078,7 @@ void RotateEncryptionKey(google::cloud::storage::Client client, int& argc,
         bucket_name, object_name, bucket_name, object_name,
         gcs::SourceEncryptionKey::FromBase64Key(old_key_base64),
         gcs::EncryptionKey::FromBase64Key(new_key_base64));
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Error rotating key on object " << object_name
                 << ", status=" << meta.status() << std::endl;
     }
@@ -1106,13 +1106,13 @@ void RenameObject(google::cloud::storage::Client client, int& argc,
      std::string new_object_name) {
     StatusOr<gcs::ObjectMetadata> meta = client.RewriteObjectBlocking(
         bucket_name, old_object_name, bucket_name, new_object_name);
-    if (not meta.ok()) {
+    if (!meta.ok()) {
       std::cerr << "Error renaming object " << old_object_name
                 << ", status=" << meta.status() << std::endl;
       return;
     }
     StatusOr<void> status = client.DeleteObject(bucket_name, old_object_name);
-    if (not status.ok()) {
+    if (!status.ok()) {
       std::cerr << "Error deleting original object " << old_object_name
                 << " in bucket " << bucket_name
                 << ", status=" << status.status() << std::endl;
@@ -1138,7 +1138,7 @@ void SetObjectEventBasedHold(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
     StatusOr<gcs::ObjectMetadata> original =
         client.GetObjectMetadata(bucket_name, object_name);
-    if (not original.ok()) {
+    if (!original.ok()) {
       std::cerr << "Error getting object metadata for object " << object_name
                 << " in bucket " << bucket_name
                 << ", status=" << original.status() << std::endl;
@@ -1148,7 +1148,7 @@ void SetObjectEventBasedHold(google::cloud::storage::Client client, int& argc,
         bucket_name, object_name,
         gcs::ObjectMetadataPatchBuilder().SetEventBasedHold(true),
         gcs::IfMetagenerationMatch(original->metageneration()));
-    if (not updated.ok()) {
+    if (!updated.ok()) {
       std::cerr << "Error patching object metadata for object " << object_name
                 << " in bucket " << bucket_name
                 << ", status=" << updated.status() << std::endl;
@@ -1177,7 +1177,7 @@ void ReleaseObjectEventBasedHold(google::cloud::storage::Client client,
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
     StatusOr<gcs::ObjectMetadata> original =
         client.GetObjectMetadata(bucket_name, object_name);
-    if (not original.ok()) {
+    if (!original.ok()) {
       std::cerr << "Error getting object metadata for object " << object_name
                 << " in bucket " << bucket_name
                 << ", status=" << original.status() << std::endl;
@@ -1187,7 +1187,7 @@ void ReleaseObjectEventBasedHold(google::cloud::storage::Client client,
         bucket_name, object_name,
         gcs::ObjectMetadataPatchBuilder().SetEventBasedHold(false),
         gcs::IfMetagenerationMatch(original->metageneration()));
-    if (not updated.ok()) {
+    if (!updated.ok()) {
       std::cerr << "Error patching object metadata for object " << object_name
                 << " in bucket " << bucket_name
                 << ", status=" << updated.status() << std::endl;
@@ -1216,7 +1216,7 @@ void SetObjectTemporaryHold(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
     StatusOr<gcs::ObjectMetadata> original =
         client.GetObjectMetadata(bucket_name, object_name);
-    if (not original.ok()) {
+    if (!original.ok()) {
       std::cerr << "Error getting object metadata for object " << object_name
                 << " in bucket " << bucket_name
                 << ", status=" << original.status() << std::endl;
@@ -1226,7 +1226,7 @@ void SetObjectTemporaryHold(google::cloud::storage::Client client, int& argc,
         bucket_name, object_name,
         gcs::ObjectMetadataPatchBuilder().SetTemporaryHold(true),
         gcs::IfMetagenerationMatch(original->metageneration()));
-    if (not updated.ok()) {
+    if (!updated.ok()) {
       std::cerr << "Error patching object metadata for object " << object_name
                 << " in bucket " << bucket_name
                 << ", status=" << updated.status() << std::endl;
@@ -1255,7 +1255,7 @@ void ReleaseObjectTemporaryHold(google::cloud::storage::Client client,
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
     StatusOr<gcs::ObjectMetadata> original =
         client.GetObjectMetadata(bucket_name, object_name);
-    if (not original.ok()) {
+    if (!original.ok()) {
       std::cerr << "Error getting object metadata for object " << object_name
                 << " in bucket " << bucket_name
                 << ", status=" << original.status() << std::endl;
@@ -1265,7 +1265,7 @@ void ReleaseObjectTemporaryHold(google::cloud::storage::Client client,
         bucket_name, object_name,
         gcs::ObjectMetadataPatchBuilder().SetTemporaryHold(false),
         gcs::IfMetagenerationMatch(original->metageneration()));
-    if (not updated.ok()) {
+    if (!updated.ok()) {
       std::cerr << "Error patching object metadata for object " << object_name
                 << " in bucket " << bucket_name
                 << ", status=" << updated.status() << std::endl;
@@ -1295,7 +1295,7 @@ void CreateGetSignedUrl(google::cloud::storage::Client client, int& argc,
         "GET", std::move(bucket_name), std::move(object_name),
         gcs::ExpirationTime(std::chrono::system_clock::now() +
                             std::chrono::minutes(15)));
-    if (not signed_url.ok()) {
+    if (!signed_url.ok()) {
       std::cerr << "Error creating signed URL, status=" << signed_url.status()
                 << std::endl;
       return;
@@ -1324,7 +1324,7 @@ void CreatePutSignedUrl(google::cloud::storage::Client client, int& argc,
         gcs::ExpirationTime(std::chrono::system_clock::now() +
                             std::chrono::minutes(15)),
         gcs::ContentType("application/octet-stream"));
-    if (not signed_url.ok()) {
+    if (!signed_url.ok()) {
       std::cerr << "Error creating signed URL, status=" << signed_url.status()
                 << std::endl;
       return;

--- a/google/cloud/storage/idempotency_policy.cc
+++ b/google/cloud/storage/idempotency_policy.cc
@@ -241,19 +241,19 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::DeleteBucketRequest const& request) const {
-  return (request.HasOption<IfMatchEtag>() or
+  return (request.HasOption<IfMatchEtag>() ||
           request.HasOption<IfMetagenerationMatch>());
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::UpdateBucketRequest const& request) const {
-  return (request.HasOption<IfMatchEtag>() or
+  return (request.HasOption<IfMatchEtag>() ||
           request.HasOption<IfMetagenerationMatch>());
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::PatchBucketRequest const& request) const {
-  return (request.HasOption<IfMatchEtag>() or
+  return (request.HasOption<IfMatchEtag>() ||
           request.HasOption<IfMetagenerationMatch>());
 }
 
@@ -314,19 +314,19 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::DeleteObjectRequest const& request) const {
-  return request.HasOption<Generation>() or
+  return request.HasOption<Generation>() ||
          request.HasOption<IfGenerationMatch>();
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::UpdateObjectRequest const& request) const {
-  return request.HasOption<IfMatchEtag>() or
+  return request.HasOption<IfMatchEtag>() ||
          request.HasOption<IfMetagenerationMatch>();
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::PatchObjectRequest const& request) const {
-  return request.HasOption<IfMatchEtag>() or
+  return request.HasOption<IfMatchEtag>() ||
          request.HasOption<IfMetagenerationMatch>();
 }
 

--- a/google/cloud/storage/internal/access_control_common.cc
+++ b/google/cloud/storage/internal/access_control_common.cc
@@ -22,7 +22,7 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 Status AccessControlCommon::ParseFromJson(AccessControlCommon& result,
                                         nl::json const& json) {
-  if (not json.is_object()) {
+  if (!json.is_object()) {
     return Status(StatusCode::kInvalidArgument, __func__);
   }
   result.bucket_ = json.value("bucket", "");

--- a/google/cloud/storage/internal/access_control_common.h
+++ b/google/cloud/storage/internal/access_control_common.h
@@ -126,13 +126,13 @@ class AccessControlCommon {
   bool operator==(AccessControlCommon const& rhs) const {
     // Start with id, bucket, etag because they should fail early, then
     // alphabetical for readability.
-    return id_ == rhs.id_ and bucket_ == rhs.bucket_ and etag_ == rhs.etag_ and
-           domain_ == rhs.domain_ and email_ == rhs.email_ and
-           entity_ == rhs.entity_ and entity_id_ == rhs.entity_id_ and
-           kind_ == rhs.kind_ and project_team_ == rhs.project_team_ and
-           role_ == rhs.role_ and self_link_ == rhs.self_link_;
+    return id_ == rhs.id_ && bucket_ == rhs.bucket_ && etag_ == rhs.etag_ &&
+           domain_ == rhs.domain_ && email_ == rhs.email_ &&
+           entity_ == rhs.entity_ && entity_id_ == rhs.entity_id_ &&
+           kind_ == rhs.kind_ && project_team_ == rhs.project_team_ &&
+           role_ == rhs.role_ && self_link_ == rhs.self_link_;
   }
-  bool operator!=(AccessControlCommon const& rhs) { return not(*this == rhs); }
+  bool operator!=(AccessControlCommon const& rhs) { return !(*this == rhs); }
 
  protected:
   static Status ParseFromJson(AccessControlCommon& result,

--- a/google/cloud/storage/internal/binary_data_as_debug_string.cc
+++ b/google/cloud/storage/internal/binary_data_as_debug_string.cc
@@ -38,7 +38,7 @@ std::string BinaryDataAsDebugString(char const* data, std::size_t size,
 
   // Limit the output to the first `max_output_bytes`.
   std::size_t n = size;
-  if (max_output_bytes > 0 and max_output_bytes < size) {
+  if (max_output_bytes > 0 && max_output_bytes < size) {
     n = max_output_bytes;
   }
 

--- a/google/cloud/storage/internal/bucket_acl_requests.cc
+++ b/google/cloud/storage/internal/bucket_acl_requests.cc
@@ -31,12 +31,12 @@ StatusOr<ListBucketAclResponse> ListBucketAclResponse::FromHttpResponse(
     HttpResponse&& response) {
   ListBucketAclResponse result;
   auto json = nl::json::parse(response.payload, nullptr, false);
-  if (not json.is_object()) {
+  if (!json.is_object()) {
     return Status(StatusCode::kInvalidArgument, __func__);
   }
   for (auto const& kv : json["items"].items()) {
     auto parsed = BucketAccessControl::ParseFromJson(kv.value());
-    if (not parsed.ok()) {
+    if (!parsed.ok()) {
       return std::move(parsed).status();
     }
     result.items.emplace_back(std::move(*parsed));

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -31,7 +31,7 @@ StatusOr<ListBucketsResponse> ListBucketsResponse::FromHttpResponse(
     HttpResponse&& response) {
   auto json =
       storage::internal::nl::json::parse(response.payload, nullptr, false);
-  if (not json.is_object()) {
+  if (!json.is_object()) {
     return Status(StatusCode::kInvalidArgument, __func__);
   }
 
@@ -40,7 +40,7 @@ StatusOr<ListBucketsResponse> ListBucketsResponse::FromHttpResponse(
 
   for (auto const& kv : json["items"].items()) {
     auto parsed = BucketMetadata::ParseFromJson(kv.value());
-    if (not parsed) {
+    if (!parsed) {
       return std::move(parsed).status();
     }
     result.items.emplace_back(std::move(*parsed));
@@ -229,14 +229,14 @@ std::ostream& operator<<(std::ostream& os, GetBucketIamPolicyRequest const& r) {
 
 StatusOr<IamPolicy> ParseIamPolicyFromString(std::string const& payload) {
   auto json = nl::json::parse(payload, nullptr, false);
-  if (not json.is_object()) {
+  if (!json.is_object()) {
     return Status(StatusCode::kInvalidArgument, __func__);
   }
   IamPolicy policy;
   policy.version = 0;
   policy.etag = json.value("etag", "");
   if (json.count("bindings") != 0U) {
-    if (not json["bindings"].is_array()) {
+    if (!json["bindings"].is_array()) {
       std::ostringstream os;
       os << "Invalid IamPolicy payload, expected array for 'bindings' field."
          << "  payload=" << payload;
@@ -250,7 +250,7 @@ StatusOr<IamPolicy> ParseIamPolicyFromString(std::string const& payload) {
            << " fields for element #" << kv.key() << ". payload=" << payload;
         google::cloud::internal::ThrowInvalidArgument(os.str());
       }
-      if (not binding["members"].is_array()) {
+      if (!binding["members"].is_array()) {
         std::ostringstream os;
         os << "Invalid IamPolicy payload, expected array for 'members'"
            << " fields for element #" << kv.key() << ". payload=" << payload;
@@ -313,7 +313,7 @@ TestBucketIamPermissionsResponse::FromHttpResponse(
     HttpResponse const& response) {
   TestBucketIamPermissionsResponse result;
   auto json = nl::json::parse(response.payload, nullptr, false);
-  if (not json.is_object()) {
+  if (!json.is_object()) {
     return Status(StatusCode::kInvalidArgument, __func__);
   }
   for (auto const& kv : json["permissions"].items()) {

--- a/google/cloud/storage/internal/common_metadata.h
+++ b/google/cloud/storage/internal/common_metadata.h
@@ -75,7 +75,7 @@ class CommonMetadata {
 
   static Status ParseFromJson(CommonMetadata<Derived>& result,
                               internal::nl::json const& json) {
-    if (not json.is_object()) {
+    if (!json.is_object()) {
       return Status(StatusCode::kInvalidArgument, __func__);
     }
     result.etag_ = json.value("etag", "");
@@ -128,13 +128,13 @@ class CommonMetadata {
     // to short-circuit this comparison.  The check the name, project number,
     // and metadata generation, which have the next best chance to
     // short-circuit.  The rest just put in alphabetical order.
-    return name_ == rhs.name_ and metageneration_ == rhs.metageneration_ and
-           id_ == rhs.id_ and etag_ == rhs.etag_ and kind_ == rhs.kind_ and
-           self_link_ == rhs.self_link_ and
-           storage_class_ == rhs.storage_class_ and
-           time_created_ == rhs.time_created_ and updated_ == rhs.updated_;
+    return name_ == rhs.name_ && metageneration_ == rhs.metageneration_ &&
+           id_ == rhs.id_ && etag_ == rhs.etag_ && kind_ == rhs.kind_ &&
+           self_link_ == rhs.self_link_ &&
+           storage_class_ == rhs.storage_class_ &&
+           time_created_ == rhs.time_created_ && updated_ == rhs.updated_;
   }
-  bool operator!=(CommonMetadata const& rhs) const { return not(*this == rhs); }
+  bool operator!=(CommonMetadata const& rhs) const { return !(*this == rhs); }
 
  private:
   // Keep the fields in alphabetical order.

--- a/google/cloud/storage/internal/compute_engine_util.cc
+++ b/google/cloud/storage/internal/compute_engine_util.cc
@@ -92,7 +92,7 @@ bool RunningOnComputeEngineVm() {
   std::string const gce_product_name = "Google Compute Engine";
   std::string const product_name_file = "/sys/class/dmi/id/product_name";
   std::ifstream is(product_name_file);
-  if (not is.is_open()) {
+  if (!is.is_open()) {
     GCP_LOG(WARNING) << "Could not find file '" << product_name_file
                      << "' when checking if running on GCE, returning false";
     return false;

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -51,7 +51,7 @@ std::shared_ptr<CurlHandleFactory> CreateHandleFactory(
 
 std::unique_ptr<HashValidator> CreateHashValidator(bool disable_md5,
                                                    bool disable_crc32c) {
-  if (disable_md5 and disable_crc32c) {
+  if (disable_md5 && disable_crc32c) {
     return google::cloud::internal::make_unique<NullHashValidator>();
   }
   if (disable_md5) {
@@ -111,7 +111,7 @@ std::string UrlEscapeString(std::string const& value) {
 
 template <typename ReturnType>
 StatusOr<ReturnType> ParseFromString(StatusOr<HttpResponse> response) {
-  if (not response.ok()) {
+  if (!response.ok()) {
     return std::move(response).status();
   }
   if (response->status_code >= 300) {
@@ -121,7 +121,7 @@ StatusOr<ReturnType> ParseFromString(StatusOr<HttpResponse> response) {
 }
 
 StatusOr<EmptyResponse> ReturnEmptyResponse(StatusOr<HttpResponse> response) {
-  if (not response.ok()) {
+  if (!response.ok()) {
     return std::move(response).status();
   }
   if (response->status_code >= 300) {
@@ -132,7 +132,7 @@ StatusOr<EmptyResponse> ReturnEmptyResponse(StatusOr<HttpResponse> response) {
 
 template <typename ReturnType>
 StatusOr<ReturnType> ParseFromHttpResponse(StatusOr<HttpResponse> response) {
-  if (not response.ok()) {
+  if (!response.ok()) {
     return std::move(response).status();
   }
   if (response->status_code >= 300) {
@@ -146,7 +146,7 @@ StatusOr<ReturnType> ParseFromHttpResponse(StatusOr<HttpResponse> response) {
 Status CurlClient::SetupBuilderCommon(CurlRequestBuilder& builder,
                                       char const* method) {
   auto auth_header = AuthorizationHeader(options_.credentials());
-  if (not auth_header.ok()) {
+  if (!auth_header.ok()) {
     return std::move(auth_header).status();
   }
   builder.SetMethod(method)
@@ -161,7 +161,7 @@ template <typename Request>
 Status CurlClient::SetupBuilder(CurlRequestBuilder& builder,
                                 Request const& request, char const* method) {
   auto status = SetupBuilderCommon(builder, method);
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   request.AddOptionsToHttpRequest(builder);
@@ -170,7 +170,7 @@ Status CurlClient::SetupBuilder(CurlRequestBuilder& builder,
     if (value.empty()) {
       value = builder.LastClientIpAddress();
     }
-    if (not value.empty()) {
+    if (!value.empty()) {
       builder.AddQueryParameter(UserIp::name(), value);
     }
   }
@@ -183,7 +183,7 @@ CurlClient::CreateResumableSessionGeneric(RequestType const& request) {
   if (request.template HasOption<UseResumableUploadSession>()) {
     auto session_id =
         request.template GetOption<UseResumableUploadSession>().value();
-    if (not session_id.empty()) {
+    if (!session_id.empty()) {
       return RestoreResumableSession(session_id);
     }
   }
@@ -191,7 +191,7 @@ CurlClient::CreateResumableSessionGeneric(RequestType const& request) {
   CurlRequestBuilder builder(
       upload_endpoint_ + "/b/" + request.bucket_name() + "/o", upload_factory_);
   auto status = SetupBuilder(builder, request, "POST");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddQueryParameter("uploadType", "resumable");
@@ -206,7 +206,7 @@ CurlClient::CreateResumableSessionGeneric(RequestType const& request) {
   builder.AddHeader("Content-Length: " +
                     std::to_string(request_payload.size()));
   auto http_response = builder.BuildRequest().MakeRequest(request_payload);
-  if (not http_response.ok()) {
+  if (!http_response.ok()) {
     return std::move(http_response).status();
   }
   if (http_response->status_code >= 300) {
@@ -214,7 +214,7 @@ CurlClient::CreateResumableSessionGeneric(RequestType const& request) {
   }
   auto response =
       ResumableUploadResponse::FromHttpResponse(*std::move(http_response));
-  if (not response.ok()) {
+  if (!response.ok()) {
     return std::move(response).status();
   }
   if (response->upload_session_url.empty()) {
@@ -264,7 +264,7 @@ StatusOr<ResumableUploadResponse> CurlClient::UploadChunk(
     UploadChunkRequest const& request) {
   CurlRequestBuilder builder(request.upload_session_url(), upload_factory_);
   auto status = SetupBuilder(builder, request, "PUT");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader(request.RangeHeader());
@@ -272,10 +272,10 @@ StatusOr<ResumableUploadResponse> CurlClient::UploadChunk(
   builder.AddHeader("Content-Length: " +
                     std::to_string(request.payload().size()));
   auto response = builder.BuildRequest().MakeRequest(request.payload());
-  if (not response.ok()) {
+  if (!response.ok()) {
     return std::move(response).status();
   }
-  if (response->status_code < 300 or response->status_code == 308) {
+  if (response->status_code < 300 || response->status_code == 308) {
     return ResumableUploadResponse::FromHttpResponse(*std::move(response));
   }
   return AsStatus(*response);
@@ -285,17 +285,17 @@ StatusOr<ResumableUploadResponse> CurlClient::QueryResumableUpload(
     QueryResumableUploadRequest const& request) {
   CurlRequestBuilder builder(request.upload_session_url(), upload_factory_);
   auto status = SetupBuilder(builder, request, "PUT");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("Content-Range: bytes */*");
   builder.AddHeader("Content-Type: application/octet-stream");
   builder.AddHeader("Content-Length: 0");
   auto response = builder.BuildRequest().MakeRequest(std::string{});
-  if (not response.ok()) {
+  if (!response.ok()) {
     return std::move(response).status();
   }
-  if (response->status_code < 300 or response->status_code == 308) {
+  if (response->status_code < 300 || response->status_code == 308) {
     return ResumableUploadResponse::FromHttpResponse(*std::move(response));
   }
   return AsStatus(*response);
@@ -305,7 +305,7 @@ StatusOr<ListBucketsResponse> CurlClient::ListBuckets(
     ListBucketsRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b", storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddQueryParameter("project", request.project_id());
@@ -318,7 +318,7 @@ StatusOr<BucketMetadata> CurlClient::CreateBucket(
   // Assume the bucket name is validated by the caller.
   CurlRequestBuilder builder(storage_endpoint_ + "/b", storage_factory_);
   auto status = SetupBuilder(builder, request, "POST");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddQueryParameter("project", request.project_id());
@@ -333,7 +333,7 @@ StatusOr<BucketMetadata> CurlClient::GetBucketMetadata(
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name(),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   return ParseFromString<BucketMetadata>(
@@ -346,7 +346,7 @@ StatusOr<EmptyResponse> CurlClient::DeleteBucket(
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name(),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "DELETE");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
@@ -358,7 +358,7 @@ StatusOr<BucketMetadata> CurlClient::UpdateBucket(
   CurlRequestBuilder builder(
       storage_endpoint_ + "/b/" + request.metadata().name(), storage_factory_);
   auto status = SetupBuilder(builder, request, "PUT");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
@@ -372,7 +372,7 @@ StatusOr<BucketMetadata> CurlClient::PatchBucket(
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket(),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PATCH");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
@@ -386,11 +386,11 @@ StatusOr<IamPolicy> CurlClient::GetBucketIamPolicy(
       storage_endpoint_ + "/b/" + request.bucket_name() + "/iam",
       storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   auto response = builder.BuildRequest().MakeRequest(std::string{});
-  if (not response.ok()) {
+  if (!response.ok()) {
     return std::move(response).status();
   }
   if (response->status_code >= 300) {
@@ -405,12 +405,12 @@ StatusOr<IamPolicy> CurlClient::SetBucketIamPolicy(
       storage_endpoint_ + "/b/" + request.bucket_name() + "/iam",
       storage_factory_);
   auto status = SetupBuilder(builder, request, "PUT");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
   auto response = builder.BuildRequest().MakeRequest(request.json_payload());
-  if (not response.ok()) {
+  if (!response.ok()) {
     return std::move(response).status();
   }
   if (response->status_code >= 300) {
@@ -425,14 +425,14 @@ StatusOr<TestBucketIamPermissionsResponse> CurlClient::TestBucketIamPermissions(
                                  "/iam/testPermissions",
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   for (auto const& perm : request.permissions()) {
     builder.AddQueryParameter("permissions", perm);
   }
   auto response = builder.BuildRequest().MakeRequest(std::string{});
-  if (not response.ok()) {
+  if (!response.ok()) {
     return std::move(response).status();
   }
   if (response->status_code >= 300) {
@@ -447,7 +447,7 @@ StatusOr<EmptyResponse> CurlClient::LockBucketRetentionPolicy(
                                  "/lockRetentionPolicy",
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "POST");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("content-type: application/json");
@@ -464,18 +464,18 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMedia(
   }
 
   // Unless the request uses a feature that disables it, prefer to use XML.
-  if (not request.HasOption<IfMetagenerationNotMatch>() and
-      not request.HasOption<IfGenerationNotMatch>() and
-      not request.HasOption<QuotaUser>() and not request.HasOption<UserIp>() and
-      not request.HasOption<Projection>() and request.HasOption<Fields>() and
+  if (!request.HasOption<IfMetagenerationNotMatch>() &&
+      !request.HasOption<IfGenerationNotMatch>() &&
+      !request.HasOption<QuotaUser>() && !request.HasOption<UserIp>() &&
+      !request.HasOption<Projection>() && request.HasOption<Fields>() &&
       request.GetOption<Fields>().value().empty()) {
     return InsertObjectMediaXml(request);
   }
 
   // If the application has set an explicit hash value we need to use multipart
   // uploads.
-  if (not request.HasOption<DisableMD5Hash>() and
-      not request.HasOption<DisableCrc32cChecksum>()) {
+  if (!request.HasOption<DisableMD5Hash>() &&
+      !request.HasOption<DisableCrc32cChecksum>()) {
     return InsertObjectMediaMultipart(request);
   }
 
@@ -492,7 +492,7 @@ StatusOr<ObjectMetadata> CurlClient::CopyObject(
           UrlEscapeString(request.destination_object()),
       storage_factory_);
   auto status = SetupBuilder(builder, request, "POST");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
@@ -511,7 +511,7 @@ StatusOr<ObjectMetadata> CurlClient::GetObjectMetadata(
                                  "/o/" + UrlEscapeString(request.object_name()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   return ParseFromString<ObjectMetadata>(
@@ -520,9 +520,9 @@ StatusOr<ObjectMetadata> CurlClient::GetObjectMetadata(
 
 StatusOr<std::unique_ptr<ObjectReadStreambuf>> CurlClient::ReadObject(
     ReadObjectRangeRequest const& request) {
-  if (not request.HasOption<IfMetagenerationNotMatch>() and
-      not request.HasOption<IfGenerationNotMatch>() and
-      not request.HasOption<QuotaUser>() and not request.HasOption<UserIp>()) {
+  if (!request.HasOption<IfMetagenerationNotMatch>() &&
+      !request.HasOption<IfGenerationNotMatch>() &&
+      !request.HasOption<QuotaUser>() && !request.HasOption<UserIp>()) {
     return ReadObjectXml(request);
   }
   // Assume the bucket name is validated by the caller.
@@ -530,7 +530,7 @@ StatusOr<std::unique_ptr<ObjectReadStreambuf>> CurlClient::ReadObject(
                                  "/o/" + UrlEscapeString(request.object_name()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddQueryParameter("alt", "media");
@@ -555,15 +555,15 @@ StatusOr<std::unique_ptr<ObjectReadStreambuf>> CurlClient::ReadObject(
 
 StatusOr<std::unique_ptr<ObjectWriteStreambuf>> CurlClient::WriteObject(
     InsertObjectStreamingRequest const& request) {
-  if (not request.HasOption<IfMetagenerationNotMatch>() and
-      not request.HasOption<IfGenerationNotMatch>() and
-      not request.HasOption<QuotaUser>() and not request.HasOption<UserIp>() and
-      not request.HasOption<Projection>() and request.HasOption<Fields>() and
+  if (!request.HasOption<IfMetagenerationNotMatch>() &&
+      !request.HasOption<IfGenerationNotMatch>() &&
+      !request.HasOption<QuotaUser>() && !request.HasOption<UserIp>() &&
+      !request.HasOption<Projection>() && request.HasOption<Fields>() &&
       request.GetOption<Fields>().value().empty()) {
     return WriteObjectXml(request);
   }
 
-  if (request.HasOption<WithObjectMetadata>() or
+  if (request.HasOption<WithObjectMetadata>() ||
       request.HasOption<UseResumableUploadSession>()) {
     return WriteObjectResumable(request);
   }
@@ -578,7 +578,7 @@ StatusOr<ListObjectsResponse> CurlClient::ListObjects(
       storage_endpoint_ + "/b/" + request.bucket_name() + "/o",
       storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddQueryParameter("pageToken", request.page_token());
@@ -593,7 +593,7 @@ StatusOr<EmptyResponse> CurlClient::DeleteObject(
                                  "/o/" + UrlEscapeString(request.object_name()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "DELETE");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
@@ -605,7 +605,7 @@ StatusOr<ObjectMetadata> CurlClient::UpdateObject(
                                  "/o/" + UrlEscapeString(request.object_name()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PUT");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
@@ -619,7 +619,7 @@ StatusOr<ObjectMetadata> CurlClient::PatchObject(
                                  "/o/" + UrlEscapeString(request.object_name()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PATCH");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
@@ -634,7 +634,7 @@ StatusOr<ObjectMetadata> CurlClient::ComposeObject(
           UrlEscapeString(request.object_name()) + "/compose",
       storage_factory_);
   auto status = SetupBuilder(builder, request, "POST");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
@@ -651,10 +651,10 @@ StatusOr<RewriteObjectResponse> CurlClient::RewriteObject(
           UrlEscapeString(request.destination_object()),
       storage_factory_);
   auto status = SetupBuilder(builder, request, "POST");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
-  if (not request.rewrite_token().empty()) {
+  if (!request.rewrite_token().empty()) {
     builder.AddQueryParameter("rewriteToken", request.rewrite_token());
   }
   builder.AddHeader("Content-Type: application/json");
@@ -664,7 +664,7 @@ StatusOr<RewriteObjectResponse> CurlClient::RewriteObject(
         request.GetOption<WithObjectMetadata>().value().JsonPayloadForCopy();
   }
   auto response = builder.BuildRequest().MakeRequest(json_payload);
-  if (not response.ok()) {
+  if (!response.ok()) {
     return std::move(response).status();
   }
   if (response->status_code >= 300) {
@@ -698,11 +698,11 @@ StatusOr<ListBucketAclResponse> CurlClient::ListBucketAcl(
       storage_endpoint_ + "/b/" + request.bucket_name() + "/acl",
       storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   auto response = builder.BuildRequest().MakeRequest(std::string{});
-  if (not response.ok()) {
+  if (!response.ok()) {
     return std::move(response).status();
   }
   if (response->status_code >= 300) {
@@ -718,7 +718,7 @@ StatusOr<BucketAccessControl> CurlClient::GetBucketAcl(
                                  "/acl/" + UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   return ParseFromString<BucketAccessControl>(
@@ -731,7 +731,7 @@ StatusOr<BucketAccessControl> CurlClient::CreateBucketAcl(
       storage_endpoint_ + "/b/" + request.bucket_name() + "/acl",
       storage_factory_);
   auto status = SetupBuilder(builder, request, "POST");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
@@ -748,7 +748,7 @@ StatusOr<EmptyResponse> CurlClient::DeleteBucketAcl(
                                  "/acl/" + UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "DELETE");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
@@ -760,7 +760,7 @@ StatusOr<BucketAccessControl> CurlClient::UpdateBucketAcl(
                                  "/acl/" + UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PUT");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
@@ -777,7 +777,7 @@ StatusOr<BucketAccessControl> CurlClient::PatchBucketAcl(
                                  "/acl/" + UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PATCH");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
@@ -793,7 +793,7 @@ StatusOr<ListObjectAclResponse> CurlClient::ListObjectAcl(
           UrlEscapeString(request.object_name()) + "/acl",
       storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   return ParseFromHttpResponse<ListObjectAclResponse>(
@@ -807,7 +807,7 @@ StatusOr<ObjectAccessControl> CurlClient::CreateObjectAcl(
           UrlEscapeString(request.object_name()) + "/acl",
       storage_factory_);
   auto status = SetupBuilder(builder, request, "POST");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
@@ -826,7 +826,7 @@ StatusOr<EmptyResponse> CurlClient::DeleteObjectAcl(
                                  "/acl/" + UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "DELETE");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
@@ -840,7 +840,7 @@ StatusOr<ObjectAccessControl> CurlClient::GetObjectAcl(
                                  "/acl/" + UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   return ParseFromString<ObjectAccessControl>(
@@ -855,7 +855,7 @@ StatusOr<ObjectAccessControl> CurlClient::UpdateObjectAcl(
                                  "/acl/" + UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PUT");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
@@ -874,7 +874,7 @@ StatusOr<ObjectAccessControl> CurlClient::PatchObjectAcl(
                                  "/acl/" + UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PATCH");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
@@ -889,7 +889,7 @@ StatusOr<ListDefaultObjectAclResponse> CurlClient::ListDefaultObjectAcl(
       storage_endpoint_ + "/b/" + request.bucket_name() + "/defaultObjectAcl",
       storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   return ParseFromHttpResponse<ListDefaultObjectAclResponse>(
@@ -902,7 +902,7 @@ StatusOr<ObjectAccessControl> CurlClient::CreateDefaultObjectAcl(
       storage_endpoint_ + "/b/" + request.bucket_name() + "/defaultObjectAcl",
       storage_factory_);
   auto status = SetupBuilder(builder, request, "POST");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   nl::json object;
@@ -920,7 +920,7 @@ StatusOr<EmptyResponse> CurlClient::DeleteDefaultObjectAcl(
                                  UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "DELETE");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
@@ -933,7 +933,7 @@ StatusOr<ObjectAccessControl> CurlClient::GetDefaultObjectAcl(
                                  UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   return ParseFromString<ObjectAccessControl>(
@@ -947,7 +947,7 @@ StatusOr<ObjectAccessControl> CurlClient::UpdateDefaultObjectAcl(
                                  UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PUT");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
@@ -965,7 +965,7 @@ StatusOr<ObjectAccessControl> CurlClient::PatchDefaultObjectAcl(
                                  UrlEscapeString(request.entity()),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "PATCH");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
@@ -979,7 +979,7 @@ StatusOr<ServiceAccount> CurlClient::GetServiceAccount(
                                  request.project_id() + "/serviceAccount",
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   return ParseFromString<ServiceAccount>(
@@ -993,7 +993,7 @@ StatusOr<ListNotificationsResponse> CurlClient::ListNotifications(
                                  "/notificationConfigs",
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   return ParseFromHttpResponse<ListNotificationsResponse>(
@@ -1006,7 +1006,7 @@ StatusOr<NotificationMetadata> CurlClient::CreateNotification(
                                  "/notificationConfigs",
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "POST");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
@@ -1021,7 +1021,7 @@ StatusOr<NotificationMetadata> CurlClient::GetNotification(
                                  request.notification_id(),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "GET");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   return ParseFromString<NotificationMetadata>(
@@ -1035,7 +1035,7 @@ StatusOr<EmptyResponse> CurlClient::DeleteNotification(
                                  request.notification_id(),
                              storage_factory_);
   auto status = SetupBuilder(builder, request, "DELETE");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
@@ -1052,7 +1052,7 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaXml(
                                  UrlEscapeString(request.object_name()),
                              xml_upload_factory_);
   auto status = SetupBuilderCommon(builder, "PUT");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("Host: storage.googleapis.com");
@@ -1064,7 +1064,7 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaXml(
   builder.AddOption(request.GetOption<ContentEncoding>());
   // Set the content type of a sensible value, the application can override this
   // in the options for the request.
-  if (not request.HasOption<ContentType>()) {
+  if (!request.HasOption<ContentType>()) {
     builder.AddHeader("content-type: application/octet-stream");
   } else {
     builder.AddOption(request.GetOption<ContentType>());
@@ -1089,13 +1089,13 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaXml(
   if (request.HasOption<MD5HashValue>()) {
     builder.AddHeader("x-goog-hash: md5=" +
                       request.GetOption<MD5HashValue>().value());
-  } else if (not request.HasOption<DisableMD5Hash>()) {
+  } else if (!request.HasOption<DisableMD5Hash>()) {
     builder.AddHeader("x-goog-hash: md5=" + ComputeMD5Hash(request.contents()));
   }
   if (request.HasOption<Crc32cChecksumValue>()) {
     builder.AddHeader("x-goog-hash: crc32c=" +
                       request.GetOption<Crc32cChecksumValue>().value());
-  } else if (not request.HasOption<DisableCrc32cChecksum>()) {
+  } else if (!request.HasOption<DisableCrc32cChecksum>()) {
     builder.AddHeader("x-goog-hash: crc32c=" +
                       ComputeCrc32cChecksum(request.contents()));
   }
@@ -1120,7 +1120,7 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaXml(
   builder.AddHeader("Content-Length: " +
                     std::to_string(request.contents().size()));
   auto response = builder.BuildRequest().MakeRequest(request.contents());
-  if (not response.ok()) {
+  if (!response.ok()) {
     return std::move(response).status();
   }
   if (response->status_code >= 300) {
@@ -1139,7 +1139,7 @@ StatusOr<std::unique_ptr<ObjectReadStreambuf>> CurlClient::ReadObjectXml(
                                  UrlEscapeString(request.object_name()),
                              xml_download_factory_);
   auto status = SetupBuilderCommon(builder, "GET");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("Host: storage.googleapis.com");
@@ -1200,7 +1200,7 @@ StatusOr<std::unique_ptr<ObjectWriteStreambuf>> CurlClient::WriteObjectXml(
                                  UrlEscapeString(request.object_name()),
                              xml_upload_factory_);
   auto status = SetupBuilderCommon(builder, "PUT");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   builder.AddHeader("Host: storage.googleapis.com");
@@ -1212,7 +1212,7 @@ StatusOr<std::unique_ptr<ObjectWriteStreambuf>> CurlClient::WriteObjectXml(
   builder.AddOption(request.GetOption<ContentEncoding>());
   // Set the content type of a sensible value, the application can override this
   // in the options for the request.
-  if (not request.HasOption<ContentType>()) {
+  if (!request.HasOption<ContentType>()) {
     builder.AddHeader("content-type: application/octet-stream");
   } else {
     builder.AddOption(request.GetOption<ContentType>());
@@ -1268,7 +1268,7 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaMultipart(
   CurlRequestBuilder builder(
       upload_endpoint_ + "/b/" + request.bucket_name() + "/o", upload_factory_);
   auto status = SetupBuilder(builder, request, "POST");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
 
@@ -1351,12 +1351,12 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaSimple(
   CurlRequestBuilder builder(
       upload_endpoint_ + "/b/" + request.bucket_name() + "/o", upload_factory_);
   auto status = SetupBuilder(builder, request, "POST");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   // Set the content type of a sensible value, the application can override this
   // in the options for the request.
-  if (not request.HasOption<ContentType>()) {
+  if (!request.HasOption<ContentType>()) {
     builder.AddHeader("content-type: application/octet-stream");
   }
   builder.AddQueryParameter("uploadType", "media");
@@ -1372,13 +1372,13 @@ StatusOr<std::unique_ptr<ObjectWriteStreambuf>> CurlClient::WriteObjectSimple(
   auto url = upload_endpoint_ + "/b/" + request.bucket_name() + "/o";
   CurlRequestBuilder builder(url, upload_factory_);
   auto status = SetupBuilder(builder, request, "POST");
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
 
   // Set the content type of a sensible value, the application can override this
   // in the options for the request.
-  if (not request.HasOption<ContentType>()) {
+  if (!request.HasOption<ContentType>()) {
     builder.AddHeader("content-type: application/octet-stream");
   }
   builder.AddQueryParameter("uploadType", "media");
@@ -1393,7 +1393,7 @@ StatusOr<std::unique_ptr<ObjectWriteStreambuf>> CurlClient::WriteObjectSimple(
 StatusOr<std::unique_ptr<ObjectWriteStreambuf>>
 CurlClient::WriteObjectResumable(InsertObjectStreamingRequest const& request) {
   auto session = CreateResumableSessionGeneric(request);
-  if (not session.ok()) {
+  if (!session.ok()) {
     return std::move(session).status();
   }
 

--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -43,19 +43,19 @@ StatusOr<HttpResponse> CurlDownloadRequest::Close() {
   closing_ = true;
   // Block until that callback is made.
   auto status = Wait([this] { return curl_closed_; });
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
 
   // Now remove the handle from the CURLM* interface and wait for the response.
   auto error = curl_multi_remove_handle(multi_.get(), handle_.handle_.get());
   status = AsStatus(error, __func__);
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
 
   StatusOr<long> http_code = handle_.GetResponseCode();
-  if (not http_code.ok()) {
+  if (!http_code.ok()) {
     return http_code.status();
   }
   return HttpResponse{http_code.value(), std::string{},
@@ -65,9 +65,9 @@ StatusOr<HttpResponse> CurlDownloadRequest::Close() {
 StatusOr<HttpResponse> CurlDownloadRequest::GetMore(std::string& buffer) {
   handle_.FlushDebug(__func__);
   auto status = Wait([this] {
-    return curl_closed_ or buffer_.size() >= initial_buffer_size_;
+    return curl_closed_ || buffer_.size() >= initial_buffer_size_;
   });
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   GCP_LOG(DEBUG) << __func__ << "(), curl.size=" << buffer_.size()
@@ -76,14 +76,14 @@ StatusOr<HttpResponse> CurlDownloadRequest::GetMore(std::string& buffer) {
     // Remove the handle from the CURLM* interface and wait for the response.
     auto error = curl_multi_remove_handle(multi_.get(), handle_.handle_.get());
     status = AsStatus(error, __func__);
-    if (not status.ok()) {
+    if (!status.ok()) {
       return status;
     }
 
     buffer_.swap(buffer);
     buffer_.clear();
     StatusOr<long> http_code = handle_.GetResponseCode();
-    if (not http_code.ok()) {
+    if (!http_code.ok()) {
       return std::move(http_code).status();
     }
     GCP_LOG(DEBUG) << __func__ << "(), size=" << buffer.size()
@@ -96,7 +96,7 @@ StatusOr<HttpResponse> CurlDownloadRequest::GetMore(std::string& buffer) {
   buffer_.clear();
   buffer_.reserve(initial_buffer_size_);
   status = handle_.EasyPause(CURLPAUSE_RECV_CONT);
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   GCP_LOG(DEBUG) << __func__ << "(), size=" << buffer.size()
@@ -119,7 +119,7 @@ void CurlDownloadRequest::ResetOptions() {
   handle_.SetOption(CURLOPT_URL, url_.c_str());
   handle_.SetOption(CURLOPT_HTTPHEADER, headers_.get());
   handle_.SetOption(CURLOPT_USERAGENT, user_agent_.c_str());
-  if (not payload_.empty()) {
+  if (!payload_.empty()) {
     handle_.SetOption(CURLOPT_POSTFIELDSIZE, payload_.length());
     handle_.SetOption(CURLOPT_POSTFIELDS, payload_.c_str());
   }
@@ -167,7 +167,7 @@ StatusOr<int> CurlDownloadRequest::PerformWork() {
 
   // Throw an exception if the result is unexpected, otherwise return.
   auto status = AsStatus(result, __func__);
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   if (running_handles == 0) {
@@ -206,7 +206,7 @@ Status CurlDownloadRequest::WaitForHandles(int& repeats) {
   GCP_LOG(DEBUG) << __func__ << "(): numfds=" << numfds << ", result=" << result
                  << ", repeats=" << repeats;
   Status status = AsStatus(result, __func__);
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   // The documentation for curl_multi_wait() recommends sleeping if it returns

--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -39,7 +39,7 @@ class CurlDownloadRequest {
   explicit CurlDownloadRequest(std::size_t initial_buffer_size);
 
   ~CurlDownloadRequest() {
-    if (not factory_) {
+    if (!factory_) {
       return;
     }
     factory_->CleanupHandle(std::move(handle_.handle_));
@@ -77,7 +77,7 @@ class CurlDownloadRequest {
     return *this;
   }
 
-  bool IsOpen() const { return not curl_closed_; }
+  bool IsOpen() const { return !curl_closed_; }
   StatusOr<HttpResponse> Close();
 
   /**
@@ -110,23 +110,23 @@ class CurlDownloadRequest {
     // We can assert that the current thread is the leader, because the
     // predicate is satisfied, and the condition variable exited. Therefore,
     // this thread must run the I/O event loop.
-    while (not predicate()) {
+    while (!predicate()) {
       handle_.FlushDebug(__func__);
       GCP_LOG(DEBUG) << __func__ << "() predicate is false"
                      << ", curl.size=" << buffer_.size();
       auto running_handles = PerformWork();
-      if (not running_handles.ok()) {
+      if (!running_handles.ok()) {
         return std::move(running_handles).status();
       }
       // Only wait if there are CURL handles with pending work *and* the
       // predicate is not satisfied. Note that if the predicate is ill-defined
       // it might continue to be unsatisfied even though the handles have
       // completed their work.
-      if (*running_handles == 0 or predicate()) {
+      if (*running_handles == 0 || predicate()) {
         return Status();
       }
       auto status = WaitForHandles(repeats);
-      if (not status.ok()) {
+      if (!status.ok()) {
         return status;
       }
     }

--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -139,7 +139,7 @@ void CurlHandle::EnableLogging(bool enabled) {
 }
 
 void CurlHandle::FlushDebug(char const* where) {
-  if (not debug_buffer_.empty()) {
+  if (!debug_buffer_.empty()) {
     GCP_LOG(DEBUG) << where << ' ' << debug_buffer_;
     debug_buffer_.clear();
   }

--- a/google/cloud/storage/internal/curl_handle_factory.cc
+++ b/google/cloud/storage/internal/curl_handle_factory.cc
@@ -36,7 +36,7 @@ CurlPtr DefaultCurlHandleFactory::CreateHandle() {
 void DefaultCurlHandleFactory::CleanupHandle(CurlPtr&& h) {
   char* ip;
   auto res = curl_easy_getinfo(h.get(), CURLINFO_LOCAL_IP, &ip);
-  if (res == CURLE_OK and ip != nullptr) {
+  if (res == CURLE_OK && ip != nullptr) {
     std::lock_guard<std::mutex> lk(mu_);
     last_client_ip_address_ = ip;
   }
@@ -67,7 +67,7 @@ PooledCurlHandleFactory::~PooledCurlHandleFactory() {
 
 CurlPtr PooledCurlHandleFactory::CreateHandle() {
   std::unique_lock<std::mutex> lk(mu_);
-  if (not handles_.empty()) {
+  if (!handles_.empty()) {
     CURL* handle = handles_.back();
     // Clear all the options in the handle so we do not leak its previous state.
     (void)curl_easy_reset(handle);
@@ -81,7 +81,7 @@ void PooledCurlHandleFactory::CleanupHandle(CurlPtr&& h) {
   std::unique_lock<std::mutex> lk(mu_);
   char* ip;
   auto res = curl_easy_getinfo(h.get(), CURLINFO_LOCAL_IP, &ip);
-  if (res == CURLE_OK and ip != nullptr) {
+  if (res == CURLE_OK && ip != nullptr) {
     last_client_ip_address_ = ip;
   }
   if (handles_.size() >= maximum_size_) {
@@ -96,7 +96,7 @@ void PooledCurlHandleFactory::CleanupHandle(CurlPtr&& h) {
 
 CurlMulti PooledCurlHandleFactory::CreateMultiHandle() {
   std::unique_lock<std::mutex> lk(mu_);
-  if (not multi_handles_.empty()) {
+  if (!multi_handles_.empty()) {
     CURL* m = multi_handles_.back();
     multi_handles_.pop_back();
     return CurlMulti(m, &curl_multi_cleanup);

--- a/google/cloud/storage/internal/curl_request.cc
+++ b/google/cloud/storage/internal/curl_request.cc
@@ -23,17 +23,17 @@ namespace internal {
 CurlRequest::CurlRequest() : headers_(nullptr, &curl_slist_free_all) {}
 
 StatusOr<HttpResponse> CurlRequest::MakeRequest(std::string const& payload) {
-  if (not payload.empty()) {
+  if (!payload.empty()) {
     handle_.SetOption(CURLOPT_POSTFIELDSIZE, payload.length());
     handle_.SetOption(CURLOPT_POSTFIELDS, payload.c_str());
   }
   auto status = handle_.EasyPerform();
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   handle_.FlushDebug(__func__);
   auto code = handle_.GetResponseCode();
-  if (not code.ok()) {
+  if (!code.ok()) {
     return std::move(code).status();
   }
   return HttpResponse{code.value(), std::move(response_payload_),

--- a/google/cloud/storage/internal/curl_request.h
+++ b/google/cloud/storage/internal/curl_request.h
@@ -36,7 +36,7 @@ class CurlRequest {
   CurlRequest();
 
   ~CurlRequest() {
-    if (not factory_) {
+    if (!factory_) {
       return;
     }
     factory_->CleanupHandle(std::move(handle_.handle_));

--- a/google/cloud/storage/internal/curl_request_builder.h
+++ b/google/cloud/storage/internal/curl_request_builder.h
@@ -83,7 +83,7 @@ class CurlRequestBuilder {
   /// Adds one of the well-known parameters as a query parameter
   template <typename P>
   CurlRequestBuilder& AddOption(WellKnownParameter<P, bool> const& p) {
-    if (not p.has_value()) {
+    if (!p.has_value()) {
       return *this;
     }
     AddQueryParameter(p.parameter_name(), p.value() ? "true" : "false");

--- a/google/cloud/storage/internal/curl_resumable_streambuf.cc
+++ b/google/cloud/storage/internal/curl_resumable_streambuf.cc
@@ -38,18 +38,18 @@ bool CurlResumableStreambuf::IsOpen() const {
 bool CurlResumableStreambuf::ValidateHash(ObjectMetadata const& meta) {
   hash_validator_->ProcessMetadata(meta);
   hash_validator_result_ = std::move(*hash_validator_).Finish();
-  return not hash_validator_result_.is_mismatch;
+  return !hash_validator_result_.is_mismatch;
 }
 
 CurlResumableStreambuf::int_type CurlResumableStreambuf::overflow(int_type ch) {
-  if (not IsOpen()) {
+  if (!IsOpen()) {
     return traits_type::eof();
   }
   auto status = Flush(false);
-  if (not status.ok()) {
+  if (!status.ok()) {
     return traits_type::eof();
   }
-  if (not traits_type::eq_int_type(ch, traits_type::eof())) {
+  if (!traits_type::eq_int_type(ch, traits_type::eof())) {
     current_ios_buffer_.push_back(traits_type::to_char_type(ch));
     pbump(1);
   }
@@ -58,7 +58,7 @@ CurlResumableStreambuf::int_type CurlResumableStreambuf::overflow(int_type ch) {
 
 int CurlResumableStreambuf::sync() {
   auto status = Flush(false);
-  if (not status.ok()) {
+  if (!status.ok()) {
     return traits_type::eof();
   }
   return 0;
@@ -66,11 +66,11 @@ int CurlResumableStreambuf::sync() {
 
 std::streamsize CurlResumableStreambuf::xsputn(char const* s,
                                                std::streamsize count) {
-  if (not IsOpen()) {
+  if (!IsOpen()) {
     return traits_type::eof();
   }
   auto status = Flush(false);
-  if (not status.ok()) {
+  if (!status.ok()) {
     return traits_type::eof();
   }
 
@@ -85,7 +85,7 @@ StatusOr<HttpResponse> CurlResumableStreambuf::DoClose() {
 }
 
 StatusOr<HttpResponse> CurlResumableStreambuf::Flush(bool final_chunk) {
-  if (not IsOpen()) {
+  if (!IsOpen()) {
     return last_response_;
   }
   // Shorten the buffer to the actual used size.
@@ -93,7 +93,7 @@ StatusOr<HttpResponse> CurlResumableStreambuf::Flush(bool final_chunk) {
   if (actual_size == 0) {
     return last_response_;
   }
-  if (actual_size <= max_buffer_size_ and not final_chunk) {
+  if (actual_size <= max_buffer_size_ && !final_chunk) {
     return last_response_;
   }
 
@@ -110,7 +110,7 @@ StatusOr<HttpResponse> CurlResumableStreambuf::Flush(bool final_chunk) {
   hash_validator_->Update(current_ios_buffer_);
 
   auto result = upload_session_->UploadChunk(current_ios_buffer_, upload_size);
-  if (not result.ok()) {
+  if (!result.ok()) {
     // This was an unrecoverable error, time to signal an error.
     return std::move(result).status();
   }

--- a/google/cloud/storage/internal/curl_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.cc
@@ -43,7 +43,7 @@ std::uint64_t CurlResumableUploadSession::next_expected_byte() const {
 
 void CurlResumableUploadSession::Update(
     StatusOr<ResumableUploadResponse> const& result) {
-  if (not result.ok()) {
+  if (!result.ok()) {
     return;
   }
   if (result->last_committed_byte == 0) {
@@ -51,7 +51,7 @@ void CurlResumableUploadSession::Update(
   } else {
     next_expected_ = result->last_committed_byte + 1;
   }
-  if (not result->upload_session_url.empty()) {
+  if (!result->upload_session_url.empty()) {
     session_id_ = result->upload_session_url;
   }
 }

--- a/google/cloud/storage/internal/curl_streambuf.cc
+++ b/google/cloud/storage/internal/curl_streambuf.cc
@@ -38,7 +38,7 @@ bool CurlReadStreambuf::IsOpen() const { return download_.IsOpen(); }
 
 void CurlReadStreambuf::Close() {
   auto response = download_.Close();
-  if (not response.ok()) {
+  if (!response.ok()) {
     status_ = std::move(response).status();
     ReportError(status_);
   }
@@ -64,7 +64,7 @@ CurlReadStreambuf::int_type CurlReadStreambuf::underflow() {
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   };
 
-  if (not IsOpen()) {
+  if (!IsOpen()) {
     // The stream is closed, reading from a closed stream can happen if there is
     // no object to read from, or the object is empty. In that case just setup
     // an empty (but valid) region and verify the checksums.
@@ -78,7 +78,7 @@ CurlReadStreambuf::int_type CurlReadStreambuf::underflow() {
 
   current_ios_buffer_.reserve(target_buffer_size_);
   StatusOr<HttpResponse> response = download_.GetMore(current_ios_buffer_);
-  if (not response.ok()) {
+  if (!response.ok()) {
     return ReportError(std::move(response).status());
   }
   for (auto const& kv : response->headers) {
@@ -89,7 +89,7 @@ CurlReadStreambuf::int_type CurlReadStreambuf::underflow() {
     return ReportError(AsStatus(*response));
   }
 
-  if (not current_ios_buffer_.empty()) {
+  if (!current_ios_buffer_.empty()) {
     hash_validator_->Update(current_ios_buffer_);
     char* data = &current_ios_buffer_[0];
     setg(data, data, data + current_ios_buffer_.size());
@@ -145,13 +145,13 @@ bool CurlWriteStreambuf::IsOpen() const { return upload_.IsOpen(); }
 bool CurlWriteStreambuf::ValidateHash(ObjectMetadata const& meta) {
   hash_validator_->ProcessMetadata(meta);
   hash_validator_result_ = std::move(*hash_validator_).Finish();
-  return not hash_validator_result_.is_mismatch;
+  return !hash_validator_result_.is_mismatch;
 }
 
 CurlWriteStreambuf::int_type CurlWriteStreambuf::overflow(int_type ch) {
   Validate(__func__);
   SwapBuffers();
-  if (not traits_type::eq_int_type(ch, traits_type::eof())) {
+  if (!traits_type::eq_int_type(ch, traits_type::eof())) {
     current_ios_buffer_.push_back(traits_type::to_char_type(ch));
     pbump(1);
   }
@@ -161,7 +161,7 @@ CurlWriteStreambuf::int_type CurlWriteStreambuf::overflow(int_type ch) {
 int CurlWriteStreambuf::sync() {
   // The default destructor calls sync(), for already closed streams this should
   // be a no-op.
-  if (not IsOpen()) {
+  if (!IsOpen()) {
     return 0;
   }
   SwapBuffers();
@@ -183,11 +183,11 @@ std::streamsize CurlWriteStreambuf::xsputn(char const* s,
 StatusOr<HttpResponse> CurlWriteStreambuf::DoClose() {
   GCP_LOG(DEBUG) << __func__ << "()";
   Status status = Validate(__func__);
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   status = SwapBuffers();
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   auto response = upload_.Close();
@@ -214,7 +214,7 @@ Status CurlWriteStreambuf::SwapBuffers() {
   // Push the buffer to the libcurl wrapper to be written as needed
   hash_validator_->Update(current_ios_buffer_);
   auto status = upload_.NextBuffer(current_ios_buffer_);
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   // Make the buffer big enough to receive more data before needing a flush.

--- a/google/cloud/storage/internal/curl_upload_request.cc
+++ b/google/cloud/storage/internal/curl_upload_request.cc
@@ -50,12 +50,12 @@ Status CurlUploadRequest::Flush() {
 
 StatusOr<HttpResponse> CurlUploadRequest::Close() {
   Status status = ValidateOpen(__func__);
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   handle_.FlushDebug(__func__);
   status = Flush();
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   // Set the the closing_ flag to trigger a return 0 from the next read
@@ -63,7 +63,7 @@ StatusOr<HttpResponse> CurlUploadRequest::Close() {
   closing_ = true;
   // Block until that callback is made.
   status = Wait([this] { return curl_closed_; });
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
 
@@ -74,7 +74,7 @@ StatusOr<HttpResponse> CurlUploadRequest::Close() {
   }
 
   StatusOr<long> http_code = handle_.GetResponseCode();
-  if (not http_code.ok()) {
+  if (!http_code.ok()) {
     return std::move(http_code).status();
   }
   return HttpResponse{http_code.value(), std::move(response_payload_),
@@ -83,7 +83,7 @@ StatusOr<HttpResponse> CurlUploadRequest::Close() {
 
 Status CurlUploadRequest::NextBuffer(std::string& next_buffer) {
   Status status = ValidateOpen(__func__);
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   status = Flush();
@@ -231,7 +231,7 @@ Status CurlUploadRequest::AsStatus(CURLMcode result, char const* where) {
 }
 
 Status CurlUploadRequest::ValidateOpen(char const* where) {
-  if (not closing_) {
+  if (!closing_) {
     return Status();
   }
   std::string msg = "Attempting to use closed CurlUploadRequest in ";

--- a/google/cloud/storage/internal/curl_upload_request.h
+++ b/google/cloud/storage/internal/curl_upload_request.h
@@ -40,7 +40,7 @@ class CurlUploadRequest {
   explicit CurlUploadRequest(std::size_t initial_buffer_size);
 
   ~CurlUploadRequest() {
-    if (not factory_) {
+    if (!factory_) {
       return;
     }
     factory_->CleanupHandle(std::move(handle_.handle_));
@@ -78,7 +78,7 @@ class CurlUploadRequest {
     return *this;
   }
 
-  bool IsOpen() const { return not closing_; }
+  bool IsOpen() const { return !closing_; }
 
   /// Blocks until the current buffer has been transferred.
   Status Flush();
@@ -112,7 +112,7 @@ class CurlUploadRequest {
     // We can assert that the current thread is the leader, because the
     // predicate is satisfied, and the condition variable exited. Therefore,
     // this thread must run the I/O event loop.
-    while (not predicate()) {
+    while (!predicate()) {
       handle_.FlushDebug(__func__);
       GCP_LOG(DEBUG) << __func__ << "() predicate is false"
                      << ", curl.size=" << buffer_.size() << ", curl.rdptr="
@@ -120,18 +120,18 @@ class CurlUploadRequest {
                      << ", curl.end="
                      << std::distance(buffer_.begin(), buffer_.end());
       auto running_handles = PerformWork();
-      if (not running_handles.ok()) {
+      if (!running_handles.ok()) {
         return std::move(running_handles).status();
       }
       // Only wait if there are CURL handles with pending work *and* the
       // predicate is not satisfied. Note that if the predicate is ill-defined
       // it might continue to be unsatisfied even though the handles have
       // completed their work.
-      if (*running_handles == 0 or predicate()) {
+      if (*running_handles == 0 || predicate()) {
         return Status();
       }
       auto status = WaitForHandles(repeats);
-      if (not status.ok()) {
+      if (!status.ok()) {
         return status;
       }
     }

--- a/google/cloud/storage/internal/curl_wrappers.cc
+++ b/google/cloud/storage/internal/curl_wrappers.cc
@@ -66,12 +66,12 @@ void InitializeSslLocking(bool enable_ssl_callbacks) {
   // Only enable the lock callbacks if needed. We need to look at what SSL
   // library is used by libcurl.  Many of them work fine without any additional
   // setup.
-  if (not SslLibraryNeedsLocking(curl_ssl)) {
+  if (!SslLibraryNeedsLocking(curl_ssl)) {
     GCP_LOG(INFO) << "SSL locking callbacks not installed because the"
                   << " SSL library does not need them.";
     return;
   }
-  if (not enable_ssl_callbacks) {
+  if (!enable_ssl_callbacks) {
     GCP_LOG(INFO) << "SSL locking callbacks not installed because the"
                   << " application disabled them.";
     return;
@@ -182,7 +182,7 @@ bool SslLibraryNeedsLocking(std::string const& curl_ssl_id) {
 
 bool SslLockingCallbacksInstalled() {
 #if GOOGLE_CLOUD_CPP_SSL_REQUIRES_LOCKS
-  return not ssl_locks.empty();
+  return !ssl_locks.empty();
 #else
   return false;
 #endif  // GOOGLE_CLOUD_CPP_SSL_REQUIRES_LOCKS
@@ -194,7 +194,7 @@ std::size_t CurlAppendHeaderData(CurlReceivedHeaders& received_headers,
     // Empty header (including the \r\n), ignore.
     return size;
   }
-  if ('\r' != data[size - 2] or '\n' != data[size - 1]) {
+  if ('\r' != data[size - 2] || '\n' != data[size - 1]) {
     // Invalid header (should end in \r\n), ignore.
     return size;
   }

--- a/google/cloud/storage/internal/curl_wrappers_locking_already_present_test.cc
+++ b/google/cloud/storage/internal/curl_wrappers_locking_already_present_test.cc
@@ -27,7 +27,7 @@ extern "C" void test_cb(int mode, int type, char const* file, int line) {}
 
 /// @test Verify that installing the libraries
 TEST(CurlWrappers, LockingDisabledTest) {
-  if (not SslLibraryNeedsLocking(CurlSslLibraryId())) {
+  if (!SslLibraryNeedsLocking(CurlSslLibraryId())) {
     // The test cannot execute in this case.
     return;
   }

--- a/google/cloud/storage/internal/curl_wrappers_locking_disabled_test.cc
+++ b/google/cloud/storage/internal/curl_wrappers_locking_disabled_test.cc
@@ -23,7 +23,7 @@ namespace internal {
 namespace {
 /// @test Verify that installing the libraries
 TEST(CurlWrappers, LockingDisabledTest) {
-  if (not SslLibraryNeedsLocking(CurlSslLibraryId())) {
+  if (!SslLibraryNeedsLocking(CurlSslLibraryId())) {
     // The test cannot execute in this case.
     return;
   }

--- a/google/cloud/storage/internal/curl_wrappers_locking_enabled_test.cc
+++ b/google/cloud/storage/internal/curl_wrappers_locking_enabled_test.cc
@@ -23,7 +23,7 @@ namespace internal {
 namespace {
 /// @test Verify that installing the libraries
 TEST(CurlWrappers, LockingEnabledTest) {
-  if (not SslLibraryNeedsLocking(CurlSslLibraryId())) {
+  if (!SslLibraryNeedsLocking(CurlSslLibraryId())) {
     // The test cannot execute in this case.
     return;
   }

--- a/google/cloud/storage/internal/default_object_acl_requests.cc
+++ b/google/cloud/storage/internal/default_object_acl_requests.cc
@@ -31,13 +31,13 @@ std::ostream& operator<<(std::ostream& os,
 StatusOr<ListDefaultObjectAclResponse>
 ListDefaultObjectAclResponse::FromHttpResponse(HttpResponse&& response) {
   auto json = nl::json::parse(response.payload, nullptr, false);
-  if (not json.is_object()) {
+  if (!json.is_object()) {
     return Status(StatusCode::kInvalidArgument, __func__);
   }
   ListDefaultObjectAclResponse result;
   for (auto const& kv : json["items"].items()) {
     auto parsed = ObjectAccessControl::ParseFromJson(kv.value());
-    if (not parsed.ok()) {
+    if (!parsed.ok()) {
       return std::move(parsed).status();
     }
     result.items.emplace_back(std::move(*parsed));

--- a/google/cloud/storage/internal/generic_request.h
+++ b/google/cloud/storage/internal/generic_request.h
@@ -141,8 +141,8 @@ class GenericRequestBase : public GenericRequestBase<Derived, Options...> {
     return option_;
   }
 
-  template <typename O, typename std::enable_if<
-                            not std::is_same<O, Option>::value, int>::type = 0>
+  template <typename O, typename std::enable_if<!std::is_same<O, Option>::value,
+                                                int>::type = 0>
   O GetOption() const {
     return GenericRequestBase<Derived, Options...>::template GetOption<O>();
   }

--- a/google/cloud/storage/internal/hash_validator.cc
+++ b/google/cloud/storage/internal/hash_validator.cc
@@ -50,7 +50,7 @@ HashValidator::Result CompositeValidator::Finish() && {
   received += "," + right_->Name() + "=" + right_result.received;
   auto computed = left_->Name() + "=" + left_result.computed;
   computed += "," + right_->Name() + "=" + right_result.computed;
-  bool is_mismatch = left_result.is_mismatch or right_result.is_mismatch;
+  bool is_mismatch = left_result.is_mismatch || right_result.is_mismatch;
   return Result{std::move(received), std::move(computed), is_mismatch};
 }
 
@@ -91,8 +91,7 @@ HashValidator::Result MD5HashValidator::Finish() && {
   std::string hash(MD5_DIGEST_LENGTH, ' ');
   MD5_Final(reinterpret_cast<unsigned char*>(&hash[0]), &context_);
   auto computed = OpenSslUtils::Base64Encode(hash);
-  bool is_mismatch =
-      not received_hash_.empty() and (received_hash_ != computed);
+  bool is_mismatch = !received_hash_.empty() && (received_hash_ != computed);
   return Result{std::move(received_hash_), std::move(computed), is_mismatch};
 }
 
@@ -137,8 +136,7 @@ HashValidator::Result Crc32cHashValidator::Finish() && {
   hash.resize(sizeof(big_endian));
   std::memcpy(&hash[0], &big_endian, sizeof(big_endian));
   auto computed = OpenSslUtils::Base64Encode(hash);
-  bool is_mismatch =
-      not received_hash_.empty() and (received_hash_ != computed);
+  bool is_mismatch = !received_hash_.empty() && (received_hash_ != computed);
   return Result{std::move(received_hash_), std::move(computed), is_mismatch};
 }
 

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -201,7 +201,7 @@ StatusOr<std::unique_ptr<ResumableUploadSession>>
 LoggingClient::CreateResumableSession(ResumableUploadRequest const& request) {
   auto result = MakeCallNoResponseLogging(
       *client_, &RawClient::CreateResumableSession, request, __func__);
-  if (not result.ok()) {
+  if (!result.ok()) {
     return std::move(result).status();
   }
   return std::unique_ptr<ResumableUploadSession>(

--- a/google/cloud/storage/internal/notification_requests.cc
+++ b/google/cloud/storage/internal/notification_requests.cc
@@ -29,13 +29,13 @@ std::ostream& operator<<(std::ostream& os, ListNotificationsRequest const& r) {
 StatusOr<ListNotificationsResponse> ListNotificationsResponse::FromHttpResponse(
     HttpResponse&& response) {
   auto json = nl::json::parse(response.payload, nullptr, false);
-  if (not json.is_object()) {
+  if (!json.is_object()) {
     return Status(StatusCode::kInvalidArgument, __func__);
   }
   ListNotificationsResponse result;
   for (auto const& kv : json["items"].items()) {
     auto parsed = NotificationMetadata::ParseFromJson(kv.value());
-    if (not parsed.ok()) {
+    if (!parsed.ok()) {
       return std::move(parsed).status();
     }
     result.items.emplace_back(std::move(*parsed));

--- a/google/cloud/storage/internal/object_acl_requests.cc
+++ b/google/cloud/storage/internal/object_acl_requests.cc
@@ -32,13 +32,13 @@ std::ostream& operator<<(std::ostream& os, ListObjectAclRequest const& r) {
 StatusOr<ListObjectAclResponse> ListObjectAclResponse::FromHttpResponse(
     HttpResponse&& response) {
   auto json = nl::json::parse(response.payload, nullptr, false);
-  if (not json.is_object()) {
+  if (!json.is_object()) {
     return Status(StatusCode::kInvalidArgument, __func__);
   }
   ListObjectAclResponse result;
   for (auto const& kv : json["items"].items()) {
     auto parsed = ObjectAccessControl::ParseFromJson(kv.value());
-    if (not parsed.ok()) {
+    if (!parsed.ok()) {
       return std::move(parsed).status();
     }
     result.items.emplace_back(std::move(*parsed));

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -34,7 +34,7 @@ StatusOr<ListObjectsResponse> ListObjectsResponse::FromHttpResponse(
     HttpResponse&& response) {
   auto json =
       storage::internal::nl::json::parse(response.payload, nullptr, false);
-  if (not json.is_object()) {
+  if (!json.is_object()) {
     return Status(StatusCode::kInvalidArgument, __func__);
   }
 
@@ -43,7 +43,7 @@ StatusOr<ListObjectsResponse> ListObjectsResponse::FromHttpResponse(
 
   for (auto const& kv : json["items"].items()) {
     auto parsed = ObjectMetadata::ParseFromJson(kv.value());
-    if (not parsed.ok()) {
+    if (!parsed.ok()) {
       return std::move(parsed).status();
     }
     result.items.emplace_back(std::move(*parsed));
@@ -130,7 +130,7 @@ ReadObjectRangeResponse ReadObjectRangeResponse::FromHttpResponse(
     raise_error();
   }
 
-  if (buffer[0] == '*' and buffer[1] == '/') {
+  if (buffer[0] == '*' && buffer[1] == '/') {
     // The header is just the indication of size ('bytes */<size>'), parse that.
     buffer += 2;
     long long object_size;
@@ -315,7 +315,7 @@ std::ostream& operator<<(std::ostream& os, RewriteObjectRequest const& r) {
 StatusOr<RewriteObjectResponse> RewriteObjectResponse::FromHttpResponse(
     HttpResponse const& response) {
   nl::json object = nl::json::parse(response.payload, nullptr, false);
-  if (not object.is_object()) {
+  if (!object.is_object()) {
     return Status(StatusCode::kInvalidArgument, __func__);
   }
 
@@ -327,7 +327,7 @@ StatusOr<RewriteObjectResponse> RewriteObjectResponse::FromHttpResponse(
   result.rewrite_token = object.value("rewriteToken", "");
   if (object.count("resource") != 0U) {
     auto parsed = ObjectMetadata::ParseFromJson(object["resource"]);
-    if (not parsed.ok()) {
+    if (!parsed.ok()) {
       return std::move(parsed).status();
     }
     result.resource = std::move(*parsed);
@@ -410,7 +410,7 @@ StatusOr<ResumableUploadResponse> ResumableUploadResponse::FromHttpResponse(
   char const* buffer = range.data() + 8;
   char* endptr;
   auto last = std::strtoll(buffer, &endptr, 10);
-  if (*endptr == '\0' and 0 <= last) {
+  if (*endptr == '\0' && 0 <= last) {
     result.last_committed_byte = static_cast<std::uint64_t>(last);
   }
 

--- a/google/cloud/storage/internal/openssl_util.cc
+++ b/google/cloud/storage/internal/openssl_util.cc
@@ -49,13 +49,13 @@ std::string OpenSslUtils::Base64Decode(std::string const& str) {
   UniqueBioPtr source(BIO_new_mem_buf(const_cast<char*>(str.data()),
                                       static_cast<int>(str.size())),
                       &BIO_free);
-  if (not source) {
+  if (!source) {
     std::ostringstream os;
     os << __func__ << ": cannot create BIO for source string=<" << str << ">";
     google::cloud::internal::ThrowRuntimeError(os.str());
   }
   UniqueBioPtr filter(BIO_new(BIO_f_base64()), &BIO_free);
-  if (not filter) {
+  if (!filter) {
     std::ostringstream os;
     os << __func__ << ": cannot create BIO for Base64 decoding";
     google::cloud::internal::ThrowRuntimeError(os.str());
@@ -102,7 +102,7 @@ std::string OpenSslUtils::Base64Encode(std::string const& str) {
     if (retval > 0) {
       break;  // Positive value == successful write.
     }
-    if (not BIO_should_retry(static_cast<BIO*>(bio_chain.get()))) {
+    if (!BIO_should_retry(static_cast<BIO*>(bio_chain.get()))) {
       std::ostringstream err_builder;
       err_builder << "Permanent error in " << __func__ << ": "
                   << "BIO_write returned non-retryable value of " << retval;
@@ -116,7 +116,7 @@ std::string OpenSslUtils::Base64Encode(std::string const& str) {
     if (retval > 0) {
       break;  // Positive value == successful flush.
     }
-    if (not BIO_should_retry(static_cast<BIO*>(bio_chain.get()))) {
+    if (!BIO_should_retry(static_cast<BIO*>(bio_chain.get()))) {
       std::ostringstream err_builder;
       err_builder << "Permanent error in " << __func__ << ": "
                   << "BIO_flush returned non-retryable value of " << retval;

--- a/google/cloud/storage/internal/openssl_util.h
+++ b/google/cloud/storage/internal/openssl_util.h
@@ -85,7 +85,7 @@ struct OpenSslUtils {
     };
 
     auto digest_ctx = GetDigestCtx();
-    if (not digest_ctx) {
+    if (!digest_ctx) {
       handle_openssl_failure("Could not create context for OpenSSL digest.");
     }
 
@@ -103,7 +103,7 @@ struct OpenSslUtils {
         BIO_new_mem_buf(const_cast<char*>(pem_contents.c_str()),
                         static_cast<int>(pem_contents.length())),
         &BIO_free);
-    if (not pem_buffer) handle_openssl_failure("Could not create PEM buffer.");
+    if (!pem_buffer) handle_openssl_failure("Could not create PEM buffer.");
 
     auto private_key = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>(
         PEM_read_bio_PrivateKey(
@@ -115,7 +115,7 @@ struct OpenSslUtils {
             // a password, which we don't currently support.
             nullptr),
         &EVP_PKEY_free);
-    if (not private_key) {
+    if (!private_key) {
       handle_openssl_failure("Could not parse PEM to get private key.");
     }
 
@@ -179,7 +179,7 @@ struct OpenSslUtils {
         BIO_new(BIO_f_base64()), &BIO_free);
     auto mem_io = std::unique_ptr<BIO, decltype(&BIO_free)>(
         BIO_new(BIO_s_mem()), &BIO_free);
-    if (not(base64_io and mem_io)) {
+    if (!(base64_io && mem_io)) {
       std::ostringstream err_builder;
       err_builder << "Permanent error in " << __func__ << ": "
                   << "Could not allocate BIO* for Base64 encoding.";

--- a/google/cloud/storage/internal/parse_rfc3339.cc
+++ b/google/cloud/storage/internal/parse_rfc3339.cc
@@ -30,7 +30,7 @@ namespace {
 }
 
 bool IsLeapYear(int year) {
-  return (year % 4 == 0 and (year % 100 != 0 or year % 400 == 0));
+  return (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0));
 }
 
 std::chrono::system_clock::time_point ParseDateTime(
@@ -49,15 +49,15 @@ std::chrono::system_clock::time_point ParseDateTime(
   // All the fields up to this point have fixed width, so total width must be:
   constexpr int EXPECTED_WIDTH = 19;
   constexpr int EXPECTED_FIELDS = 7;
-  if (count != EXPECTED_FIELDS or pos != EXPECTED_WIDTH) {
+  if (count != EXPECTED_FIELDS || pos != EXPECTED_WIDTH) {
     ReportError(timestamp,
                 "Invalid format for RFC 3339 timestamp detected while parsing"
                 " the base date and time portion.");
   }
-  if (date_time_separator != 'T' and date_time_separator != 't') {
+  if (date_time_separator != 'T' && date_time_separator != 't') {
     ReportError(timestamp, "Invalid date-time separator, expected 'T' or 't'.");
   }
-  if (month < 1 or month > 12) {
+  if (month < 1 || month > 12) {
     ReportError(timestamp, "Out of range month.");
   }
   constexpr int MAX_DAYS_IN_MONTH[] = {
@@ -74,16 +74,16 @@ std::chrono::system_clock::time_point ParseDateTime(
       30,  // November
       31,  // December
   };
-  if (day < 1 or day > MAX_DAYS_IN_MONTH[month - 1]) {
+  if (day < 1 || day > MAX_DAYS_IN_MONTH[month - 1]) {
     ReportError(timestamp, "Out of range day for given month.");
   }
-  if (2 == month and day > 28 and not IsLeapYear(year)) {
+  if (2 == month && day > 28 && !IsLeapYear(year)) {
     ReportError(timestamp, "Out of range day for given month.");
   }
-  if (hours < 0 or hours > 23) {
+  if (hours < 0 || hours > 23) {
     ReportError(timestamp, "Out of range hour.");
   }
-  if (minutes < 0 or minutes > 59) {
+  if (minutes < 0 || minutes > 59) {
     ReportError(timestamp, "Out of range minute.");
   }
   // RFC-3339 points out that the seconds field can only assume value '60' for
@@ -91,7 +91,7 @@ std::chrono::system_clock::time_point ParseDateTime(
   // should valid that `seconds` is smaller than 59 for negative leap seconds).
   // This would require loading a table, and adds too much complexity for little
   // value.
-  if (seconds < 0 or seconds > 60) {
+  if (seconds < 0 || seconds > 60) {
     ReportError(timestamp, "Out of range second.");
   }
   // Advance the pointer for all the characters read.
@@ -136,7 +136,7 @@ std::chrono::system_clock::duration ParseFractionalSeconds(
 
 std::chrono::seconds ParseOffset(char const*& buffer,
                                  std::string const& timestamp) {
-  if (buffer[0] == '+' or buffer[0] == '-') {
+  if (buffer[0] == '+' || buffer[0] == '-') {
     bool positive = (buffer[0] == '+');
     ++buffer;
     // Parse the HH:MM offset.
@@ -144,13 +144,13 @@ std::chrono::seconds ParseOffset(char const*& buffer,
     auto count = std::sscanf(buffer, "%2d:%2d%n", &hours, &minutes, &pos);
     constexpr int EXPECTED_OFFSET_WIDTH = 5;
     constexpr int EXPECTED_OFFSET_FIELDS = 2;
-    if (count != EXPECTED_OFFSET_FIELDS or pos != EXPECTED_OFFSET_WIDTH) {
+    if (count != EXPECTED_OFFSET_FIELDS || pos != EXPECTED_OFFSET_WIDTH) {
       ReportError(timestamp, "Invalid timezone offset, expected [+-]HH:MM.");
     }
-    if (hours < 0 or hours > 23) {
+    if (hours < 0 || hours > 23) {
       ReportError(timestamp, "Out of range offset hour.");
     }
-    if (minutes < 0 or minutes > 59) {
+    if (minutes < 0 || minutes > 59) {
       ReportError(timestamp, "Out of range offset minute.");
     }
     buffer += pos;
@@ -162,7 +162,7 @@ std::chrono::seconds ParseOffset(char const*& buffer,
     return duration_cast<std::chrono::seconds>(-std::chrono::hours(hours) -
                                                std::chrono::minutes(minutes));
   }
-  if (buffer[0] != 'Z' and buffer[0] != 'z') {
+  if (buffer[0] != 'Z' && buffer[0] != 'z') {
     ReportError(timestamp, "Invalid timezone offset, expected 'Z' or 'z'.");
   }
   ++buffer;

--- a/google/cloud/storage/internal/patch_builder.h
+++ b/google/cloud/storage/internal/patch_builder.h
@@ -115,7 +115,7 @@ class PatchBuilder {
                                  google::cloud::optional<T> const& lhs,
                                  google::cloud::optional<T> const& rhs) {
     if (lhs == rhs) return *this;
-    if (not rhs.has_value()) {
+    if (!rhs.has_value()) {
       patch_[field_name] = nullptr;
       return *this;
     }

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -75,20 +75,20 @@ MakeCall(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
     return Status(last_status.code(), msg);
   };
 
-  while (not retry_policy.IsExhausted()) {
+  while (!retry_policy.IsExhausted()) {
     auto result = (client.*function)(request);
     if (result.ok()) {
       return result;
     }
     last_status = std::move(result).status();
-    if (not is_idempotent) {
+    if (!is_idempotent) {
       std::ostringstream os;
       os << "Error in non-idempotent operation " << error_message << ": "
          << last_status;
       return error(std::move(os).str());
     }
-    if (not retry_policy.OnFailure(last_status)) {
-      if (not retry_policy.IsExhausted()) {
+    if (!retry_policy.OnFailure(last_status)) {
+      if (!retry_policy.IsExhausted()) {
         // The last error cannot be retried, but it is not because the retry
         // policy is exhausted, we call these "permanent errors", and they
         // get a special message.
@@ -345,7 +345,7 @@ RetryClient::CreateResumableSession(ResumableUploadRequest const& request) {
   auto result = MakeCall(*retry_policy, *backoff_policy, is_idempotent,
                          *client_, &RawClient::CreateResumableSession, request,
                          __func__);
-  if (not result.ok()) {
+  if (!result.ok()) {
     return result;
   }
 

--- a/google/cloud/storage/internal/retry_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.cc
@@ -40,20 +40,20 @@ StatusOr<ResumableUploadResponse>
 RetryResumableUploadSession::UploadChunk(std::string const& buffer,
                                          std::uint64_t upload_size) {
   Status last_status;
-  while (not retry_policy_->IsExhausted()) {
+  while (!retry_policy_->IsExhausted()) {
     auto result = session_->UploadChunk(buffer, upload_size);
     if (result.ok()) {
       return result;
     }
     last_status = std::move(result).status();
-    if (not retry_policy_->OnFailure(last_status)) {
+    if (!retry_policy_->OnFailure(last_status)) {
       return ReturnError(std::move(last_status), *retry_policy_, __func__);
     }
     auto delay = backoff_policy_->OnCompletion();
     std::this_thread::sleep_for(delay);
 
     result = ResetSession();
-    if (not result.ok()) {
+    if (!result.ok()) {
       return result;
     }
   }
@@ -65,13 +65,13 @@ RetryResumableUploadSession::UploadChunk(std::string const& buffer,
 StatusOr<ResumableUploadResponse>
 RetryResumableUploadSession::ResetSession() {
   Status last_status;
-  while (not retry_policy_->IsExhausted()) {
+  while (!retry_policy_->IsExhausted()) {
     auto result = session_->ResetSession();
     if (result.ok()) {
       return result;
     }
     last_status = std::move(result).status();
-    if (not retry_policy_->OnFailure(last_status)) {
+    if (!retry_policy_->OnFailure(last_status)) {
       return ReturnError(std::move(last_status), *retry_policy_, __func__);
     }
     auto delay = backoff_policy_->OnCompletion();

--- a/google/cloud/storage/internal/signed_url_requests.cc
+++ b/google/cloud/storage/internal/signed_url_requests.cc
@@ -45,7 +45,7 @@ std::string SignUrlRequest::StringToSign() const {
 
   CurlHandle curl;
   os << '/' << bucket_name();
-  if (not object_name().empty()) {
+  if (!object_name().empty()) {
     os << '/'  << curl.MakeEscapedString(object_name()).get();
   }
   char const* sep = "?";

--- a/google/cloud/storage/internal/signed_url_requests.h
+++ b/google/cloud/storage/internal/signed_url_requests.h
@@ -57,32 +57,32 @@ class SignUrlRequest {
 
  private:
   void set_option(MD5HashValue const& o) {
-    if (not o.has_value()) {
+    if (!o.has_value()) {
       return;
     }
     md5_hash_value_ = o.value();
   }
 
   void set_option(ContentType const& o) {
-    if (not o.has_value()) {
+    if (!o.has_value()) {
       return;
     }
     content_type_ = o.value();
   }
 
   void set_option(ExpirationTime const& o) {
-    if (not o.has_value()) {
+    if (!o.has_value()) {
       return;
     }
     expiration_time_ = o.value();
   }
 
   void set_option(AddExtensionHeaderOption const& o) {
-    if (not o.has_value()) {
+    if (!o.has_value()) {
       return;
     }
     auto res = extension_headers_.insert(o.value());
-    if (not res.second) {
+    if (!res.second) {
       // The element already exists, we need to append:
       res.first->second.push_back(',');
       res.first->second.append(o.value().second);
@@ -90,7 +90,7 @@ class SignUrlRequest {
   }
 
   void set_option(AddQueryParameterOption const& o) {
-    if (not o.has_value()) {
+    if (!o.has_value()) {
       return;
     }
     query_parameters_.push_back(o.value());

--- a/google/cloud/storage/lifecycle_rule.cc
+++ b/google/cloud/storage/lifecycle_rule.cc
@@ -93,7 +93,7 @@ std::ostream& operator<<(std::ostream& os, LifecycleRuleCondition const& rhs) {
 }
 
 StatusOr<LifecycleRule> LifecycleRule::ParseFromJson(internal::nl::json const& json) {
-  if (not json.is_object()) {
+  if (!json.is_object()) {
     return Status(StatusCode::kInvalidArgument, __func__);
   }
   LifecycleRule result;

--- a/google/cloud/storage/lifecycle_rule.h
+++ b/google/cloud/storage/lifecycle_rule.h
@@ -79,9 +79,9 @@ struct LifecycleRuleCondition {
 
 inline bool operator==(LifecycleRuleCondition const& lhs,
                        LifecycleRuleCondition const& rhs) {
-  return lhs.age == rhs.age and lhs.created_before == rhs.created_before and
-         lhs.is_live == rhs.is_live and
-         lhs.matches_storage_class == rhs.matches_storage_class and
+  return lhs.age == rhs.age && lhs.created_before == rhs.created_before &&
+         lhs.is_live == rhs.is_live &&
+         lhs.matches_storage_class == rhs.matches_storage_class &&
          lhs.num_newer_versions == rhs.num_newer_versions;
 }
 

--- a/google/cloud/storage/list_buckets_reader.cc
+++ b/google/cloud/storage/list_buckets_reader.cc
@@ -82,7 +82,7 @@ ListBucketsReader::iterator ListBucketsReader::GetNext() {
     }
     request_.set_page_token(std::move(next_page_token_));
     auto response = client_->ListBuckets(request_);
-    if (not response.ok()) {
+    if (!response.ok()) {
       next_page_token_.clear();
       current_buckets_.clear();
       on_last_page_ = true;

--- a/google/cloud/storage/list_buckets_reader.h
+++ b/google/cloud/storage/list_buckets_reader.h
@@ -68,7 +68,7 @@ class ListBucketsIterator {
       return false;
     }
     // Iterators on the same stream are equal if they point to the same object.
-    if (value_.ok() and rhs.value_.ok()) {
+    if (value_.ok() && rhs.value_.ok()) {
       return value_.value() == rhs.value_.value();
     }
     return value_.status() == rhs.value_.status();

--- a/google/cloud/storage/list_objects_reader.cc
+++ b/google/cloud/storage/list_objects_reader.cc
@@ -83,7 +83,7 @@ ListObjectsIterator ListObjectsReader::GetNext() {
     }
     request_.set_page_token(std::move(next_page_token_));
     auto response = client_->ListObjects(request_);
-    if (not response.ok()) {
+    if (!response.ok()) {
       next_page_token_.clear();
       current_objects_.clear();
       on_last_page_ = true;

--- a/google/cloud/storage/list_objects_reader.h
+++ b/google/cloud/storage/list_objects_reader.h
@@ -69,7 +69,7 @@ class ListObjectsIterator {
       return false;
     }
     // Iterators on the same stream are equal if they point to the same object.
-    if (value_.ok() and rhs.value_.ok()) {
+    if (value_.ok() && rhs.value_.ok()) {
       return value_.value() == rhs.value_.value();
     }
     return value_.status() == rhs.value_.status();

--- a/google/cloud/storage/notification_metadata.cc
+++ b/google/cloud/storage/notification_metadata.cc
@@ -20,7 +20,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 StatusOr<NotificationMetadata> NotificationMetadata::ParseFromJson(
     internal::nl::json const& json) {
-  if (not json.is_object()) {
+  if (!json.is_object()) {
     return Status(StatusCode::kInvalidArgument, __func__);
   }
   NotificationMetadata result{};
@@ -63,7 +63,7 @@ std::string NotificationMetadata::JsonPayloadForInsert() const {
   };
 
   // custom_attributes()
-  if (not custom_attributes().empty()) {
+  if (!custom_attributes().empty()) {
     internal::nl::json ca;
     for (auto const& kv : custom_attributes()) {
       ca[kv.first] = kv.second;
@@ -72,7 +72,7 @@ std::string NotificationMetadata::JsonPayloadForInsert() const {
   }
 
   // event_types()
-  if (not event_types().empty()) {
+  if (!event_types().empty()) {
     internal::nl::json events;
     for (auto const& v : event_types()) {
       events.push_back(v);
@@ -80,7 +80,7 @@ std::string NotificationMetadata::JsonPayloadForInsert() const {
     json["event_types"] = events;
   }
 
-  if (not object_name_prefix().empty()) {
+  if (!object_name_prefix().empty()) {
     json["object_name_prefix"] = object_name_prefix();
   }
 

--- a/google/cloud/storage/notification_metadata.h
+++ b/google/cloud/storage/notification_metadata.h
@@ -73,7 +73,7 @@ class NotificationMetadata {
   NotificationMetadata& upsert_custom_attributes(std::string key,
                                                  std::string value) {
     auto i = custom_attributes_.lower_bound(key);
-    if (i == custom_attributes_.end() or i->first != key) {
+    if (i == custom_attributes_.end() || i->first != key) {
       custom_attributes_.emplace_hint(i, std::move(key), std::move(value));
     } else {
       i->second = std::move(value);

--- a/google/cloud/storage/oauth2/authorized_user_credentials.h
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.h
@@ -98,14 +98,14 @@ class AuthorizedUserCredentials : public Credentials {
     namespace nl = storage::internal::nl;
 
     auto response = request_.MakeRequest(payload_);
-    if (not response.ok()) {
+    if (!response.ok()) {
       return std::move(response).status();
     }
     if (response->status_code >= 300) {
       return AsStatus(*response);
     }
     nl::json access_token = nl::json::parse(response->payload, nullptr, false);
-    if (access_token.is_discarded() or
+    if (access_token.is_discarded() ||
         access_token.count("access_token") == 0U or
         access_token.count("expires_in") == 0U or
         access_token.count("id_token") == 0U or

--- a/google/cloud/storage/oauth2/compute_engine_credentials.h
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.h
@@ -130,7 +130,7 @@ class ComputeEngineCredentials : public Credentials {
         "/computeMetadata/v1/instance/service-accounts/" +
             service_account_email_ + "/",
         true);
-    if (not response.ok()) {
+    if (!response.ok()) {
       return std::move(response).status();
     }
     if (response->status_code >= 300) {
@@ -170,7 +170,7 @@ class ComputeEngineCredentials : public Credentials {
         "/computeMetadata/v1/instance/service-accounts/" +
             service_account_email_ + "/token",
         false);
-    if (not response.ok()) {
+    if (!response.ok()) {
       return std::move(response).status();
     }
     if (response->status_code >= 300) {
@@ -180,7 +180,7 @@ class ComputeEngineCredentials : public Credentials {
     // Response should have the attributes "access_token", "expires_in", and
     // "token_type".
     nl::json access_token = nl::json::parse(response->payload, nullptr, false);
-    if (access_token.is_discarded() or
+    if (access_token.is_discarded() ||
         access_token.count("access_token") == 0U or
         access_token.count("expires_in") == 0U or
         access_token.count("token_type") == 0U) {

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -38,7 +38,7 @@ std::unique_ptr<Credentials> LoadCredsFromPath(std::string const& path) {
   namespace nl = google::cloud::storage::internal::nl;
 
   std::ifstream ifs(path);
-  if (not ifs.is_open()) {
+  if (!ifs.is_open()) {
     ThrowRuntimeError("Cannot open credentials file " + path);
   }
   std::string contents(std::istreambuf_iterator<char>{ifs}, {});
@@ -62,7 +62,7 @@ std::unique_ptr<Credentials> LoadCredsFromPath(std::string const& path) {
 
 std::unique_ptr<Credentials> MaybeLoadCredsFromAdcEnvVar() {
   auto path = GoogleAdcFilePathFromEnvVarOrEmpty();
-  if (not path.empty()) {
+  if (!path.empty()) {
     // If the path was specified, try to load that file; explicitly fail if it
     // doesn't exist or can't be read and parsed.
     return LoadCredsFromPath(path);
@@ -72,7 +72,7 @@ std::unique_ptr<Credentials> MaybeLoadCredsFromAdcEnvVar() {
 
 std::unique_ptr<Credentials> MaybeLoadCredsFromGcloudAdcFile() {
   auto path = GoogleAdcFilePathFromWellKnownPathOrEmpty();
-  if (not path.empty()) {
+  if (!path.empty()) {
     // Just because we had the necessary information to build the path doesn't
     // mean that a file exists there.
     std::error_code ec;

--- a/google/cloud/storage/oauth2/refreshing_credentials_wrapper.cc
+++ b/google/cloud/storage/oauth2/refreshing_credentials_wrapper.cc
@@ -27,7 +27,7 @@ bool RefreshingCredentialsWrapper::IsExpired() {
 }
 
 bool RefreshingCredentialsWrapper::IsValid() {
-  return not authorization_header.empty() and not IsExpired();
+  return !authorization_header.empty() && !IsExpired();
 }
 
 }  // namespace oauth2

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -49,7 +49,7 @@ ServiceAccountCredentialsInfo ParseServiceAccountCredentials(
     }
   }
   // The token_uri field may be missing, but may not be empty:
-  if (credentials.count(token_uri_key) != 0U and
+  if (credentials.count(token_uri_key) != 0U &&
       credentials.value(token_uri_key, "").empty()) {
     google::cloud::internal::ThrowInvalidArgument(
         "Invalid ServiceAccountCredentials, the " + std::string(token_uri_key) +

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -197,7 +197,7 @@ class ServiceAccountCredentials : public Credentials {
     namespace nl = storage::internal::nl;
 
     auto response = request_.MakeRequest(payload_);
-    if (not response.ok()) {
+    if (!response.ok()) {
       return std::move(response).status();
     }
     if (response->status_code >= 300) {
@@ -205,7 +205,7 @@ class ServiceAccountCredentials : public Credentials {
     }
 
     nl::json access_token = nl::json::parse(response->payload, nullptr, false);
-    if (access_token.is_discarded() or
+    if (access_token.is_discarded() ||
         access_token.count("access_token") == 0U or
         access_token.count("expires_in") == 0U or
         access_token.count("token_type") == 0U) {

--- a/google/cloud/storage/object_access_control.cc
+++ b/google/cloud/storage/object_access_control.cc
@@ -22,12 +22,12 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 StatusOr<ObjectAccessControl> ObjectAccessControl::ParseFromJson(
     internal::nl::json const& json) {
-  if (not json.is_object()) {
+  if (!json.is_object()) {
     return Status(StatusCode::kInvalidArgument, __func__);
   }
   ObjectAccessControl result{};
   auto status = AccessControlCommon::ParseFromJson(result, json);
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
   result.generation_ = internal::ParseLongField(json, "generation");
@@ -44,7 +44,7 @@ StatusOr<ObjectAccessControl> ObjectAccessControl::ParseFromString(
 bool ObjectAccessControl::operator==(ObjectAccessControl const& rhs) const {
   // Start with id, generation, object, bucket, etag because they should fail
   // early, then alphabetical for readability.
-  return object_ == rhs.object_ and generation_ == rhs.generation_ and
+  return object_ == rhs.object_ && generation_ == rhs.generation_ &&
          *static_cast<internal::AccessControlCommon const*>(this) == rhs;
 }
 

--- a/google/cloud/storage/object_access_control.h
+++ b/google/cloud/storage/object_access_control.h
@@ -81,7 +81,7 @@ class ObjectAccessControl : private internal::AccessControlCommon {
 
   bool operator==(ObjectAccessControl const& rhs) const;
   bool operator!=(ObjectAccessControl const& rhs) const {
-    return not(*this == rhs);
+    return !(*this == rhs);
   }
 
  private:

--- a/google/cloud/storage/object_metadata.cc
+++ b/google/cloud/storage/object_metadata.cc
@@ -50,19 +50,19 @@ std::ostream& operator<<(std::ostream& os, ComposeSourceObject const& r) {
 
 StatusOr<ObjectMetadata> ObjectMetadata::ParseFromJson(
     internal::nl::json const& json) {
-  if (not json.is_object()) {
+  if (!json.is_object()) {
     return Status(StatusCode::kInvalidArgument, __func__);
   }
   ObjectMetadata result{};
   auto status = CommonMetadata<ObjectMetadata>::ParseFromJson(result, json);
-  if (not status.ok()) {
+  if (!status.ok()) {
     return status;
   }
 
   if (json.count("acl") != 0) {
     for (auto const& kv : json["acl"].items()) {
       auto parsed = ObjectAccessControl::ParseFromJson(kv.value());
-      if (not parsed.ok()) {
+      if (!parsed.ok()) {
         return std::move(parsed).status();
       }
       result.acl_.emplace_back(std::move(*parsed));
@@ -128,7 +128,7 @@ std::string ObjectMetadata::JsonPayloadForCopy() const {
 internal::nl::json ObjectMetadata::JsonForUpdate() const {
   using internal::nl::json;
   json metadata_as_json;
-  if (not acl().empty()) {
+  if (!acl().empty()) {
     for (ObjectAccessControl const& a : acl()) {
       json entry;
       SetIfNotEmpty(entry, "entity", a.entity());
@@ -145,7 +145,7 @@ internal::nl::json ObjectMetadata::JsonForUpdate() const {
 
   metadata_as_json["eventBasedHold"] = event_based_hold();
 
-  if (not metadata().empty()) {
+  if (!metadata().empty()) {
     json meta_as_json;
     for (auto const& kv : metadata()) {
       meta_as_json[kv.first] = kv.second;
@@ -159,7 +159,7 @@ internal::nl::json ObjectMetadata::JsonForUpdate() const {
 internal::nl::json ObjectMetadata::JsonPayloadForCompose() const {
   using internal::nl::json;
   json metadata_as_json;
-  if (not acl().empty()) {
+  if (!acl().empty()) {
     for (ObjectAccessControl const& a : acl()) {
       json entry;
       SetIfNotEmpty(entry, "entity", a.entity());
@@ -178,7 +178,7 @@ internal::nl::json ObjectMetadata::JsonPayloadForCompose() const {
   SetIfNotEmpty(metadata_as_json, "name", name());
   SetIfNotEmpty(metadata_as_json, "storageClass", storage_class());
 
-  if (not metadata().empty()) {
+  if (!metadata().empty()) {
     json meta_as_json;
     for (auto const& kv : metadata()) {
       meta_as_json[kv.first] = kv.second;
@@ -192,22 +192,22 @@ internal::nl::json ObjectMetadata::JsonPayloadForCompose() const {
 bool ObjectMetadata::operator==(ObjectMetadata const& rhs) const {
   return static_cast<internal::CommonMetadata<ObjectMetadata> const&>(*this) ==
              rhs and
-         acl_ == rhs.acl_ and bucket_ == rhs.bucket_ and
-         cache_control_ == rhs.cache_control_ and
-         component_count_ == rhs.component_count_ and
-         content_disposition_ == rhs.content_disposition_ and
-         content_encoding_ == rhs.content_encoding_ and
-         content_language_ == rhs.content_language_ and
-         content_type_ == rhs.content_type_ and crc32c_ == rhs.crc32c_ and
-         customer_encryption_ == customer_encryption_ and
-         event_based_hold_ == rhs.event_based_hold_ and
-         generation_ == rhs.generation_ and
-         kms_key_name_ == rhs.kms_key_name_ and md5_hash_ == rhs.md5_hash_ and
-         media_link_ == rhs.media_link_ and metadata_ == rhs.metadata_ and
-         retention_expiration_time_ == rhs.retention_expiration_time_ and
-         temporary_hold_ == rhs.temporary_hold_ and
-         time_deleted_ == rhs.time_deleted_ and
-         time_storage_class_updated_ == rhs.time_storage_class_updated_ and
+         acl_ == rhs.acl_ && bucket_ == rhs.bucket_ &&
+         cache_control_ == rhs.cache_control_ &&
+         component_count_ == rhs.component_count_ &&
+         content_disposition_ == rhs.content_disposition_ &&
+         content_encoding_ == rhs.content_encoding_ &&
+         content_language_ == rhs.content_language_ &&
+         content_type_ == rhs.content_type_ && crc32c_ == rhs.crc32c_ &&
+         customer_encryption_ == customer_encryption_ &&
+         event_based_hold_ == rhs.event_based_hold_ &&
+         generation_ == rhs.generation_ && kms_key_name_ == rhs.kms_key_name_ &&
+         md5_hash_ == rhs.md5_hash_ && media_link_ == rhs.media_link_ &&
+         metadata_ == rhs.metadata_ &&
+         retention_expiration_time_ == rhs.retention_expiration_time_ &&
+         temporary_hold_ == rhs.temporary_hold_ &&
+         time_deleted_ == rhs.time_deleted_ &&
+         time_storage_class_updated_ == rhs.time_storage_class_updated_ &&
          size_ == rhs.size_;
 }
 

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -200,7 +200,7 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
   /// Insert or update the metadata entry.
   ObjectMetadata& upsert_metadata(std::string key, std::string value) {
     auto i = metadata_.lower_bound(key);
-    if (i == metadata_.end() or i->first != key) {
+    if (i == metadata_.end() || i->first != key) {
       metadata_.emplace_hint(i, std::move(key), std::move(value));
     } else {
       i->second = std::move(value);
@@ -247,7 +247,7 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
   using CommonMetadata::updated;
 
   bool operator==(ObjectMetadata const& rhs) const;
-  bool operator!=(ObjectMetadata const& rhs) const { return not(*this == rhs); }
+  bool operator!=(ObjectMetadata const& rhs) const { return !(*this == rhs); }
 
   internal::nl::json JsonForUpdate() const;
 

--- a/google/cloud/storage/object_rewriter.cc
+++ b/google/cloud/storage/object_rewriter.cc
@@ -29,7 +29,7 @@ ObjectRewriter::ObjectRewriter(std::shared_ptr<internal::RawClient> client,
 StatusOr<RewriteProgress> ObjectRewriter::Iterate() {
   StatusOr<internal::RewriteObjectResponse> response =
       client_->RewriteObject(request_);
-  if (not response.ok()) {
+  if (!response.ok()) {
     progress_.done = true;
     last_error_ = std::move(response).status();
     return last_error_;

--- a/google/cloud/storage/object_rewriter.h
+++ b/google/cloud/storage/object_rewriter.h
@@ -60,7 +60,7 @@ class ObjectRewriter {
 
   /// The current progress on the rewrite operation.
   StatusOr<RewriteProgress> CurrentProgress() const {
-    if (not last_error_.ok()) {
+    if (!last_error_.ok()) {
       return last_error_;
     }
     return progress_;
@@ -101,10 +101,10 @@ class ObjectRewriter {
                                   Functor, StatusOr<RewriteProgress>>::value,
                               int>::type = 0>
   StatusOr<ObjectMetadata> ResultWithProgressCallback(Functor cb) {
-    while (not progress_.done) {
+    while (!progress_.done) {
       cb(Iterate());
     }
-    if (not last_error_.ok()) {
+    if (!last_error_.ok()) {
       return last_error_;
     }
     return result_;

--- a/google/cloud/storage/object_stream.cc
+++ b/google/cloud/storage/object_stream.cc
@@ -27,7 +27,7 @@ static_assert(std::is_move_constructible<ObjectReadStream>::value,
               "storage::ObjectReadStream must be move constructible.");
 
 ObjectReadStream::~ObjectReadStream() {
-  if (not IsOpen()) {
+  if (!IsOpen()) {
     return;
   }
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
@@ -45,17 +45,17 @@ ObjectReadStream::~ObjectReadStream() {
 }
 
 void ObjectReadStream::Close() {
-  if (not IsOpen()) {
+  if (!IsOpen()) {
     return;
   }
   buf_->Close();
-  if (not status().ok()) {
+  if (!status().ok()) {
     setstate(std::ios_base::badbit);
   }
 }
 
 ObjectWriteStream::~ObjectWriteStream() {
-  if (not IsOpen()) {
+  if (!IsOpen()) {
     return;
   }
   // Disable exceptions, even if the application had enabled exceptions the
@@ -65,11 +65,11 @@ ObjectWriteStream::~ObjectWriteStream() {
 }
 
 void ObjectWriteStream::Close() {
-  if (not IsOpen()) {
+  if (!IsOpen()) {
     return;
   }
   StatusOr<internal::HttpResponse> response = buf_->Close();
-  if (not response.ok()) {
+  if (!response.ok()) {
     metadata_ = StatusOr<ObjectMetadata>(std::move(response).status());
     setstate(std::ios_base::badbit);
     return;
@@ -87,13 +87,13 @@ void ObjectWriteStream::Close() {
     metadata_ = ObjectMetadata{};
   } else {
     metadata_ = ObjectMetadata::ParseFromString(payload_);
-    if (not metadata_.ok()) {
+    if (!metadata_.ok()) {
       setstate(std::ios_base::badbit);
       return;
     }
   }
 
-  if (not buf_->ValidateHash(*metadata_)) {
+  if (!buf_->ValidateHash(*metadata_)) {
     setstate(std::ios_base::badbit);
   }
 }

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -82,7 +82,7 @@ class ObjectReadStream : public std::basic_istream<char> {
   /// Closes the stream (if necessary).
   ~ObjectReadStream() override;
 
-  bool IsOpen() const { return (bool)buf_ and buf_->IsOpen(); }
+  bool IsOpen() const { return (bool)buf_ && buf_->IsOpen(); }
 
   /**
    * Terminate the download, possibly before completing it.
@@ -184,7 +184,7 @@ class ObjectWriteStream : public std::basic_ostream<char> {
   ~ObjectWriteStream() override;
 
   /// Return true while the stream is open.
-  bool IsOpen() const { return buf_ != nullptr and buf_->IsOpen(); }
+  bool IsOpen() const { return buf_ != nullptr && buf_->IsOpen(); }
 
   /**
    * Close the stream, finalizing the upload.

--- a/google/cloud/storage/retry_policy.h
+++ b/google/cloud/storage/retry_policy.h
@@ -27,8 +27,8 @@ namespace internal {
 /// Defines what error codes are permanent errors.
 struct StatusTraits {
   static bool IsPermanentFailure(Status const& status) {
-    return status.code() != StatusCode::kDeadlineExceeded and
-           status.code() != StatusCode::kInternal and
+    return status.code() != StatusCode::kDeadlineExceeded &&
+           status.code() != StatusCode::kInternal &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/storage/service_account.cc
+++ b/google/cloud/storage/service_account.cc
@@ -20,7 +20,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 StatusOr<ServiceAccount> ServiceAccount::ParseFromJson(
     internal::nl::json const& json) {
-  if (not json.is_object()) {
+  if (!json.is_object()) {
     return Status(StatusCode::kInvalidArgument, __func__);
   }
   ServiceAccount result{};

--- a/google/cloud/storage/storage_version_test.cc
+++ b/google/cloud/storage/storage_version_test.cc
@@ -43,7 +43,7 @@ TEST(StorageVersionTest, Format) {
 
 /// @test Verify the version does not contain build info for release builds.
 TEST(StorageVersionTest, NoBuildInfoInRelease) {
-  if (not google::cloud::internal::is_release()) {
+  if (!google::cloud::internal::is_release()) {
     return;
   }
   EXPECT_THAT(version_string(),

--- a/google/cloud/storage/testing/mock_http_request.h
+++ b/google/cloud/storage/testing/mock_http_request.h
@@ -86,7 +86,7 @@ class MockHttpRequestBuilder {
 
   template <typename P>
   void AddWellKnownParameter(internal::WellKnownParameter<P, bool> const& p) {
-    if (not p.has_value()) {
+    if (!p.has_value()) {
       return;
     }
     mock->AddQueryParameter(p.parameter_name(), p.value() ? "true" : "false");

--- a/google/cloud/storage/testing/retry_tests.h
+++ b/google/cloud/storage/testing/retry_tests.h
@@ -146,7 +146,7 @@ void NonIdempotentFailuresTest(
   // With EXPECT_DEATH*() the mocking framework cannot detect how many times
   // the operation is called, so we cannot set an exact number of calls to
   // expect.
-  if (not has_will_repeatedly) {
+  if (!has_will_repeatedly) {
     oncall.WillRepeatedly(Return(StatusOr<ReturnType>(TransientError())));
   }
   EXPECT_DEATH_IF_SUPPORTED(tested_operation(client),
@@ -215,7 +215,7 @@ void IdempotentFailuresTest(
   // With EXPECT_DEATH*() the mocking framework cannot detect how many times
   // the operation is called, so we cannot set an exact number of calls to
   // expect.
-  if (not has_will_repeatedly) {
+  if (!has_will_repeatedly) {
     oncall.WillRepeatedly(Return(StatusOr<ReturnType>(TransientError())));
   }
   EXPECT_DEATH_IF_SUPPORTED(tested_operation(client),

--- a/google/cloud/storage/testing/storage_integration_test.h
+++ b/google/cloud/storage/testing/storage_integration_test.h
@@ -79,7 +79,7 @@ CountMatchingEntities(std::vector<AccessControlResource> const& acl,
                       AccessControlResource const& expected) {
   return std::count_if(
       acl.begin(), acl.end(), [&expected](AccessControlResource const& x) {
-        return x.entity() == expected.entity() and x.role() == expected.role();
+        return x.entity() == expected.entity() && x.role() == expected.role();
       });
 }
 

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -176,11 +176,11 @@ TEST_F(BucketIntegrationTest, FullPatch) {
                                             .set_role("READER"));
 
   // billing()
-  if (not desired_state.has_billing()) {
+  if (!desired_state.has_billing()) {
     desired_state.set_billing(BucketBilling(false));
   } else {
     desired_state.set_billing(
-        BucketBilling(not desired_state.billing().requester_pays));
+        BucketBilling(!desired_state.billing().requester_pays));
   }
 
   // cors()
@@ -220,7 +220,7 @@ TEST_F(BucketIntegrationTest, FullPatch) {
   desired_state.set_storage_class(storage_class::Coldline());
 
   // versioning()
-  if (not desired_state.has_versioning()) {
+  if (!desired_state.has_versioning()) {
     desired_state.enable_versioning();
   } else {
     desired_state.reset_versioning();

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -318,7 +318,7 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileNonRegularWarning) {
   auto count = std::count_if(
       backend->log_lines.begin(), backend->log_lines.end(),
       [file_name](std::string const& line) {
-        return line.find(file_name) != std::string::npos and
+        return line.find(file_name) != std::string::npos &&
                line.find("not a regular file") != std::string::npos;
       });
   EXPECT_NE(0U, count);
@@ -585,7 +585,7 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadClose) {
 
 /// @test Verify that MD5 hash mismatches are reported by default on downloads.
 TEST_F(ObjectMediaIntegrationTest, MismatchedMD5StreamingReadXML) {
-  if (not UsingTestbench()) {
+  if (!UsingTestbench()) {
     // This test is disabled when not using the testbench as it relies on the
     // testbench to inject faults.
     return;
@@ -628,7 +628,7 @@ TEST_F(ObjectMediaIntegrationTest, MismatchedMD5StreamingReadXML) {
 
 /// @test Verify that MD5 hash mismatches are reported by default on downloads.
 TEST_F(ObjectMediaIntegrationTest, MismatchedMD5StreamingReadJSON) {
-  if (not UsingTestbench()) {
+  if (!UsingTestbench()) {
     // This test is disabled when not using the testbench as it relies on the
     // testbench to inject faults.
     return;
@@ -672,7 +672,7 @@ TEST_F(ObjectMediaIntegrationTest, MismatchedMD5StreamingReadJSON) {
 
 /// @test Verify that MD5 hash mismatches are reported by default on downloads.
 TEST_F(ObjectMediaIntegrationTest, MismatchedMD5StreamingWriteXML) {
-  if (not UsingTestbench()) {
+  if (!UsingTestbench()) {
     // This test is disabled when not using the testbench as it relies on the
     // testbench to inject faults.
     return;
@@ -701,7 +701,7 @@ TEST_F(ObjectMediaIntegrationTest, MismatchedMD5StreamingWriteXML) {
 
 /// @test Verify that MD5 hash mismatches are reported by default on downloads.
 TEST_F(ObjectMediaIntegrationTest, MismatchedMD5StreamingWriteJSON) {
-  if (not UsingTestbench()) {
+  if (!UsingTestbench()) {
     // This test is disabled when not using the testbench as it relies on the
     // testbench to inject faults.
     return;
@@ -999,7 +999,7 @@ TEST_F(ObjectMediaIntegrationTest, DefaultCrc32cStreamingWriteJSON) {
 /// @test Verify that CRC32C checksum mismatches are reported by default on
 /// downloads.
 TEST_F(ObjectMediaIntegrationTest, MismatchedCrc32cStreamingReadXML) {
-  if (not UsingTestbench()) {
+  if (!UsingTestbench()) {
     // This test is disabled when not using the testbench as it relies on the
     // testbench to inject faults.
     return;
@@ -1044,7 +1044,7 @@ TEST_F(ObjectMediaIntegrationTest, MismatchedCrc32cStreamingReadXML) {
 /// @test Verify that CRC32C checksum mismatches are reported by default on
 /// downloads.
 TEST_F(ObjectMediaIntegrationTest, MismatchedCrc32cStreamingReadJSON) {
-  if (not UsingTestbench()) {
+  if (!UsingTestbench()) {
     // This test is disabled when not using the testbench as it relies on the
     // testbench to inject faults.
     return;
@@ -1089,7 +1089,7 @@ TEST_F(ObjectMediaIntegrationTest, MismatchedCrc32cStreamingReadJSON) {
 /// @test Verify that CRC32C checksum mismatches are reported by default on
 /// downloads.
 TEST_F(ObjectMediaIntegrationTest, MismatchedCrc32cStreamingWriteXML) {
-  if (not UsingTestbench()) {
+  if (!UsingTestbench()) {
     // This test is disabled when not using the testbench as it relies on the
     // testbench to inject faults.
     return;
@@ -1119,7 +1119,7 @@ TEST_F(ObjectMediaIntegrationTest, MismatchedCrc32cStreamingWriteXML) {
 /// @test Verify that CRC32C checksum mismatches are reported by default on
 /// downloads.
 TEST_F(ObjectMediaIntegrationTest, MismatchedCrc32cStreamingWriteJSON) {
-  if (not UsingTestbench()) {
+  if (!UsingTestbench()) {
     // This test is disabled when not using the testbench as it relies on the
     // testbench to inject faults.
     return;

--- a/google/cloud/storage/tests/thread_integration_test.cc
+++ b/google/cloud/storage/tests/thread_integration_test.cc
@@ -165,7 +165,7 @@ class CaptureSendHeaderBackend : public LogBackend {
   void Process(LogRecord const& lr) override {
     // Break the records in lines, because we will analyze the output per line.
     std::istringstream is(lr.message);
-    while (not is.eof()) {
+    while (!is.eof()) {
       std::string line;
       std::getline(is, line);
       log_lines.emplace_back(std::move(line));

--- a/google/cloud/storage/version.cc
+++ b/google/cloud/storage/version.cc
@@ -26,7 +26,7 @@ std::string version_string() {
     std::ostringstream os;
     os << "v" << version_major() << "." << version_minor() << "."
        << version_patch();
-    if (not google::cloud::internal::is_release()) {
+    if (!google::cloud::internal::is_release()) {
       os << "+" << google::cloud::internal::gitrev();
     }
     return os.str();

--- a/google/cloud/storage/well_known_headers.cc
+++ b/google/cloud/storage/well_known_headers.cc
@@ -37,7 +37,7 @@ std::string Sha256AsBase64(std::string const& key) {
 }  // namespace
 
 std::ostream& operator<<(std::ostream& os, CustomHeader const& rhs) {
-  if (not rhs.has_value()) {
+  if (!rhs.has_value()) {
     return os;
   }
   return os << rhs.custom_header_name() << ": " << rhs.value();

--- a/google/cloud/testing_util/capture_log_lines_backend.cc
+++ b/google/cloud/testing_util/capture_log_lines_backend.cc
@@ -12,7 +12,7 @@ namespace testing_util {
 void CaptureLogLinesBackend::Process(LogRecord const& lr) {
   // Break the records in lines, it is easier to analyze them as such.
   std::istringstream is(lr.message);
-  while (not is.eof()) {
+  while (!is.eof()) {
     std::string line;
     std::getline(is, line);
     log_lines.emplace_back(std::move(line));

--- a/google/cloud/testing_util/check_predicate_becomes_false.h
+++ b/google/cloud/testing_util/check_predicate_becomes_false.h
@@ -62,7 +62,7 @@ void CheckPredicateBecomesFalse(Predicate&& predicate,
       }
     } else if (must_be_false_after < iteration_start) {
       EXPECT_FALSE(actual);
-      if (not actual) {
+      if (!actual) {
         // Terminate the loop early if we can.
         ++false_count;
         break;


### PR DESCRIPTION
The [Google Style Guide forbids](https://google.github.io/styleguide/cppguide.html#Boolean_Expressions) the use of C++'s alternative operator names, and instead says to always use the punctuation operators, such as && and ||. I wrote a small script with some conservative regular expressions to update this code base, transforming and -> &&, or -> not -> !. The regular expressions were pretty basic, so I'm sure they missed some cases. I think that's fine; we can catch those in a separate pass, or while doing normal maintenance.

If a file was edited I also clang-formatted it since the lines will now be shorter. This resulted in some reformatting of untouched pieces of code, but this is pretty minimal, and is probably what we want anyway. 

Finally, there were a few cases of unit test statements of the form `EXPECT_FALSE(!x)`, which I changed to `EXPECT_TRUE(x)` to remove the double negations.

Note: This change was generated by a script, so I can easily re-generate it. So if you'd like to discuss this change, or ask for tweaks, that's fine. I don't have to re-do all the changes by hand :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1839)
<!-- Reviewable:end -->
