### PR TITLE
Cleanup BucketAccessControl public interface.

### DIFF
--- a/google/cloud/storage/bucket_access_control.cc
+++ b/google/cloud/storage/bucket_access_control.cc
@@ -19,25 +19,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-StatusOr<BucketAccessControl> BucketAccessControl::ParseFromJson(
-    internal::nl::json const& json) {
-  if (!json.is_object()) {
-    return Status(StatusCode::kInvalidArgument, __func__);
-  }
-  BucketAccessControl result{};
-  auto status = AccessControlCommon::ParseFromJson(result, json);
-  if (!status.ok()) {
-    return status;
-  }
-  return result;
-}
-
-StatusOr<BucketAccessControl> BucketAccessControl::ParseFromString(
-    std::string const& payload) {
-  auto json = internal::nl::json::parse(payload, nullptr, false);
-  return BucketAccessControl::ParseFromJson(json);
-}
-
 bool BucketAccessControl::operator==(BucketAccessControl const& rhs) const {
   return *static_cast<internal::AccessControlCommon const*>(this) == rhs;
 }

--- a/google/cloud/storage/bucket_access_control.h
+++ b/google/cloud/storage/bucket_access_control.h
@@ -23,6 +23,10 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+struct BucketAccessControlParser;
+}  // namespace internal
+
 /**
  * Wraps the bucketAccessControl resource in Google Cloud Storage.
  *
@@ -36,13 +40,6 @@ inline namespace STORAGE_CLIENT_NS {
 class BucketAccessControl : private internal::AccessControlCommon {
  public:
   BucketAccessControl() = default;
-
-  static StatusOr<BucketAccessControl> ParseFromJson(
-      internal::nl::json const& json);
-
-  /// Parse from a string in JSON format.
-  static StatusOr<BucketAccessControl> ParseFromString(
-      std::string const& payload);
 
   using AccessControlCommon::ROLE_OWNER;
   using AccessControlCommon::ROLE_READER;
@@ -79,6 +76,8 @@ class BucketAccessControl : private internal::AccessControlCommon {
   bool operator!=(BucketAccessControl const& rhs) const {
     return !(*this == rhs);
   }
+
+  friend struct internal::BucketAccessControlParser;
 };
 
 std::ostream& operator<<(std::ostream& os, BucketAccessControl const& rhs);

--- a/google/cloud/storage/bucket_access_control_test.cc
+++ b/google/cloud/storage/bucket_access_control_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/bucket_access_control.h"
+#include "google/cloud/storage/internal/bucket_acl_requests.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -20,44 +21,6 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-
-/// @test Verify that we parse JSON objects into BucketAccessControl objects.
-TEST(BucketAccessControlTest, Parse) {
-  std::string text = R"""({
-      "bucket": "foo-bar",
-      "domain": "example.com",
-      "email": "foobar@example.com",
-      "entity": "user-foobar",
-      "entityId": "user-foobar-id-123",
-      "etag": "XYZ=",
-      "id": "bucket-foo-bar-acl-234",
-      "kind": "storage#bucketAccessControl",
-      "projectTeam": {
-        "projectNumber": "3456789",
-        "team": "a-team"
-      },
-      "role": "OWNER"
-})""";
-  auto actual = BucketAccessControl::ParseFromString(text).value();
-
-  EXPECT_EQ("foo-bar", actual.bucket());
-  EXPECT_EQ("example.com", actual.domain());
-  EXPECT_EQ("foobar@example.com", actual.email());
-  EXPECT_EQ("user-foobar", actual.entity());
-  EXPECT_EQ("user-foobar-id-123", actual.entity_id());
-  EXPECT_EQ("XYZ=", actual.etag());
-  EXPECT_EQ("bucket-foo-bar-acl-234", actual.id());
-  EXPECT_EQ("storage#bucketAccessControl", actual.kind());
-  EXPECT_EQ("3456789", actual.project_team().project_number);
-  EXPECT_EQ("a-team", actual.project_team().team);
-  EXPECT_EQ("OWNER", actual.role());
-}
-
-/// @test Verify that we parse JSON objects into BucketAccessControl objects.
-TEST(BucketAccessControlTest, ParseFailure) {
-  auto actual = BucketAccessControl::ParseFromString("{123");
-  EXPECT_FALSE(actual.ok());
-}
 
 /// @test Verify that the IOStream operator works as expected.
 TEST(BucketAccessControlTest, IOStream) {
@@ -79,7 +42,7 @@ TEST(BucketAccessControlTest, IOStream) {
       "role": "OWNER"
 })""";
 
-  auto meta = BucketAccessControl::ParseFromString(text).value();
+  auto meta = internal::BucketAccessControlParser::FromString(text).value();
   std::ostringstream os;
   os << meta;
   auto actual = os.str();
@@ -124,7 +87,7 @@ TEST(BucketAccessControlTest, Compare) {
       },
       "role": "OWNER"
 })""";
-  auto original = BucketAccessControl::ParseFromString(text).value();
+  auto original = internal::BucketAccessControlParser::FromString(text).value();
   EXPECT_EQ(original, original);
 
   auto modified = original;

--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/status.h"
 #include "google/cloud/internal/ios_flags_saver.h"
 #include "google/cloud/storage/internal/format_rfc3339.h"
+#include "google/cloud/storage/internal/bucket_acl_requests.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include "google/cloud/storage/internal/nljson.h"
 
@@ -125,7 +126,7 @@ StatusOr<BucketMetadata> BucketMetadata::ParseFromJson(
 
   if (json.count("acl") != 0) {
     for (auto const& kv : json["acl"].items()) {
-      auto parsed = BucketAccessControl::ParseFromJson(kv.value());
+      auto parsed = internal::BucketAccessControlParser::FromJson(kv.value());
       if (!parsed.ok()) {
         return std::move(parsed).status();
       }

--- a/google/cloud/storage/bucket_metadata_test.cc
+++ b/google/cloud/storage/bucket_metadata_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/bucket_metadata.h"
+#include "google/cloud/storage/internal/bucket_acl_requests.h"
 #include "google/cloud/storage/internal/format_rfc3339.h"
 #include "google/cloud/storage/storage_class.h"
 #include <gmock/gmock.h>
@@ -818,7 +819,7 @@ TEST(BucketMetadataTest, ResetWebsite) {
 
 TEST(BucketMetadataPatchBuilder, SetAcl) {
   BucketMetadataPatchBuilder builder;
-  builder.SetAcl({BucketAccessControl::ParseFromString(
+  builder.SetAcl({internal::BucketAccessControlParser::FromString(
                       R"""({"entity": "user-test-user", "role": "OWNER"})""")
                       .value()});
 

--- a/google/cloud/storage/internal/access_control_common.h
+++ b/google/cloud/storage/internal/access_control_common.h
@@ -134,7 +134,6 @@ class AccessControlCommon {
   }
   bool operator!=(AccessControlCommon const& rhs) { return !(*this == rhs); }
 
- protected:
   static Status ParseFromJson(AccessControlCommon& result,
                               nl::json const& json);
 

--- a/google/cloud/storage/internal/bucket_acl_requests.h
+++ b/google/cloud/storage/internal/bucket_acl_requests.h
@@ -26,6 +26,12 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
+struct BucketAccessControlParser {
+  static StatusOr<BucketAccessControl> FromJson(internal::nl::json const& json);
+
+  static StatusOr<BucketAccessControl> FromString(std::string const& payload);
+};
+
 /// Represents a request to call the `BucketAccessControl: list` API.
 class ListBucketAclRequest
     : public GenericRequest<ListBucketAclRequest, UserProject> {

--- a/google/cloud/storage/internal/bucket_acl_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_acl_requests_test.cc
@@ -157,7 +157,7 @@ BucketAccessControl CreateBucketAccessControlForTest() {
       },
       "role": "OWNER"
 })""";
-  return BucketAccessControl::ParseFromString(text).value();
+  return internal::BucketAccessControlParser::FromString(text).value();
 }
 
 TEST(BucketAclRequestTest, PatchDiff) {

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/bucket_requests.h"
+#include "google/cloud/storage/internal/bucket_acl_requests.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -186,7 +187,7 @@ TEST(PatchBucketRequestTest, DiffSetAcl) {
   BucketMetadata original = CreateBucketMetadataForTest();
   original.set_acl({});
   BucketMetadata updated = original;
-  updated.set_acl({BucketAccessControl::ParseFromString(
+  updated.set_acl({internal::BucketAccessControlParser::FromString(
                        R"""({"entity": "user-test-user", "role": "OWNER"})""")
                        .value()});
   PatchBucketRequest request("test-bucket", original, updated);
@@ -199,7 +200,7 @@ TEST(PatchBucketRequestTest, DiffSetAcl) {
 
 TEST(PatchBucketRequestTest, DiffResetAcl) {
   BucketMetadata original = CreateBucketMetadataForTest();
-  original.set_acl({BucketAccessControl::ParseFromString(
+  original.set_acl({internal::BucketAccessControlParser::FromString(
                         R"""({"entity": "user-test-user", "role": "OWNER"})""")
                         .value()});
   BucketMetadata updated = original;


### PR DESCRIPTION
This change moves ParseFromJson() out of the public interface for the
library. We should not expect customers to use this member function, nor
do we want to expose the internal JSON representation in our public
interfaces.

More changes will follow for other similar types. This is part of the work for #1734.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1864)
<!-- Reviewable:end -->
