### PR TITLE
Use StatusOr for more Client::*Object functions.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -722,10 +722,6 @@ class Client {
    *     `IfGenerationMatch`, `IfGenerationNotMatch`, `IfMetagenerationMatch`,
    *     `IfMetagenerationNotMatch`, `Projection`, and `UserProject`.
    *
-   *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This is a read-only operation and is always idempotent.
    *
@@ -733,12 +729,12 @@ class Client {
    * @snippet storage_object_samples.cc get object metadata
    */
   template <typename... Options>
-  ObjectMetadata GetObjectMetadata(std::string const& bucket_name,
-                                   std::string const& object_name,
-                                   Options&&... options) {
+  StatusOr<ObjectMetadata> GetObjectMetadata(std::string const& bucket_name,
+                                             std::string const& object_name,
+                                             Options&&... options) {
     internal::GetObjectMetadataRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->GetObjectMetadata(request).value();
+    return raw_client_->GetObjectMetadata(request);
   }
 
   /**
@@ -991,9 +987,6 @@ class Client {
    *     `IfMetagenerationNotMatch`, `PredefinedAcl`,
    *     `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions, in this
    * case, `IfMetagenerationMatch`.
@@ -1002,12 +995,14 @@ class Client {
    * @snippet storage_object_samples.cc update object metadata
    */
   template <typename... Options>
-  ObjectMetadata UpdateObject(std::string bucket_name, std::string object_name,
-                              ObjectMetadata metadata, Options&&... options) {
+  StatusOr<ObjectMetadata> UpdateObject(std::string bucket_name,
+                                        std::string object_name,
+                                        ObjectMetadata metadata,
+                                        Options&&... options) {
     internal::UpdateObjectRequest request(
         std::move(bucket_name), std::move(object_name), std::move(metadata));
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->UpdateObject(request).value();
+    return raw_client_->UpdateObject(request);
   }
 
   /**
@@ -1029,9 +1024,6 @@ class Client {
    *     `IfMetagenerationNotMatch`, `PredefinedAcl`,
    *     `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions, in this
    * case, `IfMetagenerationMatch`.
@@ -1040,14 +1032,15 @@ class Client {
    * @snippet storage_object_samples.cc patch object delete metadata
    */
   template <typename... Options>
-  ObjectMetadata PatchObject(std::string bucket_name, std::string object_name,
-                             ObjectMetadata const& original,
-                             ObjectMetadata const& updated,
-                             Options&&... options) {
+  StatusOr<ObjectMetadata> PatchObject(std::string bucket_name,
+                                       std::string object_name,
+                                       ObjectMetadata const& original,
+                                       ObjectMetadata const& updated,
+                                       Options&&... options) {
     internal::PatchObjectRequest request(
         std::move(bucket_name), std::move(object_name), original, updated);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->PatchObject(request).value();
+    return raw_client_->PatchObject(request);
   }
 
   /**
@@ -1067,9 +1060,6 @@ class Client {
    *     `IfMetagenerationNotMatch`, `PredefinedAcl`,
    *     `Projection`, and `UserProject`.
    *
-   * @throw std::runtime_error if there is a permanent failure, or if there were
-   *     more transient failures than allowed by the current retry policy.
-   *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions, in this
    * case, `IfMetagenerationMatch`.
@@ -1078,13 +1068,13 @@ class Client {
    * @snippet storage_object_samples.cc patch object content type
    */
   template <typename... Options>
-  ObjectMetadata PatchObject(std::string bucket_name, std::string object_name,
-                             ObjectMetadataPatchBuilder const& builder,
-                             Options&&... options) {
+  StatusOr<ObjectMetadata> PatchObject(
+      std::string bucket_name, std::string object_name,
+      ObjectMetadataPatchBuilder const& builder, Options&&... options) {
     internal::PatchObjectRequest request(std::move(bucket_name),
                                          std::move(object_name), builder);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->PatchObject(request).value();
+    return raw_client_->PatchObject(request);
   }
 
   /**

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -228,10 +228,18 @@ void GetObjectMetadata(google::cloud::storage::Client client, int& argc,
   auto object_name = ConsumeArg(argc, argv);
   //! [get object metadata] [START storage_get_metadata]
   namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
-    gcs::ObjectMetadata meta =
+    StatusOr<gcs::ObjectMetadata> meta =
         client.GetObjectMetadata(bucket_name, object_name);
-    std::cout << "The metadata is " << meta << std::endl;
+    if (not meta.ok()) {
+      std::cerr << "Error getting object metadata for object " << object_name
+                << " in bucket " << bucket_name << ", status=" << meta.status()
+                << std::endl;
+      return;
+    }
+    std::cout << "The metadata for object " << meta->name() << " in bucket "
+              << meta->bucket() << " is " << *meta << std::endl;
   }
   //! [get object metadata] [END storage_get_metadata]
   (std::move(client), bucket_name, object_name);
@@ -502,16 +510,29 @@ void UpdateObjectMetadata(google::cloud::storage::Client client, int& argc,
   auto value = ConsumeArg(argc, argv);
   //! [update object metadata] [START storage_set_metadata]
   namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string key, std::string value) {
-    gcs::ObjectMetadata meta =
+    StatusOr<gcs::ObjectMetadata> meta =
         client.GetObjectMetadata(bucket_name, object_name);
-    gcs::ObjectMetadata desired = meta;
+    if (not meta.ok()) {
+      std::cerr << "Error getting object metadata for object " << object_name
+                << " in bucket " << bucket_name << ", status=" << meta.status()
+                << std::endl;
+      return;
+    }
+    gcs::ObjectMetadata desired = *meta;
     desired.mutable_metadata().emplace(key, value);
-    gcs::ObjectMetadata updated = client.UpdateObject(
-        bucket_name, object_name, desired, gcs::Generation(meta.generation()));
+    StatusOr<gcs::ObjectMetadata> updated = client.UpdateObject(
+        bucket_name, object_name, desired, gcs::Generation(meta->generation()));
+    if (not updated.ok()) {
+      std::cerr << "Error updating object metadata for object " << meta->name()
+                << " in bucket " << meta->bucket()
+                << ", status=" << updated.status() << std::endl;
+      return;
+    }
     std::cout << "Object updated. The full metadata after the update is: "
-              << updated << std::endl;
+              << *updated << std::endl;
   }
   //! [update object metadata] [END storage_set_metadata]
   (std::move(client), bucket_name, object_name, key, value);
@@ -527,16 +548,29 @@ void PatchObjectDeleteMetadata(google::cloud::storage::Client client, int& argc,
   auto key = ConsumeArg(argc, argv);
   //! [patch object delete metadata]
   namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string key) {
-    gcs::ObjectMetadata original =
+    StatusOr<gcs::ObjectMetadata> original =
         client.GetObjectMetadata(bucket_name, object_name);
-    gcs::ObjectMetadata updated = original;
-    updated.mutable_metadata().erase(key);
-    gcs::ObjectMetadata result =
-        client.PatchObject(bucket_name, object_name, original, updated);
+    if (not original.ok()) {
+      std::cerr << "Error getting object metadata for object " << object_name
+                << " in bucket " << bucket_name
+                << ", status=" << original.status() << std::endl;
+      return;
+    }
+    gcs::ObjectMetadata desired = *original;
+    desired.mutable_metadata().erase(key);
+    StatusOr<gcs::ObjectMetadata> updated =
+        client.PatchObject(bucket_name, object_name, *original, desired);
+    if (not updated.ok()) {
+      std::cerr << "Error updating object metadata for object "
+                << original->name() << " in bucket " << original->bucket()
+                << ", status=" << updated.status() << std::endl;
+      return;
+    }
     std::cout << "Object updated. The full metadata after the update is: "
-              << result << std::endl;
+              << *updated << std::endl;
   }
   //! [patch object delete metadata]
   (std::move(client), bucket_name, object_name, key);
@@ -553,13 +587,20 @@ void PatchObjectContentType(google::cloud::storage::Client client, int& argc,
   auto content_type = ConsumeArg(argc, argv);
   //! [patch object content type]
   namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string content_type) {
-    gcs::ObjectMetadata updated = client.PatchObject(
+    StatusOr<gcs::ObjectMetadata> updated = client.PatchObject(
         bucket_name, object_name,
         gcs::ObjectMetadataPatchBuilder().SetContentType(content_type));
+    if (not updated.ok()) {
+      std::cerr << "Error patching object metadata for object " << object_name
+                << " in bucket " << bucket_name
+                << ", status=" << updated.status() << std::endl;
+      return;
+    }
     std::cout << "Object updated. The full metadata after the update is: "
-              << updated << std::endl;
+              << *updated << std::endl;
   }
   //! [patch object content type]
   (std::move(client), bucket_name, object_name, content_type);
@@ -574,12 +615,19 @@ void MakeObjectPublic(google::cloud::storage::Client client, int& argc,
   auto object_name = ConsumeArg(argc, argv);
   //! [make object public] [START storage_make_public]
   namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
-    gcs::ObjectMetadata updated = client.PatchObject(
+    StatusOr<gcs::ObjectMetadata> updated = client.PatchObject(
         bucket_name, object_name, gcs::ObjectMetadataPatchBuilder(),
         gcs::PredefinedAcl::PublicRead());
+    if (not updated.ok()) {
+      std::cerr << "Error patching object metadata for object " << object_name
+                << " in bucket " << bucket_name
+                << ", status=" << updated.status() << std::endl;
+      return;
+    }
     std::cout << "Object updated. The full metadata after the update is: "
-              << updated << std::endl;
+              << *updated << std::endl;
   }
   //! [make object public] [END storage_make_public]
   (std::move(client), bucket_name, object_name);
@@ -1022,16 +1070,30 @@ void SetObjectEventBasedHold(google::cloud::storage::Client client, int& argc,
   auto object_name = ConsumeArg(argc, argv);
   //! [set event based hold] [START storage_set_event_based_hold]
   namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
-    gcs::ObjectMetadata original =
+    StatusOr<gcs::ObjectMetadata> original =
         client.GetObjectMetadata(bucket_name, object_name);
-    gcs::ObjectMetadata metadata = client.PatchObject(
+    if (not original.ok()) {
+      std::cerr << "Error getting object metadata for object " << object_name
+                << " in bucket " << bucket_name
+                << ", status=" << original.status() << std::endl;
+      return;
+    }
+    StatusOr<gcs::ObjectMetadata> updated = client.PatchObject(
         bucket_name, object_name,
         gcs::ObjectMetadataPatchBuilder().SetEventBasedHold(true),
-        gcs::IfMetagenerationMatch(original.metageneration()));
-    std::cout << "The event hold for object " << metadata.name()
-              << " in bucket " << metadata.bucket() << " is "
-              << (metadata.event_based_hold() ? "enabled" : "disabled")
+        gcs::IfMetagenerationMatch(original->metageneration()));
+    if (not updated.ok()) {
+      std::cerr << "Error patching object metadata for object " << object_name
+                << " in bucket " << bucket_name
+                << ", status=" << updated.status() << std::endl;
+      return;
+    }
+
+    std::cout << "The event hold for object " << updated->name() << " in bucket "
+              << updated->bucket() << " is "
+              << (updated->event_based_hold() ? "enabled" : "disabled")
               << std::endl;
   }
   //! [set event based hold] [END storage_set_event_based_hold]
@@ -1047,16 +1109,30 @@ void ReleaseObjectEventBasedHold(google::cloud::storage::Client client,
   auto object_name = ConsumeArg(argc, argv);
   //! [release event based hold] [START storage_release_event_based_hold]
   namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
-    gcs::ObjectMetadata original =
+    StatusOr<gcs::ObjectMetadata> original =
         client.GetObjectMetadata(bucket_name, object_name);
-    gcs::ObjectMetadata updated_metadata = client.PatchObject(
+    if (not original.ok()) {
+      std::cerr << "Error getting object metadata for object " << object_name
+                << " in bucket " << bucket_name
+                << ", status=" << original.status() << std::endl;
+      return;
+    }
+    StatusOr<gcs::ObjectMetadata> updated = client.PatchObject(
         bucket_name, object_name,
         gcs::ObjectMetadataPatchBuilder().SetEventBasedHold(false),
-        gcs::IfMetagenerationMatch(original.metageneration()));
-    std::cout << "The event hold for object " << updated_metadata.name()
-              << " in bucket " << updated_metadata.bucket() << " is "
-              << (updated_metadata.event_based_hold() ? "enabled" : "disabled")
+        gcs::IfMetagenerationMatch(original->metageneration()));
+    if (not updated.ok()) {
+      std::cerr << "Error patching object metadata for object " << object_name
+                << " in bucket " << bucket_name
+                << ", status=" << updated.status() << std::endl;
+      return;
+    }
+
+    std::cout << "The event hold for object " << updated->name()
+              << " in bucket " << updated->bucket() << " is "
+              << (updated->event_based_hold() ? "enabled" : "disabled")
               << std::endl;
   }
   //! [release event based hold] [END storage_release_event_based_hold]
@@ -1072,16 +1148,30 @@ void SetObjectTemporaryHold(google::cloud::storage::Client client, int& argc,
   auto object_name = ConsumeArg(argc, argv);
   //! [set temporary hold] [START storage_set_temporary_hold]
   namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
-    gcs::ObjectMetadata original =
+    StatusOr<gcs::ObjectMetadata> original =
         client.GetObjectMetadata(bucket_name, object_name);
-    gcs::ObjectMetadata metadata = client.PatchObject(
+    if (not original.ok()) {
+      std::cerr << "Error getting object metadata for object " << object_name
+                << " in bucket " << bucket_name
+                << ", status=" << original.status() << std::endl;
+      return;
+    }
+    StatusOr<gcs::ObjectMetadata> updated = client.PatchObject(
         bucket_name, object_name,
         gcs::ObjectMetadataPatchBuilder().SetTemporaryHold(true),
-        gcs::IfMetagenerationMatch(original.metageneration()));
-    std::cout << "The temporary hold for object " << metadata.name()
-              << " in bucket " << metadata.bucket() << " is "
-              << (metadata.temporary_hold() ? "enabled" : "disabled")
+        gcs::IfMetagenerationMatch(original->metageneration()));
+    if (not updated.ok()) {
+      std::cerr << "Error patching object metadata for object " << object_name
+                << " in bucket " << bucket_name
+                << ", status=" << updated.status() << std::endl;
+      return;
+    }
+
+    std::cout << "The temporary hold for object " << updated->name()
+              << " in bucket " << updated->bucket() << " is "
+              << (updated->temporary_hold() ? "enabled" : "disabled")
               << std::endl;
   }
   //! [set temporary hold] [END storage_set_temporary_hold]
@@ -1097,16 +1187,29 @@ void ReleaseObjectTemporaryHold(google::cloud::storage::Client client,
   auto object_name = ConsumeArg(argc, argv);
   //! [release temporary hold] [START storage_release_temporary_hold]
   namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
-    gcs::ObjectMetadata original =
+    StatusOr<gcs::ObjectMetadata> original =
         client.GetObjectMetadata(bucket_name, object_name);
-    gcs::ObjectMetadata metadata = client.PatchObject(
+    if (not original.ok()) {
+      std::cerr << "Error getting object metadata for object " << object_name
+                << " in bucket " << bucket_name
+                << ", status=" << original.status() << std::endl;
+      return;
+    }
+    StatusOr<gcs::ObjectMetadata> updated = client.PatchObject(
         bucket_name, object_name,
         gcs::ObjectMetadataPatchBuilder().SetTemporaryHold(false),
-        gcs::IfMetagenerationMatch(original.metageneration()));
-    std::cout << "The temporary hold for object " << metadata.name()
-              << " in bucket " << metadata.bucket() << " is "
-              << (metadata.temporary_hold() ? "enabled" : "disabled")
+        gcs::IfMetagenerationMatch(original->metageneration()));
+    if (not updated.ok()) {
+      std::cerr << "Error patching object metadata for object " << object_name
+                << " in bucket " << bucket_name
+                << ", status=" << updated.status() << std::endl;
+      return;
+    }
+    std::cout << "The temporary hold for object " << updated->name()
+              << " in bucket " << updated->bucket() << " is "
+              << (updated->temporary_hold() ? "enabled" : "disabled")
               << std::endl;
   }
   //! [release temporary hold] [END storage_release_temporary_hold]

--- a/google/cloud/storage/object_test.cc
+++ b/google/cloud/storage/object_test.cc
@@ -148,23 +148,26 @@ TEST_F(ObjectTest, GetObjectMetadata) {
 
   auto actual =
       client.GetObjectMetadata("test-bucket-name", "test-object-name");
-  EXPECT_EQ(expected, actual);
+  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  EXPECT_EQ(expected, *actual);
 }
 
 TEST_F(ObjectTest, GetObjectMetadataTooManyFailures) {
-  testing::TooManyFailuresTest<ObjectMetadata>(
+  testing::TooManyFailuresStatusTest<ObjectMetadata>(
       mock, EXPECT_CALL(*mock, GetObjectMetadata(_)),
       [](Client& client) {
-        client.GetObjectMetadata("test-bucket-name", "test-object-name");
+        return client.GetObjectMetadata("test-bucket-name", "test-object-name")
+            .status();
       },
       "GetObjectMetadata");
 }
 
 TEST_F(ObjectTest, GetObjectMetadataPermanentFailure) {
-  testing::PermanentFailureTest<ObjectMetadata>(
+  testing::PermanentFailureStatusTest<ObjectMetadata>(
       *client, EXPECT_CALL(*mock, GetObjectMetadata(_)),
       [](Client& client) {
-        client.GetObjectMetadata("test-bucket-name", "test-object-name");
+        return client.GetObjectMetadata("test-bucket-name", "test-object-name")
+            .status();
       },
       "GetObjectMetadata");
 }
@@ -277,33 +280,37 @@ TEST_F(ObjectTest, UpdateObject) {
   update.mutable_metadata().emplace("test-label", "test-value");
   auto actual =
       client.UpdateObject("test-bucket-name", "test-object-name", update);
-  EXPECT_EQ(expected, actual);
+  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  EXPECT_EQ(expected, *actual);
 }
 
 TEST_F(ObjectTest, UpdateObjectTooManyFailures) {
-  testing::TooManyFailuresTest<ObjectMetadata>(
+  testing::TooManyFailuresStatusTest<ObjectMetadata>(
       mock, EXPECT_CALL(*mock, UpdateObject(_)),
       [](Client& client) {
-        client.UpdateObject(
-            "test-bucket-name", "test-object-name",
-            ObjectMetadata().set_content_language("new-language"));
+        return client
+            .UpdateObject("test-bucket-name", "test-object-name",
+                          ObjectMetadata().set_content_language("new-language"))
+            .status();
       },
       [](Client& client) {
-        client.UpdateObject(
-            "test-bucket-name", "test-object-name",
-            ObjectMetadata().set_content_language("new-language"),
-            IfMetagenerationMatch(42));
+        return client
+            .UpdateObject("test-bucket-name", "test-object-name",
+                          ObjectMetadata().set_content_language("new-language"),
+                          IfMetagenerationMatch(42))
+            .status();
       },
       "UpdateObject");
 }
 
 TEST_F(ObjectTest, UpdateObjectPermanentFailure) {
-  testing::PermanentFailureTest<ObjectMetadata>(
+  testing::PermanentFailureStatusTest<ObjectMetadata>(
       *client, EXPECT_CALL(*mock, UpdateObject(_)),
       [](Client& client) {
-        client.UpdateObject(
-            "test-bucket-name", "test-object-name",
-            ObjectMetadata().set_content_language("new-language"));
+        return client
+            .UpdateObject("test-bucket-name", "test-object-name",
+                          ObjectMetadata().set_content_language("new-language"))
+            .status();
       },
       "UpdateObject");
 }
@@ -349,33 +356,40 @@ TEST_F(ObjectTest, PatchObject) {
                                    ObjectMetadataPatchBuilder()
                                        .SetContentDisposition("new-disposition")
                                        .SetContentLanguage("x-made-up-lang"));
-  EXPECT_EQ(expected, actual);
+  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  EXPECT_EQ(expected, *actual);
 }
 
 TEST_F(ObjectTest, PatchObjectTooManyFailures) {
-  testing::TooManyFailuresTest<ObjectMetadata>(
+  testing::TooManyFailuresStatusTest<ObjectMetadata>(
       mock, EXPECT_CALL(*mock, PatchObject(_)),
       [](Client& client) {
-        client.PatchObject(
-            "test-bucket-name", "test-object-name",
-            ObjectMetadataPatchBuilder().SetContentLanguage("x-pig-latin"));
+        return client
+            .PatchObject(
+                "test-bucket-name", "test-object-name",
+                ObjectMetadataPatchBuilder().SetContentLanguage("x-pig-latin"))
+            .status();
       },
       [](Client& client) {
-        client.PatchObject(
-            "test-bucket-name", "test-object-name",
-            ObjectMetadataPatchBuilder().SetContentLanguage("x-pig-latin"),
-            IfMetagenerationMatch(42));
+        return client
+            .PatchObject(
+                "test-bucket-name", "test-object-name",
+                ObjectMetadataPatchBuilder().SetContentLanguage("x-pig-latin"),
+                IfMetagenerationMatch(42))
+            .status();
       },
       "PatchObject");
 }
 
 TEST_F(ObjectTest, PatchObjectPermanentFailure) {
-  testing::PermanentFailureTest<ObjectMetadata>(
+  testing::PermanentFailureStatusTest<ObjectMetadata>(
       *client, EXPECT_CALL(*mock, PatchObject(_)),
       [](Client& client) {
-        client.PatchObject(
-            "test-bucket-name", "test-object-name",
-            ObjectMetadataPatchBuilder().SetContentLanguage("x-pig-latin"));
+        return client
+            .PatchObject(
+                "test-bucket-name", "test-object-name",
+                ObjectMetadataPatchBuilder().SetContentLanguage("x-pig-latin"))
+            .status();
       },
       "PatchObject");
 }

--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -360,13 +360,14 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclAuthenticatedRead) {
       PredefinedAcl::AuthenticatedRead(), Fields(""));
   ASSERT_TRUE(insert.ok()) << "status=" << insert.status();
 
-  ObjectMetadata meta =
+  StatusOr<ObjectMetadata> meta =
       client.GetObjectMetadata(bucket_name, object_name, Projection::Full());
-  EXPECT_LT(0, CountMatchingEntities(meta.acl(),
+  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  EXPECT_LT(0, CountMatchingEntities(meta->acl(),
                                      ObjectAccessControl()
                                          .set_entity("allAuthenticatedUsers")
                                          .set_role("READER")))
-      << meta;
+      << *meta;
 
   StatusOr<void> status = client.DeleteObject(bucket_name, object_name);
   ASSERT_TRUE(status.ok()) << "status=" << status.status();
@@ -389,12 +390,13 @@ TEST_F(ObjectInsertIntegrationTest,
       PredefinedAcl::BucketOwnerFullControl(), Fields(""));
   ASSERT_TRUE(insert.ok()) << "status=" << insert.status();
 
-  ObjectMetadata meta =
+  StatusOr<ObjectMetadata> meta =
       client.GetObjectMetadata(bucket_name, object_name, Projection::Full());
+  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
   EXPECT_LT(0, CountMatchingEntities(
-                   meta.acl(),
+                   meta->acl(),
                    ObjectAccessControl().set_entity(owner).set_role("OWNER")))
-      << meta;
+      << *meta;
 
   StatusOr<void> status = client.DeleteObject(bucket_name, object_name);
   ASSERT_TRUE(status.ok()) << "status=" << status.status();
@@ -416,12 +418,13 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclBucketOwnerRead) {
       PredefinedAcl::BucketOwnerRead(), Fields(""));
   ASSERT_TRUE(insert.ok()) << "status=" << insert.status();
 
-  ObjectMetadata meta =
+  StatusOr<ObjectMetadata> meta =
       client.GetObjectMetadata(bucket_name, object_name, Projection::Full());
+  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
   EXPECT_LT(0, CountMatchingEntities(
-                   meta.acl(),
+                   meta->acl(),
                    ObjectAccessControl().set_entity(owner).set_role("READER")))
-      << meta;
+      << *meta;
 
   StatusOr<void> status = client.DeleteObject(bucket_name, object_name);
   ASSERT_TRUE(status.ok()) << "status=" << status.status();
@@ -437,14 +440,15 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclPrivate) {
       PredefinedAcl::Private(), Fields(""));
   ASSERT_TRUE(insert.ok()) << "status=" << insert.status();
 
-  ObjectMetadata meta =
+  StatusOr<ObjectMetadata> meta =
       client.GetObjectMetadata(bucket_name, object_name, Projection::Full());
-  ASSERT_TRUE(meta.has_owner());
-  EXPECT_LT(
-      0, CountMatchingEntities(meta.acl(), ObjectAccessControl()
-                                               .set_entity(meta.owner().entity)
-                                               .set_role("OWNER")))
-      << meta;
+  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_TRUE(meta->has_owner());
+  EXPECT_LT(0, CountMatchingEntities(meta->acl(),
+                                     ObjectAccessControl()
+                                         .set_entity(meta->owner().entity)
+                                         .set_role("OWNER")))
+      << *meta;
 
   StatusOr<void> status = client.DeleteObject(bucket_name, object_name);
   ASSERT_TRUE(status.ok()) << "status=" << status.status();
@@ -460,14 +464,15 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclProjectPrivate) {
       PredefinedAcl::ProjectPrivate(), Fields(""));
   ASSERT_TRUE(insert.ok()) << "status=" << insert.status();
 
-  ObjectMetadata meta =
+  StatusOr<ObjectMetadata> meta =
       client.GetObjectMetadata(bucket_name, object_name, Projection::Full());
-  ASSERT_TRUE(meta.has_owner());
-  EXPECT_LT(
-      0, CountMatchingEntities(meta.acl(), ObjectAccessControl()
-                                               .set_entity(meta.owner().entity)
-                                               .set_role("OWNER")))
-      << meta;
+  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_TRUE(meta->has_owner());
+  EXPECT_LT(0, CountMatchingEntities(meta->acl(),
+                                     ObjectAccessControl()
+                                         .set_entity(meta->owner().entity)
+                                         .set_role("OWNER")))
+      << *meta;
 
   StatusOr<void> status = client.DeleteObject(bucket_name, object_name);
   ASSERT_TRUE(status.ok()) << "status=" << status.status();
@@ -483,13 +488,14 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclPublicRead) {
       PredefinedAcl::PublicRead(), Fields(""));
   ASSERT_TRUE(insert.ok()) << "status=" << insert.status();
 
-  ObjectMetadata meta =
+  StatusOr<ObjectMetadata> meta =
       client.GetObjectMetadata(bucket_name, object_name, Projection::Full());
+  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
   EXPECT_LT(
       0, CountMatchingEntities(
-             meta.acl(),
+             meta->acl(),
              ObjectAccessControl().set_entity("allUsers").set_role("READER")))
-      << meta;
+      << *meta;
 
   StatusOr<void> status = client.DeleteObject(bucket_name, object_name);
   ASSERT_TRUE(status.ok()) << "status=" << status.status();


### PR DESCRIPTION
In this change the remaining "CRUD" operations: GetObjectMetadata,
UpdateObject, and PatchObject.

This closes #1670, closes #1663, and closes #1662.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1851)
<!-- Reviewable:end -->
