### PR TITLE
Cleanup ObjectAccessControl public interface.

### DIFF
--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/internal/bucket_acl_requests.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include "google/cloud/storage/internal/nljson.h"
+#include "google/cloud/storage/internal/object_acl_requests.h"
 
 namespace google {
 namespace cloud {
@@ -150,7 +151,7 @@ StatusOr<BucketMetadata> BucketMetadata::ParseFromJson(
   }
   if (json.count("defaultObjectAcl") != 0) {
     for (auto const& kv : json["defaultObjectAcl"].items()) {
-      auto parsed = ObjectAccessControl::ParseFromJson(kv.value());
+      auto parsed = internal::ObjectAccessControlParser::FromJson(kv.value());
       if (!parsed.ok()) {
         return std::move(parsed).status();
       }

--- a/google/cloud/storage/bucket_metadata_test.cc
+++ b/google/cloud/storage/bucket_metadata_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/bucket_metadata.h"
 #include "google/cloud/storage/internal/bucket_acl_requests.h"
 #include "google/cloud/storage/internal/format_rfc3339.h"
+#include "google/cloud/storage/internal/object_acl_requests.h"
 #include "google/cloud/storage/storage_class.h"
 #include <gmock/gmock.h>
 
@@ -920,7 +921,7 @@ TEST(BucketMetadataPatchBuilder, ResetDefaultEventBasedHold) {
 
 TEST(BucketMetadataPatchBuilder, SetDefaultAcl) {
   BucketMetadataPatchBuilder builder;
-  builder.SetDefaultAcl({ObjectAccessControl::ParseFromString(
+  builder.SetDefaultAcl({internal::ObjectAccessControlParser::FromString(
       R"""({"entity": "user-test-user", "role": "OWNER"})""").value()});
 
   auto actual = builder.BuildPatch();

--- a/google/cloud/storage/client_default_object_acl_test.cc
+++ b/google/cloud/storage/client_default_object_acl_test.cc
@@ -56,13 +56,13 @@ class DefaultObjectAccessControlsTest : public ::testing::Test {
 
 TEST_F(DefaultObjectAccessControlsTest, ListDefaultObjectAcl) {
   std::vector<ObjectAccessControl> expected{
-      ObjectAccessControl::ParseFromString(R"""({
+      internal::ObjectAccessControlParser::FromString(R"""({
           "bucket": "test-bucket",
           "entity": "user-test-user-1",
           "role": "OWNER"
       })""")
           .value(),
-      ObjectAccessControl::ParseFromString(R"""({
+      internal::ObjectAccessControlParser::FromString(R"""({
           "bucket": "test-bucket",
           "entity": "user-test-user-2",
           "role": "READER"
@@ -106,7 +106,7 @@ TEST_F(DefaultObjectAccessControlsTest, ListDefaultObjectAclPermanentFailure) {
 }
 
 TEST_F(DefaultObjectAccessControlsTest, CreateDefaultObjectAcl) {
-  auto expected = ObjectAccessControl::ParseFromString(R"""({
+  auto expected = internal::ObjectAccessControlParser::FromString(R"""({
           "bucket": "test-bucket",
           "entity": "user-test-user-1",
           "role": "READER"
@@ -211,7 +211,7 @@ TEST_F(DefaultObjectAccessControlsTest,
 }
 
 TEST_F(DefaultObjectAccessControlsTest, GetDefaultObjectAcl) {
-  ObjectAccessControl expected = ObjectAccessControl::ParseFromString(R"""({
+  ObjectAccessControl expected = internal::ObjectAccessControlParser::FromString(R"""({
           "bucket": "test-bucket",
           "entity": "user-test-user-1",
           "role": "OWNER"
@@ -258,7 +258,7 @@ TEST_F(DefaultObjectAccessControlsTest, GetDefaultObjectAclPermanentFailure) {
 }
 
 TEST_F(DefaultObjectAccessControlsTest, UpdateDefaultObjectAcl) {
-  auto expected = ObjectAccessControl::ParseFromString(R"""({
+  auto expected = internal::ObjectAccessControlParser::FromString(R"""({
           "bucket": "test-bucket",
           "entity": "user-test-user-1",
           "role": "READER"
@@ -319,7 +319,7 @@ TEST_F(DefaultObjectAccessControlsTest,
 }
 
 TEST_F(DefaultObjectAccessControlsTest, PatchDefaultObjectAcl) {
-  auto result = ObjectAccessControl::ParseFromString(R"""({
+  auto result = internal::ObjectAccessControlParser::FromString(R"""({
           "bucket": "test-bucket",
           "entity": "user-test-user-1",
           "role": "OWNER"

--- a/google/cloud/storage/client_object_acl_test.cc
+++ b/google/cloud/storage/client_object_acl_test.cc
@@ -55,14 +55,14 @@ class ObjectAccessControlsTest : public ::testing::Test {
 
 TEST_F(ObjectAccessControlsTest, ListObjectAcl) {
   std::vector<ObjectAccessControl> expected{
-      ObjectAccessControl::ParseFromString(R"""({
+      internal::ObjectAccessControlParser::FromString(R"""({
           "bucket": "test-bucket",
           "object": "test-object",
           "entity": "user-test-user-1",
           "role": "OWNER"
       })""")
           .value(),
-      ObjectAccessControl::ParseFromString(R"""({
+      internal::ObjectAccessControlParser::FromString(R"""({
           "bucket": "test-bucket",
           "object": "test-object",
           "entity": "user-test-user-2",
@@ -109,7 +109,7 @@ TEST_F(ObjectAccessControlsTest, ListObjectAclPermanentFailure) {
 }
 
 TEST_F(ObjectAccessControlsTest, CreateObjectAcl) {
-  auto expected = ObjectAccessControl::ParseFromString(R"""({
+  auto expected = internal::ObjectAccessControlParser::FromString(R"""({
           "bucket": "test-bucket",
           "object": "test-object",
           "entity": "user-test-user-1",
@@ -218,7 +218,7 @@ TEST_F(ObjectAccessControlsTest, DeleteObjectAclPermanentFailure) {
 }
 
 TEST_F(ObjectAccessControlsTest, GetObjectAcl) {
-  auto expected = ObjectAccessControl::ParseFromString(R"""({
+  auto expected = internal::ObjectAccessControlParser::FromString(R"""({
           "bucket": "test-bucket",
           "object": "test-object",
           "entity": "user-test-user-1",
@@ -268,7 +268,7 @@ TEST_F(ObjectAccessControlsTest, GetObjectAclPermanentFailure) {
 }
 
 TEST_F(ObjectAccessControlsTest, UpdateObjectAcl) {
-  auto expected = ObjectAccessControl::ParseFromString(R"""({
+  auto expected = internal::ObjectAccessControlParser::FromString(R"""({
           "bucket": "test-bucket",
           "object": "test-object",
           "entity": "user-test-user-1",
@@ -325,7 +325,7 @@ TEST_F(ObjectAccessControlsTest, UpdateObjectAclPermanentFailure) {
 }
 
 TEST_F(ObjectAccessControlsTest, PatchObjectAcl) {
-  auto result = ObjectAccessControl::ParseFromString(R"""({
+  auto result = internal::ObjectAccessControlParser::FromString(R"""({
           "bucket": "test-bucket",
           "object": "test-object",
           "entity": "user-test-user-1",

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/internal/bucket_requests.h"
 #include "google/cloud/storage/internal/bucket_acl_requests.h"
+#include "google/cloud/storage/internal/object_acl_requests.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -292,7 +293,7 @@ TEST(PatchBucketRequestTest, DiffSetDefaultAcl) {
   original.set_default_acl({});
   BucketMetadata updated = original;
   updated.set_default_acl(
-      {ObjectAccessControl::ParseFromString(
+      {internal::ObjectAccessControlParser::FromString(
            R"""({"entity": "user-test-user", "role": "OWNER"})""")
            .value()});
   PatchBucketRequest request("test-bucket", original, updated);
@@ -306,7 +307,7 @@ TEST(PatchBucketRequestTest, DiffSetDefaultAcl) {
 
 TEST(PatchBucketRequestTest, DiffResetDefaultAcl) {
   BucketMetadata original = CreateBucketMetadataForTest();
-  original.set_default_acl({ObjectAccessControl::ParseFromString(
+  original.set_default_acl({internal::ObjectAccessControlParser::FromString(
       R"""({"entity": "user-test-user", "role": "OWNER"})""")
       .value()});
   BucketMetadata updated = original;

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -825,7 +825,7 @@ StatusOr<ObjectAccessControl> CurlClient::CreateObjectAcl(
   nl::json object;
   object["entity"] = request.entity();
   object["role"] = request.role();
-  return ParseFromString<ObjectAccessControl>(
+  return CheckedFromString<ObjectAccessControlParser>(
       builder.BuildRequest().MakeRequest(object.dump()));
 }
 
@@ -854,7 +854,7 @@ StatusOr<ObjectAccessControl> CurlClient::GetObjectAcl(
   if (!status.ok()) {
     return status;
   }
-  return ParseFromString<ObjectAccessControl>(
+  return CheckedFromString<ObjectAccessControlParser>(
       builder.BuildRequest().MakeRequest(std::string{}));
 }
 
@@ -873,7 +873,7 @@ StatusOr<ObjectAccessControl> CurlClient::UpdateObjectAcl(
   nl::json object;
   object["entity"] = request.entity();
   object["role"] = request.role();
-  return ParseFromString<ObjectAccessControl>(
+  return CheckedFromString<ObjectAccessControlParser>(
       builder.BuildRequest().MakeRequest(object.dump()));
 }
 
@@ -889,7 +889,7 @@ StatusOr<ObjectAccessControl> CurlClient::PatchObjectAcl(
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
-  return ParseFromString<ObjectAccessControl>(
+  return CheckedFromString<ObjectAccessControlParser>(
       builder.BuildRequest().MakeRequest(request.payload()));
 }
 
@@ -920,7 +920,7 @@ StatusOr<ObjectAccessControl> CurlClient::CreateDefaultObjectAcl(
   object["entity"] = request.entity();
   object["role"] = request.role();
   builder.AddHeader("Content-Type: application/json");
-  return ParseFromString<ObjectAccessControl>(
+  return CheckedFromString<ObjectAccessControlParser>(
       builder.BuildRequest().MakeRequest(object.dump()));
 }
 
@@ -947,7 +947,7 @@ StatusOr<ObjectAccessControl> CurlClient::GetDefaultObjectAcl(
   if (!status.ok()) {
     return status;
   }
-  return ParseFromString<ObjectAccessControl>(
+  return CheckedFromString<ObjectAccessControlParser>(
       builder.BuildRequest().MakeRequest(std::string{}));
 }
 
@@ -965,7 +965,7 @@ StatusOr<ObjectAccessControl> CurlClient::UpdateDefaultObjectAcl(
   nl::json object;
   object["entity"] = request.entity();
   object["role"] = request.role();
-  return ParseFromString<ObjectAccessControl>(
+  return CheckedFromString<ObjectAccessControlParser>(
       builder.BuildRequest().MakeRequest(object.dump()));
 }
 
@@ -980,7 +980,7 @@ StatusOr<ObjectAccessControl> CurlClient::PatchDefaultObjectAcl(
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
-  return ParseFromString<ObjectAccessControl>(
+  return CheckedFromString<ObjectAccessControlParser>(
       builder.BuildRequest().MakeRequest(request.payload()));
 }
 

--- a/google/cloud/storage/internal/default_object_acl_requests.cc
+++ b/google/cloud/storage/internal/default_object_acl_requests.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/internal/default_object_acl_requests.h"
 #include "google/cloud/storage/internal/nljson.h"
+#include "google/cloud/storage/internal/object_acl_requests.h"
 #include <iostream>
 
 namespace google {
@@ -36,7 +37,7 @@ ListDefaultObjectAclResponse::FromHttpResponse(HttpResponse&& response) {
   }
   ListDefaultObjectAclResponse result;
   for (auto const& kv : json["items"].items()) {
-    auto parsed = ObjectAccessControl::ParseFromJson(kv.value());
+    auto parsed = internal::ObjectAccessControlParser::FromJson(kv.value());
     if (!parsed.ok()) {
       return std::move(parsed).status();
     }

--- a/google/cloud/storage/internal/default_object_acl_requests_test.cc
+++ b/google/cloud/storage/internal/default_object_acl_requests_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/internal/default_object_acl_requests.h"
 #include "google/cloud/storage/internal/curl_request_builder.h"
+#include "google/cloud/storage/internal/object_acl_requests.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -160,7 +161,7 @@ ObjectAccessControl CreateDefaultObjectAccessControlForTest() {
       },
       "role": "OWNER"
 })""";
-  return ObjectAccessControl::ParseFromString(text).value();
+  return internal::ObjectAccessControlParser::FromString(text).value();
 }
 
 TEST(DefaultObjectAclRequestTest, PatchDiff) {

--- a/google/cloud/storage/internal/object_acl_requests.h
+++ b/google/cloud/storage/internal/object_acl_requests.h
@@ -27,6 +27,11 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
+struct ObjectAccessControlParser {
+  static StatusOr<ObjectAccessControl> FromJson(internal::nl::json const& json);
+  static StatusOr<ObjectAccessControl> FromString(std::string const& payload);
+};
+
 /**
  * Represents a request for the `ObjectAccessControls: list` API.
  */

--- a/google/cloud/storage/internal/object_acl_requests_test.cc
+++ b/google/cloud/storage/internal/object_acl_requests_test.cc
@@ -24,6 +24,75 @@ namespace internal {
 namespace {
 using ::testing::HasSubstr;
 
+/// @test Verify that we parse JSON objects into ObjectAccessControl objects.
+TEST(ObjectAccessControlTest, Parse) {
+  std::string text = R"""({
+      "bucket": "foo-bar",
+      "domain": "example.com",
+      "email": "foobar@example.com",
+      "entity": "user-foobar",
+      "entityId": "user-foobar-id-123",
+      "etag": "XYZ=",
+      "generation": 42,
+      "id": "object-foo-bar-baz-acl-234",
+      "kind": "storage#objectAccessControl",
+      "object": "baz",
+      "projectTeam": {
+        "projectNumber": "3456789",
+        "team": "a-team"
+      },
+      "role": "OWNER"
+})""";
+  auto actual = internal::ObjectAccessControlParser::FromString(text).value();
+
+  EXPECT_EQ("foo-bar", actual.bucket());
+  EXPECT_EQ("example.com", actual.domain());
+  EXPECT_EQ("foobar@example.com", actual.email());
+  EXPECT_EQ("user-foobar", actual.entity());
+  EXPECT_EQ("user-foobar-id-123", actual.entity_id());
+  EXPECT_EQ("XYZ=", actual.etag());
+  EXPECT_EQ(42, actual.generation());
+  EXPECT_EQ("object-foo-bar-baz-acl-234", actual.id());
+  EXPECT_EQ("storage#objectAccessControl", actual.kind());
+  EXPECT_EQ("baz", actual.object());
+  EXPECT_EQ("3456789", actual.project_team().project_number);
+  EXPECT_EQ("a-team", actual.project_team().team);
+  EXPECT_EQ("OWNER", actual.role());
+}
+
+/// @test Verify that the IOStream operator works as expected.
+TEST(ObjectAccessControlTest, IOStream) {
+  // The iostream operator is mostly there to support EXPECT_EQ() so it is
+  // rarely called, and that breaks our code coverage metrics.
+  std::string text = R"""({
+      "bucket": "foo-bar",
+      "domain": "example.com",
+      "email": "foobar@example.com",
+      "entity": "user-foobar",
+      "entityId": "user-foobar-id-123",
+      "etag": "XYZ=",
+      "generation": 42,
+      "id": "object-foo-bar-baz-acl-234",
+      "kind": "storage#objectAccessControl",
+      "object": "baz",
+      "projectTeam": {
+        "projectNumber": "3456789",
+        "team": "a-team"
+      },
+      "role": "OWNER"
+})""";
+
+  auto meta = internal::ObjectAccessControlParser::FromString(text).value();
+  std::ostringstream os;
+  os << meta;
+  auto actual = os.str();
+  using ::testing::HasSubstr;
+  EXPECT_THAT(actual, HasSubstr("ObjectAccessControl"));
+  EXPECT_THAT(actual, HasSubstr("bucket=foo-bar"));
+  EXPECT_THAT(actual, HasSubstr("object=baz"));
+  EXPECT_THAT(actual, HasSubstr("id=object-foo-bar-baz-acl-234"));
+}
+
 TEST(ObjectAclRequestTest, List) {
   ListObjectAclRequest request("my-bucket", "my-object");
   request.set_multiple_options(UserProject("my-project"), Generation(7));
@@ -176,7 +245,7 @@ ObjectAccessControl CreateObjectAccessControlForTest() {
       },
       "role": "OWNER"
 })""";
-  return ObjectAccessControl::ParseFromString(text).value();
+  return internal::ObjectAccessControlParser::FromString(text).value();
 }
 
 TEST(ObjectAclRequestTest, PatchDiff) {

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/internal/binary_data_as_debug_string.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include "google/cloud/storage/internal/nljson.h"
+#include "google/cloud/storage/internal/object_acl_requests.h"
 #include "google/cloud/storage/object_metadata.h"
 #include <sstream>
 
@@ -53,7 +54,7 @@ StatusOr<ObjectMetadata> ObjectMetadataParser::FromJson(
 
   if (json.count("acl") != 0) {
     for (auto const& kv : json["acl"].items()) {
-      auto parsed = ObjectAccessControl::ParseFromJson(kv.value());
+      auto parsed = ObjectAccessControlParser::FromJson(kv.value());
       if (!parsed.ok()) {
         return std::move(parsed).status();
       }

--- a/google/cloud/storage/internal/object_requests_test.cc
+++ b/google/cloud/storage/internal/object_requests_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/object_requests.h"
+#include "google/cloud/storage/internal/object_acl_requests.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -677,7 +678,7 @@ TEST(PatchObjectRequestTest, DiffSetAcl) {
   ObjectMetadata original = CreateObjectMetadataForTest();
   original.set_acl({});
   ObjectMetadata updated = original;
-  updated.set_acl({ObjectAccessControl::ParseFromString(
+  updated.set_acl({internal::ObjectAccessControlParser::FromString(
       R"""({"entity": "user-test-user", "role": "OWNER"})""")
       .value()});
   PatchObjectRequest request("test-bucket", "test-object", original, updated);
@@ -691,7 +692,7 @@ TEST(PatchObjectRequestTest, DiffSetAcl) {
 
 TEST(PatchObjectRequestTest, DiffResetAcl) {
   ObjectMetadata original = CreateObjectMetadataForTest();
-  original.set_acl({ObjectAccessControl::ParseFromString(
+  original.set_acl({internal::ObjectAccessControlParser::FromString(
       R"""({"entity": "user-test-user", "role": "OWNER"})""")
       .value()});
   ObjectMetadata updated = original;

--- a/google/cloud/storage/object_access_control.cc
+++ b/google/cloud/storage/object_access_control.cc
@@ -20,27 +20,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-StatusOr<ObjectAccessControl> ObjectAccessControl::ParseFromJson(
-    internal::nl::json const& json) {
-  if (!json.is_object()) {
-    return Status(StatusCode::kInvalidArgument, __func__);
-  }
-  ObjectAccessControl result{};
-  auto status = AccessControlCommon::ParseFromJson(result, json);
-  if (!status.ok()) {
-    return status;
-  }
-  result.generation_ = internal::ParseLongField(json, "generation");
-  result.object_ = json.value("object", "");
-  return result;
-}
-
-StatusOr<ObjectAccessControl> ObjectAccessControl::ParseFromString(
-    std::string const& payload) {
-  auto json = internal::nl::json::parse(payload, nullptr, false);
-  return ParseFromJson(json);
-}
-
 bool ObjectAccessControl::operator==(ObjectAccessControl const& rhs) const {
   // Start with id, generation, object, bucket, etag because they should fail
   // early, then alphabetical for readability.

--- a/google/cloud/storage/object_access_control.h
+++ b/google/cloud/storage/object_access_control.h
@@ -25,6 +25,10 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+struct ObjectAccessControlParser;
+}  // namespace internal
+
 /**
  * Wraps the objectAccessControl resource in Google Cloud Storage.
  *
@@ -38,11 +42,6 @@ inline namespace STORAGE_CLIENT_NS {
 class ObjectAccessControl : private internal::AccessControlCommon {
  public:
   ObjectAccessControl() : generation_(0) {}
-
-  static StatusOr<ObjectAccessControl> ParseFromJson(
-      internal::nl::json const& json);
-  static StatusOr<ObjectAccessControl> ParseFromString(
-      std::string const& payload);
 
   using AccessControlCommon::ROLE_OWNER;
   using AccessControlCommon::ROLE_READER;
@@ -85,6 +84,8 @@ class ObjectAccessControl : private internal::AccessControlCommon {
   }
 
  private:
+  friend struct internal::ObjectAccessControlParser;
+
   std::int64_t generation_;
   std::string object_;
 };

--- a/google/cloud/storage/object_metadata.cc
+++ b/google/cloud/storage/object_metadata.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/internal/format_rfc3339.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include "google/cloud/storage/internal/nljson.h"
+#include "google/cloud/storage/internal/object_acl_requests.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/object_metadata_test.cc
+++ b/google/cloud/storage/object_metadata_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/object_metadata.h"
 #include "google/cloud/storage/internal/object_requests.h"
+#include "google/cloud/storage/internal/object_acl_requests.h"
 #include "google/cloud/storage/internal/parse_rfc3339.h"
 #include <gmock/gmock.h>
 
@@ -328,7 +329,7 @@ TEST(ObjectMetadataTest, InsertMetadata) {
 
 TEST(ObjectMetadataPatchBuilder, SetAcl) {
   ObjectMetadataPatchBuilder builder;
-  builder.SetAcl({ObjectAccessControl::ParseFromString(
+  builder.SetAcl({internal::ObjectAccessControlParser::FromString(
       R"""({"entity": "user-test-user", "role": "OWNER"})""").value()});
 
   auto actual = builder.BuildPatch();


### PR DESCRIPTION
This change moves ParseFromJson() out of the public interface for the
library. We should not expect customers to use this member function, nor
do we want to expose the internal JSON representation in our public
interfaces.

More changes will follow for other similar types.

Part of the changes for #1734.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1871)
<!-- Reviewable:end -->
