### PR TITLE
Cleanup: Changes member relational operators to non-member binary operators

### DIFF
--- a/google/cloud/storage/bucket_access_control.cc
+++ b/google/cloud/storage/bucket_access_control.cc
@@ -19,8 +19,9 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-bool BucketAccessControl::operator==(BucketAccessControl const& rhs) const {
-  return *static_cast<internal::AccessControlCommon const*>(this) == rhs;
+bool operator==(BucketAccessControl const& lhs,
+                BucketAccessControl const& rhs) {
+  return *static_cast<internal::AccessControlCommon const*>(&lhs) == rhs;
 }
 
 std::ostream& operator<<(std::ostream& os, BucketAccessControl const& rhs) {

--- a/google/cloud/storage/bucket_access_control.h
+++ b/google/cloud/storage/bucket_access_control.h
@@ -30,7 +30,7 @@ struct BucketAccessControlParser;
 /**
  * Wraps the bucketAccessControl resource in Google Cloud Storage.
  *
- * bucketAccessControl describes the access to a bucket for a single entity,
+ * BucketAccessControl describes the access to a bucket for a single entity,
  * where the entity might be a user, group, or other role.
  *
  * @see
@@ -72,9 +72,11 @@ class BucketAccessControl : private internal::AccessControlCommon {
 
   using AccessControlCommon::self_link;
 
-  bool operator==(BucketAccessControl const& rhs) const;
-  bool operator!=(BucketAccessControl const& rhs) const {
-    return !(*this == rhs);
+  friend bool operator==(BucketAccessControl const& lhs,
+                         BucketAccessControl const& rhs);
+  friend bool operator!=(BucketAccessControl const& lhs,
+                         BucketAccessControl const& rhs) {
+    return !(lhs == rhs);
   }
 
   friend struct internal::BucketAccessControlParser;

--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -77,18 +77,20 @@ std::ostream& operator<<(std::ostream& os, BucketRetentionPolicy const& rhs) {
             << ", locked=" << rhs.is_locked << "}";
 }
 
-bool BucketMetadata::operator==(BucketMetadata const& rhs) const {
-  return static_cast<internal::CommonMetadata<BucketMetadata> const&>(*this) ==
-             rhs and
-         acl_ == rhs.acl_ && billing_ == rhs.billing_ && cors_ == rhs.cors_ &&
-         default_event_based_hold_ == rhs.default_event_based_hold_ &&
-         default_acl_ == rhs.default_acl_ && encryption_ == rhs.encryption_ &&
-         iam_configuration_ == rhs.iam_configuration_ &&
-         project_number_ == rhs.project_number_ &&
-         lifecycle_ == rhs.lifecycle_ && location_ == rhs.location_ &&
-         logging_ == rhs.logging_ && labels_ == rhs.labels_ &&
-         retention_policy_ == rhs.retention_policy_ &&
-         versioning_ == rhs.versioning_ && website_ == rhs.website_;
+bool operator==(BucketMetadata const& lhs, BucketMetadata const& rhs) {
+  return static_cast<internal::CommonMetadata<BucketMetadata> const&>(lhs) ==
+             rhs &&
+         lhs.acl_ == rhs.acl_ && lhs.billing_ == rhs.billing_ &&
+         lhs.cors_ == rhs.cors_ &&
+         lhs.default_event_based_hold_ == rhs.default_event_based_hold_ &&
+         lhs.default_acl_ == rhs.default_acl_ &&
+         lhs.encryption_ == rhs.encryption_ &&
+         lhs.iam_configuration_ == rhs.iam_configuration_ &&
+         lhs.project_number_ == rhs.project_number_ &&
+         lhs.lifecycle_ == rhs.lifecycle_ && lhs.location_ == rhs.location_ &&
+         lhs.logging_ == rhs.logging_ && lhs.labels_ == rhs.labels_ &&
+         lhs.retention_policy_ == rhs.retention_policy_ &&
+         lhs.versioning_ == rhs.versioning_ && lhs.website_ == rhs.website_;
 }
 
 std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs) {

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -826,8 +826,10 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   }
   //@}
 
-  bool operator==(BucketMetadata const& rhs) const;
-  bool operator!=(BucketMetadata const& rhs) const { return !(*this == rhs); }
+  friend bool operator==(BucketMetadata const& lhs, BucketMetadata const& rhs);
+  friend bool operator!=(BucketMetadata const& lhs, BucketMetadata const& rhs) {
+    return !(lhs == rhs);
+  }
 
  private:
   friend struct internal::BucketMetadataParser;

--- a/google/cloud/storage/lifecycle_rule.h
+++ b/google/cloud/storage/lifecycle_rule.h
@@ -294,6 +294,7 @@ inline bool operator==(LifecycleRule const& lhs, LifecycleRule const& rhs) {
   return std::tie(lhs.condition(), lhs.action()) ==
          std::tie(rhs.condition(), rhs.action());
 }
+
 inline bool operator<(LifecycleRule const& lhs, LifecycleRule const& rhs) {
   return std::tie(lhs.action(), lhs.condition()) <
          std::tie(rhs.action(), rhs.condition());

--- a/google/cloud/storage/lifecycle_rule.h
+++ b/google/cloud/storage/lifecycle_rule.h
@@ -137,31 +137,6 @@ class LifecycleRule {
   LifecycleRuleAction const& action() const { return action_; }
   LifecycleRuleCondition const& condition() const { return condition_; }
 
-  bool operator==(LifecycleRule const& rhs) const {
-    return std::tie(condition_, action_) ==
-           std::tie(rhs.condition_, rhs.action_);
-  }
-  bool operator<(LifecycleRule const& rhs) const {
-    return std::tie(action_, condition_) <
-           std::tie(rhs.action_, rhs.condition_);
-  }
-
-  bool operator!=(LifecycleRule const& rhs) const {
-    return std::rel_ops::operator!=(*this, rhs);
-  }
-
-  bool operator>(LifecycleRule const& rhs) const {
-    return std::rel_ops::operator>(*this, rhs);
-  }
-
-  bool operator<=(LifecycleRule const& rhs) const {
-    return std::rel_ops::operator<=(*this, rhs);
-  }
-
-  bool operator>=(LifecycleRule const& rhs) const {
-    return std::rel_ops::operator>=(*this, rhs);
-  }
-
   //@{
   /**
    * @name Creates different types of LifecycleRule actions.
@@ -314,6 +289,31 @@ class LifecycleRule {
   LifecycleRuleAction action_;
   LifecycleRuleCondition condition_;
 };
+
+inline bool operator==(LifecycleRule const& lhs, LifecycleRule const& rhs) {
+  return std::tie(lhs.condition(), lhs.action()) ==
+         std::tie(rhs.condition(), rhs.action());
+}
+inline bool operator<(LifecycleRule const& lhs, LifecycleRule const& rhs) {
+  return std::tie(lhs.action(), lhs.condition()) <
+         std::tie(rhs.action(), rhs.condition());
+}
+
+inline bool operator!=(LifecycleRule const& lhs, LifecycleRule const& rhs) {
+  return std::rel_ops::operator!=(lhs, rhs);
+}
+
+inline bool operator>(LifecycleRule const& lhs, LifecycleRule const& rhs) {
+  return std::rel_ops::operator>(lhs, rhs);
+}
+
+inline bool operator<=(LifecycleRule const& lhs, LifecycleRule const& rhs) {
+  return std::rel_ops::operator<=(lhs, rhs);
+}
+
+inline bool operator>=(LifecycleRule const& lhs, LifecycleRule const& rhs) {
+  return std::rel_ops::operator>=(lhs, rhs);
+}
 
 std::ostream& operator<<(std::ostream& os, LifecycleRule const& rhs);
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/list_buckets_reader.h
+++ b/google/cloud/storage/list_buckets_reader.h
@@ -58,24 +58,26 @@ class ListBucketsIterator {
 #endif  // GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   value_type&& operator*() && { return std::move(value_); }
 
-  bool operator==(ListBucketsIterator const& rhs) const {
+  friend bool operator==(ListBucketsIterator const& lhs,
+                         ListBucketsIterator const& rhs) {
     // All end iterators are equal.
-    if (owner_ == nullptr) {
+    if (lhs.owner_ == nullptr) {
       return rhs.owner_ == nullptr;
     }
     // Iterators on different streams are always different.
-    if (owner_ != rhs.owner_) {
+    if (lhs.owner_ != rhs.owner_) {
       return false;
     }
     // Iterators on the same stream are equal if they point to the same object.
-    if (value_.ok() && rhs.value_.ok()) {
-      return value_.value() == rhs.value_.value();
+    if (lhs.value_.ok() && rhs.value_.ok()) {
+      return lhs.value_.value() == rhs.value_.value();
     }
-    return value_.status() == rhs.value_.status();
+    return lhs.value_.status() == rhs.value_.status();
   }
 
-  bool operator!=(ListBucketsIterator const& rhs) const {
-    return !(*this == rhs);
+  friend bool operator!=(ListBucketsIterator const& lhs,
+                         ListBucketsIterator const& rhs) {
+    return !(lhs == rhs);
   }
 
  private:

--- a/google/cloud/storage/list_objects_reader.h
+++ b/google/cloud/storage/list_objects_reader.h
@@ -59,24 +59,26 @@ class ListObjectsIterator {
 #endif  // GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   value_type&& operator*() && { return std::move(value_); }
 
-  bool operator==(ListObjectsIterator const& rhs) const {
+  friend bool operator==(ListObjectsIterator const& lhs,
+                         ListObjectsIterator const& rhs) {
     // All end iterators are equal.
-    if (owner_ == nullptr) {
+    if (lhs.owner_ == nullptr) {
       return rhs.owner_ == nullptr;
     }
     // Iterators on different streams are always different.
-    if (owner_ != rhs.owner_) {
+    if (lhs.owner_ != rhs.owner_) {
       return false;
     }
     // Iterators on the same stream are equal if they point to the same object.
-    if (value_.ok() && rhs.value_.ok()) {
-      return value_.value() == rhs.value_.value();
+    if (lhs.value_.ok() && rhs.value_.ok()) {
+      return lhs.value_.value() == rhs.value_.value();
     }
-    return value_.status() == rhs.value_.status();
+    return lhs.value_.status() == rhs.value_.status();
   }
 
-  bool operator!=(ListObjectsIterator const& rhs) const {
-    return !(*this == rhs);
+  friend bool operator!=(ListObjectsIterator const& lhs,
+                         ListObjectsIterator const& rhs) {
+    return !(lhs == rhs);
   }
 
  private:

--- a/google/cloud/storage/notification_metadata.h
+++ b/google/cloud/storage/notification_metadata.h
@@ -137,38 +137,6 @@ class NotificationMetadata {
     return *this;
   }
 
-  bool operator==(NotificationMetadata const& rhs) const {
-    return std::tie(id_, custom_attributes_, etag_, event_types_, kind_,
-                    object_name_prefix_, payload_format_, self_link_, topic_) ==
-           std::tie(rhs.id_, rhs.custom_attributes_, rhs.etag_,
-                    rhs.event_types_, rhs.kind_, rhs.object_name_prefix_,
-                    rhs.payload_format_, rhs.self_link_, rhs.topic_);
-  }
-
-  bool operator<(NotificationMetadata const& rhs) const {
-    return std::tie(id_, custom_attributes_, etag_, event_types_, kind_,
-                    object_name_prefix_, payload_format_, self_link_, topic_) <
-           std::tie(rhs.id_, rhs.custom_attributes_, rhs.etag_,
-                    rhs.event_types_, rhs.kind_, rhs.object_name_prefix_,
-                    rhs.payload_format_, rhs.self_link_, rhs.topic_);
-  }
-
-  bool operator!=(NotificationMetadata const& rhs) const {
-    return std::rel_ops::operator!=(*this, rhs);
-  }
-
-  bool operator>(NotificationMetadata const& rhs) const {
-    return std::rel_ops::operator>(*this, rhs);
-  }
-
-  bool operator<=(NotificationMetadata const& rhs) const {
-    return std::rel_ops::operator<=(*this, rhs);
-  }
-
-  bool operator>=(NotificationMetadata const& rhs) const {
-    return std::rel_ops::operator>=(*this, rhs);
-  }
-
  private:
   friend struct internal::NotificationMetadataParser;
   friend std::ostream& operator<<(std::ostream& os,
@@ -185,6 +153,46 @@ class NotificationMetadata {
   std::string self_link_;
   std::string topic_;
 };
+
+inline bool operator==(NotificationMetadata const& lhs,
+                       NotificationMetadata const& rhs) {
+  return std::tie(lhs.id(), lhs.custom_attributes(), lhs.etag(),
+                  lhs.event_types(), lhs.kind(), lhs.object_name_prefix(),
+                  lhs.payload_format(), lhs.self_link(), lhs.topic()) ==
+         std::tie(rhs.id(), rhs.custom_attributes(), rhs.etag(),
+                  rhs.event_types(), rhs.kind(), rhs.object_name_prefix(),
+                  rhs.payload_format(), rhs.self_link(), rhs.topic());
+}
+
+inline bool operator<(NotificationMetadata const& lhs,
+                      NotificationMetadata const& rhs) {
+  return std::tie(lhs.id(), lhs.custom_attributes(), lhs.etag(),
+                  lhs.event_types(), lhs.kind(), lhs.object_name_prefix(),
+                  lhs.payload_format(), lhs.self_link(), lhs.topic()) <
+         std::tie(rhs.id(), rhs.custom_attributes(), rhs.etag(),
+                  rhs.event_types(), rhs.kind(), rhs.object_name_prefix(),
+                  rhs.payload_format(), rhs.self_link(), rhs.topic());
+}
+
+inline bool operator!=(NotificationMetadata const& lhs,
+                       NotificationMetadata const& rhs) {
+  return std::rel_ops::operator!=(lhs, rhs);
+}
+
+inline bool operator>(NotificationMetadata const& lhs,
+                      NotificationMetadata const& rhs) {
+  return std::rel_ops::operator>(lhs, rhs);
+}
+
+inline bool operator<=(NotificationMetadata const& lhs,
+                       NotificationMetadata const& rhs) {
+  return std::rel_ops::operator<=(lhs, rhs);
+}
+
+inline bool operator>=(NotificationMetadata const& lhs,
+                       NotificationMetadata const& rhs) {
+  return std::rel_ops::operator>=(lhs, rhs);
+}
 
 std::ostream& operator<<(std::ostream& os, NotificationMetadata const& rhs);
 

--- a/google/cloud/storage/object_access_control.cc
+++ b/google/cloud/storage/object_access_control.cc
@@ -20,11 +20,12 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-bool ObjectAccessControl::operator==(ObjectAccessControl const& rhs) const {
+bool operator==(ObjectAccessControl const& lhs,
+                ObjectAccessControl const& rhs) {
   // Start with id, generation, object, bucket, etag because they should fail
   // early, then alphabetical for readability.
-  return object_ == rhs.object_ && generation_ == rhs.generation_ &&
-         *static_cast<internal::AccessControlCommon const*>(this) == rhs;
+  return lhs.object_ == rhs.object_ && lhs.generation_ == rhs.generation_ &&
+         *static_cast<internal::AccessControlCommon const*>(&lhs) == rhs;
 }
 
 std::ostream& operator<<(std::ostream& os, ObjectAccessControl const& rhs) {

--- a/google/cloud/storage/object_access_control.h
+++ b/google/cloud/storage/object_access_control.h
@@ -78,9 +78,11 @@ class ObjectAccessControl : private internal::AccessControlCommon {
   std::int64_t generation() const { return generation_; }
   std::string const& object() const { return object_; }
 
-  bool operator==(ObjectAccessControl const& rhs) const;
-  bool operator!=(ObjectAccessControl const& rhs) const {
-    return !(*this == rhs);
+  friend bool operator==(ObjectAccessControl const& lhs,
+                         ObjectAccessControl const& rhs);
+  friend bool operator!=(ObjectAccessControl const& lhs,
+                         ObjectAccessControl const& rhs) {
+    return !(lhs == rhs);
   }
 
  private:

--- a/google/cloud/storage/object_metadata.cc
+++ b/google/cloud/storage/object_metadata.cc
@@ -23,26 +23,26 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 
-bool ObjectMetadata::operator==(ObjectMetadata const& rhs) const {
-  return static_cast<internal::CommonMetadata<ObjectMetadata> const&>(*this) ==
-             rhs and
-         acl_ == rhs.acl_ && bucket_ == rhs.bucket_ &&
-         cache_control_ == rhs.cache_control_ &&
-         component_count_ == rhs.component_count_ &&
-         content_disposition_ == rhs.content_disposition_ &&
-         content_encoding_ == rhs.content_encoding_ &&
-         content_language_ == rhs.content_language_ &&
-         content_type_ == rhs.content_type_ && crc32c_ == rhs.crc32c_ &&
-         customer_encryption_ == customer_encryption_ &&
-         event_based_hold_ == rhs.event_based_hold_ &&
-         generation_ == rhs.generation_ && kms_key_name_ == rhs.kms_key_name_ &&
-         md5_hash_ == rhs.md5_hash_ && media_link_ == rhs.media_link_ &&
-         metadata_ == rhs.metadata_ &&
-         retention_expiration_time_ == rhs.retention_expiration_time_ &&
-         temporary_hold_ == rhs.temporary_hold_ &&
-         time_deleted_ == rhs.time_deleted_ &&
-         time_storage_class_updated_ == rhs.time_storage_class_updated_ &&
-         size_ == rhs.size_;
+bool operator==(ObjectMetadata const& lhs, ObjectMetadata const& rhs) {
+  return static_cast<internal::CommonMetadata<ObjectMetadata> const&>(lhs) ==
+             rhs &&
+         lhs.acl_ == rhs.acl_ && lhs.bucket_ == rhs.bucket_ &&
+         lhs.cache_control_ == rhs.cache_control_ &&
+         lhs.component_count_ == rhs.component_count_ &&
+         lhs.content_disposition_ == rhs.content_disposition_ &&
+         lhs.content_encoding_ == rhs.content_encoding_ &&
+         lhs.content_language_ == rhs.content_language_ &&
+         lhs.content_type_ == rhs.content_type_ && lhs.crc32c_ == rhs.crc32c_ &&
+         lhs.customer_encryption_ == rhs.customer_encryption_ &&
+         lhs.event_based_hold_ == rhs.event_based_hold_ &&
+         lhs.generation_ == rhs.generation_ && lhs.kms_key_name_ == rhs.kms_key_name_ &&
+         lhs.md5_hash_ == rhs.md5_hash_ && lhs.media_link_ == rhs.media_link_ &&
+         lhs.metadata_ == rhs.metadata_ &&
+         lhs.retention_expiration_time_ == rhs.retention_expiration_time_ &&
+         lhs.temporary_hold_ == rhs.temporary_hold_ &&
+         lhs.time_deleted_ == rhs.time_deleted_ &&
+         lhs.time_storage_class_updated_ == rhs.time_storage_class_updated_ &&
+         lhs.size_ == rhs.size_;
 }
 
 std::ostream& operator<<(std::ostream& os, ObjectMetadata const& rhs) {

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -223,8 +223,10 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
 
   using CommonMetadata::updated;
 
-  bool operator==(ObjectMetadata const& rhs) const;
-  bool operator!=(ObjectMetadata const& rhs) const { return !(*this == rhs); }
+  friend bool operator==(ObjectMetadata const& lhs, ObjectMetadata const& rhs);
+  friend bool operator!=(ObjectMetadata const& lhs, ObjectMetadata const& rhs) {
+    return !(lhs == rhs);
+  }
 
  private:
   friend struct internal::ObjectMetadataParser;

--- a/google/cloud/storage/service_account.h
+++ b/google/cloud/storage/service_account.h
@@ -35,36 +35,36 @@ class ServiceAccount {
   std::string const& email_address() const { return email_address_; }
   std::string const& kind() const { return kind_; }
 
-  bool operator==(ServiceAccount const& rhs) const {
-    return std::tie(email_address_, kind_) ==
-           std::tie(rhs.email_address_, rhs.kind_);
-  }
-
-  bool operator<(ServiceAccount const& rhs) const {
-    return std::tie(email_address_, kind_) <
-           std::tie(rhs.email_address_, rhs.kind_);
-  }
-
-  bool operator!=(ServiceAccount const& rhs) const {
-    return std::rel_ops::operator!=(*this, rhs);
-  }
-
-  bool operator>(ServiceAccount const& rhs) const {
-    return std::rel_ops::operator>(*this, rhs);
-  }
-
-  bool operator<=(ServiceAccount const& rhs) const {
-    return std::rel_ops::operator<=(*this, rhs);
-  }
-
-  bool operator>=(ServiceAccount const& rhs) const {
-    return std::rel_ops::operator>=(*this, rhs);
-  }
-
  private:
   std::string email_address_;
   std::string kind_;
 };
+
+inline bool operator==(ServiceAccount const& lhs, ServiceAccount const& rhs) {
+  return std::tie(lhs.email_address(), lhs.kind()) ==
+         std::tie(rhs.email_address(), rhs.kind());
+}
+
+inline bool operator<(ServiceAccount const& lhs, ServiceAccount const& rhs) {
+  return std::tie(lhs.email_address(), lhs.kind()) <
+         std::tie(rhs.email_address(), rhs.kind());
+}
+
+inline bool operator!=(ServiceAccount const& lhs, ServiceAccount const& rhs) {
+  return std::rel_ops::operator!=(lhs, rhs);
+}
+
+inline bool operator>(ServiceAccount const& lhs, ServiceAccount const& rhs) {
+  return std::rel_ops::operator>(lhs, rhs);
+}
+
+inline bool operator<=(ServiceAccount const& lhs, ServiceAccount const& rhs) {
+  return std::rel_ops::operator<=(lhs, rhs);
+}
+
+inline bool operator>=(ServiceAccount const& lhs, ServiceAccount const& rhs) {
+  return std::rel_ops::operator>=(lhs, rhs);
+}
 
 std::ostream& operator<<(std::ostream& os, ServiceAccount const& rhs);
 


### PR DESCRIPTION
When binary operators are implemented as member functions, they are subtly asymmetric since the LHS does not participate in any implicit conversions, while the RHS does. For example:

```c++
struct A {
  bool operator==(A const& a);
};

struct Foo {
  operator A() const;  // convertible to A;
};

Foo foo;
A a;
assert(a == foo); // OK
assert(foo == a);  // Won't compile
```

To ensure that binary operators are symmetric wrt implicit conversions, it's best to implement them as non-member functions.

In this change, I changed all member relational operators to non-member operators. Some are "inline friend" functions, when friendship is needed (e.g., when casting to a privately inherited base class). In cases where I was able to remove the friendship, I did.

See also http://go/gh/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c161-use-nonmember-functions-for-symmetric-operators

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1882)
<!-- Reviewable:end -->
