### PR TITLE
Re-added "Include Order" section to the style guide

### DIFF
--- a/doc/cpp-style-guide.md
+++ b/doc/cpp-style-guide.md
@@ -73,7 +73,7 @@ headers. For example:
 #include <google/bigtable/blah.h>
 #include <map>
 #include <vector>
-#include <unitstd.h>
+#include <unistd.h>
 ```
 
 This differs substantially from the corresponding section in the GSG, but we

--- a/doc/cpp-style-guide.md
+++ b/doc/cpp-style-guide.md
@@ -65,7 +65,7 @@ projects, followed by C++ standard library headers, followed by C system
 headers. For example:
 
 ```C++
-// Within file google/cloud/x/foo.cc
+// Within the file google/cloud/x/foo.cc
 #include "google/cloud/x/foo.h"
 #include "google/cloud/x/bar.h"
 #include "google/cloud/y/baz.h"

--- a/doc/cpp-style-guide.md
+++ b/doc/cpp-style-guide.md
@@ -58,10 +58,11 @@ Enumerators (for both scoped and unscoped enums) should be named like: `ENUM_NAM
 ## Order of Includes
 
 Order includes from local to global to minimize implicit dependencies between
-headers. That is, start with the `.h` file that corresponds to the `.cc` file
-(including the corresonding unit test file), followed by other `.h` files from
-the same project, followed by inclues from external projects, followed by C++
-standard library headers, followed by C system headers. For example:
+headers. That is, start with the `.h` file that corresponds to the current
+`.cc` file (also do this for the corresonding unit test file), followed by
+other `.h` files from the same project, followed by includes from external
+projects, followed by C++ standard library headers, followed by C system
+headers. For example:
 
 ```C++
 // Within file google/cloud/x/foo.cc
@@ -76,7 +77,8 @@ standard library headers, followed by C system headers. For example:
 ```
 
 This differs substantially from the corresponding section in the GSG, but we
-feel the difference is worth it.
+feel the rule presented here is both simpler and better minimizes the implicit
+dependencies exposed to each header.
 [link to GSG's section on include order](https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes)
 
 ## Legal Notice and Author Line

--- a/doc/cpp-style-guide.md
+++ b/doc/cpp-style-guide.md
@@ -70,7 +70,7 @@ headers. For example:
 #include "google/cloud/x/bar.h
 #include "google/cloud/y/baz.h
 #include <grpcpp/blorg.h>
-#include <google/bigtable/blah.h"
+#include <google/bigtable/blah.h>
 #include <map>
 #include <vector>
 #include <unitstd.h>

--- a/doc/cpp-style-guide.md
+++ b/doc/cpp-style-guide.md
@@ -67,8 +67,8 @@ headers. For example:
 ```C++
 // Within file google/cloud/x/foo.cc
 #include "google/cloud/x/foo.h"
-#include "google/cloud/x/bar.h
-#include "google/cloud/y/baz.h
+#include "google/cloud/x/bar.h"
+#include "google/cloud/y/baz.h"
 #include <grpcpp/blorg.h>
 #include <google/bigtable/blah.h>
 #include <map>

--- a/doc/cpp-style-guide.md
+++ b/doc/cpp-style-guide.md
@@ -79,6 +79,7 @@ headers. For example:
 This differs substantially from the corresponding section in the GSG, but we
 feel the rule presented here is both simpler and better minimizes the implicit
 dependencies exposed to each header.
+
 [link to GSG's section on include order](https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes)
 
 ## Legal Notice and Author Line

--- a/doc/cpp-style-guide.md
+++ b/doc/cpp-style-guide.md
@@ -55,6 +55,30 @@ Enumerators (for both scoped and unscoped enums) should be named like: `ENUM_NAM
 
 [link to GSG's section on enumerator names](https://google.github.io/styleguide/cppguide.html#Enumerator_Names)
 
+## Order of Includes
+
+Order includes from local to global to minimize implicit dependencies between
+headers. That is, start with the `.h` file that corresponds to the `.cc` file
+(including the corresonding unit test file), followed by other `.h` files from
+the same project, followed by inclues from external projects, followed by C++
+standard library headers, followed by C system headers. For example:
+
+```C++
+// Within file google/cloud/x/foo.cc
+#include "google/cloud/x/foo.h"
+#include "google/cloud/x/bar.h
+#include "google/cloud/y/baz.h
+#include <grpcpp/blorg.h>
+#include <google/bigtable/blah.h"
+#include <map>
+#include <vector>
+#include <unitstd.h>
+```
+
+This differs substantially from the corresponding section in the GSG, but we
+feel the difference is worth it.
+[link to GSG's section on include order](https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes)
+
 ## Legal Notice and Author Line
 
 Every file should contain license boilerplate, for new files use:


### PR DESCRIPTION
When I previously changed the style guide I accidentally removed this section. When I realized that the old style guide for this project differed from the GSG on this point, my intent was to "fix" our code to align it with the GSG's guidance on this point. But then I started doing that it all the includes looked less sensible to me. So after some reflection and discussion w/ other Googler's about this style point, I think I prefer if *this* project violates the GSG on this point and keeps the current include ordering that we've been using. 

Thanks for doing this the right way from the start, Carlos! :-) Sorry I accidentally removed this section.

[skip ci]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1876)
<!-- Reviewable:end -->
