### PR TITLE
Cleanup NotificationMetadata public interface.

### DIFF
--- a/google/cloud/storage/client_notifications_test.cc
+++ b/google/cloud/storage/client_notifications_test.cc
@@ -59,12 +59,12 @@ class NotificationsTest : public ::testing::Test {
 
 TEST_F(NotificationsTest, ListNotifications) {
   std::vector<NotificationMetadata> expected{
-      NotificationMetadata::ParseFromString(R"""({
+      internal::NotificationMetadataParser::FromString(R"""({
           "id": "test-notification-1",
           "topic": "test-topic-1"
       })""")
           .value(),
-      NotificationMetadata::ParseFromString(R"""({
+      internal::NotificationMetadataParser::FromString(R"""({
           "id": "test-notification-2",
           "topic": "test-topic-2"
       })""")
@@ -107,7 +107,7 @@ TEST_F(NotificationsTest, ListNotificationsPermanentFailure) {
 }
 
 TEST_F(NotificationsTest, CreateNotification) {
-  NotificationMetadata expected = NotificationMetadata::ParseFromString(R"""({
+  NotificationMetadata expected = internal::NotificationMetadataParser::FromString(R"""({
           "id": "test-notification-1",
           "topic": "test-topic-1",
           "payload_format": "JSON_API_V1",
@@ -162,7 +162,7 @@ TEST_F(NotificationsTest, CreateNotificationPermanentFailure) {
 }
 
 TEST_F(NotificationsTest, GetNotification) {
-  NotificationMetadata expected = NotificationMetadata::ParseFromString(R"""({
+  NotificationMetadata expected = internal::NotificationMetadataParser::FromString(R"""({
           "id": "test-notification-1",
           "topic": "test-topic-1",
           "payload_format": "JSON_API_V1",

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -1021,7 +1021,7 @@ StatusOr<NotificationMetadata> CurlClient::CreateNotification(
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
-  return ParseFromString<NotificationMetadata>(
+  return CheckedFromString<NotificationMetadataParser>(
       builder.BuildRequest().MakeRequest(request.json_payload()));
 }
 
@@ -1035,7 +1035,7 @@ StatusOr<NotificationMetadata> CurlClient::GetNotification(
   if (!status.ok()) {
     return status;
   }
-  return ParseFromString<NotificationMetadata>(
+  return CheckedFromString<NotificationMetadataParser>(
       builder.BuildRequest().MakeRequest(std::string{}));
 }
 

--- a/google/cloud/storage/internal/notification_requests.h
+++ b/google/cloud/storage/internal/notification_requests.h
@@ -26,6 +26,12 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
+struct NotificationMetadataParser {
+  static StatusOr<NotificationMetadata> FromJson(
+      internal::nl::json const& json);
+  static StatusOr<NotificationMetadata> FromString(std::string const& payload);
+};
+
 /// Represents a request to call the `BucketAccessControls: list` API.
 class ListNotificationsRequest
     : public GenericRequest<ListNotificationsRequest, UserProject> {

--- a/google/cloud/storage/notification_metadata.cc
+++ b/google/cloud/storage/notification_metadata.cc
@@ -18,43 +18,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-StatusOr<NotificationMetadata> NotificationMetadata::ParseFromJson(
-    internal::nl::json const& json) {
-  if (!json.is_object()) {
-    return Status(StatusCode::kInvalidArgument, __func__);
-  }
-  NotificationMetadata result{};
-
-  if (json.count("custom_attributes") != 0U) {
-    for (auto const& kv : json["custom_attributes"].items()) {
-      result.custom_attributes_.emplace(kv.key(),
-                                        kv.value().get<std::string>());
-    }
-  }
-  result.etag_ = json.value("etag", "");
-
-  if (json.count("event_types") != 0U) {
-    for (auto const& kv : json["event_types"].items()) {
-      result.event_types_.emplace_back(kv.value().get<std::string>());
-    }
-  }
-
-  result.id_ = json.value("id", "");
-  result.kind_ = json.value("kind", "");
-  result.object_name_prefix_ = json.value("object_name_prefix", "");
-  result.payload_format_ = json.value("payload_format", "");
-  result.self_link_ = json.value("selfLink", "");
-  result.topic_ = json.value("topic", "");
-
-  return result;
-}
-
-StatusOr<NotificationMetadata> NotificationMetadata::ParseFromString(
-    std::string const& payload) {
-  internal::nl::json json = internal::nl::json::parse(payload, nullptr, false);
-  return ParseFromJson(json);
-}
-
 std::string NotificationMetadata::JsonPayloadForInsert() const {
   // Required fields, always include them, even if empty.
   internal::nl::json json{

--- a/google/cloud/storage/notification_metadata.h
+++ b/google/cloud/storage/notification_metadata.h
@@ -24,6 +24,10 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+struct NotificationMetadataParser;
+}  // namespace internal
+
 /**
  * Represents the metadata for a Google Cloud Storage Notification resource.
  *
@@ -38,11 +42,6 @@ inline namespace STORAGE_CLIENT_NS {
 class NotificationMetadata {
  public:
   NotificationMetadata() = default;
-
-  static StatusOr<NotificationMetadata> ParseFromJson(
-      internal::nl::json const& json);
-  static StatusOr<NotificationMetadata> ParseFromString(
-      std::string const& payload);
 
   /**
    * Returns the payload for a call to `Notifications: insert`.
@@ -171,6 +170,7 @@ class NotificationMetadata {
   }
 
  private:
+  friend struct internal::NotificationMetadataParser;
   friend std::ostream& operator<<(std::ostream& os,
                                   NotificationMetadata const& rhs);
 

--- a/google/cloud/storage/notification_metadata_test.cc
+++ b/google/cloud/storage/notification_metadata_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/notification_metadata.h"
+#include "google/cloud/storage/internal/notification_requests.h"
 #include "google/cloud/storage/notification_event_type.h"
 #include "google/cloud/storage/notification_payload_format.h"
 #include <gmock/gmock.h>
@@ -44,40 +45,7 @@ NotificationMetadata CreateNotificationMetadataForTest() {
       "selfLink": "https://www.googleapis.com/storage/v1/b/test-bucket/notificationConfigs/test-id-123",
       "topic": "test-topic"
 })""";
-  return NotificationMetadata::ParseFromString(text).value();
-}
-
-/// @test Verify that we parse JSON objects into NotificationMetadata objects.
-TEST(NotificationMetadataTest, Parse) {
-  auto actual = CreateNotificationMetadataForTest();
-  EXPECT_EQ(2U, actual.custom_attributes().size());
-  EXPECT_TRUE(actual.has_custom_attribute("test-ca-1"));
-  EXPECT_EQ("value1", actual.custom_attribute("test-ca-1"));
-  EXPECT_TRUE(actual.has_custom_attribute("test-ca-2"));
-  EXPECT_EQ("value2", actual.custom_attribute("test-ca-2"));
-
-  EXPECT_EQ("XYZ=", actual.etag());
-  EXPECT_EQ(4U, actual.event_type_size());
-  EXPECT_EQ(4U, actual.event_types().size());
-  EXPECT_EQ(event_type::ObjectFinalize(), actual.event_type(0));
-  EXPECT_EQ(event_type::ObjectMetadataUpdate(), actual.event_type(1));
-  EXPECT_EQ(event_type::ObjectDelete(), actual.event_type(2));
-  EXPECT_EQ(event_type::ObjectArchive(), actual.event_type(3));
-
-  EXPECT_EQ("test-id-123", actual.id());
-  EXPECT_EQ("storage#notification", actual.kind());
-  EXPECT_EQ(payload_format::JsonApiV1(), actual.payload_format());
-  EXPECT_EQ(
-      "https://www.googleapis.com/storage/v1/b/test-bucket/"
-      "notificationConfigs/test-id-123",
-      actual.self_link());
-  EXPECT_EQ("test-topic", actual.topic());
-}
-
-/// @test Verify that we parse JSON objects into NotificationMetadata objects.
-TEST(NotificationMetadataTest, ParseFailure) {
-  auto actual = NotificationMetadata::ParseFromString("{123");
-  EXPECT_FALSE(actual.ok());
+  return internal::NotificationMetadataParser::FromString(text).value();
 }
 
 /// @test Verifies NotificationMetadata iostream operator.


### PR DESCRIPTION
This change moves ParseFromJson() and ParseFromString() to the internal
namespace. We do not want to expose the internal representation for JSON
objects in the public interface, nor do we want to expose APIs that the
application developers do not need or should not use.

Part of the work for #1734.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1870)
<!-- Reviewable:end -->
