### PR TITLE
Move exceptions outside of Credentials class ctors.

### DIFF
--- a/google/cloud/storage/oauth2/authorized_user_credentials.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.cc
@@ -20,7 +20,8 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 AuthorizedUserCredentialsInfo ParseAuthorizedUserCredentials(
-    std::string const& content, std::string const& source) {
+    std::string const& content, std::string const& source,
+    std::string const& default_token_uri) {
   auto credentials =
       storage::internal::nl::json::parse(content, nullptr, false);
   if (credentials.is_discarded()) {
@@ -32,6 +33,7 @@ AuthorizedUserCredentialsInfo ParseAuthorizedUserCredentials(
   char const client_id_key[] = "client_id";
   char const client_secret_key[] = "client_secret";
   char const refresh_token_key[] = "refresh_token";
+  char const token_uri_key[] = "token_uri";  // Not required; often not present.
   for (auto const& key :
        {client_id_key, client_secret_key, refresh_token_key}) {
     if (credentials.count(key) == 0U) {
@@ -48,7 +50,11 @@ AuthorizedUserCredentialsInfo ParseAuthorizedUserCredentials(
   return AuthorizedUserCredentialsInfo{
       credentials.value(client_id_key, ""),
       credentials.value(client_secret_key, ""),
-      credentials.value(refresh_token_key, "")};
+      credentials.value(refresh_token_key, ""),
+      // Some credential formats (e.g. gcloud's ADC file) don't contain a
+      // "token_uri" attribute in the JSON object.  In this case, we try using
+      // the default value.
+      credentials.value(token_uri_key, default_token_uri)};
 }
 }  // namespace oauth2
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
@@ -158,8 +158,8 @@ TEST_F(AuthorizedUserCredentialsTest, ParseSimple) {
       "type": "magic_type"
 })""";
 
-  auto actual = ParseAuthorizedUserCredentials(
-      config, "test-data", "unused-uri");
+  auto actual =
+      ParseAuthorizedUserCredentials(config, "test-data", "unused-uri");
   EXPECT_EQ("a-client-id.example.com", actual.client_id);
   EXPECT_EQ("a-123456ABCDEF", actual.client_secret);
   EXPECT_EQ("1/THETOKEN", actual.refresh_token);
@@ -218,9 +218,9 @@ TEST_F(AuthorizedUserCredentialsTest, ParseInvalidContentsFails) {
       },
       std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(ParseAuthorizedUserCredentials(
-                                config, "test-as-a-source"),
-                            "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      ParseAuthorizedUserCredentials(config, "test-as-a-source"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 

--- a/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
@@ -173,7 +173,6 @@ TEST_F(AuthorizedUserCredentialsTest, ParseUsesExplicitDefaultTokenUri) {
       "client_id": "a-client-id.example.com",
       "client_secret": "a-123456ABCDEF",
       "refresh_token": "1/THETOKEN",
-      "token_uri": "https://oauth2.googleapis.com/test_endpoint",
       "type": "magic_type"
 })""";
 

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -48,12 +48,14 @@ std::unique_ptr<Credentials> LoadCredsFromPath(std::string const& path) {
   }
   std::string cred_type = cred_json.value("type", "no type given");
   if (cred_type == "authorized_user") {
+    auto info = ParseAuthorizedUserCredentials(contents, path);
     return google::cloud::internal::make_unique<AuthorizedUserCredentials<>>(
-        contents, path);
+        info);
   }
   if (cred_type == "service_account") {
+    auto info = ParseServiceAccountCredentials(contents, path);
     return google::cloud::internal::make_unique<ServiceAccountCredentials<>>(
-        contents, path);
+        info);
   }
   ThrowRuntimeError(
       "Unsupported credential type (" + cred_type +
@@ -127,24 +129,28 @@ std::shared_ptr<Credentials> CreateAuthorizedUserCredentialsFromJsonFilePath(
     std::string const& path) {
   std::ifstream is(path);
   std::string contents(std::istreambuf_iterator<char>{is}, {});
-  return std::make_shared<AuthorizedUserCredentials<>>(contents, path);
+  auto info = ParseAuthorizedUserCredentials(contents, path);
+  return std::make_shared<AuthorizedUserCredentials<>>(info);
 }
 
 std::shared_ptr<Credentials> CreateAuthorizedUserCredentialsFromJsonContents(
     std::string const& contents) {
-  return std::make_shared<AuthorizedUserCredentials<>>(contents, "memory");
+  auto info = ParseAuthorizedUserCredentials(contents, "memory");
+  return std::make_shared<AuthorizedUserCredentials<>>(info);
 }
 
 std::shared_ptr<Credentials> CreateServiceAccountCredentialsFromJsonFilePath(
     std::string const& path) {
   std::ifstream is(path);
   std::string contents(std::istreambuf_iterator<char>{is}, {});
-  return std::make_shared<ServiceAccountCredentials<>>(contents, path);
+  auto info = ParseServiceAccountCredentials(contents, path);
+  return std::make_shared<ServiceAccountCredentials<>>(info);
 }
 
 std::shared_ptr<Credentials> CreateServiceAccountCredentialsFromJsonContents(
     std::string const& contents) {
-  return std::make_shared<ServiceAccountCredentials<>>(contents, "memory");
+  auto info = ParseServiceAccountCredentials(contents, "memory");
+  return std::make_shared<ServiceAccountCredentials<>>(info);
 }
 
 std::shared_ptr<Credentials> CreateComputeEngineCredentials() {

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -56,13 +56,13 @@ ServiceAccountCredentialsInfo ParseServiceAccountCredentials(
         " field is empty on data loaded from " + source);
   }
   return ServiceAccountCredentialsInfo{
+      credentials.value(client_email_key, ""),
       credentials.value(private_key_id_key, ""),
       credentials.value(private_key_key, ""),
       // Some credential formats (e.g. gcloud's ADC file) don't contain a
       // "token_uri" attribute in the JSON object.  In this case, we try using
       // the default value.
       credentials.value(token_uri_key, default_token_uri),
-      credentials.value(client_email_key, ""),
   };
 }
 

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -209,8 +209,8 @@ TEST_F(ServiceAccountCredentialsTest, ParseSimple) {
       "token_uri": "https://oauth2.googleapis.com/test_endpoint"
 })""";
 
-  auto actual = ParseServiceAccountCredentials(
-      contents, "test-data", "unused-uri");
+  auto actual =
+      ParseServiceAccountCredentials(contents, "test-data", "unused-uri");
   EXPECT_EQ("not-a-key-id-just-for-testing", actual.private_key_id);
   EXPECT_EQ("not-a-valid-key-just-for-testing", actual.private_key);
   EXPECT_EQ("test-only@test-group.example.com", actual.client_email);
@@ -268,9 +268,9 @@ TEST_F(ServiceAccountCredentialsTest, ParseInvalidContentsFails) {
       },
       std::invalid_argument);
 #else
-  EXPECT_DEATH_IF_SUPPORTED(ParseServiceAccountCredentials(
-                                config, "test-as-a-source"),
-                            "exceptions are disabled");
+  EXPECT_DEATH_IF_SUPPORTED(
+      ParseServiceAccountCredentials(config, "test-as-a-source"),
+      "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 


### PR DESCRIPTION
We don't want the constructors of Credentials subclasses to throw
exceptions, so the parsing steps that could have thrown them have been
moved outside of the ctors, which now accept structs containing the
already-parsed information.

The tests have also been cleaned up a bit to test parsing separately
from credential instantiation, and the test names were tweaked to be
more specific (e.g. to indicate if we're testing that something is supposed
to fail, as opposed to a success case).  Duplicate tests were also removed
(e.g. one that tested for failure when a field was left out was removed, as
we had another test farther down that removed *each* field and checked
for failures in each case).